### PR TITLE
renaming Oses to GoOS and Arches to GoArch

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,8 +22,8 @@ type Homebrew struct {
 
 // BuildConfig contains the build configuration section
 type BuildConfig struct {
-	Oses   []string
-	Arches []string
+	GoOS   []string `yaml:"oses"`
+	GoArch []string `yaml:"arches"`
 	Main   string
 }
 
@@ -100,11 +100,11 @@ func (config *ProjectConfig) fillBasicData() {
 	if config.Build.Main == "" {
 		config.Build.Main = "main.go"
 	}
-	if len(config.Build.Oses) == 0 {
-		config.Build.Oses = []string{"linux", "darwin"}
+	if len(config.Build.GoOS) == 0 {
+		config.Build.GoOS = []string{"linux", "darwin"}
 	}
-	if len(config.Build.Arches) == 0 {
-		config.Build.Arches = []string{"amd64", "386"}
+	if len(config.Build.GoArch) == 0 {
+		config.Build.GoArch = []string{"amd64", "386"}
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,10 +13,10 @@ func TestFillBasicData(t *testing.T) {
 	config.fillBasicData()
 
 	assert.Equal("main.go", config.Build.Main)
-	assert.Contains(config.Build.Oses, "darwin")
-	assert.Contains(config.Build.Oses, "linux")
-	assert.Contains(config.Build.Arches, "386")
-	assert.Contains(config.Build.Arches, "amd64")
+	assert.Contains(config.Build.GoOS, "darwin")
+	assert.Contains(config.Build.GoOS, "linux")
+	assert.Contains(config.Build.GoArch, "386")
+	assert.Contains(config.Build.GoArch, "amd64")
 }
 
 func TestFillFilesMissingFiles(t *testing.T) {

--- a/pipeline/build/build.go
+++ b/pipeline/build/build.go
@@ -23,8 +23,8 @@ func (Pipe) Name() string {
 // Run the pipe
 func (Pipe) Run(config config.ProjectConfig) error {
 	var g errgroup.Group
-	for _, system := range config.Build.Oses {
-		for _, arch := range config.Build.Arches {
+	for _, system := range config.Build.GoOS {
+		for _, arch := range config.Build.GoArch {
 			system := system
 			arch := arch
 			g.Go(func() error {

--- a/pipeline/compress/compress.go
+++ b/pipeline/compress/compress.go
@@ -23,8 +23,8 @@ func (Pipe) Name() string {
 // Run the pipe
 func (Pipe) Run(config config.ProjectConfig) error {
 	var g errgroup.Group
-	for _, system := range config.Build.Oses {
-		for _, arch := range config.Build.Arches {
+	for _, system := range config.Build.GoOS {
+		for _, arch := range config.Build.GoArch {
 			system := system
 			arch := arch
 			g.Go(func() error {

--- a/pipeline/release/release.go
+++ b/pipeline/release/release.go
@@ -41,8 +41,8 @@ func (Pipe) Run(config config.ProjectConfig) error {
 		return err
 	}
 	var g errgroup.Group
-	for _, system := range config.Build.Oses {
-		for _, arch := range config.Build.Arches {
+	for _, system := range config.Build.GoOS {
+		for _, arch := range config.Build.GoArch {
 			system := system
 			arch := arch
 			g.Go(func() error {


### PR DESCRIPTION
YAML will still be `oses` and `arches` for now.

Addresses #42 