### PR TITLE
stop building goreleaser.exe

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,11 +1,6 @@
 brew:
   repo: goreleaser/homebrew-tap
   folder: Formula
-build:
-  goos:
-    - windows
-    - darwin
-    - linux
 archive:
   files:
     - README.md


### PR DESCRIPTION
it will probably not work on windows anyway (e.g.: calling `git` instead of `git.exe`).

The get/latest script also won't work on Windows.

For me, we can assume that this don't work and that's it...