### PR TITLE
brew depends on git

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,6 +1,8 @@
 brew:
   repo: goreleaser/homebrew-tap
   folder: Formula
+  dependencies:
+    - git
 archive:
   files:
     - README.md


### PR DESCRIPTION
It calls the `git` binary to get tags and logs. I think it's valid to add git as a dependency since now it is supported.