### PR TITLE
First implementation of plist field for brew formulae

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,11 @@ brew:
   conflicts:
     - svn
     - bash
+
+  # Packages that run as a service
+  plist:
+    <?xml version="1.0" encoding="UTF-8"?>
+    ...
 ```
 
 By defining the `brew` section, GoReleaser will take care of publishing the Homebrew tap.

--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ type Homebrew struct {
 	Repo         string
 	Folder       string
 	Caveats      string
+	Plist        string
 	Dependencies []string
 	Conflicts    []string
 }

--- a/pipeline/brew/brew.go
+++ b/pipeline/brew/brew.go
@@ -47,6 +47,14 @@ const formula = `class {{ .Name }} < Formula
     "{{ .Caveats }}"
   end
   {{- end }}
+
+  {{- if .Plist }}
+
+  def plist; <<-EOS.undent
+    {{ .Plist }}
+	EOS
+  end
+  {{- end }}
 end
 `
 
@@ -62,6 +70,7 @@ type templateData struct {
 	File         string
 	Format       string
 	SHA256       string
+	Plist        string
 	Dependencies []string
 	Conflicts    []string
 }
@@ -172,6 +181,7 @@ func dataFor(ctx *context.Context, client *github.Client) (result templateData, 
 		SHA256:       sum,
 		Dependencies: ctx.Config.Brew.Dependencies,
 		Conflicts:    ctx.Config.Brew.Conflicts,
+		Plist:        ctx.Config.Brew.Plist,
 	}, err
 }
 

--- a/pipeline/brew/brew_test.go
+++ b/pipeline/brew/brew_test.go
@@ -29,6 +29,7 @@ var defaultTemplateData = templateData{
 	File:       "test_Darwin_x86_64",
 	SHA256:     "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c68",
 	Format:     "tar.gz",
+	Plist:      "it works",
 }
 
 func assertDefaultTemplateData(t *testing.T, formulae string) {
@@ -56,6 +57,7 @@ func TestFullFormulae(t *testing.T) {
 	assert.Contains(formulae, "depends_on \"gtk\"")
 	assert.Contains(formulae, "depends_on \"git\"")
 	assert.Contains(formulae, "conflicts_with \"conflicting_dep\"")
+	assert.Contains(formulae, "def plist;")
 }
 
 func TestFormulaeSimple(t *testing.T) {


### PR DESCRIPTION
I need a plist field in one of my go projects and I did not want to give up on goreleaser :)  So I drafted a PR to discuss how to better add the feature. 

It's already working as it is but I'm not sure this is the right direction. A couple of notes:

- Wherever I added fields to structs I felt the need to reorder the fields alphabetically and put an empty line between groups (I would group the fields by type). But that's probably too personal and I'm not sure you'd like that.
- I changed the tests very little because I'm not sure you'd like to have more there. The rest of the brew tests follow the same approach.

I've tried the branch [here](https://github.com/lucapette/homebrew-tap/blob/master/tracker.rb) and it works fine.

This project gets better every time I use it. Thank you so much for your work!