### PR TITLE
Skip upload to GitHub

### DIFF
--- a/clients/github.go
+++ b/clients/github.go
@@ -6,10 +6,16 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// ErrMissingToken indicates an error when GITHUB_TOKEN is missing in the environment
+var ErrMissingToken = errors.New("Missing GITHUB_TOKEN")
+
 // GitHub client for the given token
-func GitHub(ctx *context.Context) *github.Client {
+func GitHub(ctx *context.Context) *github.Client, error {
+	if ctx.Token == "" {
+		return nil, ErrMissingToken
+	}
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: ctx.Token},
 	)
-	return github.NewClient(oauth2.NewClient(ctx, ts))
+	return github.NewClient(oauth2.NewClient(ctx, ts)), nil
 }

--- a/clients/github.go
+++ b/clients/github.go
@@ -1,6 +1,8 @@
 package clients
 
 import (
+	"errors"
+
 	"github.com/google/go-github/github"
 	"github.com/goreleaser/goreleaser/context"
 	"golang.org/x/oauth2"
@@ -10,7 +12,7 @@ import (
 var ErrMissingToken = errors.New("Missing GITHUB_TOKEN")
 
 // GitHub client for the given token
-func GitHub(ctx *context.Context) *github.Client, error {
+func GitHub(ctx *context.Context) (*github.Client, error) {
 	if ctx.Token == "" {
 		return nil, ErrMissingToken
 	}

--- a/pipeline/brew/brew.go
+++ b/pipeline/brew/brew.go
@@ -85,7 +85,7 @@ func (Pipe) Description() string {
 
 // Run the pipe
 func (Pipe) Run(ctx *context.Context) error {
-	if ctx.Config.Brew.Repo == "" {
+	if ctx.Config.Brew.Repo == "" || ctx.Config.Brew.Repo == "none" {
 		return nil
 	}
 	client := clients.GitHub(ctx)

--- a/pipeline/brew/brew.go
+++ b/pipeline/brew/brew.go
@@ -88,7 +88,10 @@ func (Pipe) Run(ctx *context.Context) error {
 	if ctx.Config.Brew.Repo == "" || ctx.Config.Brew.Repo == "none" {
 		return nil
 	}
-	client := clients.GitHub(ctx)
+	client, err := clients.GitHub(ctx)
+	if err != nil {
+		return err
+	}
 	path := filepath.Join(
 		ctx.Config.Brew.Folder, ctx.Config.Build.BinaryName+".rb",
 	)

--- a/pipeline/env/env.go
+++ b/pipeline/env/env.go
@@ -1,7 +1,6 @@
 package env
 
 import (
-	"errors"
 	"os"
 
 	"github.com/goreleaser/goreleaser/context"

--- a/pipeline/env/env.go
+++ b/pipeline/env/env.go
@@ -7,9 +7,6 @@ import (
 	"github.com/goreleaser/goreleaser/context"
 )
 
-// ErrMissingToken indicates an error when GITHUB_TOKEN is missing in the environment
-var ErrMissingToken = errors.New("Missing GITHUB_TOKEN")
-
 // Pipe for env
 type Pipe struct{}
 
@@ -21,8 +18,5 @@ func (Pipe) Description() string {
 // Run the pipe
 func (Pipe) Run(ctx *context.Context) (err error) {
 	ctx.Token = os.Getenv("GITHUB_TOKEN")
-	if ctx.Token == "" {
-		return ErrMissingToken
-	}
 	return
 }

--- a/pipeline/release/release.go
+++ b/pipeline/release/release.go
@@ -22,7 +22,13 @@ func (Pipe) Description() string {
 
 // Run the pipe
 func (Pipe) Run(ctx *context.Context) error {
-	client := clients.GitHub(ctx)
+	if ctx.Config.Brew.Repo == "" || ctx.Config.Brew.Repo == "none" {
+		return nil
+	}
+	client, err := clients.GitHub(ctx)
+	if err != nil {
+		return err
+	}
 
 	r, err := getOrCreateRelease(client, ctx)
 	if err != nil {

--- a/pipeline/release/release.go
+++ b/pipeline/release/release.go
@@ -22,7 +22,7 @@ func (Pipe) Description() string {
 
 // Run the pipe
 func (Pipe) Run(ctx *context.Context) error {
-	if ctx.Config.Brew.Repo == "" || ctx.Config.Brew.Repo == "none" {
+	if ctx.Config.Release.Repo == "" || ctx.Config.Release.Repo == "none" {
 		return nil
 	}
 	client, err := clients.GitHub(ctx)


### PR DESCRIPTION
This implements #132 

* Repo can now be set to "none" for github or brew, allowing to skip the release stage (brew modified only for compatibility),
* Defaults are unchanged (if repo is empty, it will still try to detect it with `remoteRepo` (only with explicit "none" the release step is skipped)
* GITHUB_TOKEN isn't validated in `env` anymore, but when creating the GitHub client. If the release step is skipped, then GITHUB_TOKEN is not needed