### PR TITLE
homebrew: allow choose which versions creates brew formulas

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,10 @@ brew:
   # Default is empty.
   caveats: "How to use this binary"
 
+  # Choose which versions brew should be build. Eg: for stable releases only without -rc suffix
+  # Default to any version
+  version_match: '^[0-9\.]+$'
+
   # Dependencies of your package
   dependencies:
     - git

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ type Homebrew struct {
 	Caveats      string
 	Plist        string
 	Install      string
+	VersionMatch string `yaml:"version_match"`
 	Dependencies []string
 	Conflicts    []string
 }

--- a/pipeline/brew/brew.go
+++ b/pipeline/brew/brew.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"text/template"
 
@@ -90,6 +91,14 @@ func (Pipe) Description() string {
 func (Pipe) Run(ctx *context.Context) error {
 	if ctx.Config.Brew.Repo == "" {
 		return nil
+	}
+	version := ctx.Version
+	if ctx.Config.Brew.VersionMatch != "" {
+		matched, _ := regexp.MatchString(ctx.Config.Brew.VersionMatch, version)
+		if !matched {
+			log.Println("No version match for brew, skipping")
+			return nil
+		}
 	}
 	client := clients.GitHub(ctx)
 	path := filepath.Join(


### PR DESCRIPTION
Allow homebrew task only run for some version match. Useful for only build it for stable releases, for example.