### PR TITLE
pre/post-build hooks should only run once

### DIFF
--- a/pipeline/build/build.go
+++ b/pipeline/build/build.go
@@ -47,7 +47,9 @@ func (Pipe) Run(ctx *context.Context) error {
 			})
 		}
 	}
-	err := g.Wait()
+	if err := g.Wait(); err != nil {
+		return err
+	}
 	if ctx.Config.Build.Hooks.Post != "" {
 		log.Println("Running post-build hook", ctx.Config.Build.Hooks.Post)
 		cmd := strings.Fields(ctx.Config.Build.Hooks.Post)
@@ -55,7 +57,7 @@ func (Pipe) Run(ctx *context.Context) error {
 			return err
 		}
 	}
-	return err
+	return nil
 }
 
 func build(name, goos, goarch string, ctx *context.Context) error {

--- a/pipeline/build/build.go
+++ b/pipeline/build/build.go
@@ -47,6 +47,7 @@ func build(name, goos, goarch string, ctx *context.Context) error {
 	output := "dist/" + name + "/" + ctx.Config.Build.Binary + extFor(goos)
 	log.Println("Building", output)
 	if ctx.Config.Build.Hooks.Pre != "" {
+		log.Println("Running pre-build hook", ctx.Config.Build.Hooks.Pre)
 		cmd := strings.Fields(ctx.Config.Build.Hooks.Pre)
 		if err := run(goos, goarch, cmd); err != nil {
 			return err
@@ -61,6 +62,7 @@ func build(name, goos, goarch string, ctx *context.Context) error {
 		return err
 	}
 	if ctx.Config.Build.Hooks.Post != "" {
+		log.Println("Running post-build hook", ctx.Config.Build.Hooks.Post)
 		cmd := strings.Fields(ctx.Config.Build.Hooks.Post)
 		if err := run(goos, goarch, cmd); err != nil {
 			return err


### PR DESCRIPTION
They are running for each build, which doesn't even make sense since we don't pass the binary just built as a param to the underneath script.

This patch makes it run only one time, the `pre-hook` before all builds, and the `post-build` after all builds are done.

A valid use case of this is described in #146. With this, we can now do:

> goreleaser.yml:
```yml
  hooks:
    post: ./upx.sh
```

> upx.sh:
```sh
#!/bin/bash
set -ex
upx dist/goreleaser*/goreleaser*
```

closes #146 