### PR TITLE
simplified code

### DIFF
--- a/checksum/checksum_test.go
+++ b/checksum/checksum_test.go
@@ -2,7 +2,6 @@ package checksum
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -13,20 +12,11 @@ func TestChecksums(t *testing.T) {
 	var assert = assert.New(t)
 	folder, err := ioutil.TempDir("", "gorelasertest")
 	assert.NoError(err)
-	file, err := os.OpenFile(
-		filepath.Join(folder, "subject"),
-		os.O_APPEND|os.O_WRONLY|os.O_CREATE|os.O_EXCL,
-		0600,
-	)
+	var file = filepath.Join(folder, "subject")
+	assert.NoError(ioutil.WriteFile(file, []byte("lorem ipsum"), 0644))
+	sum, err := SHA256(file)
 	assert.NoError(err)
-	_, err = file.WriteString("lorem ipsum")
-	assert.NoError(err)
-	assert.NoError(file.Close())
-	t.Run("sha256", func(t *testing.T) {
-		sum, err := SHA256(file.Name())
-		assert.NoError(err)
-		assert.Equal("5e2bf57d3f40c4b6df69daf1936cb766f832374b4fc0259a7cbff06e2f70f269", sum)
-	})
+	assert.Equal("5e2bf57d3f40c4b6df69daf1936cb766f832374b4fc0259a7cbff06e2f70f269", sum)
 }
 
 func TestOpenFailure(t *testing.T) {

--- a/pipeline/checksums/checksums_test.go
+++ b/pipeline/checksums/checksums_test.go
@@ -2,7 +2,6 @@ package checksums
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -19,21 +18,14 @@ func TestPipe(t *testing.T) {
 	var assert = assert.New(t)
 	folder, err := ioutil.TempDir("", "gorelasertest")
 	assert.NoError(err)
-	file, err := os.OpenFile(
-		filepath.Join(folder, "binary"),
-		os.O_APPEND|os.O_WRONLY|os.O_CREATE|os.O_EXCL,
-		0600,
-	)
-	assert.NoError(err)
-	_, err = file.WriteString("some string")
-	assert.NoError(err)
-	assert.NoError(file.Close())
+	var file = filepath.Join(folder, "binary")
+	assert.NoError(ioutil.WriteFile(file, []byte("some string"), 0644))
 	var ctx = &context.Context{
 		Config: config.Project{
 			Dist: folder,
 		},
 	}
-	ctx.AddArtifact(file.Name())
+	ctx.AddArtifact(file)
 	assert.NoError(Pipe{}.Run(ctx))
 	assert.Contains(ctx.Artifacts, "binary.checksums", "binary")
 	bts, err := ioutil.ReadFile(filepath.Join(folder, "binary.checksums"))


### PR DESCRIPTION
Rewrote some file creation logic in a simpler way.

It was first done like that because I was using the `os.O_EXCL` flag, which is not needed anymore.