### PR TITLE
better checksums

### DIFF
--- a/pipeline/checksums/checksums_test.go
+++ b/pipeline/checksums/checksums_test.go
@@ -16,6 +16,7 @@ func TestDescription(t *testing.T) {
 
 func TestPipe(t *testing.T) {
 	var assert = assert.New(t)
+	var checksums = "binary_checksums.txt"
 	folder, err := ioutil.TempDir("", "goreleasertest")
 	assert.NoError(err)
 	var file = filepath.Join(folder, "binary")
@@ -23,12 +24,15 @@ func TestPipe(t *testing.T) {
 	var ctx = &context.Context{
 		Config: config.Project{
 			Dist: folder,
+			Build: config.Build{
+				Binary: "binary",
+			},
 		},
 	}
 	ctx.AddArtifact(file)
 	assert.NoError(Pipe{}.Run(ctx))
-	assert.Contains(ctx.Artifacts, "binary.checksums", "binary")
-	bts, err := ioutil.ReadFile(filepath.Join(folder, "binary.checksums"))
+	assert.Contains(ctx.Artifacts, checksums, "binary")
+	bts, err := ioutil.ReadFile(filepath.Join(folder, checksums))
 	assert.NoError(err)
 	assert.Contains(string(bts), "61d034473102d7dac305902770471fd50f4c5b26f6831a56dd90b5184b3c30fc	binary")
 }

--- a/pipeline/checksums/checksums_test.go
+++ b/pipeline/checksums/checksums_test.go
@@ -16,25 +16,26 @@ func TestDescription(t *testing.T) {
 
 func TestPipe(t *testing.T) {
 	var assert = assert.New(t)
-	var checksums = "binary_checksums.txt"
+	var binary = "binary"
+	var checksums = binary + "_checksums.txt"
 	folder, err := ioutil.TempDir("", "goreleasertest")
 	assert.NoError(err)
-	var file = filepath.Join(folder, "binary")
+	var file = filepath.Join(folder, binary)
 	assert.NoError(ioutil.WriteFile(file, []byte("some string"), 0644))
 	var ctx = &context.Context{
 		Config: config.Project{
 			Dist: folder,
 			Build: config.Build{
-				Binary: "binary",
+				Binary: binary,
 			},
 		},
 	}
 	ctx.AddArtifact(file)
 	assert.NoError(Pipe{}.Run(ctx))
-	assert.Contains(ctx.Artifacts, checksums, "binary")
+	assert.Contains(ctx.Artifacts, checksums, binary)
 	bts, err := ioutil.ReadFile(filepath.Join(folder, checksums))
 	assert.NoError(err)
-	assert.Contains(string(bts), "61d034473102d7dac305902770471fd50f4c5b26f6831a56dd90b5184b3c30fc	binary")
+	assert.Equal(string(bts), "61d034473102d7dac305902770471fd50f4c5b26f6831a56dd90b5184b3c30fc	binary\n")
 }
 
 func TestPipeFileNotExist(t *testing.T) {


### PR DESCRIPTION
Proposal for #176 

This way, a user can download all archives and a single checksum file and do:

```sh
$ sha256sum -c test_checksums.txt
test_linux_64bits.tar.gz: OK
test_linux_64bits.deb: OK
test_macOS_64bits.tar.gz: OK
```

Example release: https://github.com/caarlos0/test/releases/tag/v2.0.1