### PR TITLE
Add fpm options

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,13 @@ GoReleaser can be wired to [fpm]() to generate `.deb`, `.rpm` and other archives
 ```yml
 # goreleaser.yml
 fpm:
+  # Options used in deb control file etc.
+  options:
+    vendor: "Drum Roll Inc."
+    url: "https://example.com/"
+    maintainer: "<Drummer drum-roll@example.com>"
+    description: "Software to create fast and easy drum rolls."
+    license: "Apache 2.0"
   # Formats to generate as output
   formats:
     - deb

--- a/config/config.go
+++ b/config/config.go
@@ -68,6 +68,16 @@ type FPM struct {
 	Formats      []string
 	Dependencies []string
 	Conflicts    []string
+	Options      FPMOptions
+}
+
+// FPM config options
+type FPMOptions struct {
+	Vendor      string
+	URL         string
+	Maintainer  string
+	Description string
+	License     string
 }
 
 // Project includes all project configuration

--- a/pipeline/fpm/fpm.go
+++ b/pipeline/fpm/fpm.go
@@ -70,6 +70,22 @@ func create(ctx *context.Context, format, archive, arch string) error {
 		"--package", file,
 		"--force",
 	}
+
+	if ctx.Config.FPM.Options.Vendor != "" {
+		options = append(options, "--vendor", ctx.Config.FPM.Options.Vendor)
+	}
+	if ctx.Config.FPM.Options.URL != "" {
+		options = append(options, "--url", ctx.Config.FPM.Options.URL)
+	}
+	if ctx.Config.FPM.Options.Maintainer != "" {
+		options = append(options, "--maintainer", ctx.Config.FPM.Options.Maintainer)
+	}
+	if ctx.Config.FPM.Options.Description != "" {
+		options = append(options, "--description", ctx.Config.FPM.Options.Description)
+	}
+	if ctx.Config.FPM.Options.License != "" {
+		options = append(options, "--license", ctx.Config.FPM.Options.License)
+	}
 	for _, dep := range ctx.Config.FPM.Dependencies {
 		options = append(options, "--depends", dep)
 	}


### PR DESCRIPTION
This is needed to create a proper debian control file, but will also be used for the .rpm packages.

I did not find any easy way to add a unit test for this, but I have tested it myself and verified that the debian control file looks fine.