### PR TITLE
add more fpm tests

### DIFF
--- a/pipeline/fpm/fpm_test.go
+++ b/pipeline/fpm/fpm_test.go
@@ -49,6 +49,13 @@ func TestRunPipe(t *testing.T) {
 				Formats:      []string{"deb"},
 				Dependencies: []string{"make"},
 				Conflicts:    []string{"git"},
+				Options: config.FPMOptions{
+					Description: "Some description",
+					License:     "MIT",
+					Maintainer:  "me@me",
+					Vendor:      "asdf",
+					URL:         "https://goreleaser.github.io",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
right now we only pass the args, and, since we have fpm installed, if it does not break, we assume it's right.

We may make this code more testable in the future though.