### PR TITLE
Added archive format overrides support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ build:
 # Archive customization
 archive:
   format: tar.gz
+  format_overrides:
+    - goos: windows
+      format: zip
   replacements:
     amd64: 64-bit
     darwin: macOS

--- a/config/config.go
+++ b/config/config.go
@@ -47,12 +47,19 @@ type Build struct {
 	Hooks   Hooks
 }
 
+// FormatOverride is used to specify a custom format for a specific GOOS.
+type FormatOverride struct {
+	Goos   string
+	Format string
+}
+
 // Archive config used for the archive
 type Archive struct {
-	Format       string
-	NameTemplate string `yaml:"name_template"`
-	Replacements map[string]string
-	Files        []string
+	Format          string
+	FormatOverrides []FormatOverride `yaml:"format_overrides"`
+	NameTemplate    string           `yaml:"name_template"`
+	Replacements    map[string]string
+	Files           []string
 }
 
 // Release config used for the GitHub release

--- a/pipeline/archive/archive_test.go
+++ b/pipeline/archive/archive_test.go
@@ -63,3 +63,22 @@ func TestRunPipe(t *testing.T) {
 		assert.Error(Pipe{}.Run(ctx))
 	})
 }
+
+func TestFormatFor(t *testing.T) {
+	var assert = assert.New(t)
+	var ctx = &context.Context{
+		Config: config.Project{
+			Archive: config.Archive{
+				Format: "tar.gz",
+				FormatOverrides: []config.FormatOverride{
+					{
+						Goos:   "windows",
+						Format: "zip",
+					},
+				},
+			},
+		},
+	}
+	assert.Equal("zip", formatFor(ctx, "windowsamd64"))
+	assert.Equal("tar.gz", formatFor(ctx, "linux386"))
+}

--- a/pipeline/archive/archive_test.go
+++ b/pipeline/archive/archive_test.go
@@ -34,13 +34,20 @@ func TestRunPipe(t *testing.T) {
 	assert.NoError(err)
 	var ctx = &context.Context{
 		Archives: map[string]string{
-			"darwinamd64": "mybin",
+			"darwinamd64":  "mybin",
+			"windowsamd64": "mybin",
 		},
 		Config: config.Project{
 			Dist: dist,
 			Archive: config.Archive{
 				Files: []string{
 					"README.md",
+				},
+				FormatOverrides: []config.FormatOverride{
+					{
+						Goos:   "windows",
+						Format: "zip",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
The syntax looks like:

```yml
build:
  goos:
    - linux
    - darwin
    - windows
archive:
  format: tar.gz
  format_overrides:
    - goos: windows
      format: zip
```

I ran it against goreleaser itself, the output was:

```console
~/Code/Go/src/github.com/goreleaser/goreleaser master*
❯ go run ./cmd/goreleaser/main.go --skip-validate --skip-publish
Running goreleaser dev
Setting defaults
Getting and validating git state
 -> Skipped validations because --skip-validate is set
Loading environment variables
 -> Skipped validations because --skip-validate is set
Building binaries
 -> Building dist/goreleaser_Linux_x86_64/goreleaser
 -> Building dist/goreleaser_Linux_i386/goreleaser
 -> Building dist/goreleaser_Darwin_i386/goreleaser
 -> Building dist/goreleaser_Darwin_x86_64/goreleaser
 -> Building dist/goreleaser_Windows_x86_64/goreleaser.exe
 -> Building dist/goreleaser_Windows_i386/goreleaser.exe
Creating archives
 -> Creating dist/goreleaser_Linux_x86_64.tar.gz
 -> Creating dist/goreleaser_Darwin_i386.tar.gz
 -> Creating dist/goreleaser_Windows_x86_64.zip
 -> Creating dist/goreleaser_Windows_i386.zip
 -> Creating dist/goreleaser_Linux_i386.tar.gz
 -> Creating dist/goreleaser_Darwin_x86_64.tar.gz
 -> Registered artifact goreleaser_Windows_x86_64.zip
 -> Registered artifact goreleaser_Windows_i386.zip
 -> Registered artifact goreleaser_Linux_i386.tar.gz
 -> Registered artifact goreleaser_Darwin_i386.tar.gz
 -> Registered artifact goreleaser_Linux_x86_64.tar.gz
 -> Registered artifact goreleaser_Darwin_x86_64.tar.gz
Creating Linux packages with fpm
 -> Creating dist/goreleaser_Linux_x86_64.deb
 -> Creating dist/goreleaser_Linux_i386.deb
 -> Registered artifact goreleaser_Linux_i386.deb
 -> Registered artifact goreleaser_Linux_x86_64.deb
Calculating checksums
 -> Checksumming goreleaser_Linux_x86_64.deb
 -> Checksumming goreleaser_Linux_i386.tar.gz
 -> Checksumming goreleaser_Windows_x86_64.zip
 -> Checksumming goreleaser_Linux_x86_64.tar.gz
 -> Checksumming goreleaser_Windows_i386.zip
 -> Checksumming goreleaser_Darwin_i386.tar.gz
 -> Checksumming goreleaser_Darwin_x86_64.tar.gz
 -> Checksumming goreleaser_Linux_i386.deb
 -> Registered artifact goreleaser_checksums.txt
Releasing to GitHub
 -> Skipped because --skip-publish is set
Creating homebrew formula
 -> Skipped because --skip-publish is set
Done!
```

Closes #199 
cc/ @bep 