### PR TITLE
make brew and fpm config more alike

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,14 @@ brew:
   # Default is empty.
   caveats: "How to use this binary"
 
+  # Your app's homepage
+  # Default is empty
+  homepage: "https://example.com/"
+
+  # Your app's description
+  # Default is empty
+  description: "Software to create fast and easy drum rolls."
+
   # Dependencies of your package
   dependencies:
     - git
@@ -339,13 +347,25 @@ GoReleaser can be wired to [fpm]() to generate `.deb`, `.rpm` and other archives
 ```yml
 # goreleaser.yml
 fpm:
-  # Options used in deb control file etc.
-  options:
-    vendor: "Drum Roll Inc."
-    url: "https://example.com/"
-    maintainer: "<Drummer drum-roll@example.com>"
-    description: "Software to create fast and easy drum rolls."
-    license: "Apache 2.0"
+  # Your app's vendor
+  # Default is empty
+  vendor: Drum Roll Inc.
+  # Your app's homepage
+  # Default is empty
+  homepage: https://example.com/
+
+  # Your app's maintainer (probably you)
+  # Default is empty
+  maintainer: <Drummer drum-roll@example.com>
+
+  # Your app's description
+  # Default is empty
+  description: Software to create fast and easy drum rolls.
+
+  # Your app's license
+  # Default is empty
+  license: Apache 2.0
+
   # Formats to generate as output
   formats:
     - deb

--- a/client/client.go
+++ b/client/client.go
@@ -17,7 +17,6 @@ type Info struct {
 
 // Client interface
 type Client interface {
-	GetInfo(ctx *context.Context) (info Info, err error)
 	CreateRelease(ctx *context.Context, body string) (releaseID int, err error)
 	CreateFile(ctx *context.Context, content bytes.Buffer, path string) (err error)
 	Upload(ctx *context.Context, releaseID int, name string, file *os.File) (err error)

--- a/client/github.go
+++ b/client/github.go
@@ -67,21 +67,6 @@ func (c *githubClient) CreateFile(
 	return
 }
 
-func (c *githubClient) GetInfo(ctx *context.Context) (info Info, err error) {
-	rep, _, err := c.client.Repositories.Get(
-		ctx,
-		ctx.Config.Release.GitHub.Owner,
-		ctx.Config.Release.GitHub.Name,
-	)
-	if err != nil {
-		return
-	}
-	info.Homepage = rep.GetHomepage()
-	info.URL = rep.GetHTMLURL()
-	info.Description = rep.GetDescription()
-	return
-}
-
 func (c *githubClient) CreateRelease(ctx *context.Context, body string) (releaseID int, err error) {
 	data := &github.RepositoryRelease{
 		Name:    github.String(ctx.Git.CurrentTag),

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,8 @@ type Homebrew struct {
 	Install      string
 	Dependencies []string
 	Conflicts    []string
+	Description  string
+	URL          string
 }
 
 // Hooks define actions to run before and/or after something
@@ -72,16 +74,11 @@ type FPM struct {
 	Formats      []string
 	Dependencies []string
 	Conflicts    []string
-	Options      FPMOptions
-}
-
-// FPMOptions config options
-type FPMOptions struct {
-	Vendor      string
-	URL         string
-	Maintainer  string
-	Description string
-	License     string
+	Vendor       string
+	Homepage     string
+	Maintainer   string
+	Description  string
+	License      string
 }
 
 // Project includes all project configuration

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -5,12 +5,12 @@ build:
   goos:
     - linux
     - darwin
-    # - windows
+    - windows
   goarch:
-    # - 386
+    - 386
     - amd64
-    # - arm
-    # - arm64
+    - arm
+    - arm64
 archive:
   format_overrides:
     - goos: windows
@@ -25,9 +25,9 @@ brew:
   dependencies:
     - git
 fpm:
-  url: *homepage
+  homepage: *homepage
   description: *description
-  maintainer: <root@carlosbecker.com>
+  maintainer: Carlos Alexandro Becker <root@carlosbecker.com>
   license: MIT
   vendor: GoReleaser
   formats:

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,14 +1,16 @@
+homepage: &homepage http://goreleaser.github.io
+description: &description Deliver Go binaries as fast and easily as possible
 build:
   main: ./cmd/goreleaser/main.go
   goos:
     - linux
     - darwin
-    - windows
+    # - windows
   goarch:
-    - 386
+    # - 386
     - amd64
-    - arm
-    - arm64
+    # - arm
+    # - arm64
 archive:
   format_overrides:
     - goos: windows
@@ -18,9 +20,16 @@ brew:
     owner: goreleaser
     name: homebrew-tap
   folder: Formula
+  homepage: *homepage
+  description: *description
   dependencies:
     - git
 fpm:
+  url: *homepage
+  description: *description
+  maintainer: <root@carlosbecker.com>
+  license: MIT
+  vendor: GoReleaser
   formats:
     - deb
   dependencies:

--- a/pipeline/brew/brew.go
+++ b/pipeline/brew/brew.go
@@ -143,48 +143,23 @@ func dataFor(ctx *context.Context, client client.Client) (result templateData, e
 	if err != nil {
 		return
 	}
-	homepage, description, err := getInfo(ctx, client)
-	if err != nil {
-		return
-	}
 	return templateData{
 		Name:         formulaNameFor(ctx.Config.Build.Binary),
-		Desc:         description,
-		Homepage:     homepage,
+		Desc:         ctx.Config.Brew.Description,
+		Homepage:     ctx.Config.Brew.URL,
 		Repo:         ctx.Config.Release.GitHub,
 		Tag:          ctx.Git.CurrentTag,
 		Version:      ctx.Version,
 		Binary:       ctx.Config.Build.Binary,
 		Caveats:      ctx.Config.Brew.Caveats,
 		File:         file,
-		Format:       ctx.Config.Archive.Format,
+		Format:       ctx.Config.Archive.Format, // TODO this can be broken by format_overrides
 		SHA256:       sum,
 		Dependencies: ctx.Config.Brew.Dependencies,
 		Conflicts:    ctx.Config.Brew.Conflicts,
 		Plist:        ctx.Config.Brew.Plist,
 		Install:      strings.Split(ctx.Config.Brew.Install, "\n"),
 	}, err
-}
-
-func getInfo(
-	ctx *context.Context,
-	client client.Client,
-) (homepage string, description string, err error) {
-	info, err := client.GetInfo(ctx)
-	if err != nil {
-		return
-	}
-	if info.Homepage == "" {
-		homepage = info.URL
-	} else {
-		homepage = info.Homepage
-	}
-	if info.Description == "" {
-		description = "TODO"
-	} else {
-		description = info.Description
-	}
-	return
 }
 
 func formulaNameFor(name string) string {

--- a/pipeline/brew/brew_test.go
+++ b/pipeline/brew/brew_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/goreleaser/goreleaser/client"
 	"github.com/goreleaser/goreleaser/config"
 	"github.com/goreleaser/goreleaser/context"
 	"github.com/stretchr/testify/assert"
@@ -168,10 +167,6 @@ func TestRunPipeNoPublish(t *testing.T) {
 
 type DummyClient struct {
 	CreatedFile bool
-}
-
-func (client *DummyClient) GetInfo(ctx *context.Context) (info client.Info, err error) {
-	return
 }
 
 func (client *DummyClient) CreateRelease(ctx *context.Context, body string) (releaseID int, err error) {

--- a/pipeline/fpm/fpm.go
+++ b/pipeline/fpm/fpm.go
@@ -71,20 +71,20 @@ func create(ctx *context.Context, format, archive, arch string) error {
 		"--force",
 	}
 
-	if ctx.Config.FPM.Options.Vendor != "" {
-		options = append(options, "--vendor", ctx.Config.FPM.Options.Vendor)
+	if ctx.Config.FPM.Vendor != "" {
+		options = append(options, "--vendor", ctx.Config.FPM.Vendor)
 	}
-	if ctx.Config.FPM.Options.URL != "" {
-		options = append(options, "--url", ctx.Config.FPM.Options.URL)
+	if ctx.Config.FPM.Homepage != "" {
+		options = append(options, "--url", ctx.Config.FPM.Homepage)
 	}
-	if ctx.Config.FPM.Options.Maintainer != "" {
-		options = append(options, "--maintainer", ctx.Config.FPM.Options.Maintainer)
+	if ctx.Config.FPM.Maintainer != "" {
+		options = append(options, "--maintainer", ctx.Config.FPM.Maintainer)
 	}
-	if ctx.Config.FPM.Options.Description != "" {
-		options = append(options, "--description", ctx.Config.FPM.Options.Description)
+	if ctx.Config.FPM.Description != "" {
+		options = append(options, "--description", ctx.Config.FPM.Description)
 	}
-	if ctx.Config.FPM.Options.License != "" {
-		options = append(options, "--license", ctx.Config.FPM.Options.License)
+	if ctx.Config.FPM.License != "" {
+		options = append(options, "--license", ctx.Config.FPM.License)
 	}
 	for _, dep := range ctx.Config.FPM.Dependencies {
 		options = append(options, "--depends", dep)

--- a/pipeline/fpm/fpm_test.go
+++ b/pipeline/fpm/fpm_test.go
@@ -49,13 +49,11 @@ func TestRunPipe(t *testing.T) {
 				Formats:      []string{"deb"},
 				Dependencies: []string{"make"},
 				Conflicts:    []string{"git"},
-				Options: config.FPMOptions{
-					Description: "Some description",
-					License:     "MIT",
-					Maintainer:  "me@me",
-					Vendor:      "asdf",
-					URL:         "https://goreleaser.github.io",
-				},
+				Description:  "Some description",
+				License:      "MIT",
+				Maintainer:   "me@me",
+				Vendor:       "asdf",
+				Homepage:     "https://goreleaser.github.io",
 			},
 		},
 	}

--- a/pipeline/release/release_test.go
+++ b/pipeline/release/release_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/goreleaser/goreleaser/client"
 	"github.com/goreleaser/goreleaser/config"
 	"github.com/goreleaser/goreleaser/context"
 	"github.com/stretchr/testify/assert"
@@ -142,10 +141,6 @@ type DummyClient struct {
 	FailToUpload        bool
 	CreatedRelease      bool
 	UploadedFile        bool
-}
-
-func (client *DummyClient) GetInfo(ctx *context.Context) (info client.Info, err error) {
-	return
 }
 
 func (client *DummyClient) CreateRelease(ctx *context.Context, body string) (releaseID int, err error) {


### PR DESCRIPTION
brew was discovering homepage and description from the github repository info, which was not documented at all and there were no way of overriding that. So, I added those settings, and also remove the `options` from `fpm` section, they all lay in the root now.
Also renamed `fpm.url` to `fpm.homepage`.

@bep this may impact you, I'm not doing it in a backwards compatible way because probably no one is using it yet :P 