### PR TITLE
make goreleaser installable via go get #205

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ install:
   - gem install fpm
 script:
   - make test
-  - test -n "$TRAVIS_TAG" || go run ./cmd/goreleaser/main.go --skip-validate --skip-publish
+  - test -n "$TRAVIS_TAG" || go run main.go --skip-validate --skip-publish
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-  - test -n "$TRAVIS_TAG" && go run ./cmd/goreleaser/main.go
+  - test -n "$TRAVIS_TAG" && go run main.go
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,8 @@ lint: ## Run all the linters
 
 ci: lint test ## Run all the tests and code checks
 
-build: ## Build a beta version of releaser
-	go build -o goreleaser ./cmd/goreleaser/main.go
-
-install: ## Install the binary into $GOPATH/bin
-	go install ./cmd/...
+build: ## Build a beta version of goreleaser
+	go build
 
 # Absolutely awesome: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help:

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,7 +1,6 @@
 homepage: &homepage http://goreleaser.github.io
 description: &description Deliver Go binaries as fast and easily as possible
 build:
-  main: ./cmd/goreleaser/main.go
   goos:
     - linux
     - darwin

--- a/goreleaserlib/goreleaser.go
+++ b/goreleaserlib/goreleaser.go
@@ -1,4 +1,4 @@
-package goreleaser
+package goreleaserlib
 
 import (
 	"io/ioutil"

--- a/goreleaserlib/goreleaser_test.go
+++ b/goreleaserlib/goreleaser_test.go
@@ -1,4 +1,4 @@
-package goreleaser
+package goreleaserlib
 
 import (
 	"io/ioutil"

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/goreleaser/goreleaser"
+	"github.com/goreleaser/goreleaser/goreleaserlib"
 	"github.com/urfave/cli"
 )
 
@@ -41,7 +41,7 @@ func main() {
 	}
 	app.Action = func(c *cli.Context) error {
 		log.Printf("Running goreleaser %v\n", version)
-		if err := goreleaser.Release(c); err != nil {
+		if err := goreleaserlib.Release(c); err != nil {
 			return cli.NewExitError(err.Error(), 1)
 		}
 		return nil


### PR DESCRIPTION
Move `main.go` file to top level and move Go library to `goreleaserlib` package.

This organisation would allow GoReleaser to be installable via `go get` and at the same time make the functionality usable from Go via the `goreleaserlib`.

Calling the package `goreleaserlib` instead of just `goreleaser` allow the default behaviour of `go build` to still create a binary called `goreleaser`.