### PR TITLE
Add snapshot builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ are not enforcing it though. We do remove the `v` prefix and then enforce
 that the next character is a number. So, `v0.1.0` and `0.1.0` are virtually the
 same and are both accepted, while `version0.1.0` is not.
 
+If you don't want to create a tag yet but instead simply create a package based on the latest commit, then you can also use the `--snapshot` flag.
+
 Now you can run GoReleaser at the root of your repository:
 
 ```console
@@ -164,7 +166,7 @@ func main() {
 }
 ```
 
-`version` will always be the name of the current Git tag.
+`version` will be the current Git tag or the name of the snapshot if you're using the `--snapshot` flag.
 
 ## Release customization
 
@@ -286,6 +288,20 @@ release:
 
 You can also specify a release notes file in markdown format using the
 `--release-notes` flag.
+
+### Snapshot customization
+
+```yml
+# goreleaser.yml
+snapshot:
+  # Allows you to change the name of the generated snapshot
+  # releases. The following variables are available:
+  # - Commit
+  # - Tag
+  # - Timestamp
+  # Default: SNAPSHOT-{{.Commit}}
+  name_template: SNAPSHOT-{{.Commit}}
+```
 
 ### Homebrew tap customization
 

--- a/config/config.go
+++ b/config/config.go
@@ -83,13 +83,19 @@ type FPM struct {
 	License      string   `yaml:",omitempty"`
 }
 
+// Snapshot config
+type Snapshot struct {
+	NameTemplate string `yaml:"name_template,omitempty"`
+}
+
 // Project includes all project configuration
 type Project struct {
-	Release Release  `yaml:",omitempty"`
-	Brew    Homebrew `yaml:",omitempty"`
-	Build   Build    `yaml:",omitempty"`
-	Archive Archive  `yaml:",omitempty"`
-	FPM     FPM      `yaml:",omitempty"`
+	Release  Release  `yaml:",omitempty"`
+	Brew     Homebrew `yaml:",omitempty"`
+	Build    Build    `yaml:",omitempty"`
+	Archive  Archive  `yaml:",omitempty"`
+	FPM      FPM      `yaml:",omitempty"`
+	Snapshot Snapshot `yaml:",omitempty"`
 
 	// test only property indicating the path to the dist folder
 	Dist string `yaml:"-"`

--- a/context/context.go
+++ b/context/context.go
@@ -33,6 +33,7 @@ type Context struct {
 	Version      string
 	Validate     bool
 	Publish      bool
+	Snapshot     bool
 }
 
 var lock sync.Mutex

--- a/goreleaserlib/goreleaser.go
+++ b/goreleaserlib/goreleaser.go
@@ -70,6 +70,11 @@ func Release(flags Flags) error {
 		log.Println("Loaded custom release notes from", notes)
 		ctx.ReleaseNotes = string(bts)
 	}
+	ctx.Snapshot = flags.Bool("snapshot")
+	if ctx.Snapshot {
+		log.Println("Publishing disabled in snapshot mode")
+		ctx.Publish = false
+	}
 	for _, pipe := range pipes {
 		log.Println(pipe.Description())
 		log.SetPrefix(" -> ")

--- a/main.go
+++ b/main.go
@@ -38,6 +38,10 @@ func main() {
 			Name:  "skip-publish",
 			Usage: "Skip all publishing pipes of the release",
 		},
+		cli.BoolFlag{
+			Name:  "snapshot",
+			Usage: "Generate an unversioned snapshot release",
+		},
 	}
 	app.Action = func(c *cli.Context) error {
 		log.Printf("Running goreleaser %v\n", version)

--- a/pipeline/defaults/defaults.go
+++ b/pipeline/defaults/defaults.go
@@ -15,6 +15,9 @@ var defaultFiles = []string{"licence", "license", "readme", "changelog"}
 // NameTemplate default name_template for the archive.
 const NameTemplate = "{{ .Binary }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
 
+// SnapshotNameTemplate represents the default format for snapshot release names.
+const SnapshotNameTemplate = "SNAPSHOT-{{.Commit}}"
+
 // Pipe for brew deployment
 type Pipe struct{}
 
@@ -25,6 +28,9 @@ func (Pipe) Description() string {
 
 // Run the pipe
 func (Pipe) Run(ctx *context.Context) error {
+	if ctx.Config.Snapshot.NameTemplate == "" {
+		ctx.Config.Snapshot.NameTemplate = SnapshotNameTemplate
+	}
 	if ctx.Config.Release.GitHub.Name == "" {
 		repo, err := remoteRepo()
 		ctx.Config.Release.GitHub = repo

--- a/pipeline/env/env.go
+++ b/pipeline/env/env.go
@@ -24,6 +24,10 @@ func (Pipe) Description() string {
 // Run the pipe
 func (Pipe) Run(ctx *context.Context) (err error) {
 	ctx.Token = os.Getenv("GITHUB_TOKEN")
+	if !ctx.Publish {
+		log.Println("GITHUB_TOKEN not validated because publishing has been disabled")
+		return nil
+	}
 	if !ctx.Validate {
 		log.Println("Skipped validations because --skip-validate is set")
 		return nil

--- a/pipeline/env/env_test.go
+++ b/pipeline/env/env_test.go
@@ -19,6 +19,7 @@ func TestValidEnv(t *testing.T) {
 	var ctx = &context.Context{
 		Config:   config.Project{},
 		Validate: true,
+		Publish:  true,
 	}
 	assert.NoError(Pipe{}.Run(ctx))
 }
@@ -29,8 +30,31 @@ func TestInvalidEnv(t *testing.T) {
 	var ctx = &context.Context{
 		Config:   config.Project{},
 		Validate: true,
+		Publish:  true,
 	}
 	assert.Error(Pipe{}.Run(ctx))
+}
+
+func TestInvalidEnvDisabled(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(os.Unsetenv("GITHUB_TOKEN"))
+	var ctx = &context.Context{
+		Config:   config.Project{},
+		Validate: false,
+		Publish:  true,
+	}
+	assert.NoError(Pipe{}.Run(ctx))
+}
+
+func TestEnvWithoutPublish(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(os.Unsetenv("GITHUB_TOKEN"))
+	var ctx = &context.Context{
+		Config:   config.Project{},
+		Validate: true,
+		Publish:  false,
+	}
+	assert.NoError(Pipe{}.Run(ctx))
 }
 
 func TestSkipValidate(t *testing.T) {

--- a/pipeline/git/git_test.go
+++ b/pipeline/git/git_test.go
@@ -50,6 +50,58 @@ func TestNewRepository(t *testing.T) {
 	assert.Error(Pipe{}.Run(ctx))
 }
 
+func TestNoTagsSnapshot(t *testing.T) {
+	assert := assert.New(t)
+	_, back := createAndChdir(t)
+	defer back()
+	gitInit(t)
+	gitCommit(t, "first")
+	var ctx = &context.Context{
+		Config: config.Project{
+			Snapshot: config.Snapshot{NameTemplate: "SNAPSHOT-{{.Commit}}"},
+		},
+		Snapshot: true,
+		Publish:  false,
+	}
+	assert.NoError(Pipe{}.Run(ctx))
+	assert.Contains(ctx.Version, "SNAPSHOT-")
+}
+
+func TestNoTagsSnapshotInvalidTemplate(t *testing.T) {
+	assert := assert.New(t)
+	_, back := createAndChdir(t)
+	defer back()
+	gitInit(t)
+	gitCommit(t, "first")
+	var ctx = &context.Context{
+		Config: config.Project{
+			Snapshot: config.Snapshot{NameTemplate: "{{"},
+		},
+		Snapshot: true,
+		Publish:  false,
+	}
+	assert.Error(Pipe{}.Run(ctx))
+}
+
+// TestNoTagsNoSnapshot covers the situation where a repository
+// only contains simple commits and no tags. In this case you have
+// to set the --snapshot flag otherwise an error is returned.
+func TestNoTagsNoSnapshot(t *testing.T) {
+	assert := assert.New(t)
+	_, back := createAndChdir(t)
+	defer back()
+	gitInit(t)
+	gitCommit(t, "first")
+	var ctx = &context.Context{
+		Config: config.Project{
+			Snapshot: config.Snapshot{NameTemplate: "SNAPSHOT-{{.Commit}}"},
+		},
+		Snapshot: false,
+		Publish:  false,
+	}
+	assert.Error(Pipe{}.Run(ctx))
+}
+
 func TestInvalidTagFormat(t *testing.T) {
 	var assert = assert.New(t)
 	_, back := createAndChdir(t)


### PR DESCRIPTION
This adds a new `--snapshot` flag in order to allow no-tag releases. In addition, the snapshot name can be configured with the `snapshot_name_template` top-level setting within the goreleaser.yml file.

Relates to #222