### PR TITLE
Use external, static linking.

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,5 +1,6 @@
 homepage: &homepage http://goreleaser.github.io
 description: &description Deliver Go binaries as fast and easily as possible
+ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -linkmode external -extldflags "-static"
 build:
   goos:
     - linux


### PR DESCRIPTION
Possible fix for #225 

I saw [Hugo](https://github.com/spf13/hugo/blob/master/goreleaser.yml#L4) uses this option and the Hugo release works on Alpine Linux.
But I don't think Hugo is release from Travis CI.
The only way to test this, is by making it part of a tag and let it run on Travis. 
Could also create a new repository to try this out.
But before trying this, @caarlos0, maybe you have any idea?