### PR TITLE
support globs on archive.files

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1,4 +1,4 @@
-memo = "85c15b94eaf073e2c6e87a85ac2088f1d61889c8ddcc8542c09145f0f816c6af"
+memo = "3cbc12d80513bcbb0ac166d404600ffbc63b1c301b5c6d3722dad30db6f6a549"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -23,6 +23,12 @@ memo = "85c15b94eaf073e2c6e87a85ac2088f1d61889c8ddcc8542c09145f0f816c6af"
   name = "github.com/google/go-querystring"
   packages = ["query"]
   revision = "53e6ce116135b80d037921a7fdd5138cf32d7a8a"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/mattn/go-zglob"
+  packages = [".","fastwalk"]
+  revision = "95345c4e1c0ebc9d16a3284177f09360f4d20fab"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ setup: ## Install all the build and lint dependencies
 	gometalinter --install
 
 test: ## Run all the tests
-	gotestcover $(TEST_OPTIONS) -covermode=atomic -coverprofile=coverage.txt $(SOURCE_FILES) -run $(TEST_PATTERN) -timeout=30s
+	gotestcover $(TEST_OPTIONS) -covermode=atomic -coverprofile=coverage.txt $(SOURCE_FILES) -run $(TEST_PATTERN) -timeout=2m
 
 cover: test ## Run all the tests and opens the coverage report
 	go tool cover -html=coverage.txt

--- a/README.md
+++ b/README.md
@@ -279,13 +279,15 @@ archive:
     darwin: macOS
     linux: Tux
 
-  # Additional files you want to add to the archive.
+  # Additional files/globs you want to add to the archive.
   # Defaults are any files matching `LICENCE*`, `LICENSE*`,
   # `README*` and `CHANGELOG*` (case-insensitive)
   files:
     - LICENSE.txt
     - README.md
     - CHANGELOG.md
+    - docs/*
+    - design/*.png
 ```
 
 ### Release customization

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -2,15 +2,19 @@ homepage: &homepage http://goreleaser.github.io
 description: &description Deliver Go binaries as fast and easily as possible
 build:
   goos:
-    - linux
+    # - linux
     - darwin
     - windows
   goarch:
-    - 386
+    # - 386
     - amd64
-    - arm
-    - arm64
+    # - arm
+    # - arm64
 archive:
+  files:
+    - README.*
+    - internal/**/*.go
+    - config/*
   format_overrides:
     - goos: windows
       format: zip

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -2,19 +2,15 @@ homepage: &homepage http://goreleaser.github.io
 description: &description Deliver Go binaries as fast and easily as possible
 build:
   goos:
-    # - linux
+    - linux
     - darwin
     - windows
   goarch:
-    # - 386
+    - 386
     - amd64
-    # - arm
-    # - arm64
+    - arm
+    - arm64
 archive:
-  files:
-    - README.*
-    - internal/**/*.go
-    - config/*
   format_overrides:
     - goos: windows
       format: zip

--- a/internal/ext/ext.go
+++ b/internal/ext/ext.go
@@ -1,0 +1,10 @@
+package ext
+
+import "strings"
+
+func For(platform string) (ext string) {
+	if strings.HasPrefix(platform, "windows") {
+		ext = ".exe"
+	}
+	return
+}

--- a/internal/ext/ext_test.go
+++ b/internal/ext/ext_test.go
@@ -1,0 +1,18 @@
+package ext
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtWindows(t *testing.T) {
+	assert.Equal(t, ".exe", For("windows"))
+	assert.Equal(t, ".exe", For("windowsamd64"))
+}
+
+func TestExtOthers(t *testing.T) {
+	assert.Empty(t, "", For("linux"))
+	assert.Empty(t, "", For("linuxwin"))
+	assert.Empty(t, "", For("winasdasd"))
+}

--- a/pipeline/archive/archive.go
+++ b/pipeline/archive/archive.go
@@ -13,6 +13,7 @@ import (
 	"github.com/goreleaser/goreleaser/internal/ext"
 	"github.com/goreleaser/goreleaser/pipeline/archive/tar"
 	"github.com/goreleaser/goreleaser/pipeline/archive/zip"
+	"github.com/mattn/go-zglob"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -74,7 +75,7 @@ func create(ctx *context.Context, platform, name string) error {
 
 func findFiles(ctx *context.Context) (result []string, err error) {
 	for _, glob := range ctx.Config.Archive.Files {
-		files, err := filepath.Glob(glob)
+		files, err := zglob.Glob(glob)
 		if err != nil {
 			return result, err
 		}

--- a/pipeline/archive/tar/tar.go
+++ b/pipeline/archive/tar/tar.go
@@ -46,7 +46,7 @@ func (a Archive) Add(name, path string) (err error) {
 		_ = file.Close()
 	}()
 	stat, err := file.Stat()
-	if err != nil {
+	if err != nil || stat.IsDir() {
 		return
 	}
 	header := new(tar.Header)

--- a/pipeline/archive/tar/tar_test.go
+++ b/pipeline/archive/tar/tar_test.go
@@ -23,9 +23,12 @@ func TestTarGzFile(t *testing.T) {
 	empty2, err := os.Create(folder + "/empty2.txt")
 	assert.NoError(err)
 
+	assert.NoError(os.Mkdir(folder+"/folder-inside", 0755))
+
 	archive := New(file)
 	assert.NoError(archive.Add("empty.txt", empty.Name()))
 	assert.Error(archive.Add("dont.txt", empty.Name()+"_nope"))
+	assert.NoError(archive.Add("empty.txt", folder+"/folder-inside"))
 	assert.NoError(archive.Close())
 	assert.Error(archive.Add("empty2.txt", empty2.Name()))
 }

--- a/pipeline/archive/zip/zip.go
+++ b/pipeline/archive/zip/zip.go
@@ -31,6 +31,10 @@ func (a Archive) Add(name, path string) (err error) {
 	if err != nil {
 		return
 	}
+	stat, err := file.Stat()
+	if err != nil || stat.IsDir() {
+		return
+	}
 	defer func() { _ = file.Close() }()
 	f, err := a.z.Create(name)
 	if err != nil {

--- a/pipeline/archive/zip/zip_test.go
+++ b/pipeline/archive/zip/zip_test.go
@@ -20,8 +20,11 @@ func TestZipFile(t *testing.T) {
 	empty, err := os.Create(folder + "/empty.txt")
 	assert.NoError(err)
 
+	assert.NoError(os.Mkdir(folder+"/folder-inside", 0755))
+
 	archive := New(file)
 	assert.NoError(archive.Add("empty.txt", empty.Name()))
+	assert.NoError(archive.Add("empty.txt", folder+"/folder-inside"))
 	assert.Error(archive.Add("dont.txt", empty.Name()+"_nope"))
 	assert.NoError(archive.Close())
 }

--- a/pipeline/build/build.go
+++ b/pipeline/build/build.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/goreleaser/goreleaser/context"
+	"github.com/goreleaser/goreleaser/internal/ext"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -64,7 +65,7 @@ func build(ctx *context.Context, name string, target buildTarget) error {
 	output := filepath.Join(
 		ctx.Config.Dist,
 		name,
-		ctx.Config.Build.Binary+extFor(target.goos),
+		ctx.Config.Build.Binary+ext.For(target.goos),
 	)
 	log.Println("Building", output)
 	cmd := []string{"go", "build"}

--- a/pipeline/build/name.go
+++ b/pipeline/build/name.go
@@ -42,10 +42,3 @@ func replace(replacements map[string]string, original string) string {
 	}
 	return result
 }
-
-func extFor(goos string) string {
-	if goos == "windows" {
-		return ".exe"
-	}
-	return ""
-}

--- a/pipeline/build/name_test.go
+++ b/pipeline/build/name_test.go
@@ -9,14 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestExtWindows(t *testing.T) {
-	assert.Equal(t, ".exe", extFor("windows"))
-}
-
-func TestExtOthers(t *testing.T) {
-	assert.Empty(t, "", extFor("linux"))
-}
-
 func TestNameFor(t *testing.T) {
 	assert := assert.New(t)
 

--- a/pipeline/defaults/defaults.go
+++ b/pipeline/defaults/defaults.go
@@ -4,13 +4,9 @@ package defaults
 
 import (
 	"fmt"
-	"io/ioutil"
-	"strings"
 
 	"github.com/goreleaser/goreleaser/context"
 )
-
-var defaultFiles = []string{"licence", "license", "readme", "changelog"}
 
 // NameTemplate default name_template for the archive.
 const NameTemplate = "{{ .Binary }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
@@ -98,33 +94,16 @@ func setArchiveDefaults(ctx *context.Context) error {
 		}
 	}
 	if len(ctx.Config.Archive.Files) == 0 {
-		files, err := findFiles()
-		if err != nil {
-			return err
+		ctx.Config.Archive.Files = []string{
+			"licence*",
+			"LICENCE*",
+			"license*",
+			"LICENSE*",
+			"readme*",
+			"README*",
+			"changelog*",
+			"CHANGELOG*",
 		}
-		ctx.Config.Archive.Files = files
 	}
 	return nil
-}
-
-func findFiles() (files []string, err error) {
-	all, err := ioutil.ReadDir(".")
-	if err != nil {
-		return
-	}
-	for _, file := range all {
-		if accept(file.Name()) {
-			files = append(files, file.Name())
-		}
-	}
-	return
-}
-
-func accept(file string) bool {
-	for _, accepted := range defaultFiles {
-		if strings.HasPrefix(strings.ToLower(file), accepted) {
-			return true
-		}
-	}
-	return false
 }

--- a/pipeline/defaults/defaults_test.go
+++ b/pipeline/defaults/defaults_test.go
@@ -52,46 +52,15 @@ func TestFillPartial(t *testing.T) {
 					Name:  "test",
 				},
 			},
-		},
-	}
-	assert.NoError(Pipe{}.Run(ctx))
-}
-
-func TestFilesFilled(t *testing.T) {
-	assert := assert.New(t)
-
-	var ctx = &context.Context{
-		Config: config.Project{
 			Archive: config.Archive{
 				Files: []string{
-					"README.md",
+					"glob/*",
 				},
 			},
 		},
 	}
-
 	assert.NoError(Pipe{}.Run(ctx))
 	assert.Len(ctx.Config.Archive.Files, 1)
-}
-
-func TestAcceptFiles(t *testing.T) {
-	var files = []string{
-		"LICENSE.md",
-		"LIceNSE.txt",
-		"LICENSE",
-		"LICENCE.txt",
-		"LICEncE",
-		"README",
-		"READme.md",
-		"CHANGELOG.txt",
-		"ChanGELOG.md",
-	}
-
-	for _, file := range files {
-		t.Run(file, func(t *testing.T) {
-			assert.True(t, accept(file))
-		})
-	}
 }
 
 func TestNotAGitRepo(t *testing.T) {


### PR DESCRIPTION
refs #229 

- now, the `defaults` pipe won't search for files anymore, but would set the default globs into  `config.archive.files`
- the archive pipe will then iterate over `config.archive.files` and deal with all of them as globs
- removed an unneeded read dir from the archive pipe, which required moving `extFor` function to another pkg

It should work for:

- `*.ext`
- `blah*`
- `folder/*`
- `folder/**/*`

It doesn't work, however, for `folder` only, because the archive impls require files instead of folders. We may change this in the future.

This seems to be more robust than the previous solution, not sure if ideal though. Feedback appreciated!