### PR TITLE
allow linux ppc64 and ppc64le builds, as well openbsd arm

### DIFF
--- a/pipeline/build/target_test.go
+++ b/pipeline/build/target_test.go
@@ -74,11 +74,14 @@ func TestValidGoosGoarchCombos(t *testing.T) {
 		{"linux", "mipsle"},
 		{"linux", "mips64"},
 		{"linux", "mips64le"},
+		{"linux", "ppc64"},
+		{"linux", "ppc64le"},
 		{"netbsd", "386"},
 		{"netbsd", "amd64"},
 		{"netbsd", "arm"},
 		{"openbsd", "386"},
 		{"openbsd", "amd64"},
+		{"openbsd", "arm"},
 		{"plan9", "386"},
 		{"plan9", "amd64"},
 		{"solaris", "amd64"},
@@ -100,9 +103,6 @@ func TestInvalidGoosGoarchCombos(t *testing.T) {
 		{"darwin", "arm64"},
 		{"windows", "arm"},
 		{"windows", "arm64"},
-		{"linux", "ppc64"},
-		{"linux", "ppc64le"},
-		{"openbsd", "arm"},
 	}
 	for _, p := range platforms {
 		t.Run(fmt.Sprintf("%v %v is invalid", p.os, p.arch), func(t *testing.T) {

--- a/pipeline/build/valid_os.go
+++ b/pipeline/build/valid_os.go
@@ -15,8 +15,8 @@ var valids = []string{
 	"linuxamd64",
 	"linuxarm",
 	"linuxarm64",
-	// "linuxppc64", - https://github.com/golang/go/issues/10087
-	// "linuxppc64le", - https://github.com/golang/go/issues/10087
+	"linuxppc64",
+	"linuxppc64le",
 	"linuxmips",
 	"linuxmipsle",
 	"linuxmips64",
@@ -26,7 +26,7 @@ var valids = []string{
 	"netbsdarm",
 	"openbsd386",
 	"openbsdamd64",
-	// "openbsdarm", - https://github.com/golang/go/issues/10087
+	"openbsdarm",
 	"plan9386",
 	"plan9amd64",
 	"solarisamd64",


### PR DESCRIPTION
closes https://github.com/goreleaser/goreleaser/issues/255