### PR TITLE
Use git status --porcelain

### DIFF
--- a/pipeline/git/git.go
+++ b/pipeline/git/git.go
@@ -132,7 +132,7 @@ func getSnapshotName(ctx *context.Context, tag, commit string) (string, error) {
 }
 
 func validate(ctx *context.Context, commit, tag string) error {
-	out, err := git("status", "-s")
+	out, err := git("status", "--porcelain")
 	if strings.TrimSpace(out) != "" || err != nil {
 		return ErrDirty{out}
 	}


### PR DESCRIPTION
to ensure output is always readable no matter what configuration a user has set (cc #268)