### PR TITLE
archive format overrides could break brew formula

### DIFF
--- a/internal/archiveformat/format.go
+++ b/internal/archiveformat/format.go
@@ -1,0 +1,19 @@
+// Package archiveformat provides functions to get the format of given package
+// based on the config
+package archiveformat
+
+import (
+	"strings"
+
+	"github.com/goreleaser/goreleaser/context"
+)
+
+// For return the archive format, considering overrides and all that
+func For(ctx *context.Context, platform string) string {
+	for _, override := range ctx.Config.Archive.FormatOverrides {
+		if strings.HasPrefix(platform, override.Goos) {
+			return override.Format
+		}
+	}
+	return ctx.Config.Archive.Format
+}

--- a/internal/archiveformat/format_test.go
+++ b/internal/archiveformat/format_test.go
@@ -1,0 +1,28 @@
+package archiveformat
+
+import (
+	"testing"
+
+	"github.com/goreleaser/goreleaser/config"
+	"github.com/goreleaser/goreleaser/context"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatFor(t *testing.T) {
+	var assert = assert.New(t)
+	var ctx = &context.Context{
+		Config: config.Project{
+			Archive: config.Archive{
+				Format: "tar.gz",
+				FormatOverrides: []config.FormatOverride{
+					{
+						Goos:   "windows",
+						Format: "zip",
+					},
+				},
+			},
+		},
+	}
+	assert.Equal("zip", For(ctx, "windowsamd64"))
+	assert.Equal("tar.gz", For(ctx, "linux386"))
+}

--- a/pipeline/archive/archive.go
+++ b/pipeline/archive/archive.go
@@ -6,11 +6,11 @@ package archive
 import (
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/apex/log"
 	"github.com/goreleaser/archive"
 	"github.com/goreleaser/goreleaser/context"
+	"github.com/goreleaser/goreleaser/internal/archiveformat"
 	"github.com/goreleaser/goreleaser/internal/ext"
 	"github.com/mattn/go-zglob"
 	"golang.org/x/sync/errgroup"
@@ -39,7 +39,7 @@ func (Pipe) Run(ctx *context.Context) error {
 
 func create(ctx *context.Context, platform, name string) error {
 	var folder = filepath.Join(ctx.Config.Dist, name)
-	var format = formatFor(ctx, platform)
+	var format = archiveformat.For(ctx, platform)
 	file, err := os.Create(folder + "." + format)
 	if err != nil {
 		return err
@@ -75,13 +75,4 @@ func findFiles(ctx *context.Context) (result []string, err error) {
 		result = append(result, files...)
 	}
 	return
-}
-
-func formatFor(ctx *context.Context, platform string) string {
-	for _, override := range ctx.Config.Archive.FormatOverrides {
-		if strings.HasPrefix(platform, override.Goos) {
-			return override.Format
-		}
-	}
-	return ctx.Config.Archive.Format
 }

--- a/pipeline/archive/archive_test.go
+++ b/pipeline/archive/archive_test.go
@@ -82,25 +82,6 @@ func TestRunPipeDistRemoved(t *testing.T) {
 	assert.Error(Pipe{}.Run(ctx))
 }
 
-func TestFormatFor(t *testing.T) {
-	var assert = assert.New(t)
-	var ctx = &context.Context{
-		Config: config.Project{
-			Archive: config.Archive{
-				Format: "tar.gz",
-				FormatOverrides: []config.FormatOverride{
-					{
-						Goos:   "windows",
-						Format: "zip",
-					},
-				},
-			},
-		},
-	}
-	assert.Equal("zip", formatFor(ctx, "windowsamd64"))
-	assert.Equal("tar.gz", formatFor(ctx, "linux386"))
-}
-
 func TestRunPipeInvalidGlob(t *testing.T) {
 	var assert = assert.New(t)
 	var ctx = &context.Context{

--- a/pipeline/brew/brew_test.go
+++ b/pipeline/brew/brew_test.go
@@ -39,9 +39,8 @@ var defaultTemplateData = templateData{
 	},
 	Tag:     "v0.1.3",
 	Version: "0.1.3",
-	File:    "test_Darwin_x86_64",
+	File:    "test_Darwin_x86_64.tar.gz",
 	SHA256:  "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c68",
-	Format:  "tar.gz",
 }
 
 func assertDefaultTemplateData(t *testing.T, formulae string) {
@@ -113,6 +112,69 @@ func TestRunPipe(t *testing.T) {
 	client := &DummyClient{}
 	assert.NoError(doRun(ctx, client))
 	assert.True(client.CreatedFile)
+}
+
+func TestRunPipeFormatOverride(t *testing.T) {
+	assert := assert.New(t)
+	folder, err := ioutil.TempDir("", "goreleasertest")
+	assert.NoError(err)
+	_, err = os.Create(filepath.Join(folder, "bin.zip"))
+	assert.NoError(err)
+	var ctx = &context.Context{
+		Config: config.Project{
+			Dist: folder,
+			Archive: config.Archive{
+				Format: "tar.gz",
+				FormatOverrides: []config.FormatOverride{
+					{
+						Format: "zip",
+						Goos:   "darwin",
+					},
+				},
+			},
+			Brew: config.Homebrew{
+				GitHub: config.Repo{
+					Owner: "test",
+					Name:  "test",
+				},
+			},
+		},
+		Archives: map[string]string{
+			"darwinamd64": "bin",
+		},
+		Publish: true,
+	}
+	client := &DummyClient{}
+	assert.NoError(doRun(ctx, client))
+	assert.True(client.CreatedFile)
+	assert.Contains(client.Content, "bin.zip")
+}
+
+func TestRunPipeArchiveDoesntExist(t *testing.T) {
+	assert := assert.New(t)
+	folder, err := ioutil.TempDir("", "goreleasertest")
+	assert.NoError(err)
+	var ctx = &context.Context{
+		Config: config.Project{
+			Dist: folder,
+			Archive: config.Archive{
+				Format: "tar.gz",
+			},
+			Brew: config.Homebrew{
+				GitHub: config.Repo{
+					Owner: "test",
+					Name:  "test",
+				},
+			},
+		},
+		Archives: map[string]string{
+			"darwinamd64": "bin",
+		},
+		Publish: true,
+	}
+	client := &DummyClient{}
+	assert.Error(doRun(ctx, client))
+	assert.False(client.CreatedFile)
 }
 
 func TestRunPipeNoDarwin64Build(t *testing.T) {
@@ -188,6 +250,7 @@ func TestRunPipeDraftRelease(t *testing.T) {
 
 type DummyClient struct {
 	CreatedFile bool
+	Content     string
 }
 
 func (client *DummyClient) CreateRelease(ctx *context.Context, body string) (releaseID int, err error) {
@@ -196,6 +259,8 @@ func (client *DummyClient) CreateRelease(ctx *context.Context, body string) (rel
 
 func (client *DummyClient) CreateFile(ctx *context.Context, content bytes.Buffer, path string) (err error) {
 	client.CreatedFile = true
+	bts, _ := ioutil.ReadAll(&content)
+	client.Content = string(bts)
 	return
 }
 


### PR DESCRIPTION
There was a `TODO this can be broken by format_overrides`.

Fixed and also improved the brew pipe test coverage.