### PR TITLE
improved link to goreleaser

### DIFF
--- a/pipeline/release/body.go
+++ b/pipeline/release/body.go
@@ -11,7 +11,7 @@ import (
 const bodyTemplate = `{{ .ReleaseNotes }}
 
 ---
-Automated with @goreleaser
+Automated with [GoReleaser](https://github.com/goreleaser)
 Built with {{ .GoVersion }}
 `
 

--- a/pipeline/release/body_test.go
+++ b/pipeline/release/body_test.go
@@ -17,7 +17,7 @@ func TestDescribeBody(t *testing.T) {
 	out, err := describeBody(ctx)
 	assert.NoError(err)
 	assert.Contains(out.String(), changelog)
-	assert.Contains(out.String(), "Automated with @goreleaser")
+	assert.Contains(out.String(), "Automated with [GoReleaser]")
 	assert.Contains(out.String(), "Built with go version go1.8")
 }
 


### PR DESCRIPTION
closes https://github.com/goreleaser/goreleaser/issues/245

@goreleaser only work in some places apparently, this should work everywhere!