### PR TITLE
Update contributing guide and fix local tests.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,11 +12,12 @@ Prerequisites are:
 * Build:
   * `make`
   * [Go 1.8+](http://golang.org/doc/install)
+  * [fpm](https://fpm.readthedocs.io/en/latest/installing.html)
 
 Clone `goreleaser` from source into `$GOPATH`:
 
 ```sh
-$ pkdir -p $GOPATH/src/github.com/github.com/goreleaser
+$ mkdir -p $GOPATH/src/github.com/github.com/goreleaser
 $ cd $_
 $ git clone git@github.com:goreleaser/goreleaser.git
 $ cd goreleaser

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -100,6 +100,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d3f68b6665e34ba913718b1ea7bbe0dbb185290b5209146133ca8d70615c09ac"
+  inputs-digest = "5aac2f70507156662f63f0938ce9730bed3895cc5c519ac97307b9c8004088fe"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -99,3 +99,8 @@
 [[constraint]]
   branch = "v2"
   name = "gopkg.in/yaml.v2"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/apex/log"
+

--- a/goreleaserlib/goreleaser_test.go
+++ b/goreleaserlib/goreleaser_test.go
@@ -166,6 +166,7 @@ func setup(t *testing.T) (current string, back func()) {
 	assert.NoError(os.Chdir(folder))
 	var gitCmds = [][]string{
 		{"init"},
+		{"config", "commit.gpgSign", "false"},
 		{"add", "-A"},
 		{"commit", "--allow-empty", "-m", "asdf"},
 		{"tag", "v0.0.1"},

--- a/internal/buildtarget/targets.go
+++ b/internal/buildtarget/targets.go
@@ -40,10 +40,16 @@ func allBuildTargets(build config.Build) (targets []Target) {
 
 func ignored(build config.Build, target Target) bool {
 	for _, ig := range build.Ignore {
-		var ignored = New(ig.Goos, ig.Goarch, ig.Goarm)
-		if ignored == target {
-			return true
+		if ig.Goos != "" && ig.Goos != target.OS {
+			continue
 		}
+		if ig.Goarch != "" && ig.Goarch != target.Arch {
+			continue
+		}
+		if ig.Goarm != "" && ig.Goarm != target.Arm {
+			continue
+		}
+		return true
 	}
 	return false
 }

--- a/internal/buildtarget/targets_test.go
+++ b/internal/buildtarget/targets_test.go
@@ -15,6 +15,7 @@ func TestAllBuildTargets(t *testing.T) {
 			"linux",
 			"darwin",
 			"freebsd",
+			"openbsd",
 		},
 		Goarch: []string{
 			"386",
@@ -34,6 +35,9 @@ func TestAllBuildTargets(t *testing.T) {
 				Goos:   "linux",
 				Goarch: "arm",
 				Goarm:  "7",
+			}, {
+				Goos:   "openbsd",
+				Goarch: "arm",
 			},
 		},
 	}
@@ -47,6 +51,8 @@ func TestAllBuildTargets(t *testing.T) {
 		New("freebsd", "amd64", ""),
 		New("freebsd", "arm", "6"),
 		New("freebsd", "arm", "7"),
+		New("openbsd", "386", ""),
+		New("openbsd", "amd64", ""),
 	}, All(build))
 }
 

--- a/pipeline/git/git_test.go
+++ b/pipeline/git/git_test.go
@@ -277,6 +277,8 @@ func gitInit(t *testing.T) {
 	out, err := git("init")
 	assert.NoError(err)
 	assert.Contains(out, "Initialized empty Git repository")
+	_, err = git("config", "commit.gpgSign", "false")
+	assert.NoError(err)
 }
 
 func gitCommit(t *testing.T, msg string) {


### PR DESCRIPTION
- fpm is required to pass tests.
- apex/log package needs to be available.
- gpgSign git option needs to be disabled for test repo.
  This is an issue when a developer has set gpgSign to true in
  their global .gitconfig file.

https://github.com/goreleaser/goreleaser/pull/294 needs to be merged first.