### PR TITLE
Add fpm path mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,11 @@ fpm:
   conflicts:
     - svn
     - bash
+
+  # Files or directories to add to your package (beyond the binary)
+  files:
+    "scripts/etc/init.d/": "/etc/init.d"
+
 ```
 
 Note that GoReleaser will not install `fpm` nor any of its dependencies for you.

--- a/config/config.go
+++ b/config/config.go
@@ -110,14 +110,15 @@ type Release struct {
 
 // FPM config
 type FPM struct {
-	Formats      []string `yaml:",omitempty"`
-	Dependencies []string `yaml:",omitempty"`
-	Conflicts    []string `yaml:",omitempty"`
-	Vendor       string   `yaml:",omitempty"`
-	Homepage     string   `yaml:",omitempty"`
-	Maintainer   string   `yaml:",omitempty"`
-	Description  string   `yaml:",omitempty"`
-	License      string   `yaml:",omitempty"`
+	Formats      []string          `yaml:",omitempty"`
+	Dependencies []string          `yaml:",omitempty"`
+	Conflicts    []string          `yaml:",omitempty"`
+	Vendor       string            `yaml:",omitempty"`
+	Homepage     string            `yaml:",omitempty"`
+	Maintainer   string            `yaml:",omitempty"`
+	Description  string            `yaml:",omitempty"`
+	License      string            `yaml:",omitempty"`
+	Files        map[string]string `yaml:",omitempty"`
 
 	// Capture all undefined fields and should be empty after loading
 	XXX map[string]interface{} `yaml:",inline"`

--- a/pipeline/fpm/fpm.go
+++ b/pipeline/fpm/fpm.go
@@ -112,6 +112,17 @@ func create(ctx *context.Context, format, folder, arch string, binaries []contex
 		))
 	}
 
+	for src, dest := range ctx.Config.FPM.Files {
+		log.WithField("src", src).
+			WithField("dest", dest).
+			Info("passed extra file to fpm")
+		options = append(options, fmt.Sprintf(
+			"%s=%s",
+			src,
+			dest,
+		))
+	}
+
 	if out, err := exec.Command("fpm", options...).CombinedOutput(); err != nil {
 		return errors.New(string(out))
 	}

--- a/pipeline/fpm/fpm_test.go
+++ b/pipeline/fpm/fpm_test.go
@@ -99,9 +99,24 @@ func TestCreateFileDoesntExist(t *testing.T) {
 			Dist: dist,
 			FPM: config.FPM{
 				Formats: []string{"deb"},
+				Files: map[string]string{
+					"testdata/testfile.txt": "/var/lib/test/testfile.txt",
+				},
 			},
 		},
 	}
 	ctx.AddBinary("linuxamd64", "mybin", "mybin", filepath.Join(dist, "mybin", "mybin"))
 	assert.Error(Pipe{}.Run(ctx))
+}
+
+func TestRunPipeWithExtraFiles(t *testing.T) {
+	var assert = assert.New(t)
+	var ctx = &context.Context{
+		Config: config.Project{
+			FPM: config.FPM{
+				Formats: []string{"deb"},
+			},
+		},
+	}
+	assert.NoError(Pipe{}.Run(ctx))
 }

--- a/pipeline/fpm/testdata/testfile.txt
+++ b/pipeline/fpm/testdata/testfile.txt
@@ -1,0 +1,1 @@
+this is a test file


### PR DESCRIPTION
This adds a way to add arbitrary extra files or dirs to fpm packages:

```
fpm:
  files:
    "scripts/etc/init.d/": "/etc/init.d"
```