### PR TITLE
improved logs

### DIFF
--- a/pipeline/fpm/fpm.go
+++ b/pipeline/fpm/fpm.go
@@ -27,7 +27,7 @@ func (Pipe) Description() string {
 // Run the pipe
 func (Pipe) Run(ctx *context.Context) error {
 	if len(ctx.Config.FPM.Formats) == 0 {
-		log.Info("no output formats configured, skipping")
+		log.Warn("skipping because no output formats configured")
 		return nil
 	}
 	_, err := exec.LookPath("fpm")

--- a/pipeline/snapcraft/snapcraft.go
+++ b/pipeline/snapcraft/snapcraft.go
@@ -19,6 +19,12 @@ import (
 // ErrNoSnapcraft is shown when snapcraft cannot be found in $PATH
 var ErrNoSnapcraft = errors.New("snapcraft not present in $PATH")
 
+// ErrNoDescription is shown when no description provided
+var ErrNoDescription = errors.New("no description provided for snapcraft")
+
+// ErrNoSummary is shown when no summary provided
+var ErrNoSummary = errors.New("no summary provided for snapcraft")
+
 // SnapcraftMetadata to generate the snap package
 type SnapcraftMetadata struct {
 	Name          string
@@ -48,13 +54,15 @@ func (Pipe) Description() string {
 
 // Run the pipe
 func (Pipe) Run(ctx *context.Context) error {
-	if ctx.Config.Snapcraft.Summary == "" {
-		log.Error("no snapcraft summary defined, skipping")
+	if ctx.Config.Snapcraft.Summary == "" && ctx.Config.Snapcraft.Description == "" {
+		log.Warn("skipping because no summary nor description were provided")
 		return nil
 	}
+	if ctx.Config.Snapcraft.Summary == "" {
+		return ErrNoSummary
+	}
 	if ctx.Config.Snapcraft.Description == "" {
-		log.Error("no snapcraft description defined, skipping")
-		return nil
+		return ErrNoDescription
 	}
 	_, err := exec.LookPath("snapcraft")
 	if err != nil {

--- a/pipeline/snapcraft/snapcraft_test.go
+++ b/pipeline/snapcraft/snapcraft_test.go
@@ -1,6 +1,7 @@
 package snapcraft
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -17,24 +18,23 @@ func TestDescription(t *testing.T) {
 }
 
 func TestRunPipeMissingInfo(t *testing.T) {
-	for name, snap := range map[string]config.Snapcraft{
-		"missing summary": {
+	for eerr, snap := range map[error]config.Snapcraft{
+		ErrNoSummary: {
 			Description: "dummy desc",
 		},
-		"missing description": {
+		ErrNoDescription: {
 			Summary: "dummy summary",
 		},
+		nil: {}, // should skip instead of error
 	} {
-		t.Run(name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("testing if %v happens", eerr), func(t *testing.T) {
 			var assert = assert.New(t)
 			var ctx = &context.Context{
 				Config: config.Project{
 					Snapcraft: snap,
 				},
 			}
-			// FIXME: there is no way to tell here if the pipe actually ran
-			// or if it was indeed skipped.
-			assert.NoError(Pipe{}.Run(ctx))
+			assert.Equal(eerr, Pipe{}.Run(ctx))
 		})
 	}
 }


### PR DESCRIPTION
- following the same template of the other logs: `skipping because X`
- improved validation of snapcraft pipe