### PR TITLE
skip pipe as an error type and improved output

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -53,7 +53,7 @@ func (ctx *Context) AddArtifact(file string) {
 	defer artifactsLock.Unlock()
 	file = strings.TrimPrefix(file, ctx.Config.Dist+string(filepath.Separator))
 	ctx.Artifacts = append(ctx.Artifacts, file)
-	log.WithField("artifact", file).Info("new artifact")
+	log.WithField("artifact", file).Info("new release artifact")
 }
 
 // AddBinary adds a built binary to the current context
@@ -77,7 +77,7 @@ func (ctx *Context) AddBinary(platform, folder, name, path string) {
 		WithField("folder", folder).
 		WithField("name", name).
 		WithField("path", path).
-		Info("new binary")
+		Debug("new binary")
 }
 
 // New context

--- a/goreleaserlib/goreleaser.go
+++ b/goreleaserlib/goreleaser.go
@@ -84,18 +84,24 @@ func Release(flags Flags) error {
 	ctx.RmDist = flags.Bool("rm-dist")
 	for _, pipe := range pipes {
 		log.Infof("\033[1m%s\033[0m", strings.ToUpper(pipe.Description()))
-		var err = pipe.Run(ctx)
-		if err == nil {
-			continue
-		}
-		if skip, ok := err.(pipeline.ErrSkip); ok {
-			log.WithField("reason", skip.Error()).Warn("skipped")
-		} else {
+		if err := handle(pipe.Run(ctx)); err != nil {
 			return err
 		}
 	}
 	log.Infof("\033[1mSUCCESS!\033[0m")
 	return nil
+}
+
+func handle(err error) error {
+	if err == nil {
+		return nil
+	}
+	skip, ok := err.(pipeline.ErrSkip)
+	if ok {
+		log.WithField("reason", skip.Error()).Warn("skipped")
+		return nil
+	}
+	return err
 }
 
 // InitProject creates an example goreleaser.yml in the current directory

--- a/goreleaserlib/goreleaser.go
+++ b/goreleaserlib/goreleaser.go
@@ -88,7 +88,7 @@ func Release(flags Flags) error {
 		if err == nil {
 			continue
 		}
-		if skip, ok := err.(pipeline.SkipErr); ok {
+		if skip, ok := err.(pipeline.ErrSkip); ok {
 			log.WithField("reason", skip.Error()).Warn("skipped")
 		} else {
 			return err

--- a/goreleaserlib/goreleaser.go
+++ b/goreleaserlib/goreleaser.go
@@ -84,7 +84,13 @@ func Release(flags Flags) error {
 	ctx.RmDist = flags.Bool("rm-dist")
 	for _, pipe := range pipes {
 		log.Infof("\033[1m%s\033[0m", strings.ToUpper(pipe.Description()))
-		if err := pipe.Run(ctx); err != nil {
+		var err = pipe.Run(ctx)
+		if err == nil {
+			continue
+		}
+		if skip, ok := err.(pipeline.SkipErr); ok {
+			log.WithField("reason", skip.Error()).Warn("skipped")
+		} else {
 			return err
 		}
 	}

--- a/internal/buildtarget/targets.go
+++ b/internal/buildtarget/targets.go
@@ -10,12 +10,12 @@ func All(build config.Build) (targets []Target) {
 	for _, target := range allBuildTargets(build) {
 		if !valid(target) {
 			log.WithField("target", target.PrettyString()).
-				Warn("skipped invalid build")
+				Debug("skipped invalid build")
 			continue
 		}
 		if ignored(build, target) {
 			log.WithField("target", target.PrettyString()).
-				Warn("skipped ignored build")
+				Debug("skipped ignored build")
 			continue
 		}
 		targets = append(targets, target)

--- a/internal/testlib/skip.go
+++ b/internal/testlib/skip.go
@@ -1,0 +1,14 @@
+package testlib
+
+import (
+	"testing"
+
+	"github.com/goreleaser/goreleaser/pipeline"
+	"github.com/stretchr/testify/assert"
+)
+
+// AssertSkipped asserts that a pipe was skipped
+func AssertSkipped(t *testing.T, err error) {
+	_, ok := err.(pipeline.ErrSkip)
+	assert.True(t, ok)
+}

--- a/internal/testlib/skip_test.go
+++ b/internal/testlib/skip_test.go
@@ -1,0 +1,11 @@
+package testlib
+
+import (
+	"testing"
+
+	"github.com/goreleaser/goreleaser/pipeline"
+)
+
+func TestAssertSkipped(t *testing.T) {
+	AssertSkipped(t, pipeline.Skip("skip"))
+}

--- a/pipeline/brew/brew.go
+++ b/pipeline/brew/brew.go
@@ -14,6 +14,7 @@ import (
 	"github.com/goreleaser/goreleaser/context"
 	"github.com/goreleaser/goreleaser/internal/archiveformat"
 	"github.com/goreleaser/goreleaser/internal/client"
+	"github.com/goreleaser/goreleaser/pipeline"
 )
 
 // ErrNoDarwin64Build when there is no build for darwin_amd64 (goos doesn't
@@ -37,20 +38,16 @@ func (Pipe) Run(ctx *context.Context) error {
 
 func doRun(ctx *context.Context, client client.Client) error {
 	if !ctx.Publish {
-		log.Warn("skipped because --skip-publish is set")
-		return nil
+		return pipeline.Skip("--skip-publish is set")
 	}
 	if ctx.Config.Brew.GitHub.Name == "" {
-		log.Warn("skipped because brew section is not configured")
-		return nil
+		return pipeline.Skip("brew section is not configured")
 	}
 	if ctx.Config.Release.Draft {
-		log.Warn("skipped because release is marked as draft")
-		return nil
+		return pipeline.Skip("release is marked as draft")
 	}
 	if ctx.Config.Archive.Format == "binary" {
-		log.Warn("skipped because archive format is binary")
-		return nil
+		return pipeline.Skip("archive format is binary")
 	}
 
 	var group = ctx.Binaries["darwinamd64"]

--- a/pipeline/brew/brew_test.go
+++ b/pipeline/brew/brew_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/goreleaser/goreleaser/config"
 	"github.com/goreleaser/goreleaser/context"
+	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -202,7 +203,7 @@ func TestRunPipeBrewNotSetup(t *testing.T) {
 		Publish: true,
 	}
 	client := &DummyClient{}
-	assert.NoError(doRun(ctx, client))
+	testlib.AssertSkipped(t, doRun(ctx, client))
 	assert.False(client.CreatedFile)
 }
 
@@ -224,7 +225,7 @@ func TestRunPipeBinaryRelease(t *testing.T) {
 	}
 	ctx.AddBinary("darwinamd64", "foo", "bar", "baz")
 	client := &DummyClient{}
-	assert.NoError(doRun(ctx, client))
+	testlib.AssertSkipped(t, doRun(ctx, client))
 	assert.False(client.CreatedFile)
 }
 
@@ -234,7 +235,7 @@ func TestRunPipeNoPublish(t *testing.T) {
 		Publish: false,
 	}
 	client := &DummyClient{}
-	assert.NoError(doRun(ctx, client))
+	testlib.AssertSkipped(t, doRun(ctx, client))
 	assert.False(client.CreatedFile)
 }
 
@@ -255,7 +256,7 @@ func TestRunPipeDraftRelease(t *testing.T) {
 		},
 	}
 	client := &DummyClient{}
-	assert.NoError(doRun(ctx, client))
+	testlib.AssertSkipped(t, doRun(ctx, client))
 	assert.False(client.CreatedFile)
 }
 
@@ -269,7 +270,7 @@ func TestRunPipeFormatBinary(t *testing.T) {
 		},
 	}
 	client := &DummyClient{}
-	assert.NoError(doRun(ctx, client))
+	testlib.AssertSkipped(t, doRun(ctx, client))
 	assert.False(client.CreatedFile)
 }
 

--- a/pipeline/cleandist/dist.go
+++ b/pipeline/cleandist/dist.go
@@ -27,7 +27,7 @@ func (Pipe) Run(ctx *context.Context) (err error) {
 		return nil
 	}
 	if ctx.RmDist {
-		log.Info("rm-dist is set, removing ./dist")
+		log.Info("--rm-dist is set, removing ./dist")
 		return os.RemoveAll(ctx.Config.Dist)
 	}
 	files, err := ioutil.ReadDir(ctx.Config.Dist)

--- a/pipeline/cleandist/dist.go
+++ b/pipeline/cleandist/dist.go
@@ -27,7 +27,7 @@ func (Pipe) Run(ctx *context.Context) (err error) {
 		return nil
 	}
 	if ctx.RmDist {
-		log.Warn("rm-dist is set, removing ./dist")
+		log.Info("rm-dist is set, removing ./dist")
 		return os.RemoveAll(ctx.Config.Dist)
 	}
 	files, err := ioutil.ReadDir(ctx.Config.Dist)

--- a/pipeline/env/env.go
+++ b/pipeline/env/env.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"os"
 
-	"github.com/apex/log"
 	"github.com/goreleaser/goreleaser/context"
+	"github.com/goreleaser/goreleaser/pipeline"
 )
 
 // ErrMissingToken indicates an error when GITHUB_TOKEN is missing in the environment
@@ -25,12 +25,10 @@ func (Pipe) Description() string {
 func (Pipe) Run(ctx *context.Context) (err error) {
 	ctx.Token = os.Getenv("GITHUB_TOKEN")
 	if !ctx.Publish {
-		log.Warn("github token not validated because publishing has been disabled")
-		return nil
+		return pipeline.Skip("publishing is disabled")
 	}
 	if !ctx.Validate {
-		log.Warn("skipped validations because --skip-validate is set")
-		return nil
+		return pipeline.Skip("--skip-validate is set")
 	}
 	if ctx.Token == "" {
 		return ErrMissingToken

--- a/pipeline/env/env_test.go
+++ b/pipeline/env/env_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/goreleaser/goreleaser/config"
 	"github.com/goreleaser/goreleaser/context"
+	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -61,7 +62,7 @@ func TestInvalidEnvChecksSkipped(t *testing.T) {
 				Publish:  flag.Publish,
 				Snapshot: flag.Snapshot,
 			}
-			assert.NoError(Pipe{}.Run(ctx))
+			testlib.AssertSkipped(t, Pipe{}.Run(ctx))
 		})
 	}
 }

--- a/pipeline/fpm/fpm.go
+++ b/pipeline/fpm/fpm.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/goreleaser/goreleaser/context"
+	"github.com/goreleaser/goreleaser/pipeline"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -27,8 +28,7 @@ func (Pipe) Description() string {
 // Run the pipe
 func (Pipe) Run(ctx *context.Context) error {
 	if len(ctx.Config.FPM.Formats) == 0 {
-		log.Warn("skipping because no output formats configured")
-		return nil
+		return pipeline.Skip("no output formats configured")
 	}
 	_, err := exec.LookPath("fpm")
 	if err != nil {

--- a/pipeline/fpm/fpm_test.go
+++ b/pipeline/fpm/fpm_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/goreleaser/goreleaser/config"
 	"github.com/goreleaser/goreleaser/context"
+	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,12 +17,11 @@ func TestDescription(t *testing.T) {
 }
 
 func TestRunPipeNoFormats(t *testing.T) {
-	var assert = assert.New(t)
 	var ctx = &context.Context{
 		Version: "1.0.0",
 		Config:  config.Project{},
 	}
-	assert.NoError(Pipe{}.Run(ctx))
+	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
 }
 
 func TestRunPipe(t *testing.T) {

--- a/pipeline/git/git.go
+++ b/pipeline/git/git.go
@@ -13,6 +13,7 @@ import (
 	"github.com/apex/log"
 	"github.com/goreleaser/goreleaser/context"
 	"github.com/goreleaser/goreleaser/internal/git"
+	"github.com/goreleaser/goreleaser/pipeline"
 )
 
 // Pipe for brew deployment
@@ -43,8 +44,7 @@ func (Pipe) Run(ctx *context.Context) (err error) {
 		return
 	}
 	if !ctx.Validate {
-		log.Warn("skipped validations because --skip-validate is set")
-		return nil
+		return pipeline.Skip("--skip-validate is set")
 	}
 	return validate(ctx, commit, tag)
 }

--- a/pipeline/git/git_test.go
+++ b/pipeline/git/git_test.go
@@ -37,7 +37,7 @@ func TestSingleCommit(t *testing.T) {
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}
-	assert.NoError(Pipe{}.Run(ctx))
+	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
 	assert.Equal("v0.0.1", ctx.Git.CurrentTag)
 }
 
@@ -67,7 +67,7 @@ func TestNoTagsSnapshot(t *testing.T) {
 		Snapshot: true,
 		Publish:  false,
 	}
-	assert.NoError(Pipe{}.Run(ctx))
+	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
 	assert.Contains(ctx.Version, "SNAPSHOT-")
 }
 
@@ -182,7 +182,6 @@ func TestValidState(t *testing.T) {
 }
 
 func TestNoValidate(t *testing.T) {
-	var assert = assert.New(t)
 	_, back := testlib.Mktmp(t)
 	defer back()
 	testlib.GitInit(t)
@@ -194,7 +193,7 @@ func TestNoValidate(t *testing.T) {
 		Config:   config.Project{},
 		Validate: false,
 	}
-	assert.NoError(Pipe{}.Run(ctx))
+	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
 }
 
 func TestChangelog(t *testing.T) {
@@ -210,7 +209,7 @@ func TestChangelog(t *testing.T) {
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}
-	assert.NoError(Pipe{}.Run(ctx))
+	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
 	assert.Equal("v0.0.2", ctx.Git.CurrentTag)
 	assert.Contains(ctx.ReleaseNotes, "## Changelog")
 	assert.NotContains(ctx.ReleaseNotes, "first")
@@ -236,7 +235,7 @@ func TestChangelogOfFirstRelease(t *testing.T) {
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}
-	assert.NoError(Pipe{}.Run(ctx))
+	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
 	assert.Equal("v0.0.1", ctx.Git.CurrentTag)
 	assert.Contains(ctx.ReleaseNotes, "## Changelog")
 	for _, msg := range msgs {
@@ -255,7 +254,7 @@ func TestCustomReleaseNotes(t *testing.T) {
 		Config:       config.Project{},
 		ReleaseNotes: "custom",
 	}
-	assert.NoError(Pipe{}.Run(ctx))
+	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
 	assert.Equal("v0.0.1", ctx.Git.CurrentTag)
 	assert.Equal(ctx.ReleaseNotes, "custom")
 }

--- a/pipeline/pipe.go
+++ b/pipeline/pipe.go
@@ -1,7 +1,9 @@
 // Package pipeline provides a generic pipe interface.
 package pipeline
 
-import "github.com/goreleaser/goreleaser/context"
+import (
+	"github.com/goreleaser/goreleaser/context"
+)
 
 // Pipe interface
 type Pipe interface {
@@ -10,4 +12,19 @@ type Pipe interface {
 
 	// Run the pipe
 	Run(ctx *context.Context) error
+}
+
+// ErrSkip occurs when a pipe is skipped for some reason
+type ErrSkip struct {
+	reason string
+}
+
+// Error implements the error interface. returns the reason the pipe was skipped
+func (e ErrSkip) Error() string {
+	return e.reason
+}
+
+// Skip skips this pipe with the given reason
+func Skip(reason string) ErrSkip {
+	return ErrSkip{reason}
 }

--- a/pipeline/pipe.go
+++ b/pipeline/pipe.go
@@ -1,9 +1,7 @@
 // Package pipeline provides a generic pipe interface.
 package pipeline
 
-import (
-	"github.com/goreleaser/goreleaser/context"
-)
+import "github.com/goreleaser/goreleaser/context"
 
 // Pipe interface
 type Pipe interface {

--- a/pipeline/pipe_test.go
+++ b/pipeline/pipe_test.go
@@ -1,0 +1,15 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSkipPipe(t *testing.T) {
+	var assert = assert.New(t)
+	var reason = "this is a test"
+	var err = Skip(reason)
+	assert.Error(err)
+	assert.Equal(reason, err.Error())
+}

--- a/pipeline/release/release.go
+++ b/pipeline/release/release.go
@@ -9,6 +9,7 @@ import (
 	"github.com/apex/log"
 	"github.com/goreleaser/goreleaser/context"
 	"github.com/goreleaser/goreleaser/internal/client"
+	"github.com/goreleaser/goreleaser/pipeline"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -27,8 +28,7 @@ func (Pipe) Run(ctx *context.Context) error {
 
 func doRun(ctx *context.Context, client client.Client) error {
 	if !ctx.Publish {
-		log.Warn("skipped because --skip-publish is set")
-		return nil
+		return pipeline.Skip("--skip-publish is set")
 	}
 	log.WithField("tag", ctx.Git.CurrentTag).
 		WithField("repo", ctx.Config.Release.GitHub.String()).

--- a/pipeline/release/release_test.go
+++ b/pipeline/release/release_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/goreleaser/goreleaser/config"
 	"github.com/goreleaser/goreleaser/context"
+	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -121,7 +122,7 @@ func TestSkipPublish(t *testing.T) {
 		Parallelism: 1,
 	}
 	client := &DummyClient{}
-	assert.NoError(doRun(ctx, client))
+	testlib.AssertSkipped(t, doRun(ctx, client))
 	assert.False(client.CreatedRelease)
 	assert.False(client.UploadedFile)
 }

--- a/pipeline/snapcraft/snapcraft_test.go
+++ b/pipeline/snapcraft/snapcraft_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/goreleaser/goreleaser/config"
 	"github.com/goreleaser/goreleaser/context"
+	"github.com/goreleaser/goreleaser/pipeline"
 	"github.com/stretchr/testify/assert"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -25,7 +26,7 @@ func TestRunPipeMissingInfo(t *testing.T) {
 		ErrNoDescription: {
 			Summary: "dummy summary",
 		},
-		nil: {}, // should skip instead of error
+		pipeline.Skip("no summary nor description were provided"): {},
 	} {
 		t.Run(fmt.Sprintf("testing if %v happens", eerr), func(t *testing.T) {
 			var assert = assert.New(t)
@@ -145,7 +146,14 @@ func TestNoSnapcraftInPath(t *testing.T) {
 
 func addBinaries(t *testing.T, ctx *context.Context, name, dist string) {
 	var assert = assert.New(t)
-	for _, plat := range []string{"linuxamd64", "linux386", "darwinamd64", "linuxarm64", "linuxarmhf"} {
+	for _, plat := range []string{
+		"linuxamd64",
+		"linux386",
+		"darwinamd64",
+		"linuxarm64",
+		"linuxarm6",
+		"linuxwtf",
+	} {
 		var folder = name + "_" + plat
 		assert.NoError(os.Mkdir(filepath.Join(dist, folder), 0755))
 		var binPath = filepath.Join(dist, folder, name)


### PR DESCRIPTION
- skipping a pipe is now an error type
- improved some logs
- improved snapcraft test coverage