### PR TITLE
fixed arm .deb

### DIFF
--- a/internal/linux/arch.go
+++ b/internal/linux/arch.go
@@ -1,0 +1,19 @@
+// Package linux contains functions that are useful to generate linux packages.
+package linux
+
+import "strings"
+
+// Arch converts a goarch to a linux-compatible arch
+func Arch(key string) string {
+	switch {
+	case strings.Contains(key, "amd64"):
+		return "amd64"
+	case strings.Contains(key, "386"):
+		return "i386"
+	case strings.Contains(key, "arm64"):
+		return "arm64"
+	case strings.Contains(key, "arm6"):
+		return "armhf"
+	}
+	return key
+}

--- a/internal/linux/arch_test.go
+++ b/internal/linux/arch_test.go
@@ -1,0 +1,22 @@
+package linux
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestArch(t *testing.T) {
+	for from, to := range map[string]string{
+		"amd64": "amd64",
+		"386":   "i386",
+		"arm64": "arm64",
+		"arm6":  "armhf",
+		"what":  "what",
+	} {
+		t.Run(fmt.Sprintf("%s to %s", from, to), func(t *testing.T) {
+			assert.Equal(t, to, Arch(from))
+		})
+	}
+}

--- a/pipeline/fpm/fpm.go
+++ b/pipeline/fpm/fpm.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/goreleaser/goreleaser/context"
+	"github.com/goreleaser/goreleaser/internal/linux"
 	"github.com/goreleaser/goreleaser/pipeline"
 	"golang.org/x/sync/errgroup"
 )
@@ -43,7 +44,7 @@ func (Pipe) Run(ctx *context.Context) error {
 				continue
 			}
 			format := format
-			arch := archFor(platform)
+			arch := linux.Arch(platform)
 			for folder, binaries := range groups {
 				g.Go(func() error {
 					return create(ctx, format, folder, arch, binaries)
@@ -52,13 +53,6 @@ func (Pipe) Run(ctx *context.Context) error {
 		}
 	}
 	return g.Wait()
-}
-
-func archFor(key string) string {
-	if strings.Contains(key, "386") {
-		return "i386"
-	}
-	return "x86_64"
 }
 
 func create(ctx *context.Context, format, folder, arch string, binaries []context.Binary) error {

--- a/pipeline/snapcraft/snapcraft.go
+++ b/pipeline/snapcraft/snapcraft.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/goreleaser/goreleaser/context"
+	"github.com/goreleaser/goreleaser/internal/linux"
 	"github.com/goreleaser/goreleaser/pipeline"
 	"golang.org/x/sync/errgroup"
 	yaml "gopkg.in/yaml.v2"
@@ -75,7 +76,7 @@ func (Pipe) Run(ctx *context.Context) error {
 			log.WithField("platform", platform).Debug("skipped non-linux builds for snapcraft")
 			continue
 		}
-		arch := archFor(platform)
+		arch := linux.Arch(platform)
 		for folder, binaries := range groups {
 			g.Go(func() error {
 				return create(ctx, folder, arch, binaries)
@@ -83,20 +84,6 @@ func (Pipe) Run(ctx *context.Context) error {
 		}
 	}
 	return g.Wait()
-}
-
-func archFor(key string) string {
-	switch {
-	case strings.Contains(key, "amd64"):
-		return "amd64"
-	case strings.Contains(key, "386"):
-		return "i386"
-	case strings.Contains(key, "arm64"):
-		return "arm64"
-	case strings.Contains(key, "arm6"):
-		return "armhf"
-	}
-	return key
 }
 
 func create(ctx *context.Context, folder, arch string, binaries []context.Binary) error {


### PR DESCRIPTION
seems right now:

```
root@4bdeb544b41c:/tmp/dist# dpkg -i goreleaser_Linux_armv6.deb
(Reading database ... 10301 files and directories currently installed.)
Preparing to unpack goreleaser_Linux_armv6.deb ...
Unpacking goreleaser (0.30.0) over (0.30.0) ...
Setting up goreleaser (0.30.0) ...
root@4bdeb544b41c:/tmp/dist# goreleaser -h
NAME:
   goreleaser - Deliver Go binaries as fast and easily as possible

USAGE:
   goreleaser [global options] command [command options] [arguments...]

VERSION:
   0.30.0, commit 42446c807989f83b98f4fa11a41b728eb0b38661, built at 2017-08-27T16:10:05Z

COMMANDS:
     init, i  generate .goreleaser.yml
     help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --config FILE, --file FILE, -c FILE, -f FILE  Load configuration from FILE (default: ".goreleaser.yml")
   --release-notes FILE                          Load custom release notes from a markdown FILE
   --skip-validate                               Skip all the validations against the release
   --skip-publish                                Skip all publishing pipes of the release
   --snapshot                                    Generate an unversioned snapshot release
   --rm-dist                                     Remove ./dist before building
   --parallelism value, -p value                 Amount of builds launch in parallel (default: 4)
   --debug                                       Enable debug mode
   --help, -h                                    show help
   --version, -v                                 print the version
root@4bdeb544b41c:/tmp/dist# uname -a
Linux 4bdeb544b41c 4.9.36-moby #1 SMP Wed Jul 12 15:29:07 UTC 2017 armv7l armv7l armv7l GNU/Linux
root@4bdeb544b41c:/tmp/dist#
```

closes #345 