### PR TITLE
better handling of git errors

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,9 @@ type Repo struct {
 
 // String of the repo, e.g. owner/name
 func (r Repo) String() string {
+	if r.Owner == "" && r.Name == "" {
+		return ""
+	}
 	return r.Owner + "/" + r.Name
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,8 +13,11 @@ import (
 
 func TestRepo(t *testing.T) {
 	var assert = assert.New(t)
-	r := Repo{Owner: "goreleaser", Name: "godownloader"}
-	assert.Equal("goreleaser/godownloader", r.String(), "not equal")
+	assert.Equal("goreleaser/godownloader", Repo{
+		Owner: "goreleaser",
+		Name:  "godownloader",
+	}.String())
+	assert.Empty(Repo{}.String())
 }
 
 func TestLoadReader(t *testing.T) {

--- a/goreleaserlib/goreleaser_test.go
+++ b/goreleaserlib/goreleaser_test.go
@@ -147,15 +147,6 @@ func TestInitProjectFileExist(t *testing.T) {
 	assert.Error(InitProject(filename))
 }
 
-func TestInitProjectDefaultPipeFails(t *testing.T) {
-	var assert = assert.New(t)
-	_, back := setup(t)
-	defer back()
-	var filename = "test_goreleaser.yml"
-	assert.NoError(os.RemoveAll(".git"))
-	assert.Error(InitProject(filename))
-}
-
 // fakeFlags is a mock of the cli flags
 type fakeFlags struct {
 	flags map[string]string

--- a/pipeline/defaults/defaults.go
+++ b/pipeline/defaults/defaults.go
@@ -37,9 +37,7 @@ func (Pipe) Run(ctx *context.Context) error {
 	if ctx.Config.Checksum.NameTemplate == "" {
 		ctx.Config.Checksum.NameTemplate = ChecksumNameTemplate
 	}
-	if err := setReleaseDefaults(ctx); err != nil {
-		return err
-	}
+	setReleaseDefaults(ctx)
 	if ctx.Config.ProjectName == "" {
 		ctx.Config.ProjectName = ctx.Config.Release.GitHub.Name
 	}
@@ -100,16 +98,16 @@ func contains(ss []string, s string) bool {
 	return false
 }
 
-func setReleaseDefaults(ctx *context.Context) error {
+func setReleaseDefaults(ctx *context.Context) {
 	if ctx.Config.Release.GitHub.Name != "" {
-		return nil
+		return
 	}
 	repo, err := remoteRepo()
 	if err != nil {
-		return fmt.Errorf("failed reading repo from git: %v", err.Error())
+		log.WithError(err).Warn("failed read remote from git - is the current folder a repository with a valid remote?")
+		return
 	}
 	ctx.Config.Release.GitHub = repo
-	return nil
 }
 
 func setBuildDefaults(ctx *context.Context) {

--- a/pipeline/defaults/defaults_test.go
+++ b/pipeline/defaults/defaults_test.go
@@ -1,12 +1,11 @@
 package defaults
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/config"
 	"github.com/goreleaser/goreleaser/context"
+	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,6 +14,11 @@ func TestDescription(t *testing.T) {
 }
 
 func TestFillBasicData(t *testing.T) {
+	_, back := testlib.Mktmp(t)
+	defer back()
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:goreleaser/goreleaser.git")
+
 	var assert = assert.New(t)
 	var ctx = &context.Context{
 		Config: config.Project{},
@@ -41,8 +45,12 @@ func TestFillBasicData(t *testing.T) {
 }
 
 func TestFillPartial(t *testing.T) {
-	var assert = assert.New(t)
+	_, back := testlib.Mktmp(t)
+	defer back()
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:goreleaser/goreleaser.git")
 
+	var assert = assert.New(t)
 	var ctx = &context.Context{
 		Config: config.Project{
 			Release: config.Release{
@@ -82,8 +90,12 @@ func TestFillPartial(t *testing.T) {
 }
 
 func TestFillSingleBuild(t *testing.T) {
-	var assert = assert.New(t)
+	_, back := testlib.Mktmp(t)
+	defer back()
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:goreleaser/goreleaser.git")
 
+	var assert = assert.New(t)
 	var ctx = &context.Context{
 		Config: config.Project{
 			SingleBuild: config.Build{
@@ -98,16 +110,23 @@ func TestFillSingleBuild(t *testing.T) {
 
 func TestNotAGitRepo(t *testing.T) {
 	var assert = assert.New(t)
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	assert.NoError(err)
-	previous, err := os.Getwd()
-	assert.NoError(err)
-	assert.NoError(os.Chdir(folder))
-	defer func() {
-		assert.NoError(os.Chdir(previous))
-	}()
+	_, back := testlib.Mktmp(t)
+	defer back()
+	testlib.GitInit(t)
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}
-	assert.Error(Pipe{}.Run(ctx))
+	assert.NoError(Pipe{}.Run(ctx))
+	assert.Empty(ctx.Config.Release.GitHub.String())
+}
+
+func TestGitRepoWithoutRemote(t *testing.T) {
+	var assert = assert.New(t)
+	_, back := testlib.Mktmp(t)
+	defer back()
+	var ctx = &context.Context{
+		Config: config.Project{},
+	}
+	assert.NoError(Pipe{}.Run(ctx))
+	assert.Empty(ctx.Config.Release.GitHub.String())
 }

--- a/pipeline/defaults/remote.go
+++ b/pipeline/defaults/remote.go
@@ -1,19 +1,23 @@
 package defaults
 
 import (
-	"errors"
+	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/goreleaser/goreleaser/config"
+	"github.com/pkg/errors"
 )
 
 // remoteRepo gets the repo name from the Git config.
 func remoteRepo() (result config.Repo, err error) {
+	if _, err := os.Stat(".git"); os.IsNotExist(err) {
+		return result, errors.Wrap(err, "current folder is not a git repository")
+	}
 	cmd := exec.Command("git", "config", "--get", "remote.origin.url")
 	bts, err := cmd.CombinedOutput()
 	if err != nil {
-		return result, errors.New(err.Error() + ": " + string(bts))
+		return result, errors.Wrap(err, "repository doesn't have an `origin` remote")
 	}
 	return extractRepoFromURL(string(bts)), nil
 }

--- a/pipeline/defaults/remote.go
+++ b/pipeline/defaults/remote.go
@@ -11,7 +11,7 @@ import (
 
 // remoteRepo gets the repo name from the Git config.
 func remoteRepo() (result config.Repo, err error) {
-	if _, err := os.Stat(".git"); os.IsNotExist(err) {
+	if _, err = os.Stat(".git"); os.IsNotExist(err) {
 		return result, errors.Wrap(err, "current folder is not a git repository")
 	}
 	cmd := exec.Command("git", "config", "--get", "remote.origin.url")

--- a/pipeline/defaults/remote_test.go
+++ b/pipeline/defaults/remote_test.go
@@ -3,11 +3,17 @@ package defaults
 import (
 	"testing"
 
+	"github.com/goreleaser/goreleaser/internal/testlib"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRepoName(t *testing.T) {
 	var assert = assert.New(t)
+	_, back := testlib.Mktmp(t)
+	defer back()
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:goreleaser/goreleaser.git")
 	repo, err := remoteRepo()
 	assert.NoError(err)
 	assert.Equal("goreleaser/goreleaser", repo.String())

--- a/pipeline/release/body_test.go
+++ b/pipeline/release/body_test.go
@@ -24,7 +24,6 @@ func TestDescribeBody(t *testing.T) {
 
 	bts, err := ioutil.ReadFile("testdata/release1.txt")
 	assert.NoError(err)
-	ioutil.WriteFile("testdata/release1.txt", out.Bytes(), 0755)
 
 	assert.Equal(string(bts), out.String())
 }
@@ -40,7 +39,6 @@ func TestDescribeBodyNoDockerImages(t *testing.T) {
 
 	bts, err := ioutil.ReadFile("testdata/release2.txt")
 	assert.NoError(err)
-	ioutil.WriteFile("testdata/release2.txt", out.Bytes(), 0755)
 
 	assert.Equal(string(bts), out.String())
 }


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] `make ci` passes on my machine.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

----

from now on, on defaults pipe, if the current folder is not a git repo or does not have a remote set up, it will only warn but will not break.

this should fix #356, but I'm not sure this is the right way of doing so...