### PR TITLE
Add config field to overwrite brew commit author

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,19 +36,26 @@ func (r Repo) String() string {
 
 // Homebrew contains the brew section
 type Homebrew struct {
-	GitHub       Repo     `yaml:",omitempty"`
-	Folder       string   `yaml:",omitempty"`
-	Caveats      string   `yaml:",omitempty"`
-	Plist        string   `yaml:",omitempty"`
-	Install      string   `yaml:",omitempty"`
-	Dependencies []string `yaml:",omitempty"`
-	Test         string   `yaml:",omitempty"`
-	Conflicts    []string `yaml:",omitempty"`
-	Description  string   `yaml:",omitempty"`
-	Homepage     string   `yaml:",omitempty"`
+	GitHub       Repo         `yaml:",omitempty"`
+	CommitAuthor CommitAuthor `yaml:"commit_author,omitempty"`
+	Folder       string       `yaml:",omitempty"`
+	Caveats      string       `yaml:",omitempty"`
+	Plist        string       `yaml:",omitempty"`
+	Install      string       `yaml:",omitempty"`
+	Dependencies []string     `yaml:",omitempty"`
+	Test         string       `yaml:",omitempty"`
+	Conflicts    []string     `yaml:",omitempty"`
+	Description  string       `yaml:",omitempty"`
+	Homepage     string       `yaml:",omitempty"`
 
 	// Capture all undefined fields and should be empty after loading
 	XXX map[string]interface{} `yaml:",inline"`
+}
+
+// CommitAuthor is the author of a Git commit
+type CommitAuthor struct {
+	Name  string `yaml:",omitempty"`
+	Email string `yaml:",omitempty"`
 }
 
 // Hooks define actions to run before and/or after something

--- a/docs/120-homebrew.md
+++ b/docs/120-homebrew.md
@@ -20,6 +20,11 @@ brew:
     owner: user
     name: homebrew-tap
 
+  # Git author used to commit to the repository.
+  commit_author:
+    name: goreleaserbot
+    email: goreleaser@carlosbecker.com
+
   # Folder inside the repository to put the formula.
   # Default is the root folder.
   folder: Formula

--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -44,8 +44,8 @@ func (c *githubClient) CreateFile(
 ) (err error) {
 	options := &github.RepositoryContentFileOptions{
 		Committer: &github.CommitAuthor{
-			Name:  github.String("goreleaserbot"),
-			Email: github.String("goreleaser@carlosbecker.com"),
+			Name:  github.String(ctx.Config.Brew.CommitAuthor.Name),
+			Email: github.String(ctx.Config.Brew.CommitAuthor.Email),
 		},
 		Content: content.Bytes(),
 		Message: github.String(

--- a/pipeline/defaults/defaults.go
+++ b/pipeline/defaults/defaults.go
@@ -43,7 +43,9 @@ func (Pipe) Run(ctx *context.Context) error {
 	if ctx.Config.ProjectName == "" {
 		ctx.Config.ProjectName = ctx.Config.Release.GitHub.Name
 	}
+
 	setBuildDefaults(ctx)
+
 	if ctx.Config.Brew.Install == "" {
 		var installs []string
 		for _, build := range ctx.Config.Builds {
@@ -56,6 +58,13 @@ func (Pipe) Run(ctx *context.Context) error {
 			)
 		}
 		ctx.Config.Brew.Install = strings.Join(installs, "\n")
+	}
+
+	if ctx.Config.Brew.CommitAuthor.Name == "" {
+		ctx.Config.Brew.CommitAuthor.Name = "goreleaserbot"
+	}
+	if ctx.Config.Brew.CommitAuthor.Email == "" {
+		ctx.Config.Brew.CommitAuthor.Email = "goreleaser@carlosbecker.com"
 	}
 
 	err := setArchiveDefaults(ctx)

--- a/pipeline/defaults/defaults_test.go
+++ b/pipeline/defaults/defaults_test.go
@@ -32,6 +32,8 @@ func TestFillBasicData(t *testing.T) {
 	assert.Contains(ctx.Config.Builds[0].Goarch, "amd64")
 	assert.Equal("tar.gz", ctx.Config.Archive.Format)
 	assert.Contains(ctx.Config.Brew.Install, "bin.install \"goreleaser\"")
+	assert.Contains(ctx.Config.Brew.CommitAuthor.Name, "goreleaserbot")
+	assert.Contains(ctx.Config.Brew.CommitAuthor.Email, "goreleaser@carlosbecker.com")
 	assert.Empty(ctx.Config.Dockers)
 	assert.NotEmpty(
 		ctx.Config.Archive.NameTemplate,


### PR DESCRIPTION
Default author name and email can be set in config file.
Close #292.

I think it is most flexible if we allow the user to set the commit author in the config file instead 
of guessing a correct value.
In most cases users won't care so I left the old default values.
In other cases I think the logged in user is not the best guess since organizations mostly rather specify a separate email to indicate that this commit was made by a bot, not a human.

I hope I didn't forget to update any relevant code.
And I am not completely sure I put it in the best place in the config file - open to suggestions here.




## Types of changes

- New feature (non-breaking change which adds functionality)
- I have updated the documentation accordingly.
- I have updated the tests to cover my changes.

