### PR TITLE
docs: Add example for --release-notes flag (#284)

### DIFF
--- a/docs/115-release.md
+++ b/docs/115-release.md
@@ -28,3 +28,9 @@ You can have a markdown file previously created with the release notes, and
 pass it down to goreleaser with the `--release-notes=FILE` flag.
 GoReleaser will then skip its own release notes generation,
 using the contents of your file instead.
+
+On Unix systems you can also generate the release notes in-line by using [process substitution](https://en.wikipedia.org/wiki/Process_substitution).
+To list all commits since the last tag, but skip ones starting with `Merge` or `docs`, you could run this command:
+```sh
+goreleaser --release-notes <(git log --pretty=oneline --abbrev-commit $(git describe --tags --abbrev=0)^.. | grep -v '^[^ ]* \(Merge\|docs\)')
+```


### PR DESCRIPTION
I added an example to the docs of the `--release-notes` flag to make the usage more clear (see https://github.com/goreleaser/goreleaser/issues/284).
The example is an realistic use case and might help others to generate their own changelog.