### PR TITLE
feat: Add archive config 'wrap_in_directory'

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -106,6 +106,7 @@ type Archive struct {
 	Format          string            `yaml:",omitempty"`
 	FormatOverrides []FormatOverride  `yaml:"format_overrides,omitempty"`
 	NameTemplate    string            `yaml:"name_template,omitempty"`
+	WrapInDirectory bool              `yaml:"wrap_in_directory,omitempty"`
 	Replacements    map[string]string `yaml:",omitempty"`
 	Files           []string          `yaml:",omitempty"`
 

--- a/docs/060-archive.md
+++ b/docs/060-archive.md
@@ -23,6 +23,13 @@ archive:
   # Default is `{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}`.
   name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
+  # Set to true, if you want all files in the archive to be in a single directory.
+  # If set to true and you extract the archive 'goreleaser_Linux_arm64.tar.gz',
+  # you get a folder 'goreleaser_Linux_arm64'.
+  # If set to false, all files are extracted separately.
+  # Default is false.
+  wrap_in_directory: true
+
   # Archive format. Valid options are `tar.gz`, `zip` and `binary`.
   # If format is `binary`, no archives are created and the binaries are instead uploaded directly.
   # In that case name_template and the below specified files are ignored.


### PR DESCRIPTION
The field is optional. When set to true, files in archive are wrapped
in a directory, which has the same name as the archive itself.
Tests have also been extended to cover this.

Closes #251

If you think another name for the option is more clear or we need further customization, please let me know.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] `make ci` passes on my machine.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

