### PR TITLE
docs: Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Prerequisites:
 Clone `goreleaser` from source into `$GOPATH`:
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/github.com/goreleaser
+$ mkdir -p $GOPATH/src/github.com/goreleaser/goreleaser
 $ cd $_
 $ git clone git@github.com:goreleaser/goreleaser.git
 $ cd goreleaser


### PR DESCRIPTION
Fixed a typo with the `go get` path using `github.com`
as the user instead of `goreleaser`.