### PR TITLE
feat: Add prerelease option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -116,8 +116,9 @@ type Archive struct {
 
 // Release config used for the GitHub release
 type Release struct {
-	GitHub Repo `yaml:",omitempty"`
-	Draft  bool `yaml:",omitempty"`
+	GitHub     Repo `yaml:",omitempty"`
+	Draft      bool `yaml:",omitempty"`
+	Prerelease bool `yaml:",omitempty"`
 
 	// Capture all undefined fields and should be empty after loading
 	XXX map[string]interface{} `yaml:",inline"`

--- a/docs/115-release.md
+++ b/docs/115-release.md
@@ -19,6 +19,10 @@ release:
   # If set to true, will not auto-publish the release.
   # Default is false.
   draft: true
+
+  # If set to true, will mark the release as not ready for production.
+  # Default is false.
+  prerelease: true
 ```
 
 ## Custom release notes

--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -84,10 +84,11 @@ func (c *githubClient) CreateFile(
 func (c *githubClient) CreateRelease(ctx *context.Context, body string) (releaseID int, err error) {
 	var release *github.RepositoryRelease
 	var data = &github.RepositoryRelease{
-		Name:    github.String(ctx.Git.CurrentTag),
-		TagName: github.String(ctx.Git.CurrentTag),
-		Body:    github.String(body),
-		Draft:   github.Bool(ctx.Config.Release.Draft),
+		Name:       github.String(ctx.Git.CurrentTag),
+		TagName:    github.String(ctx.Git.CurrentTag),
+		Body:       github.String(body),
+		Draft:      github.Bool(ctx.Config.Release.Draft),
+		Prerelease: github.Bool(ctx.Config.Release.Prerelease),
 	}
 	release, _, err = c.client.Repositories.GetReleaseByTag(
 		ctx,


### PR DESCRIPTION
Add an config option to `release` section to set a release at not ready
for production.

Closes #384

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- New feature (non-breaking change which adds functionality)
- I have updated the documentation accordingly.