### PR TITLE
fix: docker tests should not depend on the main docker registry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ services:
   - docker
 install:
   - make setup
-  - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
   - gem install fpm
   - sudo apt-get update
   - sudo apt-get install --yes snapd rpm
@@ -17,6 +16,7 @@ script:
   - test -n "$TRAVIS_TAG" || go run main.go --skip-validate --skip-publish
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+  - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
   - test -n "$TRAVIS_TAG" && go run main.go
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - test -n "$TRAVIS_TAG" || go run main.go --skip-validate --skip-publish
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-  - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+  - test -n "$TRAVIS_TAG" && docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
   - test -n "$TRAVIS_TAG" && go run main.go
 notifications:
   email: false

--- a/pipeline/docker/docker_test.go
+++ b/pipeline/docker/docker_test.go
@@ -7,12 +7,31 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/apex/log"
+
 	"github.com/goreleaser/goreleaser/config"
 	"github.com/goreleaser/goreleaser/context"
 	"github.com/goreleaser/goreleaser/pipeline"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func killAndRm() {
+	_ = exec.Command("docker", "kill", "registry").Run()
+	_ = exec.Command("docker", "rm", "registry").Run()
+}
+
+func TestMain(m *testing.M) {
+	killAndRm()
+	if err := exec.Command(
+		"docker", "run", "-d", "-p", "5000:5000", "--restart=always", "--name", "registry", "registry:2",
+	).Run(); err != nil {
+		log.WithError(err).Fatal("failed to start docker registry")
+	}
+	code := m.Run()
+	killAndRm()
+	os.Exit(code)
+}
 
 func TestRunPipe(t *testing.T) {
 	folder, err := ioutil.TempDir("", "archivetest")
@@ -24,8 +43,8 @@ func TestRunPipe(t *testing.T) {
 	_, err = os.Create(binPath)
 	assert.NoError(t, err)
 	var images = []string{
-		"goreleaser/test_run_pipe:1.0.0",
-		"goreleaser/test_run_pipe:latest",
+		"localhost:5000/goreleaser/test_run_pipe:1.0.0",
+		"localhost:5000/goreleaser/test_run_pipe:latest",
 	}
 	// this might fail as the image doesnt exist yet, so lets ignore the error
 	for _, img := range images {
@@ -39,7 +58,7 @@ func TestRunPipe(t *testing.T) {
 			Dist:        dist,
 			Dockers: []config.Docker{
 				{
-					Image:      "goreleaser/test_run_pipe",
+					Image:      "localhost:5000/goreleaser/test_run_pipe",
 					Goos:       "linux",
 					Goarch:     "amd64",
 					Dockerfile: "testdata/Dockerfile",
@@ -47,7 +66,7 @@ func TestRunPipe(t *testing.T) {
 					Latest:     true,
 				},
 				{
-					Image:      "goreleaser/test_run_pipe_nope",
+					Image:      "localhost:5000/goreleaser/test_run_pipe_nope",
 					Goos:       "linux",
 					Goarch:     "amd64",
 					Dockerfile: "testdata/Dockerfile",
@@ -70,7 +89,9 @@ func TestRunPipe(t *testing.T) {
 	// the test_run_pipe_nope image should not have been created, so deleting
 	// it should fail
 	assert.Error(t,
-		exec.Command("docker", "rmi", "goreleaser/test_run_pipe_nope:1.0.0").Run(),
+		exec.Command(
+			"docker", "rmi", "localhost:5000/goreleaser/test_run_pipe_nope:1.0.0",
+		).Run(),
 	)
 }
 

--- a/pipeline/docker/docker_test.go
+++ b/pipeline/docker/docker_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func killAndRm() {
+	log.Info("killing registry")
 	_ = exec.Command("docker", "kill", "registry").Run()
 	_ = exec.Command("docker", "rm", "registry").Run()
 }
@@ -24,13 +25,12 @@ func killAndRm() {
 func TestMain(m *testing.M) {
 	killAndRm()
 	if err := exec.Command(
-		"docker", "run", "-d", "-p", "5000:5000", "--restart=always", "--name", "registry", "registry:2",
+		"docker", "run", "-d", "-p", "5000:5000", "--name", "registry", "registry:2",
 	).Run(); err != nil {
 		log.WithError(err).Fatal("failed to start docker registry")
 	}
-	code := m.Run()
-	killAndRm()
-	os.Exit(code)
+	defer killAndRm()
+	os.Exit(m.Run())
 }
 
 func TestRunPipe(t *testing.T) {


### PR DESCRIPTION
Makes it not necessary to be logged in the in the docker registry for
the tests to work by using a local registry.

Fixes #379

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] `make ci` passes on my machine.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

