### PR TITLE
refactor: improved git error handling

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,9 @@ type Repo struct {
 
 // String of the repo, e.g. owner/name
 func (r Repo) String() string {
+	if r.Owner == "" && r.Name == "" {
+		return ""
+	}
 	return r.Owner + "/" + r.Name
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,8 +12,15 @@ import (
 )
 
 func TestRepo(t *testing.T) {
-	r := Repo{Owner: "goreleaser", Name: "godownloader"}
-	assert.Equal(t, "goreleaser/godownloader", r.String(), "not equal")
+	assert.Equal(
+		t,
+		"goreleaser/godownloader",
+		Repo{Owner: "goreleaser", Name: "godownloader"}.String(),
+	)
+}
+
+func TestEmptyRepoNameAndOwner(t *testing.T) {
+	assert.Empty(t, Repo{}.String())
 }
 
 func TestLoadReader(t *testing.T) {

--- a/pipeline/defaults/defaults.go
+++ b/pipeline/defaults/defaults.go
@@ -115,7 +115,7 @@ func setReleaseDefaults(ctx *context.Context) error {
 	}
 	repo, err := remoteRepo()
 	if err != nil {
-		return fmt.Errorf("failed reading repo from git: %v", err.Error())
+		return err
 	}
 	ctx.Config.Release.GitHub = repo
 	return nil

--- a/pipeline/defaults/remote.go
+++ b/pipeline/defaults/remote.go
@@ -1,19 +1,23 @@
 package defaults
 
 import (
-	"errors"
+	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/goreleaser/goreleaser/config"
+	"github.com/pkg/errors"
 )
 
 // remoteRepo gets the repo name from the Git config.
 func remoteRepo() (result config.Repo, err error) {
+	if _, err = os.Stat(".git"); os.IsNotExist(err) {
+		return result, errors.Wrap(err, "current folder is not a git repository")
+	}
 	cmd := exec.Command("git", "config", "--get", "remote.origin.url")
 	bts, err := cmd.CombinedOutput()
 	if err != nil {
-		return result, errors.New(err.Error() + ": " + string(bts))
+		return result, errors.Wrap(err, "repository doesn't have an `origin` remote")
 	}
 	return extractRepoFromURL(string(bts)), nil
 }

--- a/pipeline/defaults/remote_test.go
+++ b/pipeline/defaults/remote_test.go
@@ -3,10 +3,16 @@ package defaults
 import (
 	"testing"
 
+	"github.com/goreleaser/goreleaser/internal/testlib"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRepoName(t *testing.T) {
+	_, back := testlib.Mktmp(t)
+	defer back()
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:goreleaser/goreleaser.git")
 	repo, err := remoteRepo()
 	assert.NoError(t, err)
 	assert.Equal(t, "goreleaser/goreleaser", repo.String())

--- a/pipeline/git/git.go
+++ b/pipeline/git/git.go
@@ -14,6 +14,7 @@ import (
 	"github.com/goreleaser/goreleaser/context"
 	"github.com/goreleaser/goreleaser/internal/git"
 	"github.com/goreleaser/goreleaser/pipeline"
+	"github.com/pkg/errors"
 )
 
 // Pipe for brew deployment
@@ -54,7 +55,7 @@ func setVersion(ctx *context.Context, tag, commit string) (err error) {
 	if ctx.Snapshot {
 		snapshotName, err := getSnapshotName(ctx, tag, commit)
 		if err != nil {
-			return fmt.Errorf("failed to generate snapshot name: %s", err.Error())
+			return errors.Wrap(err, "failed to generate snapshot name")
 		}
 		ctx.Version = snapshotName
 		return nil


### PR DESCRIPTION
Improved the error handling in git code,
mostly in the defaults pipe. The idea is to
output better error messages, hopefully avoiding
confusion on "whats wrong".

refs #356

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] `make ci` passes on my machine.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

