### PR TITLE
change test so can detect if git repo is actually a parent dir

### DIFF
--- a/pipeline/defaults/remote.go
+++ b/pipeline/defaults/remote.go
@@ -1,7 +1,6 @@
 package defaults
 
 import (
-	"os"
 	"os/exec"
 	"strings"
 
@@ -11,11 +10,13 @@ import (
 
 // remoteRepo gets the repo name from the Git config.
 func remoteRepo() (result config.Repo, err error) {
-	if _, err = os.Stat(".git"); os.IsNotExist(err) {
-		return result, errors.Wrap(err, "current folder is not a git repository")
-	}
-	cmd := exec.Command("git", "config", "--get", "remote.origin.url")
+	cmd := exec.Command("git", "status")
 	bts, err := cmd.CombinedOutput()
+	if err != nil || strings.Contains(string(bts), "fatal: Not a git repository") {
+		return result, errors.Wrap(err, "current folder is not in a git repository")
+	}
+	cmd = exec.Command("git", "config", "--get", "remote.origin.url")
+	bts, err = cmd.CombinedOutput()
 	if err != nil {
 		return result, errors.Wrap(err, "repository doesn't have an `origin` remote")
 	}


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x ] I have read the **CONTRIBUTING** document.
- [ ] `make ci` passes on my machine.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


tweaked the detection mechanism to shell out to git, such that can detect if the folder is contained in a git repo. This is common if using goreleaser from a monorepo, such that there may even be multiple goreleaser files in a single git repository.

