### PR TITLE
fix: detect if current folder is a subfolder of a parent git repo

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -4,7 +4,14 @@ package git
 import (
 	"errors"
 	"os/exec"
+	"strings"
 )
+
+// IsRepo returns true if current folder is a git repository
+func IsRepo() bool {
+	out, err := Run("rev-parse", "--is-inside-work-tree")
+	return err == nil && strings.TrimSpace(out) == "true"
+}
 
 // Run runs a git command and returns its output or errors
 func Run(args ...string) (output string, err error) {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,4 +20,11 @@ func TestGit(t *testing.T) {
 		"git: 'command-that-dont-exist' is not a git command. See 'git --help'.\n",
 		err.Error(),
 	)
+}
+
+func TestRepo(t *testing.T) {
+	assert.True(t, IsRepo(), "goreleaser folder should be a git repo")
+
+	assert.NoError(t, os.Chdir(os.TempDir()))
+	assert.False(t, IsRepo(), os.TempDir()+" folder should be a git repo")
 }

--- a/pipeline/defaults/remote.go
+++ b/pipeline/defaults/remote.go
@@ -1,25 +1,23 @@
 package defaults
 
 import (
-	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/goreleaser/goreleaser/config"
+	"github.com/goreleaser/goreleaser/internal/git"
 	"github.com/pkg/errors"
 )
 
 // remoteRepo gets the repo name from the Git config.
 func remoteRepo() (result config.Repo, err error) {
-	if _, err = os.Stat(".git"); os.IsNotExist(err) {
-		return result, errors.Wrap(err, "current folder is not a git repository")
+	if !git.IsRepo() {
+		return result, errors.New("current folder is not a git repository")
 	}
-	cmd := exec.Command("git", "config", "--get", "remote.origin.url")
-	bts, err := cmd.CombinedOutput()
+	out, err := git.Run("config", "--get", "remote.origin.url")
 	if err != nil {
 		return result, errors.Wrap(err, "repository doesn't have an `origin` remote")
 	}
-	return extractRepoFromURL(string(bts)), nil
+	return extractRepoFromURL(out), nil
 }
 
 func extractRepoFromURL(s string) config.Repo {


### PR DESCRIPTION
We were checking for a .git folder, which would break in cases
where goreleaser is running from a subfolder of a monorepo, for example.

Check https://github.com/goreleaser/goreleaser/commit/529af6fe72a391207ab25ef6ca7676eaf4c45954#commitcomment-25011738

Closes #402 #403 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] `make ci` passes on my machine.
- [x] I have added tests to cover my changes.

