### PR TITLE
feat: added sorting support to the changelog pipe

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -201,6 +201,7 @@ type Filters struct {
 // Changelog Config
 type Changelog struct {
 	Filters Filters `yaml:",omitempty"`
+	Sort    string  `yaml:",omitempty"`
 }
 
 // Project includes all project configuration

--- a/docs/115-release.md
+++ b/docs/115-release.md
@@ -45,10 +45,14 @@ changelog:
   filters:
     # commit messages matching the regexp listed here will be removed from
     # the changelog
+    # Default is emtpy
     exclude:
       - '^docs:'
       - typo
       - (?i)foo
+    # could either be asc, desc or empty
+    # Default is empty
+    sort: asc
 ```
 
 ## Custom release notes


### PR DESCRIPTION
We can now add:

```yaml
changelog:
  sort: asc
```

to group together our commits by prefix or just to sort them...

Closes #284

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)
- [x] I have read the **CONTRIBUTING** document.
- [ ] `make ci` passes on my machine.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

