### PR TITLE
fix: fpm fails randomly

### DIFF
--- a/pipeline/fpm/fpm.go
+++ b/pipeline/fpm/fpm.go
@@ -12,7 +12,6 @@ import (
 	"github.com/goreleaser/goreleaser/context"
 	"github.com/goreleaser/goreleaser/internal/linux"
 	"github.com/goreleaser/goreleaser/pipeline"
-	"golang.org/x/sync/errgroup"
 )
 
 // ErrNoFPM is shown when fpm cannot be found in $PATH
@@ -39,23 +38,21 @@ func (Pipe) Run(ctx *context.Context) error {
 }
 
 func doRun(ctx *context.Context) error {
-	var g errgroup.Group
 	for _, format := range ctx.Config.FPM.Formats {
 		for platform, groups := range ctx.Binaries {
 			if !strings.Contains(platform, "linux") {
 				log.WithField("platform", platform).Debug("skipped non-linux builds for fpm")
 				continue
 			}
-			format := format
 			arch := linux.Arch(platform)
 			for folder, binaries := range groups {
-				g.Go(func() error {
-					return create(ctx, format, folder, arch, binaries)
-				})
+				if err := create(ctx, format, folder, arch, binaries); err != nil {
+					return err
+				}
 			}
 		}
 	}
-	return g.Wait()
+	return nil
 }
 
 func create(ctx *context.Context, format, folder, arch string, binaries []context.Binary) error {


### PR DESCRIPTION
FPM would randomly fail to build deb and rpm packages. It apparently
happens because fpm (or some tool it uses) shares state between runs
(possibly by overriding files that are going inside the archive).

The error `file changed as we read it` was happening, which is a `tar`
error.

I don't know how to fix this, but, in order to make goreleaser more
stable, I'll disable the concurrency here for now.

closes #333

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the **CONTRIBUTING** document.
- [x] `make ci` passes on my machine.
