### PR TITLE
feat: validate changelog config for invalid fields

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -196,12 +196,18 @@ type Docker struct {
 // Filters config
 type Filters struct {
 	Exclude []string `yaml:",omitempty"`
+
+	// Capture all undefined fields and should be empty after loading
+	XXX map[string]interface{} `yaml:",inline"`
 }
 
 // Changelog Config
 type Changelog struct {
 	Filters Filters `yaml:",omitempty"`
 	Sort    string  `yaml:",omitempty"`
+
+	// Capture all undefined fields and should be empty after loading
+	XXX map[string]interface{} `yaml:",inline"`
 }
 
 // Project includes all project configuration
@@ -284,6 +290,8 @@ func checkOverflows(config Project) error {
 	for i, docker := range config.Dockers {
 		overflow.check(docker.XXX, fmt.Sprintf("docker[%d]", i))
 	}
+	overflow.check(config.Changelog.XXX, "changelog")
+	overflow.check(config.Changelog.Filters.XXX, "changelog.filters")
 	return overflow.err()
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -59,7 +59,7 @@ func TestFileNotFound(t *testing.T) {
 
 func TestInvalidFields(t *testing.T) {
 	_, err := Load("testdata/invalid_config.yml")
-	assert.EqualError(t, err, "unknown fields in the config file: invalid_root, archive.invalid_archive, archive.format_overrides[0].invalid_archive_fmtoverrides, brew.invalid_brew, brew.github.invalid_brew_github, builds[0].invalid_builds, builds[0].hooks.invalid_builds_hooks, builds[0].ignored_builds[0].invalid_builds_ignore, fpm.invalid_fpm, release.invalid_release, release.github.invalid_release_github, build.invalid_build, builds.hooks.invalid_build_hook, builds.ignored_builds[0].invalid_build_ignore, snapshot.invalid_snapshot, docker[0].invalid_docker")
+	assert.EqualError(t, err, "unknown fields in the config file: invalid_root, archive.invalid_archive, archive.format_overrides[0].invalid_archive_fmtoverrides, brew.invalid_brew, brew.github.invalid_brew_github, builds[0].invalid_builds, builds[0].hooks.invalid_builds_hooks, builds[0].ignored_builds[0].invalid_builds_ignore, fpm.invalid_fpm, release.invalid_release, release.github.invalid_release_github, build.invalid_build, builds.hooks.invalid_build_hook, builds.ignored_builds[0].invalid_build_ignore, snapshot.invalid_snapshot, docker[0].invalid_docker, changelog.invalid_changelog, changelog.filters.invalid_filters")
 }
 
 func TestInvalidYaml(t *testing.T) {

--- a/config/testdata/invalid_config.yml
+++ b/config/testdata/invalid_config.yml
@@ -29,3 +29,7 @@ snapshot:
   invalid_snapshot: 1
 dockers:
   - invalid_docker: 1
+changelog:
+  invalid_changelog: 1
+  filters:
+    invalid_filters: 1


### PR DESCRIPTION
If the user configures the changelog section with an invalid key, show
an error.
