### PR TITLE
Enabled parallelism again in fpm pile

### DIFF
--- a/pipeline/fpm/fpm_test.go
+++ b/pipeline/fpm/fpm_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/config"
@@ -18,8 +19,9 @@ func TestDescription(t *testing.T) {
 
 func TestRunPipeNoFormats(t *testing.T) {
 	var ctx = &context.Context{
-		Version: "1.0.0",
-		Config:  config.Project{},
+		Version:     "1.0.0",
+		Config:      config.Project{},
+		Parallelism: runtime.NumCPU(),
 	}
 	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
 }
@@ -34,7 +36,8 @@ func TestRunPipe(t *testing.T) {
 	_, err = os.Create(binPath)
 	assert.NoError(t, err)
 	var ctx = &context.Context{
-		Version: "1.0.0",
+		Version:     "1.0.0",
+		Parallelism: runtime.NumCPU(),
 		Config: config.Project{
 			ProjectName: "mybin",
 			Dist:        dist,
@@ -63,7 +66,8 @@ func TestNoFPMInPath(t *testing.T) {
 	}()
 	assert.NoError(t, os.Setenv("PATH", ""))
 	var ctx = &context.Context{
-		Version: "1.0.0",
+		Version:     "1.0.0",
+		Parallelism: runtime.NumCPU(),
 		Config: config.Project{
 			FPM: config.FPM{
 				Formats: []string{"deb", "rpm"},
@@ -80,7 +84,8 @@ func TestCreateFileDoesntExist(t *testing.T) {
 	assert.NoError(t, os.Mkdir(dist, 0755))
 	assert.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var ctx = &context.Context{
-		Version: "1.0.0",
+		Version:     "1.0.0",
+		Parallelism: runtime.NumCPU(),
 		Config: config.Project{
 			Dist: dist,
 			FPM: config.FPM{
@@ -97,7 +102,8 @@ func TestCreateFileDoesntExist(t *testing.T) {
 
 func TestRunPipeWithExtraFiles(t *testing.T) {
 	var ctx = &context.Context{
-		Version: "1.0.0",
+		Version:     "1.0.0",
+		Parallelism: runtime.NumCPU(),
 		Config: config.Project{
 			FPM: config.FPM{
 				Formats: []string{"deb", "rpm"},


### PR DESCRIPTION
- fixed the previous issue with random failures
- make fpm respect the --parallelism setting

I had 

```
while true; do
  go test -v ./pipeline/fpm/... || break
done
```

running for 15min and the issue didn't happened 🎉 