### PR TITLE
feat: Allow overriding fpm destination for binaries

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -137,6 +137,7 @@ type FPM struct {
 	Maintainer   string            `yaml:",omitempty"`
 	Description  string            `yaml:",omitempty"`
 	License      string            `yaml:",omitempty"`
+	Bindir       string            `yaml:",omitempty"`
 	Files        map[string]string `yaml:",omitempty"`
 
 	// Capture all undefined fields and should be empty after loading

--- a/docs/100-fpm.md
+++ b/docs/100-fpm.md
@@ -43,6 +43,9 @@ fpm:
     - svn
     - bash
 
+  # Override default /usr/local/bin destination for binaries
+  bindir: /usr/bin
+
   # Files or directories to add to your package (beyond the binary).
   # Keys are source paths to get the files from.
   # Values are the destination locations of the files in the package.

--- a/pipeline/defaults/defaults.go
+++ b/pipeline/defaults/defaults.go
@@ -75,6 +75,7 @@ func (Pipe) Run(ctx *context.Context) error { // nolint: gocyclo
 
 	err := setArchiveDefaults(ctx)
 	setDockerDefaults(ctx)
+	setFpmDefaults(ctx)
 	log.WithField("config", ctx.Config).Debug("defaults set")
 	return err
 }
@@ -180,4 +181,10 @@ func setArchiveDefaults(ctx *context.Context) error {
 		}
 	}
 	return nil
+}
+
+func setFpmDefaults(ctx *context.Context) {
+	if ctx.Config.FPM.Bindir == "" {
+		ctx.Config.FPM.Bindir = "/usr/local/bin"
+	}
 }

--- a/pipeline/fpm/fpm.go
+++ b/pipeline/fpm/fpm.go
@@ -75,8 +75,13 @@ func create(ctx *context.Context, format, folder, arch string, binaries []contex
 	log.WithField("file", file).WithField("workdir", dir).Info("creating fpm archive")
 	var options = basicOptions(ctx, dir, format, arch, file)
 
+	bindir := "/usr/local/bin"
+	if ctx.Config.FPM.Bindir != "" {
+		bindir = ctx.Config.FPM.Bindir
+	}
+
 	for _, binary := range binaries {
-		// This basically tells fpm to put the binary in the /usr/local/bin
+		// This basically tells fpm to put the binary in the bindir, e.g. /usr/local/bin
 		// binary=/usr/local/bin/binary
 		log.WithField("path", binary.Path).
 			WithField("name", binary.Name).
@@ -84,7 +89,7 @@ func create(ctx *context.Context, format, folder, arch string, binaries []contex
 		options = append(options, fmt.Sprintf(
 			"%s=%s",
 			binary.Path,
-			filepath.Join("/usr/local/bin", binary.Name),
+			filepath.Join(bindir, binary.Name),
 		))
 	}
 

--- a/pipeline/fpm/fpm.go
+++ b/pipeline/fpm/fpm.go
@@ -75,11 +75,6 @@ func create(ctx *context.Context, format, folder, arch string, binaries []contex
 	log.WithField("file", file).WithField("workdir", dir).Info("creating fpm archive")
 	var options = basicOptions(ctx, dir, format, arch, file)
 
-	bindir := "/usr/local/bin"
-	if ctx.Config.FPM.Bindir != "" {
-		bindir = ctx.Config.FPM.Bindir
-	}
-
 	for _, binary := range binaries {
 		// This basically tells fpm to put the binary in the bindir, e.g. /usr/local/bin
 		// binary=/usr/local/bin/binary
@@ -89,7 +84,7 @@ func create(ctx *context.Context, format, folder, arch string, binaries []contex
 		options = append(options, fmt.Sprintf(
 			"%s=%s",
 			binary.Path,
-			filepath.Join(bindir, binary.Name),
+			filepath.Join(ctx.Config.FPM.Bindir, binary.Name),
 		))
 	}
 


### PR DESCRIPTION
Some packagers may want to put binaries in a location other than
/usr/local/bin. This allows one to override the destination for
binaries when using fpm, using the `fpm.bindir` config key.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] `make ci` passes on my machine.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

