### PR TITLE
feat: support environment variables on ldflags

### DIFF
--- a/docs/000-introduction.md
+++ b/docs/000-introduction.md
@@ -22,5 +22,5 @@ that and rewrote the whole thing in Go.
 There are three ways to get going.
 
 1. Install Goreleaser via go get (`goreleaser` command will be globally available) `go get github.com/goreleaser/goreleaser`
-2. On a Mac use [Homebrew](https://github.com/goreleaser/homebrew-tap).
-3. Install directly [from the binaries](https://github.com/goreleaser/goreleaser/releases/latest).
+1. On a Mac use [Homebrew](https://github.com/goreleaser/homebrew-tap).
+1. Install directly [from the binaries](https://github.com/goreleaser/goreleaser/releases/latest).

--- a/docs/040-project.md
+++ b/docs/040-project.md
@@ -5,7 +5,6 @@ title: Project Name
 The project name is used in the name of the Brew formula, archives, etc.
 If none is given, it will be inferred from the name of the Git project.
 
-
 ```yaml
 # .goreleaser.yml
 project_name: myproject

--- a/docs/050-build.md
+++ b/docs/050-build.md
@@ -78,3 +78,19 @@ builds:
       pre: rice embed-go
       post: ./script.sh
 ```
+
+## Passing environment variables to ldflags
+
+You can do that by using `{{ .Env.VARIABLE_NAME }}` in the template, for
+example:
+
+```yaml
+builds:
+  - ldflags: -s -w -X "main.goversion={{.Env.GOVERSION}}"
+```
+
+Then you can run:
+
+```console
+GOVERSION=$(go version) goreleaser
+```

--- a/pipeline/build/ldflags.go
+++ b/pipeline/build/ldflags.go
@@ -2,6 +2,8 @@ package build
 
 import (
 	"bytes"
+	"os"
+	"strings"
 	"text/template"
 	"time"
 
@@ -14,6 +16,7 @@ type ldflagsData struct {
 	Tag     string
 	Commit  string
 	Version string
+	Env     map[string]string
 }
 
 func ldflags(ctx *context.Context, build config.Build) (string, error) {
@@ -22,6 +25,7 @@ func ldflags(ctx *context.Context, build config.Build) (string, error) {
 		Tag:     ctx.Git.CurrentTag,
 		Version: ctx.Version,
 		Date:    time.Now().UTC().Format(time.RFC3339),
+		Env:     loadEnvs(),
 	}
 	var out bytes.Buffer
 	t, err := template.New("ldflags").Parse(build.Ldflags)
@@ -30,4 +34,13 @@ func ldflags(ctx *context.Context, build config.Build) (string, error) {
 	}
 	err = t.Execute(&out, data)
 	return out.String(), err
+}
+
+func loadEnvs() map[string]string {
+	r := map[string]string{}
+	for _, e := range os.Environ() {
+		env := strings.Split(e, "=")
+		r[env[0]] = env[1]
+	}
+	return r
 }

--- a/pipeline/build/ldflags_test.go
+++ b/pipeline/build/ldflags_test.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"os"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/config"
@@ -12,10 +13,12 @@ func TestLdFlagsFullTemplate(t *testing.T) {
 	var config = config.Project{
 		Builds: []config.Build{
 			{
-				Ldflags: "-s -w -X main.version={{.Version}} -X main.tag={{.Tag}} -X main.date={{.Date}} -X main.commit={{.Commit}}",
+				Ldflags: `-s -w -X main.version={{.Version}} -X main.tag={{.Tag}} -X main.date={{.Date}} -X main.commit={{.Commit}} -X "main.foo={{.Env.FOO}}"`,
 			},
 		},
 	}
+	os.Setenv("FOO", "123")
+	defer os.Unsetenv("FOO")
 	var ctx = &context.Context{
 		Git: context.GitInfo{
 			CurrentTag: "v1.2.3",
@@ -31,6 +34,7 @@ func TestLdFlagsFullTemplate(t *testing.T) {
 	assert.Contains(t, flags, "-X main.tag=v1.2.3")
 	assert.Contains(t, flags, "-X main.commit=123")
 	assert.Contains(t, flags, "-X main.date=")
+	assert.Contains(t, flags, `-X "main.foo=123"`)
 }
 
 func TestInvalidTemplate(t *testing.T) {


### PR DESCRIPTION
Supports passing environment variables to ldflags by using .Env.VARNAME.

Closes #426

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] `make ci` passes on my machine.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

