### PR TITLE
feat: env vars for Docker tag_template

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -8,6 +8,7 @@ package context
 
 import (
 	ctx "context"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -31,6 +32,7 @@ type Binary struct {
 type Context struct {
 	ctx.Context
 	Config       config.Project
+	Env          map[string]string
 	Token        string
 	Git          GitInfo
 	Binaries     map[string]map[string][]Binary
@@ -96,6 +98,16 @@ func New(config config.Project) *Context {
 	return &Context{
 		Context:     ctx.Background(),
 		Config:      config,
+		Env:         splitEnv(os.Environ()),
 		Parallelism: 4,
 	}
+}
+
+func splitEnv(env []string) map[string]string {
+	r := map[string]string{}
+	for _, e := range env {
+		p := strings.SplitN(e, "=", 2)
+		r[p[0]] = p[1]
+	}
+	return r
 }

--- a/docs/130-docker.md
+++ b/docs/130-docker.md
@@ -51,7 +51,7 @@ dockers:
     # Path to the Dockerfile (from the project root).
     dockerfile: Dockerfile
     # Template of the docker tag. Defaults to `{{ .Version }}`. Other allowed
-    # fields are `.Tag`.
+    # fields are `.Tag` and `.Env.VARIABLE_NAME`.
     tag_template: "{{ .Tag }}"
     # Also tag and push myuser/myimage:latest.
     latest: true
@@ -64,3 +64,20 @@ dockers:
 These settings should allow you to generate multiple Docker images,
 for example, using multiple `FROM` statements,
 as well as generate one image for each binary in your project.
+
+## Passing environment variables to tag_template
+
+You can do that by using `{{ .Env.VARIABLE_NAME }}` in the template, for
+example:
+
+```yaml
+dockers:
+  -
+    tag_template: "{{ .Tag }}-{{ .Env.GOVERSION_NR }}"
+```
+
+Then you can run:
+
+```console
+GOVERSION_NR=$(go version | awk '{print $3}') goreleaser
+```

--- a/pipeline/build/ldflags.go
+++ b/pipeline/build/ldflags.go
@@ -2,8 +2,6 @@ package build
 
 import (
 	"bytes"
-	"os"
-	"strings"
 	"text/template"
 	"time"
 
@@ -25,7 +23,7 @@ func ldflags(ctx *context.Context, build config.Build) (string, error) {
 		Tag:     ctx.Git.CurrentTag,
 		Version: ctx.Version,
 		Date:    time.Now().UTC().Format(time.RFC3339),
-		Env:     loadEnvs(),
+		Env:     ctx.Env,
 	}
 	var out bytes.Buffer
 	t, err := template.New("ldflags").Parse(build.Ldflags)
@@ -34,13 +32,4 @@ func ldflags(ctx *context.Context, build config.Build) (string, error) {
 	}
 	err = t.Execute(&out, data)
 	return out.String(), err
-}
-
-func loadEnvs() map[string]string {
-	r := map[string]string{}
-	for _, e := range os.Environ() {
-		env := strings.SplitN(e, "=", 2)
-		r[env[0]] = env[1]
-	}
-	return r
 }

--- a/pipeline/build/ldflags.go
+++ b/pipeline/build/ldflags.go
@@ -39,7 +39,7 @@ func ldflags(ctx *context.Context, build config.Build) (string, error) {
 func loadEnvs() map[string]string {
 	r := map[string]string{}
 	for _, e := range os.Environ() {
-		env := strings.Split(e, "=")
+		env := strings.SplitN(e, "=", 2)
 		r[env[0]] = env[1]
 	}
 	return r

--- a/pipeline/build/ldflags_test.go
+++ b/pipeline/build/ldflags_test.go
@@ -1,7 +1,6 @@
 package build
 
 import (
-	"os"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/config"
@@ -17,8 +16,6 @@ func TestLdFlagsFullTemplate(t *testing.T) {
 			},
 		},
 	}
-	os.Setenv("FOO", "123")
-	defer os.Unsetenv("FOO")
 	var ctx = &context.Context{
 		Git: context.GitInfo{
 			CurrentTag: "v1.2.3",
@@ -26,6 +23,7 @@ func TestLdFlagsFullTemplate(t *testing.T) {
 		},
 		Version: "1.2.3",
 		Config:  config,
+		Env:     map[string]string{"FOO": "123"},
 	}
 	flags, err := ldflags(ctx, ctx.Config.Builds[0])
 	assert.NoError(t, err)

--- a/pipeline/docker/docker.go
+++ b/pipeline/docker/docker.go
@@ -95,9 +95,11 @@ func tagName(ctx *context.Context, docker config.Docker) (string, error) {
 	}
 	data := struct {
 		Version, Tag string
+		Env          map[string]string
 	}{
 		Version: ctx.Version,
 		Tag:     ctx.Git.CurrentTag,
+		Env:     ctx.Env,
 	}
 	err = t.Execute(&out, data)
 	return out.String(), err

--- a/pipeline/docker/docker_test.go
+++ b/pipeline/docker/docker_test.go
@@ -53,7 +53,7 @@ func TestRunPipe(t *testing.T) {
 				Dockerfile:  "testdata/Dockerfile",
 				Binary:      "mybin",
 				Latest:      true,
-				TagTemplate: "{{.Tag}}",
+				TagTemplate: "{{.Tag}}-{{.Env.FOO}}",
 			},
 			err: "",
 		},
@@ -82,7 +82,7 @@ func TestRunPipe(t *testing.T) {
 		},
 	}
 	var images = []string{
-		"localhost:5000/goreleaser/test_run_pipe:v1.0.0",
+		"localhost:5000/goreleaser/test_run_pipe:v1.0.0-123",
 		"localhost:5000/goreleaser/test_run_pipe:latest",
 	}
 	// this might fail as the image doesnt exist yet, so lets ignore the error
@@ -105,6 +105,7 @@ func TestRunPipe(t *testing.T) {
 						docker.docker,
 					},
 				},
+				Env: map[string]string{"FOO": "123"},
 			}
 			for _, plat := range []string{"linuxamd64", "linux386", "darwinamd64"} {
 				ctx.AddBinary(plat, "mybin", "mybin", binPath)


### PR DESCRIPTION
* fix `loadEnv()` function to split env vars only into two pars
* move env vars into `context.Context`
* add env var support for Docker `tag_template`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [ ] `make ci` passes on my machine. (fpm not installed)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
