### PR TITLE
fix: do not decorate git log output

### DIFF
--- a/pipeline/changelog/changelog.go
+++ b/pipeline/changelog/changelog.go
@@ -124,7 +124,7 @@ func getChangelog(tag string) (string, error) {
 }
 
 func gitLog(refs ...string) (string, error) {
-	var args = []string{"log", "--pretty=oneline", "--abbrev-commit"}
+	var args = []string{"log", "--pretty=oneline", "--abbrev-commit", "--no-decorate"}
 	args = append(args, refs...)
 	return git.Run(args...)
 }


### PR DESCRIPTION
Ensure that the git log output is not decorated. Otherwise, the format
changes and the tests fail.

Fixes #439

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [ ] `make ci` passes on my machine.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

