### PR TITLE
chore: push docs to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ deploy:
   github_token: $GITHUB_TOKEN
   repo: goreleaser/goreleaser.github.io
   local_dir: ./dist/goreleaser.github.io
+  target_branch: master
   on:
-    # TODO: change this to tags
-    branch: master
+    tags: true
 notifications:
   email: false


### PR DESCRIPTION
Docs are using master instead of gh-pages.

refs #378 