### PR TITLE
fix: remove brew taps listing from release notes

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -38,7 +38,6 @@ type Context struct {
 	Binaries     map[string]map[string][]Binary
 	Artifacts    []string
 	Dockers      []string
-	Brews        []string
 	ReleaseNotes string
 	Version      string
 	Validate     bool
@@ -53,7 +52,6 @@ var (
 	artifactsLock sync.Mutex
 	dockersLock   sync.Mutex
 	binariesLock  sync.Mutex
-	brewsLock     sync.Mutex
 )
 
 // AddArtifact adds a file to upload list
@@ -63,14 +61,6 @@ func (ctx *Context) AddArtifact(file string) {
 	file = strings.TrimPrefix(file, ctx.Config.Dist+string(filepath.Separator))
 	ctx.Artifacts = append(ctx.Artifacts, file)
 	log.WithField("artifact", file).Info("new release artifact")
-}
-
-// AddBrew adds a brew tap to the brews list
-func (ctx *Context) AddBrew(tap string) {
-	brewsLock.Lock()
-	defer brewsLock.Unlock()
-	ctx.Brews = append(ctx.Brews, tap)
-	log.WithField("tap", tap).Info("new brew tap")
 }
 
 // AddDocker adds a docker image to the docker images list

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -20,10 +20,6 @@ func TestMultipleAdds(t *testing.T) {
 		"c/d:2.0.0",
 		"e/f:3.0.0",
 	}
-	var brews = []string{
-		"foo/tap/foo",
-		"bar/bar/bar",
-	}
 	var ctx = New(config.Project{
 		Dist: "dist",
 	})
@@ -44,20 +40,10 @@ func TestMultipleAdds(t *testing.T) {
 		})
 	}
 	assert.NoError(t, g.Wait())
-	for _, b := range brews {
-		b := b
-		g.Go(func() error {
-			ctx.AddBrew(b)
-			return nil
-		})
-	}
-	assert.NoError(t, g.Wait())
 	assert.Len(t, ctx.Artifacts, len(artifacts))
 	assert.Contains(t, ctx.Artifacts, "a", "b", "c", "d")
 	assert.Len(t, ctx.Dockers, len(dockerfiles))
 	assert.Contains(t, ctx.Dockers, "a/b:1.0.0", "c/d:2.0.0", "e/f:3.0.0")
-	assert.Len(t, ctx.Brews, len(brews))
-	assert.Contains(t, ctx.Brews, "foo/tap/foo", "bar/bar/bar")
 }
 
 func TestMultipleBinaryAdds(t *testing.T) {

--- a/pipeline/brew/brew.go
+++ b/pipeline/brew/brew.go
@@ -115,19 +115,7 @@ func doRun(ctx *context.Context, client client.Client) error {
 	if err != nil {
 		return err
 	}
-	ctx.AddBrew(brewTapPath(ctx))
 	return client.CreateFile(ctx, content, path)
-}
-
-func brewTapPath(ctx *context.Context) string {
-	return strings.Join(
-		[]string{
-			ctx.Config.Brew.GitHub.Owner,
-			strings.TrimPrefix(ctx.Config.Brew.GitHub.Name, "homebrew-"),
-			ctx.Config.ProjectName,
-		},
-		"/",
-	)
 }
 
 func buildFormula(ctx *context.Context, client client.Client, folder string) (bytes.Buffer, error) {

--- a/pipeline/brew/brew_test.go
+++ b/pipeline/brew/brew_test.go
@@ -139,8 +139,6 @@ func TestRunPipe(t *testing.T) {
 	// ioutil.WriteFile("testdata/run_pipe.rb", []byte(client.Content), 0644)
 
 	assert.Equal(t, string(bts), client.Content)
-
-	assert.Equal(t, "test/test/run-pipe", ctx.Brews[0])
 }
 
 func TestRunPipeFormatOverride(t *testing.T) {
@@ -302,20 +300,6 @@ func TestDefault(t *testing.T) {
 	assert.NotEmpty(t, ctx.Config.Brew.CommitAuthor.Name)
 	assert.NotEmpty(t, ctx.Config.Brew.CommitAuthor.Email)
 	assert.Equal(t, `bin.install "foo"`, ctx.Config.Brew.Install)
-}
-
-func TestBrewTapPath(t *testing.T) {
-	assert.Equal(t, "goreleaser/tap/goreleaser", brewTapPath(&context.Context{
-		Config: config.Project{
-			ProjectName: "goreleaser",
-			Brew: config.Homebrew{
-				GitHub: config.Repo{
-					Owner: "goreleaser",
-					Name:  "homebrew-tap",
-				},
-			},
-		},
-	}))
 }
 
 type DummyClient struct {

--- a/pipeline/release/body.go
+++ b/pipeline/release/body.go
@@ -18,14 +18,6 @@ const bodyTemplate = `{{ .ReleaseNotes }}
 {{- end -}}
 {{- end }}
 
-{{- if .Brews }}
-
-## Homebrew taps
-{{ range $element := .Brews }}
-- ` + "`brew install {{ . -}}`" + `
-{{- end -}}
-{{- end }}
-
 ---
 Automated with [GoReleaser](https://github.com/goreleaser)
 Built with {{ .GoVersion }}`
@@ -45,12 +37,10 @@ func describeBodyVersion(ctx *context.Context, version string) (bytes.Buffer, er
 	err := template.Execute(&out, struct {
 		ReleaseNotes, GoVersion string
 		DockerImages            []string
-		Brews                   []string
 	}{
 		ReleaseNotes: ctx.ReleaseNotes,
 		GoVersion:    version,
 		DockerImages: ctx.Dockers,
-		Brews:        ctx.Brews,
 	})
 	return out, err
 }

--- a/pipeline/release/body_test.go
+++ b/pipeline/release/body_test.go
@@ -18,10 +18,6 @@ func TestDescribeBody(t *testing.T) {
 			"goreleaser/goreleaser:latest",
 			"goreleaser/godownloader:v0.1.0",
 		},
-		Brews: []string{
-			"caarlos0/tap/foo",
-			"goreleaser/tap/bar",
-		},
 	}
 	out, err := describeBodyVersion(ctx, "go version go1.9 darwin/amd64")
 	assert.NoError(t, err)

--- a/pipeline/release/testdata/release1.txt
+++ b/pipeline/release/testdata/release1.txt
@@ -8,11 +8,6 @@ feature2: other description
 - `docker pull goreleaser/goreleaser:latest`
 - `docker pull goreleaser/godownloader:v0.1.0`
 
-## Homebrew taps
-
-- `brew install caarlos0/tap/foo`
-- `brew install goreleaser/tap/bar`
-
 ---
 Automated with [GoReleaser](https://github.com/goreleaser)
 Built with go version go1.9 darwin/amd64


### PR DESCRIPTION
It never worked, because the brew pipe is the last
to run.

Either way, it is not a really useful thing to
have I think.

yeah, I'm literally fixing a bug by removing the feature 🎉 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] `make ci` passes on my machine.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

