### PR TITLE
feat: write the effective config to ./dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist/
+!pipeline/dist
 vendor
 coverage.txt
 goreleaser

--- a/goreleaserlib/goreleaser.go
+++ b/goreleaserlib/goreleaser.go
@@ -40,8 +40,8 @@ func init() {
 var pipes = []pipeline.Piper{
 	defaults.Pipe{},        // load default configs
 	dist.Pipe{},            // ensure ./dist is clean
-	effectiveconfig.Pipe{}, // writes the actual config (with defaults et al set) to dist
 	git.Pipe{},             // get and validate git repo state
+	effectiveconfig.Pipe{}, // writes the actual config (with defaults et al set) to dist
 	changelog.Pipe{},       // builds the release changelog
 	env.Pipe{},             // load and validate environment variables
 	build.Pipe{},           // build

--- a/goreleaserlib/goreleaser.go
+++ b/goreleaserlib/goreleaser.go
@@ -16,10 +16,11 @@ import (
 	"github.com/goreleaser/goreleaser/pipeline/build"
 	"github.com/goreleaser/goreleaser/pipeline/changelog"
 	"github.com/goreleaser/goreleaser/pipeline/checksums"
-	"github.com/goreleaser/goreleaser/pipeline/cleandist"
 	"github.com/goreleaser/goreleaser/pipeline/defaults"
+	"github.com/goreleaser/goreleaser/pipeline/dist"
 	"github.com/goreleaser/goreleaser/pipeline/docker"
 	"github.com/goreleaser/goreleaser/pipeline/env"
+	"github.com/goreleaser/goreleaser/pipeline/finalconfig"
 	"github.com/goreleaser/goreleaser/pipeline/fpm"
 	"github.com/goreleaser/goreleaser/pipeline/git"
 	"github.com/goreleaser/goreleaser/pipeline/release"
@@ -37,19 +38,20 @@ func init() {
 }
 
 var pipes = []pipeline.Piper{
-	defaults.Pipe{},  // load default configs
-	git.Pipe{},       // get and validate git repo state
-	changelog.Pipe{}, // builds the release changelog
-	env.Pipe{},       // load and validate environment variables
-	cleandist.Pipe{}, // ensure ./dist is clean
-	build.Pipe{},     // build
-	archive.Pipe{},   // archive (tar.gz, zip, etc)
-	fpm.Pipe{},       // archive via fpm (deb, rpm, etc)
-	snapcraft.Pipe{}, // archive via snapcraft (snap)
-	checksums.Pipe{}, // checksums of the files
-	docker.Pipe{},    // create and push docker images
-	release.Pipe{},   // release to github
-	brew.Pipe{},      // push to brew tap
+	defaults.Pipe{},    // load default configs
+	dist.Pipe{},        // ensure ./dist is clean
+	finalconfig.Pipe{}, // writes the actual config (with defaults et al set) to dist
+	git.Pipe{},         // get and validate git repo state
+	changelog.Pipe{},   // builds the release changelog
+	env.Pipe{},         // load and validate environment variables
+	build.Pipe{},       // build
+	archive.Pipe{},     // archive (tar.gz, zip, etc)
+	fpm.Pipe{},         // archive via fpm (deb, rpm, etc)
+	snapcraft.Pipe{},   // archive via snapcraft (snap)
+	checksums.Pipe{},   // checksums of the files
+	docker.Pipe{},      // create and push docker images
+	release.Pipe{},     // release to github
+	brew.Pipe{},        // push to brew tap
 }
 
 // Flags interface represents an extractor of cli flags

--- a/goreleaserlib/goreleaser.go
+++ b/goreleaserlib/goreleaser.go
@@ -19,8 +19,8 @@ import (
 	"github.com/goreleaser/goreleaser/pipeline/defaults"
 	"github.com/goreleaser/goreleaser/pipeline/dist"
 	"github.com/goreleaser/goreleaser/pipeline/docker"
+	"github.com/goreleaser/goreleaser/pipeline/effectiveconfig"
 	"github.com/goreleaser/goreleaser/pipeline/env"
-	"github.com/goreleaser/goreleaser/pipeline/finalconfig"
 	"github.com/goreleaser/goreleaser/pipeline/fpm"
 	"github.com/goreleaser/goreleaser/pipeline/git"
 	"github.com/goreleaser/goreleaser/pipeline/release"
@@ -38,20 +38,20 @@ func init() {
 }
 
 var pipes = []pipeline.Piper{
-	defaults.Pipe{},    // load default configs
-	dist.Pipe{},        // ensure ./dist is clean
-	finalconfig.Pipe{}, // writes the actual config (with defaults et al set) to dist
-	git.Pipe{},         // get and validate git repo state
-	changelog.Pipe{},   // builds the release changelog
-	env.Pipe{},         // load and validate environment variables
-	build.Pipe{},       // build
-	archive.Pipe{},     // archive (tar.gz, zip, etc)
-	fpm.Pipe{},         // archive via fpm (deb, rpm, etc)
-	snapcraft.Pipe{},   // archive via snapcraft (snap)
-	checksums.Pipe{},   // checksums of the files
-	docker.Pipe{},      // create and push docker images
-	release.Pipe{},     // release to github
-	brew.Pipe{},        // push to brew tap
+	defaults.Pipe{},        // load default configs
+	dist.Pipe{},            // ensure ./dist is clean
+	effectiveconfig.Pipe{}, // writes the actual config (with defaults et al set) to dist
+	git.Pipe{},             // get and validate git repo state
+	changelog.Pipe{},       // builds the release changelog
+	env.Pipe{},             // load and validate environment variables
+	build.Pipe{},           // build
+	archive.Pipe{},         // archive (tar.gz, zip, etc)
+	fpm.Pipe{},             // archive via fpm (deb, rpm, etc)
+	snapcraft.Pipe{},       // archive via snapcraft (snap)
+	checksums.Pipe{},       // checksums of the files
+	docker.Pipe{},          // create and push docker images
+	release.Pipe{},         // release to github
+	brew.Pipe{},            // push to brew tap
 }
 
 // Flags interface represents an extractor of cli flags

--- a/pipeline/defaults/defaults.go
+++ b/pipeline/defaults/defaults.go
@@ -48,6 +48,6 @@ func (Pipe) Run(ctx *context.Context) error {
 	if ctx.Config.ProjectName == "" {
 		ctx.Config.ProjectName = ctx.Config.Release.GitHub.Name
 	}
-	log.WithField("config", ctx.Config).Debug("defaults set")
 	return nil
 }
+

--- a/pipeline/defaults/defaults.go
+++ b/pipeline/defaults/defaults.go
@@ -16,7 +16,7 @@ import (
 	"github.com/goreleaser/goreleaser/pipeline/snapshot"
 )
 
-// Pipe for brew deployment
+// Pipe that sets the defaults
 type Pipe struct{}
 
 func (Pipe) String() string {
@@ -50,4 +50,3 @@ func (Pipe) Run(ctx *context.Context) error {
 	}
 	return nil
 }
-

--- a/pipeline/dist/dist.go
+++ b/pipeline/dist/dist.go
@@ -1,6 +1,6 @@
-// Package cleandist provides checks to make sure the dist folder is always
+// Package dist provides checks to make sure the dist folder is always
 // empty.
-package cleandist
+package dist
 
 import (
 	"fmt"
@@ -22,12 +22,16 @@ func (Pipe) String() string {
 func (Pipe) Run(ctx *context.Context) (err error) {
 	_, err = os.Stat(ctx.Config.Dist)
 	if os.IsNotExist(err) {
-		log.Debug("./dist doesn't exist, moving on")
-		return nil
+		log.Debug("./dist doesn't exist, creating empty folder")
+		return mkdir(ctx)
 	}
 	if ctx.RmDist {
-		log.Info("--rm-dist is set, removing ./dist")
-		return os.RemoveAll(ctx.Config.Dist)
+		log.Info("--rm-dist is set, cleaning it up")
+		err = os.RemoveAll(ctx.Config.Dist)
+		if err == nil {
+			err = mkdir(ctx)
+		}
+		return err
 	}
 	files, err := ioutil.ReadDir(ctx.Config.Dist)
 	if err != nil {
@@ -41,5 +45,9 @@ func (Pipe) Run(ctx *context.Context) (err error) {
 		)
 	}
 	log.Debug("./dist is empty")
-	return
+	return mkdir(ctx)
+}
+
+func mkdir(ctx *context.Context) error {
+	return os.Mkdir(ctx.Config.Dist, 0755)
 }

--- a/pipeline/dist/dist.go
+++ b/pipeline/dist/dist.go
@@ -49,5 +49,6 @@ func (Pipe) Run(ctx *context.Context) (err error) {
 }
 
 func mkdir(ctx *context.Context) error {
+	// #nosec
 	return os.MkdirAll(ctx.Config.Dist, 0755)
 }

--- a/pipeline/dist/dist.go
+++ b/pipeline/dist/dist.go
@@ -49,5 +49,5 @@ func (Pipe) Run(ctx *context.Context) (err error) {
 }
 
 func mkdir(ctx *context.Context) error {
-	return os.Mkdir(ctx.Config.Dist, 0755)
+	return os.MkdirAll(ctx.Config.Dist, 0755)
 }

--- a/pipeline/dist/dist_test.go
+++ b/pipeline/dist/dist_test.go
@@ -12,12 +12,15 @@ import (
 )
 
 func TestDistDoesNotExist(t *testing.T) {
+	folder, err := ioutil.TempDir("", "disttest")
+	assert.NoError(t, err)
+	var dist = filepath.Join(folder, "dist")
 	assert.NoError(
 		t,
 		Pipe{}.Run(
 			&context.Context{
 				Config: config.Project{
-					Dist: "/wtf-this-shouldnt-exist",
+					Dist: dist,
 				},
 			},
 		),
@@ -55,7 +58,7 @@ func TestEmptyDistExists(t *testing.T) {
 	}
 	assert.NoError(t, Pipe{}.Run(ctx))
 	_, err = os.Stat(dist)
-	assert.False(t, os.IsExist(err))
+	assert.False(t, os.IsNotExist(err))
 }
 
 func TestDescription(t *testing.T) {

--- a/pipeline/dist/dist_test.go
+++ b/pipeline/dist/dist_test.go
@@ -1,4 +1,4 @@
-package cleandist
+package dist
 
 import (
 	"io/ioutil"

--- a/pipeline/effectiveconfig/config.go
+++ b/pipeline/effectiveconfig/config.go
@@ -1,4 +1,4 @@
-package finalconfig
+package effectiveconfig
 
 import (
 	"io/ioutil"
@@ -9,19 +9,21 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+// Pipe that writes the effective config file to dist
 type Pipe struct {
 }
 
 func (Pipe) String() string {
-	return "writing the final config file to dist folder"
+	return "writing effective config file"
 }
 
+// Run the pipe
 func (Pipe) Run(ctx *context.Context) (err error) {
 	var path = filepath.Join(ctx.Config.Dist, "config.yaml")
 	bts, err := yaml.Marshal(ctx.Config)
 	if err != nil {
 		return err
 	}
-	log.WithField("path", path).Info("writting")
+	log.WithField("config", path).Info("writting")
 	return ioutil.WriteFile(path, bts, 0644)
 }

--- a/pipeline/effectiveconfig/config_test.go
+++ b/pipeline/effectiveconfig/config_test.go
@@ -1,0 +1,33 @@
+package effectiveconfig
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/goreleaser/goreleaser/config"
+	"github.com/goreleaser/goreleaser/context"
+	"github.com/goreleaser/goreleaser/internal/testlib"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPipeDescription(t *testing.T) {
+	assert.NotEmpty(t, Pipe{}.String())
+}
+
+func Test(t *testing.T) {
+	folder, back := testlib.Mktmp(t)
+	defer back()
+	dist := filepath.Join(folder, "dist")
+	assert.NoError(t, os.Mkdir(dist, 0755))
+	var ctx = context.New(
+		config.Project{
+			Dist: dist,
+		},
+	)
+	assert.NoError(t, Pipe{}.Run(ctx))
+	bts, err := ioutil.ReadFile(filepath.Join(dist, "config.yaml"))
+	assert.NoError(t, err)
+	assert.NotEmpty(t, string(bts))
+}

--- a/pipeline/finalconfig/finalconfig.go
+++ b/pipeline/finalconfig/finalconfig.go
@@ -1,0 +1,27 @@
+package finalconfig
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/apex/log"
+	"github.com/goreleaser/goreleaser/context"
+	yaml "gopkg.in/yaml.v2"
+)
+
+type Pipe struct {
+}
+
+func (Pipe) String() string {
+	return "writing the final config file to dist folder"
+}
+
+func (Pipe) Run(ctx *context.Context) (err error) {
+	var path = filepath.Join(ctx.Config.Dist, "config.yaml")
+	bts, err := yaml.Marshal(ctx.Config)
+	if err != nil {
+		return err
+	}
+	log.WithField("path", path).Info("writting")
+	return ioutil.WriteFile(path, bts, 0644)
+}


### PR DESCRIPTION
Writes the actual config file (with defaults
merged, etc) into the dist folder.

Can be useful for debug purposes.

refs #419

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] `make ci` passes on my machine.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

