### PR TITLE
feat: allow env vars for checksum name_template

### DIFF
--- a/docs/070-checksum.md
+++ b/docs/070-checksum.md
@@ -16,6 +16,7 @@ checksum:
   # - ProjectName
   # - Tag
   # - Version (Git tag without `v` prefix)
+  # - Env (environment variables)
   # Default is `{{ .ProjectName }}_{{ .Version }}_checksums.txt`.
   name_template: "{{ .ProjectName }}_checksums.txt"
 ```

--- a/pipeline/checksums/name.go
+++ b/pipeline/checksums/name.go
@@ -14,11 +14,15 @@ func filenameFor(ctx *context.Context) (string, error) {
 		return "", err
 	}
 	err = t.Execute(&out, struct {
-		ProjectName, Tag, Version string
+		ProjectName string
+		Tag         string
+		Version     string
+		Env         map[string]string
 	}{
 		ProjectName: ctx.Config.ProjectName,
 		Tag:         ctx.Git.CurrentTag,
 		Version:     ctx.Version,
+		Env:         ctx.Env,
 	})
 	return out.String(), err
 }


### PR DESCRIPTION
Allow env vars for the checksum name_template.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] I have read the **CONTRIBUTING** document.
* [ ] `make ci` passes on my machine.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
