### PR TITLE
feat: docker - added linker for extra directories

### DIFF
--- a/pipeline/docker/docker_test.go
+++ b/pipeline/docker/docker_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/pipeline"
 	"github.com/stretchr/testify/assert"
+	"syscall"
 )
 
 func killAndRm(t *testing.T) {
@@ -235,4 +236,61 @@ func TestDefaultSet(t *testing.T) {
 	assert.Equal(t, "bar", docker.Binary)
 	assert.Equal(t, "{{ .Version }}", docker.TagTemplate)
 	assert.Equal(t, "Dockerfile.foo", docker.Dockerfile)
+}
+
+func TestLinkFile(t *testing.T) {
+	const srcFile = "/tmp/test"
+	const dstFile = "/tmp/linked"
+	err := ioutil.WriteFile(srcFile, []byte("foo"), 0644)
+	if err != nil {
+		t.Log("Cannot setup test file")
+		t.Fail()
+	}
+	err = link(srcFile, dstFile)
+	if err != nil {
+		t.Log("Failed to link: ", err)
+		t.Fail()
+	}
+	if inode(srcFile) != inode(dstFile) {
+		t.Log("Inodes do not match, destination file is not a link")
+		t.Fail()
+	}
+	// cleanup
+	os.Remove(srcFile)
+	os.Remove(dstFile)
+}
+
+func TestLinkDirectory(t *testing.T) {
+	const srcDir = "/tmp/testdir"
+	const testFile = "test"
+	const dstDir = "/tmp/linkedDir"
+
+	os.Mkdir(srcDir, 0755)
+	err := ioutil.WriteFile(srcDir+"/"+testFile, []byte("foo"), 0644)
+	if err != nil {
+		t.Log("Cannot setup test file")
+		t.Fail()
+	}
+	err = directoryLink(srcDir, dstDir, nil)
+	if err != nil {
+		t.Log("Failed to link: ", err)
+		t.Fail()
+	}
+	if inode(srcDir+"/"+testFile) != inode(dstDir+"/"+testFile) {
+		t.Log("Inodes do not match, destination file is not a link")
+		t.Fail()
+	}
+
+	// cleanup
+	os.RemoveAll(srcDir)
+	os.RemoveAll(dstDir)
+}
+
+func inode(file string) uint64 {
+	fileInfo, err := os.Stat(file)
+	if err != nil {
+		return 0
+	}
+	stat := fileInfo.Sys().(*syscall.Stat_t)
+	return stat.Ino
 }

--- a/pipeline/docker/docker_test.go
+++ b/pipeline/docker/docker_test.go
@@ -286,6 +286,42 @@ func TestLinkDirectory(t *testing.T) {
 	os.RemoveAll(dstDir)
 }
 
+func TestLinkTwoLevelDirectory(t *testing.T) {
+	const srcDir = "/tmp/testdir"
+	const srcLevel2 = srcDir+"/level2"
+	const testFile = "test"
+	const dstDir = "/tmp/linkedDir"
+
+	os.Mkdir(srcDir, 0755)
+	os.Mkdir(srcLevel2, 0755)
+	err := ioutil.WriteFile(srcDir+"/"+testFile, []byte("foo"), 0644)
+	if err != nil {
+		t.Log("Cannot setup test file")
+		t.Fail()
+	}
+	err = ioutil.WriteFile(srcLevel2+"/"+testFile, []byte("foo"), 0644)
+	if err != nil {
+		t.Log("Cannot setup test file")
+		t.Fail()
+	}
+	err = directoryLink(srcDir, dstDir, nil)
+	if err != nil {
+		t.Log("Failed to link: ", err)
+		t.Fail()
+	}
+	if inode(srcDir+"/"+testFile) != inode(dstDir+"/"+testFile) {
+		t.Log("Inodes do not match")
+		t.Fail()
+	}
+	if inode(srcLevel2+"/"+testFile) != inode(dstDir+"/level2/"+testFile) {
+		t.Log("Inodes do not match")
+		t.Fail()
+	}
+	// cleanup
+	os.RemoveAll(srcDir)
+	os.RemoveAll(dstDir)
+}
+
 func inode(file string) uint64 {
 	fileInfo, err := os.Stat(file)
 	if err != nil {


### PR DESCRIPTION
## Types of changes

* [ ] Bug fix (non-breaking change which fixes an issue)
* [X] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] I have read the **CONTRIBUTING** document.
* [X] `make ci` passes on my machine.
* [X] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.

When adding extra files to docker using a hard link it is impossible
to add a directory because only files can be linked hard. For directories
I added a linker that recursively linkes all files in a directory and re-
creates the directory structure in the dist directory.
