### PR TITLE
fix: Typo in debug message for custom release notes

### DIFF
--- a/goreleaserlib/goreleaser.go
+++ b/goreleaserlib/goreleaser.go
@@ -101,7 +101,7 @@ func Release(flags Flags) error {
 			return err
 		}
 		log.WithField("file", notes).Info("loaded custom release notes")
-		log.WithField("file", notes).Debugf("custon release notes: \n%s", string(bts))
+		log.WithField("file", notes).Debugf("custom release notes: \n%s", string(bts))
 		ctx.ReleaseNotes = string(bts)
 	}
 	ctx.Snapshot = flags.Bool("snapshot")


### PR DESCRIPTION
When release notes are added via the --release-notes
and we run in debug mode, a message "custom release notes ..."
is logged. This message had a typo.

## Types of changes

* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] I have read the **CONTRIBUTING** document.
* [X] `make ci` passes on my machine.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
