### PR TITLE
fix: Typo in buildtarget

### DIFF
--- a/internal/buildtarget/buildtarget.go
+++ b/internal/buildtarget/buildtarget.go
@@ -5,10 +5,10 @@ import (
 	"runtime"
 )
 
-// Runtime is the current runtime buildTarget
+// Runtime is the current runtime build target
 var Runtime = Target{runtime.GOOS, runtime.GOARCH, ""}
 
-// New builtarget
+// New build Target
 func New(goos, goarch, goarm string) Target {
 	return Target{goos, goarch, goarm}
 }


### PR DESCRIPTION
The buildtarget contained a typo. This fixes it.

## Types of changes

* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] I have read the **CONTRIBUTING** document.
* [X] `make ci` passes on my machine.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
