### PR TITLE
fix: Fix segfault by catching all stat errors

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -161,8 +161,8 @@ func checkMain(ctx *context.Context, build config.Build) error {
 		main = "."
 	}
 	stat, ferr := os.Stat(main)
-	if os.IsNotExist(ferr) {
-		return errors.Wrapf(ferr, "could not open %s", main)
+	if ferr != nil {
+		return ferr
 	}
 	if stat.IsDir() {
 		packs, err := parser.ParseDir(token.NewFileSet(), main, nil, 0)

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -246,7 +246,7 @@ func TestRunPipeWithoutMainFunc(t *testing.T) {
 		ctx.Config.Builds[0].Main = "foo.go"
 		assert.EqualError(t, Default.Build(ctx, ctx.Config.Builds[0], api.Options{
 			Target: runtimeTarget,
-		}), `could not open foo.go: stat foo.go: no such file or directory`)
+		}), `stat foo.go: no such file or directory`)
 	})
 	t.Run("glob", func(t *testing.T) {
 		ctx.Config.Builds[0].Main = "."


### PR DESCRIPTION

When adding a line `main: siren/main.go` to the yaml config, but `siren` is an executable resulted in a segfault:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x7ca59a]
...
```

The reason is that the error returned from `stat()` is a `not a directory`, but the code only checked for `IsNotExists`. This PR changes the check to check for any error.

It also simplifies the error because the error got very weird in the "not a directory" case. This was the original:
```
   ⨯ release failed after 0.01s error=could not open foo/such.go: stat foo/such.go: no such file or directory
```
With this PR it is:
```
   ⨯ release failed after 0.01s error=stat foo/such.go: no such file or directory
```
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] I have read the **CONTRIBUTING** document.
* [x, but see note] `make ci` passes on my machine.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.

note: I don't have docker and other things needed to run `make ci`, but the basic go unittests pass. It also gives me this error:
```
--- FAIL: TestRunPipe_ArtifactoryDown (0.00s)
        Error Trace:    artifactory_test.go:329
	Error:      	Error message not equal:
	            	expected: "artifactory: upload failed: Put http://localhost:1234/example-repo-local/goreleaser/2.0.0/bin.tar.gz: dial tcp 127.0.0.1:1234: getsockopt: connection refused"
	            	actual  : "artifactory: upload failed: Put http://localhost:1234/example-repo-local/goreleaser/2.0.0/bin.tar.gz: dial tcp [::1]:1234: getsockopt: connection refused"
	Test:       	TestRunPipe_ArtifactoryDown
```