### PR TITLE
fix: snapcraft snap deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - sudo apt-get update
   - sudo apt-get install --yes snapd rpm
   - export PATH=/snap/bin:$PATH
-  - sudo snap install snapcraft --candidate --classic
+  - sudo snap install snapcraft --classic
 script:
   - make ci
   - test -n "$TRAVIS_TAG" || go run main.go --skip-validate --skip-publish

--- a/pipeline/snapcraft/snapcraft.go
+++ b/pipeline/snapcraft/snapcraft.go
@@ -163,7 +163,7 @@ func create(ctx *context.Context, arch string, binaries []artifact.Artifact) err
 
 	var snap = filepath.Join(ctx.Config.Dist, folder+".snap")
 	/* #nosec */
-	var cmd = exec.CommandContext(ctx, "snapcraft", "snap", primeDir, "--output", snap)
+	var cmd = exec.CommandContext(ctx, "snapcraft", "pack", primeDir, "--output", snap)
 	if out, err = cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to generate snap package: %s", string(out))
 	}


### PR DESCRIPTION
```
DEPRECATED: Use of the 'snap' command with a directory has been deprecated in favour of the 'pack' command.
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] I have read the **CONTRIBUTING** document.
* [ ] `make ci` passes on my machine.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
