### PR TITLE
fix: update brew template to use tilde heredoc syntax

### DIFF
--- a/pipeline/brew/template.go
+++ b/pipeline/brew/template.go
@@ -58,7 +58,7 @@ const formulaTemplate = `class {{ .Name }} < Formula
 
   plist_options :startup => false
 
-  def plist; <<-EOS.undent
+  def plist; <<~EOS
     {{ .Plist }}
     EOS
   end

--- a/pipeline/brew/testdata/run_pipe.rb.golden
+++ b/pipeline/brew/testdata/run_pipe.rb.golden
@@ -21,7 +21,7 @@ class RunPipe < Formula
 
   plist_options :startup => false
 
-  def plist; <<-EOS.undent
+  def plist; <<~EOS
     <xml>whatever</xml>
     EOS
   end

--- a/pipeline/brew/testdata/run_pipe_download_strategy.rb.golden
+++ b/pipeline/brew/testdata/run_pipe_download_strategy.rb.golden
@@ -21,7 +21,7 @@ class RunPipe < Formula
 
   plist_options :startup => false
 
-  def plist; <<-EOS.undent
+  def plist; <<~EOS
     <xml>whatever</xml>
     EOS
   end

--- a/pipeline/brew/testdata/run_pipe_enterprise.rb.golden
+++ b/pipeline/brew/testdata/run_pipe_enterprise.rb.golden
@@ -21,7 +21,7 @@ class RunPipe < Formula
 
   plist_options :startup => false
 
-  def plist; <<-EOS.undent
+  def plist; <<~EOS
     <xml>whatever</xml>
     EOS
   end

--- a/pipeline/brew/testdata/test.rb.golden
+++ b/pipeline/brew/testdata/test.rb.golden
@@ -20,7 +20,7 @@ class Test < Formula
 
   plist_options :startup => false
 
-  def plist; <<-EOS.undent
+  def plist; <<~EOS
     it works
     EOS
   end


### PR DESCRIPTION
brew recently deprecated the use of `<<-EOS.undent` in favor of `<<~EOS` (cf. https://github.com/Homebrew/brew/pull/3694/files#diff-d667e35be86b1a2b5d1f95ff39b4a878R3). This PR updates the brew template and test files to use the new syntax.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] I have read the **CONTRIBUTING** document.
* [x] `make ci` passes on my machine.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
