### PR TITLE
feat: nfpm support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,7 +54,7 @@ scoop:
   homepage:  https://goreleaser.com
   description: Deliver Go binaries as fast and easily as possible
   license: MIT
-fpm:
+nfpm:
   name_template: '{{ .ProjectName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
   homepage:  https://goreleaser.com
   description: Deliver Go binaries as fast and easily as possible

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -75,8 +75,8 @@
     "deb",
     "rpm"
   ]
-  revision = "4b73ac9428cd413b36fd962aa4fd9faf7ad9f179"
-  version = "v0.2.0"
+  revision = "8bbb5913ccde1ae01391be001b4c3de340ae57be"
+  version = "v0.3.0"
 
 [[projects]]
   name = "github.com/masterminds/semver"
@@ -142,7 +142,7 @@
     "context",
     "context/ctxhttp"
   ]
-  revision = "dc948dff8834a7fe1ca525f8d04e261c2b56e70d"
+  revision = "136a25c244d3019482a795d728110278d6ba09a4"
 
 [[projects]]
   branch = "master"
@@ -188,6 +188,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5bfb7f4991e958fe8f53a9dd255326b0010940d2c245227b28f37a9883696dfe"
+  inputs-digest = "e285c44ad7f186982ec9664758175370a3d8f710ef20e665dcdb993dbea7f4cf"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -75,8 +75,8 @@
     "deb",
     "rpm"
   ]
-  revision = "8bbb5913ccde1ae01391be001b4c3de340ae57be"
-  version = "v0.3.0"
+  revision = "cb781e182dd5a49482ff65f5ca2d6e1a532ce72c"
+  version = "v0.3.1"
 
 [[projects]]
   name = "github.com/masterminds/semver"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -11,6 +11,12 @@
   revision = "ff0f66940b829dc66c81dad34746d4349b83eb9e"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/blakesmith/ar"
+  packages = ["."]
+  revision = "8bd4349a67f2533b078dbc524689d15dba0f4659"
+
+[[projects]]
   name = "github.com/caarlos0/ctrlc"
   packages = ["."]
   revision = "70dc48d5d792f20f684a8f1d29bbac298f4b2ef4"
@@ -61,6 +67,16 @@
   ]
   revision = "a0333715c7d5ee99eac4c71f457155f2b0c0c4f8"
   version = "v1.0.3"
+
+[[projects]]
+  name = "github.com/goreleaser/nfpm"
+  packages = [
+    ".",
+    "deb",
+    "rpm"
+  ]
+  revision = "37a2dbf86bc30fce37fdb68fef410f267a15ee37"
+  version = "v0.1.0"
 
 [[projects]]
   name = "github.com/masterminds/semver"
@@ -172,6 +188,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "503ca2b65156ad338879d612768c325176abafb95f1d425bb9f6e01f5dcb1327"
+  inputs-digest = "058e44db1c18902aef5f8bb3890e5e43478a56a0fb7a02f0252ff6557b3109e6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -37,8 +37,8 @@
 [[projects]]
   name = "github.com/fatih/color"
   packages = ["."]
-  revision = "570b54cabe6b8eb0bc2dfce68d964677d63b5260"
-  version = "v1.5.0"
+  revision = "507f6050b8568533fb3f5504de8e5205fa62a114"
+  version = "v1.6.0"
 
 [[projects]]
   name = "github.com/golang/protobuf"
@@ -75,8 +75,8 @@
     "deb",
     "rpm"
   ]
-  revision = "37a2dbf86bc30fce37fdb68fef410f267a15ee37"
-  version = "v0.1.0"
+  revision = "4b73ac9428cd413b36fd962aa4fd9faf7ad9f179"
+  version = "v0.2.0"
 
 [[projects]]
   name = "github.com/masterminds/semver"
@@ -142,7 +142,7 @@
     "context",
     "context/ctxhttp"
   ]
-  revision = "f5dfe339be1d06f81b22525fe34671ee7d2c8904"
+  revision = "dc948dff8834a7fe1ca525f8d04e261c2b56e70d"
 
 [[projects]]
   branch = "master"
@@ -188,6 +188,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "058e44db1c18902aef5f8bb3890e5e43478a56a0fb7a02f0252ff6557b3109e6"
+  inputs-digest = "5bfb7f4991e958fe8f53a9dd255326b0010940d2c245227b28f37a9883696dfe"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -54,4 +54,4 @@
 
 [[constraint]]
   name = "github.com/goreleaser/nfpm"
-  version = "0.2.0"
+  version = "0.3.0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -51,3 +51,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/mitchellh/go-homedir"
+
+[[constraint]]
+  name = "github.com/goreleaser/nfpm"
+  version = "0.1.0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -54,4 +54,4 @@
 
 [[constraint]]
   name = "github.com/goreleaser/nfpm"
-  version = "0.3.0"
+  version = "~0.3.0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -54,4 +54,4 @@
 
 [[constraint]]
   name = "github.com/goreleaser/nfpm"
-  version = "0.1.0"
+  version = "0.2.0"

--- a/config/config.go
+++ b/config/config.go
@@ -202,6 +202,7 @@ type Project struct {
 	Builds        []Build       `yaml:",omitempty"`
 	Archive       Archive       `yaml:",omitempty"`
 	FPM           FPM           `yaml:",omitempty"`
+	NFPM          FPM           `yaml:",omitempty"`
 	Snapcraft     Snapcraft     `yaml:",omitempty"`
 	Snapshot      Snapshot      `yaml:",omitempty"`
 	Checksum      Checksum      `yaml:",omitempty"`

--- a/docs/100-nfpm.md
+++ b/docs/100-nfpm.md
@@ -1,14 +1,18 @@
 ---
-title: FPM
+title: FPM and nFPM
 ---
 
-GoReleaser can be wired to [fpm](https://github.com/jordansissel/fpm) to
-generate `.deb`, `.rpm` and other archives. Check its
-[wiki](https://github.com/jordansissel/fpm/wiki) for more info.
+GoReleaser can be wired to [nfpm](https://github.com/goreleaser/nfpm) and
+[fpm](https://github.com/jordansissel/fpm) to generate `.deb` and `.rpm`
+archives.
+
+FPM support will be removed soon, and if everything goes well only
+nFPM will be supported in future version of GoReleaser.
 
 ```yml
 # .goreleaser.yml
-fpm:
+# change the key to fpm if you want to use fpm instead of nfpm
+nfpm:
   # You can change the name of the package.
   # This is parsed with the Go template engine and the following variables
   # are available:
@@ -76,4 +80,7 @@ fpm:
     "scripts/etc/init.d/": "/etc/init.d"
 ```
 
-Note that GoReleaser will not install `fpm` or any of its dependencies for you.
+Note that GoReleaser will not install `fpm`, `rpmbuild` or any of their
+dependencies for you. `nfpm` is used as a lib, so it is included in
+GoReleaser binaries, but you still need to install `rpmbuild` to generate
+RPM packages.

--- a/docs/990-deprecations.md
+++ b/docs/990-deprecations.md
@@ -1,0 +1,5 @@
+---
+title: Deprecation notices
+---
+
+This page will be used to list deprecation notices accross GoReleaser.

--- a/goreleaserlib/goreleaser.go
+++ b/goreleaserlib/goreleaser.go
@@ -29,6 +29,7 @@ import (
 	"github.com/goreleaser/goreleaser/pipeline/env"
 	"github.com/goreleaser/goreleaser/pipeline/fpm"
 	"github.com/goreleaser/goreleaser/pipeline/git"
+	"github.com/goreleaser/goreleaser/pipeline/nfpm"
 	"github.com/goreleaser/goreleaser/pipeline/release"
 	"github.com/goreleaser/goreleaser/pipeline/scoop"
 	"github.com/goreleaser/goreleaser/pipeline/sign"
@@ -52,8 +53,9 @@ var pipes = []pipeline.Piper{
 	changelog.Pipe{},       // builds the release changelog
 	env.Pipe{},             // load and validate environment variables
 	build.Pipe{},           // build
-	archive.Pipe{},         // archive (tar.gz, zip, etc)
-	fpm.Pipe{},             // archive via fpm (deb, rpm, etc)
+	archive.Pipe{},         // archive in tar.gz, zip or binary (which does no archiving at all)
+	fpm.Pipe{},             // archive via fpm (deb, rpm) using fpm
+	nfpm.Pipe{},            // archive via fpm (deb, rpm) using "native" go impl
 	snapcraft.Pipe{},       // archive via snapcraft (snap)
 	checksums.Pipe{},       // checksums of the files
 	sign.Pipe{},            // sign artifacts

--- a/pipeline/defaults/defaults.go
+++ b/pipeline/defaults/defaults.go
@@ -14,6 +14,7 @@ import (
 	"github.com/goreleaser/goreleaser/pipeline/docker"
 	"github.com/goreleaser/goreleaser/pipeline/env"
 	"github.com/goreleaser/goreleaser/pipeline/fpm"
+	"github.com/goreleaser/goreleaser/pipeline/nfpm"
 	"github.com/goreleaser/goreleaser/pipeline/release"
 	"github.com/goreleaser/goreleaser/pipeline/scoop"
 	"github.com/goreleaser/goreleaser/pipeline/sign"
@@ -35,6 +36,7 @@ var defaulters = []pipeline.Defaulter{
 	archive.Pipe{},
 	build.Pipe{},
 	fpm.Pipe{},
+	nfpm.Pipe{},
 	snapcraft.Pipe{},
 	checksums.Pipe{},
 	sign.Pipe{},

--- a/pipeline/nfpm/nfpm.go
+++ b/pipeline/nfpm/nfpm.go
@@ -9,6 +9,10 @@ import (
 
 	"github.com/apex/log"
 	"github.com/goreleaser/nfpm"
+	"github.com/pkg/errors"
+
+	// blank imports here because the formats implementations need register
+	// themselves
 	_ "github.com/goreleaser/nfpm/deb"
 	_ "github.com/goreleaser/nfpm/rpm"
 
@@ -101,7 +105,7 @@ func create(ctx *context.Context, format, arch string, binaries []artifact.Artif
 		License:     ctx.Config.NFPM.License,
 		Files:       ctx.Config.NFPM.Files,
 		Bindir:      ctx.Config.NFPM.Bindir,
-		// ConfigFiles: "",
+		// ConfigFiles: "" TODO: add this config_files to nfpm settings,
 	}
 	for _, binary := range binaries {
 		src := binary.Path
@@ -121,8 +125,8 @@ func create(ctx *context.Context, format, arch string, binaries []artifact.Artif
 	if err != nil {
 		return err
 	}
-	if err := packager.Package(info, w); err != nil {
-		return err
+	if err := packager.Package(nfpm.WithDefaults(info), w); err != nil {
+		return errors.Wrap(err, "nfpm failed")
 	}
 	ctx.Artifacts.Add(artifact.Artifact{
 		Type:   artifact.LinuxPackage,

--- a/pipeline/nfpm/nfpm.go
+++ b/pipeline/nfpm/nfpm.go
@@ -100,6 +100,7 @@ func create(ctx *context.Context, format, arch string, binaries []artifact.Artif
 		Homepage:    ctx.Config.NFPM.Homepage,
 		License:     ctx.Config.NFPM.License,
 		Files:       ctx.Config.NFPM.Files,
+		Bindir:      ctx.Config.NFPM.Bindir,
 		// ConfigFiles: "",
 	}
 	for _, binary := range binaries {

--- a/pipeline/nfpm/nfpm.go
+++ b/pipeline/nfpm/nfpm.go
@@ -1,0 +1,132 @@
+// Package nfpm implements the Pipe interface providing NFPM bindings.
+package nfpm
+
+import (
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/apex/log"
+	"github.com/goreleaser/nfpm"
+	_ "github.com/goreleaser/nfpm/deb"
+	_ "github.com/goreleaser/nfpm/rpm"
+
+	"github.com/goreleaser/goreleaser/context"
+	"github.com/goreleaser/goreleaser/internal/artifact"
+	"github.com/goreleaser/goreleaser/internal/filenametemplate"
+	"github.com/goreleaser/goreleaser/internal/linux"
+	"github.com/goreleaser/goreleaser/pipeline"
+)
+
+const defaultNameTemplate = "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+
+// Pipe for fpm packaging
+type Pipe struct{}
+
+func (Pipe) String() string {
+	return "creating Linux packages with nfpm"
+}
+
+// Default sets the pipe defaults
+func (Pipe) Default(ctx *context.Context) error {
+	var fpm = &ctx.Config.NFPM
+	if fpm.Bindir == "" {
+		fpm.Bindir = "/usr/local/bin"
+	}
+	if fpm.NameTemplate == "" {
+		fpm.NameTemplate = defaultNameTemplate
+	}
+	if fpm.Files == nil {
+		fpm.Files = make(map[string]string)
+	}
+	return nil
+}
+
+// Run the pipe
+func (Pipe) Run(ctx *context.Context) error {
+	if len(ctx.Config.NFPM.Formats) == 0 {
+		return pipeline.Skip("no output formats configured")
+	}
+	return doRun(ctx)
+}
+
+func doRun(ctx *context.Context) error {
+	var g errgroup.Group
+	sem := make(chan bool, ctx.Parallelism)
+	for _, format := range ctx.Config.NFPM.Formats {
+		for platform, artifacts := range ctx.Artifacts.Filter(
+			artifact.And(
+				artifact.ByType(artifact.Binary),
+				artifact.ByGoos("linux"),
+			),
+		).GroupByPlatform() {
+			sem <- true
+			format := format
+			arch := linux.Arch(platform)
+			artifacts := artifacts
+			g.Go(func() error {
+				defer func() {
+					<-sem
+				}()
+				return create(ctx, format, arch, artifacts)
+			})
+		}
+	}
+	return g.Wait()
+}
+
+func create(ctx *context.Context, format, arch string, binaries []artifact.Artifact) error {
+	name, err := filenametemplate.Apply(
+		ctx.Config.NFPM.NameTemplate,
+		filenametemplate.NewFields(ctx, ctx.Config.NFPM.Replacements, binaries...),
+	)
+	if err != nil {
+		return err
+	}
+
+	var info = nfpm.Info{
+		Arch:        arch,
+		Platform:    "linux",
+		Conflicts:   ctx.Config.NFPM.Conflicts,
+		Depends:     ctx.Config.NFPM.Dependencies,
+		Name:        ctx.Config.ProjectName,
+		Version:     ctx.Version,
+		Section:     "",
+		Priority:    "",
+		Maintainer:  ctx.Config.NFPM.Maintainer,
+		Description: ctx.Config.NFPM.Description,
+		Vendor:      ctx.Config.NFPM.Vendor,
+		Homepage:    ctx.Config.NFPM.Homepage,
+		License:     ctx.Config.NFPM.License,
+		Files:       ctx.Config.NFPM.Files,
+		// ConfigFiles: "",
+	}
+	for _, binary := range binaries {
+		info.Files[binary.Path] = filepath.Join(ctx.Config.NFPM.Bindir, binary.Name)
+	}
+
+	packager, err := nfpm.Get(format)
+	if err != nil {
+		return err
+	}
+
+	var path = filepath.Join(ctx.Config.Dist, name+"."+format)
+	log.WithField("file", path).Info("creating")
+	w, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	if err := packager.Package(info, w); err != nil {
+		return err
+	}
+	ctx.Artifacts.Add(artifact.Artifact{
+		Type:   artifact.LinuxPackage,
+		Name:   name + "." + format,
+		Path:   path,
+		Goos:   binaries[0].Goos,
+		Goarch: binaries[0].Goarch,
+		Goarm:  binaries[0].Goarm,
+	})
+	return nil
+}

--- a/pipeline/nfpm/nfpm.go
+++ b/pipeline/nfpm/nfpm.go
@@ -103,7 +103,10 @@ func create(ctx *context.Context, format, arch string, binaries []artifact.Artif
 		// ConfigFiles: "",
 	}
 	for _, binary := range binaries {
-		info.Files[binary.Path] = filepath.Join(ctx.Config.NFPM.Bindir, binary.Name)
+		src := binary.Path
+		dst := filepath.Join(ctx.Config.NFPM.Bindir, binary.Name)
+		log.WithField("src", src).WithField("dst", dst).Info("adding binary to package")
+		info.Files[src] = dst
 	}
 
 	packager, err := nfpm.Get(format)

--- a/pipeline/nfpm/nfpm_test.go
+++ b/pipeline/nfpm/nfpm_test.go
@@ -1,0 +1,139 @@
+package nfpm
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/goreleaser/goreleaser/config"
+	"github.com/goreleaser/goreleaser/context"
+	"github.com/goreleaser/goreleaser/internal/artifact"
+	"github.com/goreleaser/goreleaser/internal/testlib"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDescription(t *testing.T) {
+	assert.NotEmpty(t, Pipe{}.String())
+}
+
+func TestRunPipeNoFormats(t *testing.T) {
+	var ctx = &context.Context{
+		Version:     "1.0.0",
+		Config:      config.Project{},
+		Parallelism: runtime.NumCPU(),
+	}
+	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
+}
+
+func TestRunPipe(t *testing.T) {
+	folder, err := ioutil.TempDir("", "archivetest")
+	assert.NoError(t, err)
+	var dist = filepath.Join(folder, "dist")
+	assert.NoError(t, os.Mkdir(dist, 0755))
+	assert.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
+	var binPath = filepath.Join(dist, "mybin", "mybin")
+	_, err = os.Create(binPath)
+	assert.NoError(t, err)
+	var ctx = context.New(config.Project{
+		ProjectName: "mybin",
+		Dist:        dist,
+		NFPM: config.FPM{
+			NameTemplate: defaultNameTemplate,
+			Formats:      []string{"deb", "rpm"},
+			Dependencies: []string{"make"},
+			Conflicts:    []string{"git"},
+			Description:  "Some description",
+			License:      "MIT",
+			Maintainer:   "me@me",
+			Vendor:       "asdf",
+			Homepage:     "https://goreleaser.github.io",
+			Files:        map[string]string{},
+		},
+	})
+	ctx.Version = "1.0.0"
+	for _, goos := range []string{"linux", "darwin"} {
+		for _, goarch := range []string{"amd64", "386"} {
+			ctx.Artifacts.Add(artifact.Artifact{
+				Name:   "mybin",
+				Path:   binPath,
+				Goarch: goarch,
+				Goos:   goos,
+				Type:   artifact.Binary,
+			})
+		}
+	}
+	assert.NoError(t, Pipe{}.Run(ctx))
+}
+
+func TestInvalidNameTemplate(t *testing.T) {
+	var ctx = &context.Context{
+		Parallelism: runtime.NumCPU(),
+		Artifacts:   artifact.New(),
+		Config: config.Project{
+			NFPM: config.FPM{
+				NameTemplate: "{{.Foo}",
+				Formats:      []string{"deb"},
+			},
+		},
+	}
+	ctx.Artifacts.Add(artifact.Artifact{
+		Name:   "mybin",
+		Goos:   "linux",
+		Goarch: "amd64",
+		Type:   artifact.Binary,
+	})
+	assert.Contains(t, Pipe{}.Run(ctx).Error(), `template: {{.Foo}:1: unexpected "}" in operand`)
+}
+
+func TestCreateFileDoesntExist(t *testing.T) {
+	folder, err := ioutil.TempDir("", "archivetest")
+	assert.NoError(t, err)
+	var dist = filepath.Join(folder, "dist")
+	assert.NoError(t, os.Mkdir(dist, 0755))
+	assert.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
+	var ctx = context.New(config.Project{
+		Dist: dist,
+		NFPM: config.FPM{
+			Formats: []string{"deb", "rpm"},
+			Files: map[string]string{
+				"testdata/testfile.txt": "/var/lib/test/testfile.txt",
+			},
+		},
+	})
+	ctx.Version = "1.0.0"
+	ctx.Artifacts.Add(artifact.Artifact{
+		Name:   "mybin",
+		Path:   filepath.Join(dist, "mybin", "mybin"),
+		Goos:   "linux",
+		Goarch: "amd64",
+		Type:   artifact.Binary,
+	})
+	assert.Contains(t, Pipe{}.Run(ctx).Error(), `dist/mybin/mybin', does it exist?`)
+}
+
+func TestDefault(t *testing.T) {
+	var ctx = &context.Context{
+		Config: config.Project{
+			NFPM: config.FPM{},
+		},
+	}
+	assert.NoError(t, Pipe{}.Default(ctx))
+	assert.Equal(t, "/usr/local/bin", ctx.Config.NFPM.Bindir)
+	assert.Equal(t, defaultNameTemplate, ctx.Config.NFPM.NameTemplate)
+}
+
+func TestDefaultSet(t *testing.T) {
+	var ctx = &context.Context{
+		Config: config.Project{
+			NFPM: config.FPM{
+				Bindir:       "/bin",
+				NameTemplate: "foo",
+			},
+		},
+	}
+	assert.NoError(t, Pipe{}.Default(ctx))
+	assert.Equal(t, "/bin", ctx.Config.NFPM.Bindir)
+	assert.Equal(t, "foo", ctx.Config.NFPM.NameTemplate)
+}

--- a/pipeline/nfpm/nfpm_test.go
+++ b/pipeline/nfpm/nfpm_test.go
@@ -40,6 +40,7 @@ func TestRunPipe(t *testing.T) {
 		ProjectName: "mybin",
 		Dist:        dist,
 		NFPM: config.FPM{
+			Bindir:       "/usr/bin",
 			NameTemplate: defaultNameTemplate,
 			Formats:      []string{"deb", "rpm"},
 			Dependencies: []string{"make"},

--- a/pipeline/nfpm/testdata/testfile.txt
+++ b/pipeline/nfpm/testdata/testfile.txt
@@ -1,0 +1,1 @@
+this is a test file


### PR DESCRIPTION
the idea is to replace fpm with goreleaser/nfpm.

nfpm is an implementation of deb/rpm packaging that uses pure go when possible (depends on rpmbuild, unfortunately), and we can use it as a lib instead of calling a 3rd party binary.

this will hopefully increases the reliability of the entire pipeline.

not sure if the new `nfpm` field is the right thing to do or if we just replace the whole thing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] I have read the **CONTRIBUTING** document.
* [x] `make ci` passes on my machine.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
