### PR TITLE
feat: Adds template support to binary property

### DIFF
--- a/docs/050-build.md
+++ b/docs/050-build.md
@@ -17,6 +17,13 @@ builds:
     main: ./cmd/main.go
 
     # Name of the binary.
+    # This is parsed with the Go template engine and the following variables
+    # are available:
+    # - Date
+    # - Commit
+    # - Tag
+    # - Version (Git tag without `v` prefix)
+    # Date format is `2006-01-02_15:04:05`.
     # Default is the name of the project directory.
     binary: program
 

--- a/pipeline/build/build.go
+++ b/pipeline/build/build.go
@@ -18,6 +18,9 @@ import (
 
 	// langs to init
 	_ "github.com/goreleaser/goreleaser/internal/builders/golang"
+	"time"
+	"bytes"
+	"text/template"
 )
 
 // Pipe for build
@@ -58,6 +61,7 @@ func buildWithDefaults(ctx *context.Context, build config.Build) config.Build {
 	if build.Binary == "" {
 		build.Binary = ctx.Config.Release.GitHub.Name
 	}
+
 	return builders.For(build.Lang).WithDefaults(build)
 }
 
@@ -95,6 +99,13 @@ func runHook(ctx *context.Context, env []string, hook string) error {
 
 func doBuild(ctx *context.Context, build config.Build, target string) error {
 	var ext = extFor(target)
+
+	binary, err := binary(ctx, build)
+	if err != nil {
+		return err
+	}
+
+	build.Binary = binary
 	var name = build.Binary + ext
 	var path = filepath.Join(ctx.Config.Dist, target, name)
 	log.WithField("binary", path).Info("building")
@@ -104,6 +115,31 @@ func doBuild(ctx *context.Context, build config.Build, target string) error {
 		Path:   path,
 		Ext:    ext,
 	})
+}
+
+func binary(ctx *context.Context, build config.Build) (string, error) {
+	var data = struct {
+		Commit  string
+		Tag     string
+		Version string
+		Date    string
+		Env     map[string]string
+	}{
+		Commit:  ctx.Git.Commit,
+		Tag:     ctx.Git.CurrentTag,
+		Version: ctx.Version,
+		Date:    time.Now().UTC().Format(time.RFC3339),
+		Env:     ctx.Env,
+	}
+	var out bytes.Buffer
+	t, err := template.New("binary").
+		Option("missingkey=error").
+		Parse(build.Binary)
+	if err != nil {
+		return "", err
+	}
+	err = t.Execute(&out, data)
+	return out.String(), err
 }
 
 func extFor(target string) string {

--- a/pipeline/build/build_test.go
+++ b/pipeline/build/build_test.go
@@ -52,14 +52,23 @@ func TestBuild(t *testing.T) {
 		Builds: []config.Build{
 			{
 				Lang:   "fake",
-				Binary: "testing",
+				Binary: "testing.v{{.Version}}",
 				Flags:  "-n",
 				Env:    []string{"BLAH=1"},
 			},
 		},
 	}
-	var ctx = context.New(config)
-	assert.NoError(t, doBuild(ctx, ctx.Config.Builds[0], "darwin_amd64"))
+	var ctx = &context.Context{
+		Artifacts: artifact.New(),
+		Git: context.GitInfo{
+			CurrentTag: "v1.2.3",
+			Commit:     "123",
+		},
+		Version: "1.2.3",
+		Config:  config,
+	}
+	error := doBuild(ctx, ctx.Config.Builds[0], "darwin_amd64")
+	assert.NoError(t, error)
 }
 
 func TestRunPipe(t *testing.T) {
@@ -256,6 +265,33 @@ func TestExtOthers(t *testing.T) {
 	assert.Empty(t, "", extFor("linux_amd64"))
 	assert.Empty(t, "", extFor("linuxwin_386"))
 	assert.Empty(t, "", extFor("winasdasd_sad"))
+}
+
+func TestBinaryFullTemplate(t *testing.T) {
+	var config = config.Project{
+		Builds: []config.Build{
+			{
+				Binary: `-s -w -X main.version={{.Version}} -X main.tag={{.Tag}} -X main.date={{.Date}} -X main.commit={{.Commit}} -X "main.foo={{.Env.FOO}}"`,
+			},
+		},
+	}
+	var ctx = &context.Context{
+		Git: context.GitInfo{
+			CurrentTag: "v1.2.3",
+			Commit:     "123",
+		},
+		Version: "1.2.3",
+		Config:  config,
+		Env:     map[string]string{"FOO": "123"},
+	}
+	binary, err := binary(ctx, ctx.Config.Builds[0])
+	assert.NoError(t, err)
+	assert.Contains(t, binary, "-s -w")
+	assert.Contains(t, binary, "-X main.version=1.2.3")
+	assert.Contains(t, binary, "-X main.tag=v1.2.3")
+	assert.Contains(t, binary, "-X main.commit=123")
+	assert.Contains(t, binary, "-X main.date=")
+	assert.Contains(t, binary, `-X "main.foo=123"`)
 }
 
 //


### PR DESCRIPTION
I added support for using the Go template engine with the binary
property. This is needed for generating binaries that include
the current version number in their file name. For example
`terraform-provider-NAME_vX.Y.Z`.

## Types of changes

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] I have read the **CONTRIBUTING** document.
* [ ] `make ci` passes on my machine.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
