### PR TITLE
refactor: Changed Client.CreateFile to be more generic

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"os"
 
+	"github.com/goreleaser/goreleaser/config"
 	"github.com/goreleaser/goreleaser/context"
 )
 
@@ -18,6 +19,6 @@ type Info struct {
 // Client interface
 type Client interface {
 	CreateRelease(ctx *context.Context, body string) (releaseID int64, err error)
-	CreateFile(ctx *context.Context, content bytes.Buffer, path string) (err error)
+	CreateFile(ctx *context.Context, commitAuthor config.CommitAuthor, repo config.Repo, content bytes.Buffer, path string) (err error)
 	Upload(ctx *context.Context, releaseID int64, name string, file *os.File) (err error)
 }

--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/google/go-github/github"
+	"github.com/goreleaser/goreleaser/config"
 	"github.com/goreleaser/goreleaser/context"
 	"golang.org/x/oauth2"
 )
@@ -39,6 +40,8 @@ func NewGitHub(ctx *context.Context) (Client, error) {
 
 func (c *githubClient) CreateFile(
 	ctx *context.Context,
+	commitAuthor config.CommitAuthor,
+	repo config.Repo,
 	content bytes.Buffer,
 	path string,
 ) (err error) {

--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -47,8 +47,8 @@ func (c *githubClient) CreateFile(
 ) (err error) {
 	options := &github.RepositoryContentFileOptions{
 		Committer: &github.CommitAuthor{
-			Name:  github.String(ctx.Config.Brew.CommitAuthor.Name),
-			Email: github.String(ctx.Config.Brew.CommitAuthor.Email),
+			Name:  github.String(commitAuthor.Name),
+			Email: github.String(commitAuthor.Email),
 		},
 		Content: content.Bytes(),
 		Message: github.String(
@@ -58,16 +58,16 @@ func (c *githubClient) CreateFile(
 
 	file, _, res, err := c.client.Repositories.GetContents(
 		ctx,
-		ctx.Config.Brew.GitHub.Owner,
-		ctx.Config.Brew.GitHub.Name,
+		repo.Owner,
+		repo.Name,
 		path,
 		&github.RepositoryContentGetOptions{},
 	)
 	if err != nil && res.StatusCode == 404 {
 		_, _, err = c.client.Repositories.CreateFile(
 			ctx,
-			ctx.Config.Brew.GitHub.Owner,
-			ctx.Config.Brew.GitHub.Name,
+			repo.Owner,
+			repo.Name,
 			path,
 			options,
 		)
@@ -76,8 +76,8 @@ func (c *githubClient) CreateFile(
 	options.SHA = file.SHA
 	_, _, err = c.client.Repositories.UpdateFile(
 		ctx,
-		ctx.Config.Brew.GitHub.Owner,
-		ctx.Config.Brew.GitHub.Name,
+		repo.Owner,
+		repo.Name,
 		path,
 		options,
 	)

--- a/pipeline/brew/brew.go
+++ b/pipeline/brew/brew.go
@@ -133,7 +133,7 @@ func doRun(ctx *context.Context, client client.Client) error {
 	log.WithField("formula", path).
 		WithField("repo", ctx.Config.Brew.GitHub.String()).
 		Info("pushing")
-	return client.CreateFile(ctx, content, path)
+	return client.CreateFile(ctx, ctx.Config.Brew.CommitAuthor, ctx.Config.Brew.GitHub, content, path)
 }
 
 func buildFormula(ctx *context.Context, client client.Client, artifact artifact.Artifact) (bytes.Buffer, error) {

--- a/pipeline/brew/brew_test.go
+++ b/pipeline/brew/brew_test.go
@@ -391,7 +391,7 @@ func (client *DummyClient) CreateRelease(ctx *context.Context, body string) (rel
 	return
 }
 
-func (client *DummyClient) CreateFile(ctx *context.Context, content bytes.Buffer, path string) (err error) {
+func (client *DummyClient) CreateFile(ctx *context.Context, commitAuthor config.CommitAuthor, repo config.Repo, content bytes.Buffer, path string) (err error) {
 	client.CreatedFile = true
 	bts, _ := ioutil.ReadAll(&content)
 	client.Content = string(bts)

--- a/pipeline/release/release_test.go
+++ b/pipeline/release/release_test.go
@@ -211,7 +211,7 @@ func (client *DummyClient) CreateRelease(ctx *context.Context, body string) (rel
 	return
 }
 
-func (client *DummyClient) CreateFile(ctx *context.Context, content bytes.Buffer, path string) (err error) {
+func (client *DummyClient) CreateFile(ctx *context.Context, commitAuthor config.CommitAuthor, repo config.Repo, content bytes.Buffer, path string) (err error) {
 	return
 }
 


### PR DESCRIPTION
The GitHub implementation of CreateFile implicitly uses HomeBrew data.
Added parameters for CommitAuthor and Repo so the call site can specify
these parameters based on the context.

This is only a very minor code change that the Scoop feature (and possible other future features that rely on pushing arbitrary files to arbitrary repos).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] I have read the **CONTRIBUTING** document.
* [x] `make ci` passes on my machine.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
