### PR TITLE
fix: Silent failure caused by branching logic

### DIFF
--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -63,7 +63,11 @@ func (c *githubClient) CreateFile(
 		path,
 		&github.RepositoryContentGetOptions{},
 	)
-	if err != nil && res.StatusCode == 404 {
+	if err != nil && res.StatusCode != 404 {
+		return
+	}
+
+	if res.StatusCode == 404 {
 		_, _, err = c.client.Repositories.CreateFile(
 			ctx,
 			repo.Owner,
@@ -71,16 +75,16 @@ func (c *githubClient) CreateFile(
 			path,
 			options,
 		)
-		return
+	} else {
+		options.SHA = file.SHA
+		_, _, err = c.client.Repositories.UpdateFile(
+			ctx,
+			repo.Owner,
+			repo.Name,
+			path,
+			options,
+		)
 	}
-	options.SHA = file.SHA
-	_, _, err = c.client.Repositories.UpdateFile(
-		ctx,
-		repo.Owner,
-		repo.Name,
-		path,
-		options,
-	)
 	return
 }
 


### PR DESCRIPTION
Just a little something I noticed during #547 and #546 - the current code results in calls to `UpdateFile` even if `err != nil` still.

Changed the branching after the `GetContents` call to *first* check for
a non-404 error (internal failure of some sort) and then proceed to
check the status to determine whether to `CreateFile` or `UpdateFile`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] I have read the **CONTRIBUTING** document.
* [x] `make ci` passes on my machine.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
