### PR TITLE
feat: expand env on build envs

### DIFF
--- a/pipeline/build/build.go
+++ b/pipeline/build/build.go
@@ -58,6 +58,9 @@ func buildWithDefaults(ctx *context.Context, build config.Build) config.Build {
 	if build.Binary == "" {
 		build.Binary = ctx.Config.Release.GitHub.Name
 	}
+	for k, v := range build.Env {
+		build.Env[k] = os.ExpandEnv(v)
+	}
 	return builders.For(build.Lang).WithDefaults(build)
 }
 

--- a/pipeline/build/build_test.go
+++ b/pipeline/build/build_test.go
@@ -165,6 +165,24 @@ func TestDefaultNoBuilds(t *testing.T) {
 	assert.NoError(t, Pipe{}.Default(ctx))
 }
 
+func TestDefaultExpandEnv(t *testing.T) {
+	assert.NoError(t, os.Setenv("BAR", "FOOBAR"))
+	var ctx = &context.Context{
+		Config: config.Project{
+			Builds: []config.Build{
+				{
+					Env: []string{
+						"FOO=bar_$BAR",
+					},
+				},
+			},
+		},
+	}
+	assert.NoError(t, Pipe{}.Default(ctx))
+	var env = ctx.Config.Builds[0].Env[0]
+	assert.Equal(t, "FOO=bar_FOOBAR", env)
+}
+
 func TestDefaultEmptyBuild(t *testing.T) {
 	var ctx = &context.Context{
 		Config: config.Project{


### PR DESCRIPTION
found while debugging #540 

instead of hardcoding the path, we can use the `$PWD` environment variable, for example, and it should work.

Not sure if this is a feature or a bugfix, will treat it like a feat :D 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] I have read the **CONTRIBUTING** document.
* [x] `make ci` passes on my machine.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
