### PR TITLE
feat: Configuration to use short git hashes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -8,7 +8,7 @@ import (
 	"os"
 
 	"github.com/apex/log"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 // GitHubURLs holds the URLs to be used when using github enterprise
@@ -212,6 +212,11 @@ type EnvFiles struct {
 	GitHubToken string `yaml:"github_token,omitempty"`
 }
 
+// Git config
+type Git struct {
+	ShortHash bool `yaml:"short_hash,omitempty"`
+}
+
 // Project includes all project configuration
 type Project struct {
 	ProjectName   string        `yaml:"project_name,omitempty"`
@@ -231,6 +236,7 @@ type Project struct {
 	Dist          string        `yaml:",omitempty"`
 	Sign          Sign          `yaml:",omitempty"`
 	EnvFiles      EnvFiles      `yaml:"env_files,omitempty"`
+	Git           Git           `yaml:",omitempty"`
 
 	// this is a hack ¯\_(ツ)_/¯
 	SingleBuild Build `yaml:"build,omitempty"`

--- a/docs/020-environment.md
+++ b/docs/020-environment.md
@@ -65,3 +65,16 @@ func main() {
 the snapshot, if you're using the `--snapshot` flag.
 
 You can override this by changing the `ldflags` option in the `build` section.
+
+## Customizing Git
+
+By default, GoReleaser uses full length commit hashes when setting a `main.commit`
+_ldflag_ or creating filenames in `--snapshot` mode.
+
+You can use short, 7 character long commit hashes by setting it in the `.goreleaser.yml`:
+
+```yaml
+# .goreleaser.yml
+git:
+  short_hash: true
+```

--- a/pipeline/git/git.go
+++ b/pipeline/git/git.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"bytes"
+	"fmt"
 	"regexp"
 	"strings"
 	"text/template"
@@ -53,7 +54,7 @@ func getInfo(ctx *context.Context) (context.GitInfo, error) {
 }
 
 func getGitInfo(ctx *context.Context) (context.GitInfo, error) {
-	commit, err := getCommit()
+	commit, err := getCommit(ctx)
 	if err != nil {
 		return context.GitInfo{}, errors.Wrap(err, "couldn't get current commit")
 	}
@@ -122,8 +123,12 @@ func validate(ctx *context.Context) error {
 	return nil
 }
 
-func getCommit() (string, error) {
-	return git.Clean(git.Run("show", "--format='%H'", "HEAD"))
+func getCommit(ctx *context.Context) (string, error) {
+	format := "%H"
+	if ctx.Config.Git.ShortHash {
+		format = "%h"
+	}
+	return git.Clean(git.Run("show", fmt.Sprintf("--format='%s'", format), "HEAD"))
 }
 
 func getTag() (string, error) {

--- a/pipeline/git/git_test.go
+++ b/pipeline/git/git_test.go
@@ -173,3 +173,19 @@ func TestSnapshotDirty(t *testing.T) {
 	ctx.Snapshot = true
 	assert.NoError(t, Pipe{}.Run(ctx))
 }
+
+func TestShortCommitHash(t *testing.T) {
+	_, back := testlib.Mktmp(t)
+	defer back()
+	testlib.GitInit(t)
+	testlib.GitCommit(t, "first")
+	var ctx = context.New(config.Project{
+		Snapshot: config.Snapshot{
+			NameTemplate: "{{.Commit}}",
+		},
+	})
+	ctx.Snapshot = true
+	ctx.Config.Git.ShortHash = true
+	assert.NoError(t, Pipe{}.Run(ctx))
+	assert.Len(t, ctx.Version, 7)
+}


### PR DESCRIPTION
Add a git configuration to control to either use long commit hashes
(current default) or use the short version with only the first 7
characters of the hash.

See #578

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] I have read the **CONTRIBUTING** document.
* [ ] `make ci` passes on my machine.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
