### PR TITLE
feat: Custom brew tap name

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,7 @@ func (r Repo) String() string {
 
 // Homebrew contains the brew section
 type Homebrew struct {
+	Name             string       `yaml:",omitempty"`
 	GitHub           Repo         `yaml:",omitempty"`
 	CommitAuthor     CommitAuthor `yaml:"commit_author,omitempty"`
 	Folder           string       `yaml:",omitempty"`

--- a/docs/120-homebrew.md
+++ b/docs/120-homebrew.md
@@ -15,6 +15,10 @@ for more details.
 ```yml
 # .goreleaser.yml
 brew:
+  # Name of the recipe
+  # Default to project name
+  name: myproject
+
   # Reporitory to push the tap to.
   github:
     owner: user

--- a/pipeline/brew/brew.go
+++ b/pipeline/brew/brew.go
@@ -113,6 +113,9 @@ func doRun(ctx *context.Context, client client.Client) error {
 	}
 
 	var filename = ctx.Config.ProjectName + ".rb"
+	if ctx.Config.Brew.Name != "" {
+		filename = ctx.Config.Brew.Name + ".rb"
+	}
 	var path = filepath.Join(ctx.Config.Dist, filename)
 	log.WithField("formula", path).Info("writing")
 	if err := ioutil.WriteFile(path, content.Bytes(), 0644); err != nil {

--- a/pipeline/brew/brew_test.go
+++ b/pipeline/brew/brew_test.go
@@ -196,6 +196,15 @@ func TestRunPipe(t *testing.T) {
 		assert.NoError(tt, err)
 		assert.Equal(tt, string(bts), string(distBts))
 	})
+
+	t.Run("custom name", func(tt *testing.T) {
+		ctx.Config.Brew.Name = "custom-brew-name"
+		assert.NoError(tt, doRun(ctx, client))
+		assert.True(tt, client.CreatedFile)
+
+		_, err := os.Stat(filepath.Join(folder, "custom-brew-name.rb"))
+		assert.NoError(t, err)
+	})
 }
 
 func TestRunPipeNoDarwin64Build(t *testing.T) {


### PR DESCRIPTION
Add optional Name field to Brew configuration to allow
overriding the name of the final Brew tap recipe.

closes #595

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] I have read the **CONTRIBUTING** document.
* [ ] `make ci` passes on my machine.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
