### PR TITLE
fix: archive.format_overrides section supports binary format correctly

### DIFF
--- a/pipeline/archive/archive.go
+++ b/pipeline/archive/archive.go
@@ -66,7 +66,7 @@ func (Pipe) Run(ctx *context.Context) error {
 	for _, artifacts := range filtered.GroupByPlatform() {
 		artifacts := artifacts
 		g.Go(func() error {
-			if ctx.Config.Archive.Format == "binary" {
+			if packageFormat(ctx, artifacts[0].Goos) == "binary" {
 				return skip(ctx, artifacts)
 			}
 			return create(ctx, artifacts)


### PR DESCRIPTION
Fix the problem in case
```yaml
archive:
 format_overrides:
    - goos: windows
      format: binary
```
released file was archive (`archive.format`) and name have extension `.binary`
e.g. https://github.com/avast/stor-client/releases/tag/2.1.2

now is possible use `binary` format in `format`overrides` section