### PR TITLE
fix: Fix Brew formula class name when using custom name

### DIFF
--- a/pipeline/brew/brew.go
+++ b/pipeline/brew/brew.go
@@ -165,7 +165,7 @@ func dataFor(ctx *context.Context, client client.Client, artifact artifact.Artif
 	}
 	var cfg = ctx.Config.Brew
 	return templateData{
-		Name:             formulaNameFor(ctx.Config.ProjectName),
+		Name:             formulaNameFor(ctx.Config.Brew.Name),
 		DownloadURL:      ctx.Config.GitHubURLs.Download,
 		Desc:             cfg.Description,
 		Homepage:         cfg.Homepage,

--- a/pipeline/brew/brew_test.go
+++ b/pipeline/brew/brew_test.go
@@ -203,8 +203,13 @@ func TestRunPipe(t *testing.T) {
 		assert.NoError(tt, doRun(ctx, client))
 		assert.True(tt, client.CreatedFile)
 
-		_, err := os.Stat(filepath.Join(folder, "custom-brew-name.rb"))
+		distFile := filepath.Join(folder, "custom-brew-name.rb")
+		_, err := os.Stat(distFile)
 		assert.NoError(t, err)
+
+		distBts, err := ioutil.ReadFile(distFile)
+		assert.NoError(tt, err)
+		assert.Contains(tt, string(distBts), "class CustomBrewName < Formula")
 	})
 }
 


### PR DESCRIPTION
The #597 added support for customizing the final Brew formula name.
The generated *.rb file still were using the project name as
class name and installing with custom name didn't work.
Fixed the issue by using the `name` field as an input for
building the class name, which defaults to project name
if no name given.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] I have read the **CONTRIBUTING** document.
* [ ] `make ci` passes on my machine.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
