### PR TITLE
feat: Add cleanup pipeline

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -219,6 +219,11 @@ type Git struct {
 	ShortHash bool `yaml:"short_hash,omitempty"`
 }
 
+// Before config
+type Before struct {
+	Hooks []string `yaml:",omitempty"`
+}
+
 // Project includes all project configuration
 type Project struct {
 	ProjectName   string        `yaml:"project_name,omitempty"`
@@ -239,6 +244,7 @@ type Project struct {
 	Sign          Sign          `yaml:",omitempty"`
 	EnvFiles      EnvFiles      `yaml:"env_files,omitempty"`
 	Git           Git           `yaml:",omitempty"`
+	Before        Before        `yaml:",omitempty"`
 
 	// this is a hack ¯\_(ツ)_/¯
 	SingleBuild Build `yaml:"build,omitempty"`

--- a/docs/045-hooks.md
+++ b/docs/045-hooks.md
@@ -1,0 +1,20 @@
+---
+title: Global Hooks
+---
+
+Some builds may need pre-build steps before building, e.g. `go generate`.
+The `before` section allows for global hooks which will be executed before
+the build is started.
+
+The configuration is very simple, here is a complete example:
+
+```yml
+# .goreleaser.yml
+before:
+  hooks:
+  - make clean
+  - go generate ./...
+```
+
+If any of the hooks fails the build process is aborted.
+

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/goreleaser/goreleaser/pipeline"
 	"github.com/goreleaser/goreleaser/pipeline/archive"
 	"github.com/goreleaser/goreleaser/pipeline/artifactory"
+	"github.com/goreleaser/goreleaser/pipeline/before"
 	"github.com/goreleaser/goreleaser/pipeline/brew"
 	"github.com/goreleaser/goreleaser/pipeline/build"
 	"github.com/goreleaser/goreleaser/pipeline/changelog"
@@ -43,6 +44,7 @@ var (
 
 var pipes = []Piper{
 	defaults.Pipe{},        // load default configs
+	before.Pipe{},          // run global hooks before build
 	dist.Pipe{},            // ensure ./dist is clean
 	git.Pipe{},             // get and validate git repo state
 	effectiveconfig.Pipe{}, // writes the actual config (with defaults et al set) to dist

--- a/pipeline/before/before.go
+++ b/pipeline/before/before.go
@@ -1,0 +1,38 @@
+package before
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/goreleaser/goreleaser/context"
+)
+
+// Pipe is a global hook pipe
+type Pipe struct{}
+
+// String is the name of this pipe
+func (Pipe) String() string {
+	return "Run global hooks before starting the relase process"
+}
+
+// Default initialized the default values
+func (Pipe) Default(ctx *context.Context) error {
+	if ctx.Config.Before.Hooks == nil {
+		ctx.Config.Before.Hooks = []string{}
+	}
+	return nil
+}
+
+// Run executes the hooks
+func (Pipe) Run(ctx *context.Context) error {
+	/* #nosec */
+	for _, step := range ctx.Config.Before.Hooks {
+		args := strings.Fields(step)
+		cmd := exec.Command(args[0], args[1:]...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("hook failed: %s\n%v", step, string(out))
+		}
+	}
+	return nil
+}

--- a/pipeline/before/before_test.go
+++ b/pipeline/before/before_test.go
@@ -1,0 +1,46 @@
+package before
+
+import (
+	"testing"
+
+	"github.com/goreleaser/goreleaser/config"
+	"github.com/goreleaser/goreleaser/context"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDescription(t *testing.T) {
+	assert.NotEmpty(t, Pipe{}.String())
+}
+
+func TestRunPipe(t *testing.T) {
+	for _, tc := range [][]string{
+		nil,
+		[]string{},
+		[]string{"go version"},
+		[]string{"go version", "go list"},
+	} {
+		ctx := context.New(
+			config.Project{
+				Before: config.Before{
+					Hooks: tc,
+				},
+			},
+		)
+		assert.NoError(t, Pipe{}.Run(ctx))
+	}
+}
+
+func TestRunPipeFail(t *testing.T) {
+	for _, tc := range [][]string{
+		[]string{"go tool foobar"},
+	} {
+		ctx := context.New(
+			config.Project{
+				Before: config.Before{
+					Hooks: tc,
+				},
+			},
+		)
+		assert.Error(t, Pipe{}.Run(ctx))
+	}
+}


### PR DESCRIPTION
This PR adds a new pipeline step to run additional hooks (in my case: `make clean`) before the build starts.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] I have read the **CONTRIBUTING** document.
* [ ] `make ci` passes on my machine.
* [x] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
