### PR TITLE
feat: Read release body template from config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -115,6 +115,7 @@ type Release struct {
 	Draft        bool   `yaml:",omitempty"`
 	Prerelease   bool   `yaml:",omitempty"`
 	NameTemplate string `yaml:"name_template,omitempty"`
+	BodyTemplate string `yaml:"body_template,omitempty"`
 }
 
 // NFPM config

--- a/pipeline/release/body.go
+++ b/pipeline/release/body.go
@@ -40,11 +40,19 @@ func describeBody(ctx *context.Context) (bytes.Buffer, error) {
 
 func describeBodyVersion(ctx *context.Context, version string) (bytes.Buffer, error) {
 	var out bytes.Buffer
+	tpl := bodyTemplate
+	if ctx.Config.Release.BodyTemplate != "" {
+		var err error
+		tpl, err = template.New("release").Parse(ctx.Config.Release.BodyTemplate)
+		if err != nil {
+			return out, err
+		}
+	}
 	var dockers []string
 	for _, a := range ctx.Artifacts.Filter(artifact.ByType(artifact.DockerImage)).List() {
 		dockers = append(dockers, a.Name)
 	}
-	err := bodyTemplate.Execute(&out, struct {
+	err := tpl.Execute(&out, struct {
 		ReleaseNotes, GoVersion string
 		DockerImages            []string
 	}{


### PR DESCRIPTION
This PR makes it possible to override the relase notes template from the config to e.g. avoid the ugly footer.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] I have read the **CONTRIBUTING** document.
* [ ] `make ci` passes on my machine.
* [x] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
