### PR TITLE
Provide time template func to release name template

### DIFF
--- a/docs/123-release.md
+++ b/docs/123-release.md
@@ -31,6 +31,8 @@ release:
   # - ProjectName
   # - Tag
   # - Version (Git tag without `v` prefix)
+  # There is also a template function "time" that takes a Go time format
+  # string to insert a formated timestamp into the release name.
   # Default is ``
   name_template: "{{.ProjectName}}-v{{.Version}}"
 ```

--- a/internal/client/name.go
+++ b/internal/client/name.go
@@ -3,14 +3,20 @@ package client
 import (
 	"bytes"
 	"text/template"
+	"time"
 
 	"github.com/goreleaser/goreleaser/context"
+)
+
+var (
+	timeNow = time.Now
 )
 
 func releaseTitle(ctx *context.Context) (string, error) {
 	var out bytes.Buffer
 	t, err := template.New("github").
 		Option("missingkey=error").
+		Funcs(mkFuncMap()).
 		Parse(ctx.Config.Release.NameTemplate)
 	if err != nil {
 		return "", err
@@ -23,4 +29,15 @@ func releaseTitle(ctx *context.Context) (string, error) {
 		Version:     ctx.Version,
 	})
 	return out.String(), err
+}
+
+func mkFuncMap() template.FuncMap {
+	return template.FuncMap{
+		"time": func(s ...string) (string, error) {
+			if len(s) < 1 {
+				return "", nil
+			}
+			return timeNow().Format(s[0]), nil
+		},
+	}
 }

--- a/internal/client/name_test.go
+++ b/internal/client/name_test.go
@@ -1,0 +1,40 @@
+package client
+
+import (
+	"testing"
+	"time"
+
+	"github.com/goreleaser/goreleaser/config"
+	"github.com/goreleaser/goreleaser/context"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFuncMap(t *testing.T) {
+	timeNow = func() time.Time {
+		return time.Date(2018, 12, 11, 10, 9, 8, 7, time.UTC)
+	}
+	var ctx = context.New(config.Project{
+		ProjectName: "proj",
+	})
+	for _, tc := range []struct {
+		Template string
+		Name     string
+		Output   string
+	}{
+		{
+			Template: `{{ time "2006-01-02" }}`,
+			Name:     "YYYY-MM-DD",
+			Output:   "2018-12-11",
+		},
+		{
+			Template: `{{ time "01/02/2006" }}`,
+			Name:     "MM/DD/YYYY",
+			Output:   "12/11/2018",
+		},
+	} {
+		ctx.Config.Release.NameTemplate = tc.Template
+		out, err := releaseTitle(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, tc.Output, out)
+	}
+}


### PR DESCRIPTION
This PR adds a template function to be used in the release title. It allows for specifying the release date as part of the title.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] I have read the **CONTRIBUTING** document.
* [ ] `make ci` passes on my machine.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
