### PR TITLE
feat: Extract Release Notes from changelog

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -206,6 +206,7 @@ type Filters struct {
 type Changelog struct {
 	Filters Filters `yaml:",omitempty"`
 	Sort    string  `yaml:",omitempty"`
+	Extract string  `yaml:",omitempty"`
 }
 
 // EnvFiles holds paths to files that contains environment variables


### PR DESCRIPTION
This PR adds a small feature that allows to specify a changelog file to be read from to feed the release notes instead of the autogenerated commit list.

This is a very change very specific to our requirements, but I personally don't like the autogenerated list at all and this one possible approach to automatically upload a manually curated change list.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] I have read the **CONTRIBUTING** document.
* [ ] `make ci` passes on my machine.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
