### PR TITLE
Improve generated Homebrew formulae caveats

### DIFF
--- a/pipeline/brew/brew.go
+++ b/pipeline/brew/brew.go
@@ -186,7 +186,11 @@ func dataFor(ctx *context.Context, client client.Client, artifact artifact.Artif
 }
 
 func split(s string) []string {
-	return strings.Split(strings.TrimSpace(s), "\n")
+	strings := strings.Split(strings.TrimSpace(s), "\n")
+	if len(strings) == 1 && strings[0] == "" {
+		return []string{}
+	}
+	return strings
 }
 
 func formulaNameFor(name string) string {

--- a/pipeline/brew/brew_test.go
+++ b/pipeline/brew/brew_test.go
@@ -45,6 +45,7 @@ var defaultTemplateData = templateData{
 	},
 	Tag:     "v0.1.3",
 	Version: "0.1.3",
+	Caveats: []string{},
 	File:    "test_Darwin_x86_64.tar.gz",
 	SHA256:  "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c68",
 }
@@ -91,6 +92,10 @@ func TestFormulaeSimple(t *testing.T) {
 func TestSplit(t *testing.T) {
 	var parts = split("system \"true\"\nsystem \"#{bin}/foo -h\"")
 	assert.Equal(t, []string{"system \"true\"", "system \"#{bin}/foo -h\""}, parts)
+	parts = split("")
+	assert.Equal(t, []string{}, parts)
+	parts = split("\n  ")
+	assert.Equal(t, []string{}, parts)
 }
 
 func TestRunPipe(t *testing.T) {

--- a/pipeline/brew/template.go
+++ b/pipeline/brew/template.go
@@ -60,7 +60,7 @@ const formulaTemplate = `class {{ .Name }} < Formula
 
   {{- with .Caveats }}
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     {{- range $index, $element := . }}
     {{ . -}}
     {{- end }}

--- a/pipeline/brew/testdata/build_from_source.rb.golden
+++ b/pipeline/brew/testdata/build_from_source.rb.golden
@@ -17,7 +17,7 @@ class BuildFromSource < Formula
     bin.install "foo"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     don't do this
   EOS
   end

--- a/pipeline/brew/testdata/custom_download_strategy.rb.golden
+++ b/pipeline/brew/testdata/custom_download_strategy.rb.golden
@@ -15,7 +15,7 @@ class CustomDownloadStrategy < Formula
     bin.install "foo"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     don't do this
   EOS
   end

--- a/pipeline/brew/testdata/default.rb.golden
+++ b/pipeline/brew/testdata/default.rb.golden
@@ -15,7 +15,7 @@ class Default < Formula
     bin.install "foo"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     don't do this
   EOS
   end

--- a/pipeline/brew/testdata/github_enterprise_url.rb.golden
+++ b/pipeline/brew/testdata/github_enterprise_url.rb.golden
@@ -15,7 +15,7 @@ class GithubEnterpriseUrl < Formula
     bin.install "foo"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     don't do this
   EOS
   end

--- a/pipeline/brew/testdata/test.rb.golden
+++ b/pipeline/brew/testdata/test.rb.golden
@@ -14,7 +14,7 @@ class Test < Formula
     another install script
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Here are some caveats
   EOS
   end


### PR DESCRIPTION
Pull request #625 made some changes to the way that caveats are included in Homebrew formulae. Previously, the string value of the caveats config field was included directly into the formula. Now, surrounding whitespace is trimmed, it is split by line, and the lines are included into the formula with some leading whitespace for readability reasons. That's all sensible, but this leads to an unintended problem: if `cfg.Caveats` is the empty string (as will be the case if it's not present in the config file), `split()` will return a slice containing the empty string. This is considered truthy by the template processor, resulting in it including the caveats section with a blank line. We deal with this by adding a check in `split()` for this scenario and returning an empty slice instead.

Relatedly, #542 switched from using the deprecated `<<-EOS.undent` in Homebrew formulae to `<<~EOS` but, when #625 moved to using a heredoc for the caveats section, this subtlety was missed, and `<<-EOS.undent` was used instead.