### PR TITLE
fix: added nfpm validations

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -97,8 +97,8 @@
     "glob",
     "rpm"
   ]
-  revision = "c52d07bcc82976b0206e6ab8dc9c12a23e1b142e"
-  version = "v0.6.2"
+  revision = "672aa2bd659a22558aa5d727bd6e76ec5d3aafb2"
+  version = "v0.6.3"
 
 [[projects]]
   name = "github.com/masterminds/semver"

--- a/pipeline/nfpm/nfpm.go
+++ b/pipeline/nfpm/nfpm.go
@@ -121,7 +121,7 @@ func create(ctx *context.Context, format, arch string, binaries []artifact.Artif
 		ConfigFiles: ctx.Config.NFPM.ConfigFiles,
 	}
 
-	if err := nfpm.Validate(info); err != nil {
+	if err = nfpm.Validate(info); err != nil {
 		return errors.Wrap(err, "invalid nfpm config")
 	}
 

--- a/pipeline/nfpm/nfpm.go
+++ b/pipeline/nfpm/nfpm.go
@@ -121,6 +121,10 @@ func create(ctx *context.Context, format, arch string, binaries []artifact.Artif
 		ConfigFiles: ctx.Config.NFPM.ConfigFiles,
 	}
 
+	if err := nfpm.Validate(info); err != nil {
+		return errors.Wrap(err, "invalid nfpm config")
+	}
+
 	packager, err := nfpm.Get(format)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!-- 

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

Call `nfpm.Validate` before packaging to ensure config is about right.

<!-- Why is this change being made? -->

This is because users reported on slack that their build was failing due to missing `homepage` config (which is not necessary, fixed on underlying nfpm impl).

<!-- # Provide links to any relevant tickets, URLs or other resources -->
