### PR TITLE
feat: Create new tags for GitHub release

### DIFF
--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -94,11 +94,12 @@ func (c *githubClient) CreateRelease(ctx *context.Context, body string) (int64, 
 		return 0, err
 	}
 	var data = &github.RepositoryRelease{
-		Name:       github.String(title),
-		TagName:    github.String(ctx.Git.CurrentTag),
-		Body:       github.String(body),
-		Draft:      github.Bool(ctx.Config.Release.Draft),
-		Prerelease: github.Bool(ctx.Config.Release.Prerelease),
+		Name:            github.String(title),
+		TagName:         github.String(ctx.Git.CurrentTag),
+		TargetCommitish: github.String(ctx.Git.Commit),
+		Body:            github.String(body),
+		Draft:           github.Bool(ctx.Config.Release.Draft),
+		Prerelease:      github.Bool(ctx.Config.Release.Prerelease),
 	}
 	release, _, err = c.client.Repositories.GetReleaseByTag(
 		ctx,


### PR DESCRIPTION
If applied, this commit will create a new tag if it does not already exist in the remote repository. If the tag already exists, the provided target commitish will not be used. This will not impact users following the existing workflow (tag, push, release).

This commit allows the user to perform `git tag v1.0.0 && goreleaser` without pushing the tags to the remote repository. The git account used for compiling the code may not have different permissions than the token used to create the release. Also, currently `git tag v1.0.0 && goreleaser` without the tags pushed will run successfully but create an invalid release pointing to the latest master commit.

One caveat, this change has no effect if a short hash is used. 

From the GitHub docs [:](https://developer.github.com/v3/repos/releases/)

> target_commitish: Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists. Default: the repository's default branch (usually master).
