### PR TITLE
fix: Use right architecture for ARM packages

### DIFF
--- a/internal/linux/arch.go
+++ b/internal/linux/arch.go
@@ -13,6 +13,8 @@ func Arch(key string) string {
 	case strings.Contains(key, "arm64"):
 		return "arm64"
 	case strings.Contains(key, "arm6"):
+		return "armel"
+	case strings.Contains(key, "arm7"):
 		return "armhf"
 	}
 	return key

--- a/internal/linux/arch_test.go
+++ b/internal/linux/arch_test.go
@@ -12,7 +12,8 @@ func TestArch(t *testing.T) {
 		"amd64": "amd64",
 		"386":   "i386",
 		"arm64": "arm64",
-		"arm6":  "armhf",
+		"arm6":  "armel",
+		"arm7":  "armhf",
 		"what":  "what",
 	} {
 		t.Run(fmt.Sprintf("%s to %s", from, to), func(t *testing.T) {


### PR DESCRIPTION
Previously when creating deb package for ARMv6 and ARMv7 the
architecture information were invalid in the generated package.
For example ARMv6 package got armhf architecture which is not right.
According to https://wiki.debian.org/ArmHardFloatPort,
armel is armv4t, armv5, armv6 and armhf is armv7 so updated
to use correct architecture.

<!-- # Provide links to any relevant tickets, URLs or other resources -->
Fixes https://github.com/goreleaser/nfpm/issues/32