### PR TITLE
feat: Add asmflags and gcflags fields

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -80,18 +80,20 @@ type IgnoredBuild struct {
 
 // Build contains the build configuration section
 type Build struct {
-	Goos    []string       `yaml:",omitempty"`
-	Goarch  []string       `yaml:",omitempty"`
-	Goarm   []string       `yaml:",omitempty"`
-	Targets []string       `yaml:",omitempty"`
-	Ignore  []IgnoredBuild `yaml:",omitempty"`
-	Main    string         `yaml:",omitempty"`
-	Ldflags string         `yaml:",omitempty"`
-	Flags   string         `yaml:",omitempty"`
-	Binary  string         `yaml:",omitempty"`
-	Hooks   Hooks          `yaml:",omitempty"`
-	Env     []string       `yaml:",omitempty"`
-	Lang    string         `yaml:",omitempty"`
+	Goos     []string       `yaml:",omitempty"`
+	Goarch   []string       `yaml:",omitempty"`
+	Goarm    []string       `yaml:",omitempty"`
+	Targets  []string       `yaml:",omitempty"`
+	Ignore   []IgnoredBuild `yaml:",omitempty"`
+	Main     string         `yaml:",omitempty"`
+	Ldflags  string         `yaml:",omitempty"`
+	Flags    string         `yaml:",omitempty"`
+	Binary   string         `yaml:",omitempty"`
+	Hooks    Hooks          `yaml:",omitempty"`
+	Env      []string       `yaml:",omitempty"`
+	Lang     string         `yaml:",omitempty"`
+	Asmflags string         `yaml:",omitempty"`
+	Gcflags  string         `yaml:",omitempty"`
 }
 
 // FormatOverride is used to specify a custom format for a specific GOOS.

--- a/docs/050-build.md
+++ b/docs/050-build.md
@@ -31,6 +31,36 @@ builds:
     # Default is empty.
     flags: -tags dev
 
+    # Custom asmflags template.
+    # This is parsed with the Go template engine and the following variables
+    # are available:
+    # - Date
+    # - Commit
+    # - Tag
+    # - Version (Git tag without `v` prefix)
+    # - Env (environment variables)
+    # Date format is `2006-01-02_15:04:05`.
+    # You can use the `time` function instead of `Date`, for example:
+    # `time "2006-01-02"` too if you need custom formats
+    #
+    # Default is empty.
+    asmflags: all=-trimpath={{.Env.GOPATH}}
+
+    # Custom gcflags template.
+    # This is parsed with the Go template engine and the following variables
+    # are available:
+    # - Date
+    # - Commit
+    # - Tag
+    # - Version (Git tag without `v` prefix)
+    # - Env (environment variables)
+    # Date format is `2006-01-02_15:04:05`.
+    # You can use the `time` function instead of `Date`, for example:
+    # `time "2006-01-02"` too if you need custom formats
+    #
+    # Default is empty.
+    gcflags: all=-trimpath={{.Env.GOPATH}}
+
     # Custom ldflags template.
     # This is parsed with the Go template engine and the following variables
     # are available:
@@ -38,6 +68,7 @@ builds:
     # - Commit
     # - Tag
     # - Version (Git tag without `v` prefix)
+    # - Env (environment variables)
     # Date format is `2006-01-02_15:04:05`.
     # You can use the `time` function instead of `Date`, for example:
     # `time "2006-01-02"` too if you need custom formats

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -84,6 +84,8 @@ func TestBuild(t *testing.T) {
 					"windows_amd64",
 					"linux_arm_6",
 				},
+				Asmflags: "all=",
+				Gcflags:  "all=",
 			},
 		},
 	}
@@ -195,6 +197,50 @@ func TestBuildInvalidTarget(t *testing.T) {
 	})
 	assert.EqualError(t, err, "linux is not a valid build target")
 	assert.Len(t, ctx.Artifacts.List(), 0)
+}
+
+func TestRunInvalidAsmflags(t *testing.T) {
+	folder, back := testlib.Mktmp(t)
+	defer back()
+	writeGoodMain(t, folder)
+	var config = config.Project{
+		Builds: []config.Build{
+			{
+				Binary:   "nametest",
+				Asmflags: "{{.Version}",
+				Targets: []string{
+					runtimeTarget,
+				},
+			},
+		},
+	}
+	var ctx = context.New(config)
+	var err = Default.Build(ctx, ctx.Config.Builds[0], api.Options{
+		Target: runtimeTarget,
+	})
+	assert.EqualError(t, err, `template: asmflags:1: unexpected "}" in operand`)
+}
+
+func TestRunInvalidGcflags(t *testing.T) {
+	folder, back := testlib.Mktmp(t)
+	defer back()
+	writeGoodMain(t, folder)
+	var config = config.Project{
+		Builds: []config.Build{
+			{
+				Binary:  "nametest",
+				Gcflags: "{{.Version}",
+				Targets: []string{
+					runtimeTarget,
+				},
+			},
+		},
+	}
+	var ctx = context.New(config)
+	var err = Default.Build(ctx, ctx.Config.Builds[0], api.Options{
+		Target: runtimeTarget,
+	})
+	assert.EqualError(t, err, `template: gcflags:1: unexpected "}" in operand`)
 }
 
 func TestRunInvalidLdflags(t *testing.T) {
@@ -319,7 +365,7 @@ func TestLdFlagsFullTemplate(t *testing.T) {
 		Config:  config,
 		Env:     map[string]string{"FOO": "123"},
 	}
-	flags, err := ldflags(ctx, ctx.Config.Builds[0])
+	flags, err := processField(ctx, ctx.Config.Builds[0].Ldflags, "ldflags")
 	assert.NoError(t, err)
 	assert.Contains(t, flags, "-s -w")
 	assert.Contains(t, flags, "-X main.version=1.2.3")
@@ -345,7 +391,7 @@ func TestInvalidTemplate(t *testing.T) {
 			var ctx = &context.Context{
 				Config: config,
 			}
-			flags, err := ldflags(ctx, ctx.Config.Builds[0])
+			flags, err := processField(ctx, template, "ldflags")
 			assert.EqualError(tt, err, eerr)
 			assert.Empty(tt, flags)
 		})


### PR DESCRIPTION
This adds support for templated `asmflags` and `gcflags` fields to the config file to match the `ldflags` field. While less often useful than the `ldflags` field, these fields are sometimes useful, especially when set to `all=-trimpath={{.Env.GOPATH}}`.

Resolves #638.