### PR TITLE
feat: Support per-format NFPM overrides

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -123,23 +123,16 @@ type Release struct {
 
 // NFPM config
 type NFPM struct {
-	NameTemplate string            `yaml:"name_template,omitempty"`
-	Replacements map[string]string `yaml:",omitempty"`
+	NFPMOverridables `yaml:",inline"`
+	Overrides        map[string]NFPMOverridables `yaml:"overrides,omitempty"`
 
-	Formats      []string          `yaml:",omitempty"`
-	Dependencies []string          `yaml:",omitempty"`
-	Recommends   []string          `yaml:",omitempty"`
-	Suggests     []string          `yaml:",omitempty"`
-	Conflicts    []string          `yaml:",omitempty"`
-	Vendor       string            `yaml:",omitempty"`
-	Homepage     string            `yaml:",omitempty"`
-	Maintainer   string            `yaml:",omitempty"`
-	Description  string            `yaml:",omitempty"`
-	License      string            `yaml:",omitempty"`
-	Bindir       string            `yaml:",omitempty"`
-	Files        map[string]string `yaml:",omitempty"`
-	ConfigFiles  map[string]string `yaml:"config_files,omitempty"`
-	Scripts      NFPMScripts       `yaml:"scripts,omitempty"`
+	Formats     []string `yaml:",omitempty"`
+	Vendor      string   `yaml:",omitempty"`
+	Homepage    string   `yaml:",omitempty"`
+	Maintainer  string   `yaml:",omitempty"`
+	Description string   `yaml:",omitempty"`
+	License     string   `yaml:",omitempty"`
+	Bindir      string   `yaml:",omitempty"`
 }
 
 // NFPMScripts is used to specify maintainer scripts
@@ -148,6 +141,19 @@ type NFPMScripts struct {
 	PostInstall string `yaml:"postinstall,omitempty"`
 	PreRemove   string `yaml:"preremove,omitempty"`
 	PostRemove  string `yaml:"postremove,omitempty"`
+}
+
+// NFPMOverridables is used to specify per package format settings
+type NFPMOverridables struct {
+	NameTemplate string            `yaml:"name_template,omitempty"`
+	Replacements map[string]string `yaml:",omitempty"`
+	Dependencies []string          `yaml:",omitempty"`
+	Recommends   []string          `yaml:",omitempty"`
+	Suggests     []string          `yaml:",omitempty"`
+	Conflicts    []string          `yaml:",omitempty"`
+	Files        map[string]string `yaml:",omitempty"`
+	ConfigFiles  map[string]string `yaml:"config_files,omitempty"`
+	Scripts      NFPMScripts       `yaml:"scripts,omitempty"`
 }
 
 // Sign config

--- a/docs/100-linux-packages.md
+++ b/docs/100-linux-packages.md
@@ -112,6 +112,28 @@ nfpm:
     postinstall: "scripts/postinstall.sh"
     preremove: "scripts/preremove.sh"
     postremove: "scripts/postremove.sh"
+
+  # Some attributes can be overrided per package format.
+  overrides:
+    deb:
+      conflicts:
+        - subversion
+      dependencies:
+        - git
+      suggests:
+        - gitk
+      recommends:
+        - tig
+    rpm:
+      replacements:
+        amd64: x86_64
+      name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Arch }}"
+      files:
+        "tmp/man.gz": "/usr/share/man/man8/app.8.gz"
+      config_files:
+        "tmp/app_generated.conf": /etc/app-rpm.conf"
+      scripts:
+        preinstall: "scripts/preinstall-rpm.sh"
 ```
 
 Note that GoReleaser will not install `rpmbuild` or any dependencies for you.

--- a/pipeline/nfpm/nfpm.go
+++ b/pipeline/nfpm/nfpm.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/goreleaser/nfpm"
+	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
 
 	// blank imports here because the formats implementations need register
@@ -16,6 +17,7 @@ import (
 	_ "github.com/goreleaser/nfpm/deb"
 	_ "github.com/goreleaser/nfpm/rpm"
 
+	"github.com/goreleaser/goreleaser/config"
 	"github.com/goreleaser/goreleaser/context"
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/internal/filenametemplate"
@@ -79,16 +81,35 @@ func doRun(ctx *context.Context) error {
 	return g.Wait()
 }
 
+func mergeOverrides(ctx *context.Context, format string) (*config.NFPMOverridables, error) {
+	var overrided config.NFPMOverridables
+	if err := mergo.Merge(&overrided, ctx.Config.NFPM.NFPMOverridables); err != nil {
+		return nil, err
+	}
+	perFormat, ok := ctx.Config.NFPM.Overrides[format]
+	if ok {
+		err := mergo.Merge(&overrided, perFormat, mergo.WithOverride)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &overrided, nil
+}
+
 func create(ctx *context.Context, format, arch string, binaries []artifact.Artifact) error {
+	overrided, err := mergeOverrides(ctx, format)
+	if err != nil {
+		return err
+	}
 	name, err := filenametemplate.Apply(
-		ctx.Config.NFPM.NameTemplate,
-		filenametemplate.NewFields(ctx, ctx.Config.NFPM.Replacements, binaries...),
+		overrided.NameTemplate,
+		filenametemplate.NewFields(ctx, overrided.Replacements, binaries...),
 	)
 	if err != nil {
 		return err
 	}
 	var files = map[string]string{}
-	for k, v := range ctx.Config.NFPM.Files {
+	for k, v := range overrided.Files {
 		files[k] = v
 	}
 	var log = log.WithField("package", name+"."+format)
@@ -114,17 +135,17 @@ func create(ctx *context.Context, format, arch string, binaries []artifact.Artif
 		License:     ctx.Config.NFPM.License,
 		Bindir:      ctx.Config.NFPM.Bindir,
 		Overridables: nfpm.Overridables{
-			Conflicts:   ctx.Config.NFPM.Conflicts,
-			Depends:     ctx.Config.NFPM.Dependencies,
-			Recommends:  ctx.Config.NFPM.Recommends,
-			Suggests:    ctx.Config.NFPM.Suggests,
+			Conflicts:   overrided.Conflicts,
+			Depends:     overrided.Dependencies,
+			Recommends:  overrided.Recommends,
+			Suggests:    overrided.Suggests,
 			Files:       files,
-			ConfigFiles: ctx.Config.NFPM.ConfigFiles,
+			ConfigFiles: overrided.ConfigFiles,
 			Scripts: nfpm.Scripts{
-				PreInstall:  ctx.Config.NFPM.Scripts.PreInstall,
-				PostInstall: ctx.Config.NFPM.Scripts.PostInstall,
-				PreRemove:   ctx.Config.NFPM.Scripts.PreRemove,
-				PostRemove:  ctx.Config.NFPM.Scripts.PostRemove,
+				PreInstall:  overrided.Scripts.PreInstall,
+				PostInstall: overrided.Scripts.PostInstall,
+				PreRemove:   overrided.Scripts.PreRemove,
+				PostRemove:  overrided.Scripts.PostRemove,
 			},
 		},
 	}


### PR DESCRIPTION
Support per-format NFPM overrides (as recently implemented in NFPM),
plus a pair or Goreleaser specific overrides, for "Replacements"
and "NameTemplate" (to address #640).

This keeps backward compatibility with existing config files:
settings at the root of the nfpm config section will still work as
previously (which is also useful to define common/shared settings
that we don't want to override anyway).

See #640 