### PR TITLE
fix: accept empty GITHUB_TOKEN if release is disabled

### DIFF
--- a/pipeline/env/env.go
+++ b/pipeline/env/env.go
@@ -38,6 +38,9 @@ func (Pipe) Run(ctx *context.Context) error {
 	if ctx.SkipPublish {
 		return pipeline.ErrSkipPublishEnabled
 	}
+	if ctx.Config.Release.Disable {
+		return pipeline.Skip("release pipe is disabled")
+	}
 	if ctx.Token == "" && err == nil {
 		return ErrMissingToken
 	}

--- a/pipeline/env/env_test.go
+++ b/pipeline/env/env_test.go
@@ -82,6 +82,18 @@ func TestInvalidEnvChecksSkipped(t *testing.T) {
 	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
 }
 
+func TestInvalidEnvReleaseDisabled(t *testing.T) {
+	assert.NoError(t, os.Unsetenv("GITHUB_TOKEN"))
+	var ctx = &context.Context{
+		Config: config.Project{
+			Release: config.Release{
+				Disable: true,
+			},
+		},
+	}
+	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
+}
+
 func TestLoadEnv(t *testing.T) {
 	t.Run("env exists", func(tt *testing.T) {
 		var env = "SUPER_SECRET_ENV"


### PR DESCRIPTION
closes #669