### PR TITLE
test: Use multiple calls to assert.NotEmpty()

### DIFF
--- a/pipeline/defaults/defaults_test.go
+++ b/pipeline/defaults/defaults_test.go
@@ -37,13 +37,10 @@ func TestFillBasicData(t *testing.T) {
 	assert.Contains(t, ctx.Config.Brew.Install, "bin.install \"goreleaser\"")
 	assert.Empty(t, ctx.Config.Dockers)
 	assert.Equal(t, "https://github.com", ctx.Config.GitHubURLs.Download)
-	assert.NotEmpty(
-		t,
-		ctx.Config.Archive.NameTemplate,
-		ctx.Config.Builds[0].Ldflags,
-		ctx.Config.Archive.Files,
-		ctx.Config.Dist,
-	)
+	assert.NotEmpty(t, ctx.Config.Archive.NameTemplate)
+	assert.NotEmpty(t, ctx.Config.Builds[0].Ldflags)
+	assert.NotEmpty(t, ctx.Config.Archive.Files)
+	assert.NotEmpty(t, ctx.Config.Dist)
 }
 
 func TestFillPartial(t *testing.T) {


### PR DESCRIPTION
`assert.NotEmpty()` appears to have been used here as if it would check multiple arguments. [In actuality][docs], it checks the second argument and, if it determines that it is empty, fails the test with an error message containing all subsequent arguments. This changes the test to call `assert.NotEmpty()` multiple times.

Feel free to close this PR without merging if I am mistaken as to the intent of the code in question.

[docs]: https://godoc.org/github.com/stretchr/testify/assert#NotEmpty