### PR TITLE
fix: Remove broken documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ For questions join the [#goreleaser](https://gophers.slack.com/messages/goreleas
 
 ## Documentation
 
-Documentation can be found in the [docs folder](docs) and live
-at https://goreleaser.com
+Documentation is hosted live at https://goreleaser.com
 
 ## Sponsors
 


### PR DESCRIPTION
If applied, this commit will remove a broken link to the docs (https://github.com/goreleaser/goreleaser/blob/master/docs) on the README.

The `docs` folder seems to have moved and hence the link is broken. [This](https://github.com/goreleaser/goreleaser.github.io) is the best I could find and it isn't ideal to be in the README.