### PR TITLE
fix: allow more fields into docker tag_template

### DIFF
--- a/internal/nametemplate/name.go
+++ b/internal/nametemplate/name.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/goreleaser/goreleaser/context"
+	"github.com/masterminds/semver"
 )
 
 // Apply applies the given name template using the context as source.
@@ -23,15 +24,27 @@ func Apply(ctx *context.Context, tmpl string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	sv, err := semver.NewVersion(ctx.Git.CurrentTag)
+	if err != nil {
+		return "", err
+	}
 	err = t.Execute(&out, struct {
 		ProjectName string
 		Tag         string
 		Version     string
+		Commit      string
+		Major       int64
+		Minor       int64
+		Patch       int64
 		Env         map[string]string
 	}{
 		ProjectName: ctx.Config.ProjectName,
 		Tag:         ctx.Git.CurrentTag,
 		Version:     ctx.Version,
+		Commit:      ctx.Git.Commit,
+		Major:       sv.Major(),
+		Minor:       sv.Minor(),
+		Patch:       sv.Patch(),
 		Env:         ctx.Env,
 	})
 	return out.String(), err

--- a/internal/nametemplate/name_test.go
+++ b/internal/nametemplate/name_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEnv(t *testing.T) {
+func TestComplexTemplates(t *testing.T) {
 	testCases := []struct {
 		desc string
 		in   string
@@ -24,11 +24,17 @@ func TestEnv(t *testing.T) {
 			in:   "{{ .Env.BAR }}",
 			out:  "",
 		},
+		{
+			desc: "semver",
+			in:   "{{.Major}}-{{.Minor}}-{{.Patch}}",
+			out:  "1-2-3",
+		},
 	}
 	var ctx = context.New(config.Project{})
 	ctx.Env = map[string]string{
 		"FOO": "BAR",
 	}
+	ctx.Git.CurrentTag = "v1.2.3"
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
 			out, _ := Apply(ctx, tC.in)

--- a/pipeline/docker/docker.go
+++ b/pipeline/docker/docker.go
@@ -2,16 +2,13 @@
 package docker
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"text/template"
 
 	"github.com/apex/log"
-	"github.com/masterminds/semver"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
@@ -19,6 +16,7 @@ import (
 	"github.com/goreleaser/goreleaser/context"
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/internal/deprecate"
+	"github.com/goreleaser/goreleaser/internal/nametemplate"
 	"github.com/goreleaser/goreleaser/pipeline"
 )
 
@@ -116,43 +114,12 @@ func doRun(ctx *context.Context) error {
 	return g.Wait()
 }
 
-func tagName(ctx *context.Context, tagTemplate string) (string, error) {
-	var out bytes.Buffer
-	t, err := template.New("tag").Option("missingkey=error").Parse(tagTemplate)
-	if err != nil {
-		return "", err
-	}
-	sv, err := semver.NewVersion(ctx.Git.CurrentTag)
-	if err != nil {
-		return "", err
-	}
-	data := struct {
-		Version string
-		Tag     string
-		Commit  string
-		Major   int64
-		Minor   int64
-		Patch   int64
-		Env     map[string]string
-	}{
-		Version: ctx.Version,
-		Commit:  ctx.Git.Commit,
-		Tag:     ctx.Git.CurrentTag,
-		Env:     ctx.Env,
-		Major:   sv.Major(),
-		Minor:   sv.Minor(),
-		Patch:   sv.Patch(),
-	}
-	err = t.Execute(&out, data)
-	return out.String(), err
-}
-
 func process(ctx *context.Context, docker config.Docker, artifact artifact.Artifact, seed int) error {
 	var root = filepath.Dir(artifact.Path)
 	var dockerfile = filepath.Join(root, filepath.Base(docker.Dockerfile)) + fmt.Sprintf(".%d", seed)
 	var images []string
 	for _, tagTemplate := range docker.TagTemplates {
-		tag, err := tagName(ctx, tagTemplate)
+		tag, err := nametemplate.Apply(ctx, tagTemplate)
 		if err != nil {
 			return errors.Wrapf(err, "failed to execute tag template '%s'", tagTemplate)
 		}

--- a/pipeline/docker/docker_test.go
+++ b/pipeline/docker/docker_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/pipeline"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var it = flag.Bool("it", false, "push images to docker hub")
@@ -52,8 +53,8 @@ func TestRunPipe(t *testing.T) {
 	type errChecker func(*testing.T, error)
 	var shouldErr = func(msg string) errChecker {
 		return func(t *testing.T, err error) {
-			assert.Error(t, err)
-			assert.Contains(t, err.Error(), msg)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), msg)
 		}
 	}
 	var shouldNotErr = func(t *testing.T, err error) {
@@ -70,7 +71,7 @@ func TestRunPipe(t *testing.T) {
 			publish: true,
 			dockers: []config.Docker{
 				{
-					Image:      registry + "goreleaser/test_run_pipe",
+					Image:      registry + "goreleaser/valid",
 					Goos:       "linux",
 					Goarch:     "amd64",
 					Dockerfile: "testdata/Dockerfile",
@@ -88,10 +89,10 @@ func TestRunPipe(t *testing.T) {
 				},
 			},
 			expect: []string{
-				registry + "goreleaser/test_run_pipe:v1.0.0-123",
-				registry + "goreleaser/test_run_pipe:v1",
-				registry + "goreleaser/test_run_pipe:v1.0",
-				registry + "goreleaser/test_run_pipe:latest",
+				registry + "goreleaser/valid:v1.0.0-123",
+				registry + "goreleaser/valid:v1",
+				registry + "goreleaser/valid:v1.0",
+				registry + "goreleaser/valid:latest",
 			},
 			assertError: shouldNotErr,
 		},
@@ -99,7 +100,7 @@ func TestRunPipe(t *testing.T) {
 			publish: true,
 			dockers: []config.Docker{
 				{
-					Image:        registry + "goreleaser/test_run_pipe",
+					Image:        registry + "goreleaser/multiple",
 					Goos:         "linux",
 					Goarch:       "amd64",
 					Dockerfile:   "testdata/Dockerfile",
@@ -107,7 +108,7 @@ func TestRunPipe(t *testing.T) {
 					TagTemplates: []string{"latest"},
 				},
 				{
-					Image:        registry + "goreleaser/test_run_pipe2",
+					Image:        registry + "goreleaser/multiple2",
 					Goos:         "linux",
 					Goarch:       "amd64",
 					Dockerfile:   "testdata/Dockerfile",
@@ -116,8 +117,8 @@ func TestRunPipe(t *testing.T) {
 				},
 			},
 			expect: []string{
-				registry + "goreleaser/test_run_pipe:latest",
-				registry + "goreleaser/test_run_pipe2:latest",
+				registry + "goreleaser/multiple:latest",
+				registry + "goreleaser/multiple2:latest",
 			},
 			assertError: shouldNotErr,
 		},
@@ -125,7 +126,7 @@ func TestRunPipe(t *testing.T) {
 			publish: true,
 			dockers: []config.Docker{
 				{
-					Image:      registry + "goreleaser/test_run_pipe",
+					Image:      registry + "goreleaser/skippush",
 					Goos:       "linux",
 					Goarch:     "amd64",
 					Dockerfile: "testdata/Dockerfile",
@@ -143,10 +144,10 @@ func TestRunPipe(t *testing.T) {
 				},
 			},
 			expect: []string{
-				registry + "goreleaser/test_run_pipe:v1.0.0-123",
-				registry + "goreleaser/test_run_pipe:v1",
-				registry + "goreleaser/test_run_pipe:v1.0",
-				registry + "goreleaser/test_run_pipe:latest",
+				registry + "goreleaser/skippush:v1.0.0-123",
+				registry + "goreleaser/skippush:v1",
+				registry + "goreleaser/skippush:v1.0",
+				registry + "goreleaser/skippush:latest",
 			},
 			assertError: shouldNotErr,
 		},
@@ -154,7 +155,7 @@ func TestRunPipe(t *testing.T) {
 			publish: true,
 			dockers: []config.Docker{
 				{
-					Image:      registry + "goreleaser/test_run_pipe",
+					Image:      registry + "goreleaser/nolatest",
 					Goos:       "linux",
 					Goarch:     "amd64",
 					Dockerfile: "testdata/Dockerfile",
@@ -168,7 +169,7 @@ func TestRunPipe(t *testing.T) {
 				},
 			},
 			expect: []string{
-				registry + "goreleaser/test_run_pipe:1.0.0",
+				registry + "goreleaser/nolatest:1.0.0",
 			},
 			assertError: shouldNotErr,
 		},
@@ -176,7 +177,7 @@ func TestRunPipe(t *testing.T) {
 			publish: false,
 			dockers: []config.Docker{
 				{
-					Image:      registry + "goreleaser/test_run_pipe",
+					Image:      registry + "goreleaser/dontpublish",
 					Goos:       "linux",
 					Goarch:     "amd64",
 					Dockerfile: "testdata/Dockerfile",
@@ -191,16 +192,15 @@ func TestRunPipe(t *testing.T) {
 				},
 			},
 			expect: []string{
-				registry + "goreleaser/test_run_pipe:v1.0.0-123",
-				registry + "goreleaser/test_run_pipe:latest",
+				registry + "goreleaser/dontpublish:v1.0.0-123",
+				registry + "goreleaser/dontpublish:latest",
 			},
 			assertError: shouldNotErr,
 		},
 		"bad_dockerfile": {
-			publish: true,
 			dockers: []config.Docker{
 				{
-					Image:      registry + "goreleaser/test_run_pipe",
+					Image:      registry + "goreleaser/bad_dockerfile",
 					Goos:       "linux",
 					Goarch:     "amd64",
 					Dockerfile: "testdata/Dockerfile.bad",
@@ -226,13 +226,13 @@ func TestRunPipe(t *testing.T) {
 					},
 				},
 			},
-			assertError: shouldErr(`template: tag:1: unexpected "}" in operand`),
+			assertError: shouldErr(`'{{.Tag}': template: release:1: unexpected "}" in operand`),
 		},
 		"missing_env_on_template": {
 			publish: true,
 			dockers: []config.Docker{
 				{
-					Image:      registry + "goreleaser/test_run_pipe",
+					Image:      registry + "goreleaser/templateerror",
 					Goos:       "linux",
 					Goarch:     "amd64",
 					Dockerfile: "testdata/Dockerfile",
@@ -242,13 +242,33 @@ func TestRunPipe(t *testing.T) {
 					},
 				},
 			},
-			assertError: shouldErr(`template: tag:1:6: executing "tag" at <.Env.NOPE>: map has no entry for key "NOPE"`),
+			assertError: shouldErr(`'{{.Env.NOPE}}': template: release:1:6: executing "release" at <.Env.NOPE>: map has no entry for key "NOPE"`),
 		},
+		// "lots_of_fields_in_template": {
+		// 	publish: true,
+		// 	dockers: []config.Docker{
+		// 		{
+		// 			Image:      registry + "goreleaser/test_run_pipe",
+		// 			Goos:       "linux",
+		// 			Goarch:     "amd64",
+		// 			Dockerfile: "testdata/Dockerfile",
+		// 			Binary:     "mybin",
+		// 			TagTemplates: []string{
+		// 				"{{.ProjectName}}_{{.Minor}}",
+		// 			},
+		// 		},
+		// 	},
+		// 	expect: []string{
+		// 		registry + "goreleaser/test_run_pipe:v1.0.0-123",
+		// 		registry + "goreleaser/test_run_pipe:latest",
+		// 	},
+		// 	assertError: shouldNotErr,
+		// },
 		"no_permissions": {
 			publish: true,
 			dockers: []config.Docker{
 				{
-					Image:      "docker.io/nope",
+					Image:      "docker.io/noperms",
 					Goos:       "linux",
 					Goarch:     "amd64",
 					Binary:     "mybin",
@@ -261,8 +281,8 @@ func TestRunPipe(t *testing.T) {
 				},
 			},
 			expect: []string{
-				"docker.io/nope:latest",
-				"docker.io/nope:v1.0.0",
+				"docker.io/noperms:latest",
+				"docker.io/noperms:v1.0.0",
 			},
 			assertError: shouldErr(`requested access to the resource is denied`),
 		},
@@ -343,6 +363,7 @@ func TestRunPipe(t *testing.T) {
 			ctx.Version = "1.0.0"
 			ctx.Git = context.GitInfo{
 				CurrentTag: "v1.0.0",
+				Commit:     "c0f33",
 			}
 			for _, os := range []string{"linux", "darwin"} {
 				for _, arch := range []string{"amd64", "386"} {
@@ -364,7 +385,7 @@ func TestRunPipe(t *testing.T) {
 				_ = exec.Command("docker", "rmi", img).Run()
 			}
 
-			docker.assertError(t, Pipe{}.Run(ctx))
+			docker.assertError(tt, Pipe{}.Run(ctx))
 
 			// this might should not fail as the image should have been created when
 			// the step ran
@@ -549,8 +570,8 @@ func TestLinkTwoLevelDirectory(t *testing.T) {
 	const testFile = "test"
 	const dstDir = "/tmp/linkedDir"
 
-	os.Mkdir(srcDir, 0755)
-	os.Mkdir(srcLevel2, 0755)
+	require.NoError(t, os.Mkdir(srcDir, 0755))
+	require.NoError(t, os.Mkdir(srcLevel2, 0755))
 	err := ioutil.WriteFile(srcDir+"/"+testFile, []byte("foo"), 0644)
 	if err != nil {
 		t.Log("Cannot setup test file")

--- a/pipeline/docker/docker_test.go
+++ b/pipeline/docker/docker_test.go
@@ -244,26 +244,26 @@ func TestRunPipe(t *testing.T) {
 			},
 			assertError: shouldErr(`'{{.Env.NOPE}}': template: release:1:6: executing "release" at <.Env.NOPE>: map has no entry for key "NOPE"`),
 		},
-		// "lots_of_fields_in_template": {
-		// 	publish: true,
-		// 	dockers: []config.Docker{
-		// 		{
-		// 			Image:      registry + "goreleaser/test_run_pipe",
-		// 			Goos:       "linux",
-		// 			Goarch:     "amd64",
-		// 			Dockerfile: "testdata/Dockerfile",
-		// 			Binary:     "mybin",
-		// 			TagTemplates: []string{
-		// 				"{{.ProjectName}}_{{.Minor}}",
-		// 			},
-		// 		},
-		// 	},
-		// 	expect: []string{
-		// 		registry + "goreleaser/test_run_pipe:v1.0.0-123",
-		// 		registry + "goreleaser/test_run_pipe:latest",
-		// 	},
-		// 	assertError: shouldNotErr,
-		// },
+		"new_fields_added_to_template": {
+			publish: true,
+			dockers: []config.Docker{
+				{
+					Image:      registry + "goreleaser/new_fields_added_to_template",
+					Goos:       "linux",
+					Goarch:     "amd64",
+					Dockerfile: "testdata/Dockerfile",
+					Binary:     "mybin",
+					TagTemplates: []string{
+						"{{.ProjectName}}_{{.Minor}}",
+					},
+				},
+			},
+			expect: []string{
+				registry + "goreleaser/test_run_pipe:v1.0.0-123",
+				registry + "goreleaser/test_run_pipe:latest",
+			},
+			assertError: shouldNotErr,
+		},
 		"no_permissions": {
 			publish: true,
 			dockers: []config.Docker{


### PR DESCRIPTION
just use the internal nametemplate package.

Also supporting Minor, Major and Patch fields in other
namtemplates

refs #707 