### PR TITLE
Update ci.md

### DIFF
--- a/www/content/ci.md
+++ b/www/content/ci.md
@@ -73,12 +73,12 @@ deployment:
 
 ## Drone
 
-By default, drone does not fetch tags. `plugins/git` is used with default values, 
-in most cases we'll need overwrite the `clone` step enabling tags in order to make 
+By default, drone does not fetch tags. `plugins/git` is used with default values,
+in most cases we'll need overwrite the `clone` step enabling tags in order to make
 `goreleaser` work correctly.
 
 In this example we're creating a new release every time a new tag is pushed.
-Note that you'll need to enable `tags` in repo settings and add `github_token` 
+Note that you'll need to enable `tags` in repo settings and add `github_token`
 secret.
 
 ```yml

--- a/www/content/ci.md
+++ b/www/content/ci.md
@@ -71,11 +71,15 @@ deployment:
       - curl -sL https://git.io/goreleaser | bash
 ```
 
-# Drone
+## Drone
 
-By default, drone does not fetch tags. `plugins/git` is used with default values, in most of the case we'll need overwrite the `clone` step with tags enabled in order to make `goreleaser` work correctly.
+By default, drone does not fetch tags. `plugins/git` is used with default values, 
+in most cases we'll need overwrite the `clone` step enabling tags in order to make 
+`goreleaser` work correctly.
+
 In this example we're creating a new release every time a new tag is pushed.
-Note that you'll need to enable `tags` in repo settings and add `github_token` secret.
+Note that you'll need to enable `tags` in repo settings and add `github_token` 
+secret.
 
 ```yml
 pipeline:

--- a/www/content/ci.md
+++ b/www/content/ci.md
@@ -70,3 +70,29 @@ deployment:
     commands:
       - curl -sL https://git.io/goreleaser | bash
 ```
+
+# Drone
+
+By default, drone does not fetch tags. `plugins/git` is used with default values, in most of the case we'll need overwrite the `clone` step with tags enabled in order to make `goreleaser` work correctly.
+In this example we're creating a new release every time a new tag is pushed.
+Note that you'll need to enable `tags` in repo settings and add `github_token` secret.
+
+```yml
+pipeline:
+  clone:
+    image: plugins/git
+    tags: true
+
+  test:
+    image: golang:1.10
+    commands:
+      - go test ./... -race
+
+  release:
+    image: golang:1.10
+    secrets: [github_token]
+    commands:
+      curl -sL https://git.io/goreleaser | bash
+    when:
+      event: tag
+```


### PR DESCRIPTION
This adds drone instructions. The main problem is that tags are not fetched with default settings.
More info: http://plugins.drone.io/drone-plugins/drone-git/:
> The git plugin is used to clone a git repository. Note that Drone uses the git plugin by default for all repositories, without any configuration required.
