### PR TITLE
Proposal: Support monorepos

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -266,7 +266,8 @@ type EnvFiles struct {
 
 // Git config
 type Git struct {
-	ShortHash bool `yaml:"short_hash,omitempty"`
+	TagsPrefix string `yaml:"tags_prefix,omitempty"`
+	ShortHash  bool   `yaml:"short_hash,omitempty"`
 }
 
 // Before config

--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -82,7 +82,7 @@ func (t *Template) Apply(s string) (string, error) {
 		return "", err
 	}
 
-	sv, err := semver.NewVersion(t.fields[tag].(string))
+	sv, err := semver.NewVersion(t.fields[version].(string))
 	if err != nil {
 		return "", errors.Wrap(err, "tmpl")
 	}

--- a/pipeline/git/git.go
+++ b/pipeline/git/git.go
@@ -63,7 +63,7 @@ func getGitInfo(ctx *context.Context) (context.GitInfo, error) {
 	if err != nil {
 		return context.GitInfo{}, errors.Wrap(err, "couldn't get current commit")
 	}
-	tag, err := getTag()
+	tag, err := getTag(ctx.Config.Git.TagsPrefix)
 	if err != nil {
 		return context.GitInfo{
 			Commit:     commit,
@@ -86,7 +86,10 @@ func setVersion(ctx *context.Context) error {
 		return nil
 	}
 	// removes usual `v` prefix
-	ctx.Version = strings.TrimPrefix(ctx.Git.CurrentTag, "v")
+	ctx.Version = strings.TrimPrefix(
+		strings.TrimPrefix(ctx.Git.CurrentTag, ctx.Config.Git.TagsPrefix),
+		"v",
+	)
 	return nil
 }
 
@@ -122,6 +125,9 @@ func getCommit(ctx *context.Context) (string, error) {
 	return git.Clean(git.Run("show", fmt.Sprintf("--format='%s'", format), "HEAD"))
 }
 
-func getTag() (string, error) {
-	return git.Clean(git.Run("describe", "--tags", "--abbrev=0"))
+func getTag(prefix string) (string, error) {
+	match := fmt.Sprintf("--match=%s*", prefix)
+	tag, err := git.Clean(git.Run("describe", "--tags", "--abbrev=0", match))
+	log.Infof("git tag with prefix %q: %q", prefix, tag)
+	return tag, err
 }


### PR DESCRIPTION
[Vegeta](https://github.com/tsenart/vegeta) hosts both a Go library and a CLI in a single repo. In that sense, it is a mono-repo, with multiple projects that ought to be versioned separately.

This version split only happened recently with [this PR](https://github.com/tsenart/vegeta/pull/309). When releasing, I found goreleaser didn't have a way of selecting which tags to use for a release.

I had to unblock myself and release Vegeta so I hacked my way in go-releaser. This proposal is not so much to bring in this code which is not robust enough in all likelihood. It's about discussing the idea of supporting monorepos which contain multiple independent components that ought to be versioned separately.

In my case, as convention, I decided to prefix all tags of a given component with the component's identifier (i.e. `cli/v8.1.0`, `lib/v9.0.0`).