### PR TITLE
fix: improve docker error handling

### DIFF
--- a/pipeline/docker/docker.go
+++ b/pipeline/docker/docker.go
@@ -95,15 +95,14 @@ func doRun(ctx *context.Context) error {
 					},
 				),
 			).List()
-			if len(binaries) == 0 {
-				log.Warnf("no binaries found for %s", docker.Binary)
+			if len(binaries) != 1 {
+				return fmt.Errorf(
+					"%d binaries match docker definition: %s: %s_%s_%s",
+					len(binaries),
+					docker.Binary, docker.Goos, docker.Goarch, docker.Goarm,
+				)
 			}
-			for _, binary := range binaries {
-				if err := process(ctx, docker, binary, seed); err != nil {
-					return err
-				}
-			}
-			return nil
+			return process(ctx, docker, binaries[0], seed)
 		})
 	}
 	return g.Wait()

--- a/pipeline/docker/docker_test.go
+++ b/pipeline/docker/docker_test.go
@@ -314,7 +314,7 @@ func TestRunPipe(t *testing.T) {
 					Dockerfile: "testdata/Dockerfile",
 				},
 			},
-			assertError: shouldNotErr,
+			assertError: shouldErr(`0 binaries match docker definition: mybinnnn: darwin_amd64_`),
 		},
 	}
 


### PR DESCRIPTION
improved the case in which a docker image may be declared but have no binaries matching it (which can really happen) and the case of a binary + goos + goarch + goarm combination matching more than one binary (can't happen right now).

Later it will just warn on the first case and do things wrong on the second, now it will error in both cases.