### PR TITLE
feat: add use_env_vars for s3

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -276,11 +276,12 @@ type Before struct {
 
 // S3 contains s3 config
 type S3 struct {
-	Region   string
-	Bucket   string
-	Folder   string
-	Profile  string
-	Endpoint string // used for minio for example
+	Region   	string
+	Bucket   	string
+	Folder   	string
+	Profile  	string
+	Endpoint 	string // used for minio for example
+	UseEnvVars 	bool `yaml:"use_env_vars,omitempty"`
 }
 
 // Put HTTP upload configuration

--- a/pipeline/s3/s3.go
+++ b/pipeline/s3/s3.go
@@ -61,9 +61,13 @@ func upload(ctx *context.Context, conf config.S3) error {
 		awsConfig.Endpoint = aws.String(conf.Endpoint)
 		awsConfig.S3ForcePathStyle = aws.Bool(true)
 	}
-	// TODO: add a test for this
-	if conf.Profile != "" {
-		awsConfig.Credentials = credentials.NewSharedCredentials("", conf.Profile)
+	if conf.UseEnvVars {
+		awsConfig.Credentials = credentials.NewEnvCredentials()
+	} else {
+		// TODO: add a test for this
+		if conf.Profile != "" {
+			awsConfig.Credentials = credentials.NewSharedCredentials("", conf.Profile)
+		}
 	}
 	sess := session.Must(session.NewSession(awsConfig))
 	svc := s3.New(sess, &aws.Config{

--- a/www/content/s3.md
+++ b/www/content/s3.md
@@ -39,6 +39,10 @@ s3:
     # want to push your artifacts to a minio server for example.
     # Default is AWS S3 URL.
     endpoint: "http://minio.foo.com"
+    # Use environment variables, such as: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+    # instead of using ~/.aws config file.
+    # Default is false.
+    use_env_vars: true
 ```
 
 > Learn more about the [name template engine](/templates).


### PR DESCRIPTION
Hi there!

I add option `use_env_vars` to s3 configuration. This option tells s3 to take credentials from environment variables, such as: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` instead of using `~/.aws` config file. I consider that this will be handy while using goreleaser on a CI-server.