### PR TITLE
feat: add acl option for s3

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -281,6 +281,7 @@ type S3 struct {
 	Folder   string
 	Profile  string
 	Endpoint string // used for minio for example
+	ACL		 string
 }
 
 // Put HTTP upload configuration

--- a/pipeline/s3/s3.go
+++ b/pipeline/s3/s3.go
@@ -38,6 +38,9 @@ func (Pipe) Default(ctx *context.Context) error {
 		if s3.Region == "" {
 			s3.Region = "us-east-1"
 		}
+		if s3.ACL == "" {
+			s3.ACL = "private"
+		}
 	}
 	return nil
 }
@@ -99,6 +102,7 @@ func upload(ctx *context.Context, conf config.S3) error {
 				Bucket: aws.String(conf.Bucket),
 				Key:    aws.String(filepath.Join(folder, artifact.Name)),
 				Body:   f,
+				ACL:    aws.String(conf.ACL),
 			})
 			return err
 		})

--- a/pipeline/s3/s3_test.go
+++ b/pipeline/s3/s3_test.go
@@ -49,6 +49,7 @@ func TestDefaults(t *testing.T) {
 		Bucket: "foo",
 		Region: "us-east-1",
 		Folder: "{{ .ProjectName }}/{{ .Tag }}",
+		ACL: 	"private",
 	}}, ctx.Config.S3)
 }
 

--- a/www/content/s3.md
+++ b/www/content/s3.md
@@ -39,9 +39,13 @@ s3:
     # want to push your artifacts to a minio server for example.
     # Default is AWS S3 URL.
     endpoint: "http://minio.foo.com"
+    # Sets the ACL of the object using the specified canned ACL.
+    # Default is private.
+    acl: public-read
 ```
 
 > Learn more about the [name template engine](/templates).
+> Learn more about the [acl](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUTacl.html).
 
 ## Authentication
 


### PR DESCRIPTION
Hi there!

By default, goreleaser uploads archives to s3 as private files. So I add option `acl` to s3 configuration which let upload an archive as a public file.