### PR TITLE
feat: s3: credentials from env as well

### DIFF
--- a/pipeline/s3/s3.go
+++ b/pipeline/s3/s3.go
@@ -64,10 +64,12 @@ func upload(ctx *context.Context, conf config.S3) error {
 		awsConfig.Endpoint = aws.String(conf.Endpoint)
 		awsConfig.S3ForcePathStyle = aws.Bool(true)
 	}
-	// TODO: add a test for this
-	if conf.Profile != "" {
-		awsConfig.Credentials = credentials.NewSharedCredentials("", conf.Profile)
-	}
+	awsConfig.Credentials = credentials.NewChainCredentials([]credentials.Provider{
+		&credentials.EnvProvider{},
+		&credentials.SharedCredentialsProvider{
+			Profile: conf.Profile,
+		},
+	})
 	sess := session.Must(session.NewSession(awsConfig))
 	svc := s3.New(sess, &aws.Config{
 		Region: aws.String(conf.Region),


### PR DESCRIPTION
closes #731 

uses the chained credential provider to get either from the config file or from env.