### PR TITLE
feat: add s3 as an option to use in a brew formula

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -50,6 +50,7 @@ type Homebrew struct {
 	SkipUpload       bool         `yaml:"skip_upload,omitempty"`
 	DownloadStrategy string       `yaml:"download_strategy,omitempty"`
 	SourceTarball    string       `yaml:"-"`
+	URLTemplate      string       `yaml:"url_template,omitempty"`
 }
 
 // Scoop contains the scoop.sh section

--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -33,10 +33,11 @@ const (
 	timestamp   = "Timestamp"
 
 	// artifact-only keys
-	os     = "Os"
-	arch   = "Arch"
-	arm    = "Arm"
-	binary = "Binary"
+	os           = "Os"
+	arch         = "Arch"
+	arm          = "Arm"
+	binary       = "Binary"
+	artifactName = "ArtifactName"
 )
 
 // New Template
@@ -64,6 +65,7 @@ func (t *Template) WithArtifact(a artifact.Artifact, replacements map[string]str
 	t.fields[arch] = replace(replacements, a.Goarch)
 	t.fields[arm] = replace(replacements, a.Goarm)
 	t.fields[binary] = bin
+	t.fields[artifactName] = a.Name
 	return t
 }
 

--- a/pipeline/brew/brew_test.go
+++ b/pipeline/brew/brew_test.go
@@ -37,17 +37,11 @@ func TestSimpleName(t *testing.T) {
 var defaultTemplateData = templateData{
 	Desc:        "Some desc",
 	Homepage:    "https://google.com",
-	DownloadURL: "https://github.com",
+	DownloadURL: "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_x86_64.tar.gz",
 	Name:        "Test",
-	Repo: config.Repo{
-		Owner: "caarlos0",
-		Name:  "test",
-	},
-	Tag:     "v0.1.3",
-	Version: "0.1.3",
-	Caveats: []string{},
-	File:    "test_Darwin_x86_64.tar.gz",
-	SHA256:  "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c68",
+	Version:     "0.1.3",
+	Caveats:     []string{},
+	SHA256:      "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c68",
 }
 
 func assertDefaultTemplateData(t *testing.T, formulae string) {
@@ -292,6 +286,7 @@ func TestRunPipeNoUpload(t *testing.T) {
 			},
 		},
 	})
+	ctx.Git = context.GitInfo{CurrentTag: "v1.0.1"}
 	var path = filepath.Join(folder, "whatever.tar.gz")
 	_, err = os.Create(path)
 	assert.NoError(t, err)

--- a/pipeline/brew/template.go
+++ b/pipeline/brew/template.go
@@ -1,17 +1,12 @@
 package brew
 
-import "github.com/goreleaser/goreleaser/config"
-
 type templateData struct {
 	Name             string
 	Desc             string
 	Homepage         string
 	DownloadURL      string
-	Repo             config.Repo // FIXME: will not work for anything but github right now.
-	Tag              string
 	Version          string
 	Caveats          []string
-	File             string
 	SHA256           string
 	Plist            string
 	DownloadStrategy string
@@ -24,7 +19,7 @@ type templateData struct {
 const formulaTemplate = `class {{ .Name }} < Formula
   desc "{{ .Desc }}"
   homepage "{{ .Homepage }}"
-  url "{{ .DownloadURL }}/{{ .Repo.Owner }}/{{ .Repo.Name }}/releases/download/{{ .Tag }}/{{ .File }}"
+  url "{{ .DownloadURL }}"
   {{- if .DownloadStrategy }}, :using => {{ .DownloadStrategy }}{{- end }}
   version "{{ .Version }}"
   sha256 "{{ .SHA256 }}"

--- a/www/content/homebrew.md
+++ b/www/content/homebrew.md
@@ -27,6 +27,10 @@ brew:
     owner: user
     name: homebrew-tap
 
+  # Template for the url.
+  # Default is "https://github.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+  url_template: "http://github.mycompany.com/foo/bar/releases/{{ .Tag }}/{{ .ArtifactName }}"
+
   # Allows you to set a custom download strategy.
   # Default is empty.
   download_strategy: GitHubPrivateRepositoryReleaseDownloadStrategy

--- a/www/content/templates.md
+++ b/www/content/templates.md
@@ -29,12 +29,13 @@ On fields that support templating, this fields are always available:
 On fields that are related to a single artifact (e.g., the binary name), you
 may have some extra fields:
 
-|    Key    |              Description              |
-| :-------: | :-----------------------------------: |
-|   `.Os`   |  `GOOS` (usually allow replacements)  |
-|  `.Arch`  | `GOARCH` (usually allow replacements) |
-|  `.Arm`   | `GOARM` (usually allow replacements)  |
-| `.Binary` |              Binary name              |
+|       Key       |              Description              |
+| :-------------: | :-----------------------------------: |
+|      `.Os`      |  `GOOS` (usually allow replacements)  |
+|     `.Arch`     | `GOARCH` (usually allow replacements) |
+|     `.Arm`      | `GOARM` (usually allow replacements)  |
+|    `.Binary`    |              Binary name              |
+| `.ArtifactName` |              Archive name             |
 
 On all fields, you have these available functions:
 


### PR DESCRIPTION
Hi there!

`goreleaser` can publish archives to s3, but can't use s3-links in `brew` formulas. This solution fixes that.