### PR TITLE
docs: Update doc for CircleCI 2.0

### DIFF
--- a/www/content/ci.md
+++ b/www/content/ci.md
@@ -57,9 +57,32 @@ Note the last line (`condition: $TRAVIS_OS_NAME = linux`): it is important
 if you run a build matrix with multiple Go versions and/or multiple OSes. If
 that's the case you will want to make sure GoReleaser is run just once.
 
-# Circle
+## CircleCI
 
-Here is how to do it with [CircleCI](https://circleci.com):
+Here is how to do it with [CircleCI 2.0](https://circleci.com):
+
+```yml
+# .circleci/config.yml
+jobs:
+  release:
+    docker:
+      - image: circleci/golang:1.10
+    steps:
+      - checkout
+      - run: curl -sL https://git.io/goreleaser | bash
+workflows:
+  version: 2
+  release:
+    jobs:
+      - release:
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /v[0-9]+(\.[0-9]+)*(-.*)*/
+```
+
+For CircleCI 1.0:
 
 ```yml
 # circle.yml


### PR DESCRIPTION
Since support for CircleCI 1.0 will end on August 31, 2018, the documentation needs to be updated with CircleCI 2.0. Since I have just recently added `goreleaser` to my own package, I'm sharing the config I used, based on the discussion in #350.

The configuration is kept to the bare minimum needed to run `gorelease` on a tag push. I excluded other steps such as setting up dependencies, which should be on per project basis.



<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->

<!-- # Provide links to any relevant tickets, URLs or other resources -->
