### PR TITLE
fix: typos

### DIFF
--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -55,7 +55,7 @@ func New(ctx *context.Context) *Template {
 	}
 }
 
-// WithArtifacts populate fields from the artifact and replacements
+// WithArtifact populates fields from the artifact and replacements
 func (t *Template) WithArtifact(a artifact.Artifact, replacements map[string]string) *Template {
 	var bin = a.Extra[binary]
 	if bin == "" {

--- a/pipeline/brew/brew_test.go
+++ b/pipeline/brew/brew_test.go
@@ -101,7 +101,7 @@ func TestRunPipe(t *testing.T) {
 		"custom_download_strategy": func(ctx *context.Context) {
 			ctx.Config.Brew.DownloadStrategy = "GitHubPrivateRepositoryReleaseDownloadStrategy"
 		},
-		"binary_overriden": func(ctx *context.Context) {
+		"binary_overridden": func(ctx *context.Context) {
 			ctx.Config.Archive.Format = "binary"
 			ctx.Config.Archive.FormatOverrides = []config.FormatOverride{
 				{


### PR DESCRIPTION
Fix two smalls typos that are avoiding a full 100% on Go Report Card

https://goreportcard.com/report/github.com/goreleaser/goreleaser#golint
https://goreportcard.com/report/github.com/goreleaser/goreleaser#misspell