### PR TITLE
feat: Add default command for snapcraft

### DIFF
--- a/internal/pipeline/snapcraft/snapcraft.go
+++ b/internal/pipeline/snapcraft/snapcraft.go
@@ -160,6 +160,13 @@ func create(ctx *context.Context, arch string, binaries []artifact.Artifact) err
 			return err
 		}
 	}
+
+	if _, ok := metadata.Apps[metadata.Name]; !ok {
+		metadata.Apps[metadata.Name] = AppMetadata{
+			Command: binaries[0].Name,
+		}
+	}
+
 	out, err := yaml.Marshal(metadata)
 	if err != nil {
 		return err

--- a/internal/pipeline/snapcraft/snapcraft_test.go
+++ b/internal/pipeline/snapcraft/snapcraft_test.go
@@ -108,6 +108,8 @@ func TestRunPipeWithName(t *testing.T) {
 	err = yaml.Unmarshal(yamlFile, &metadata)
 	assert.NoError(t, err)
 	assert.Equal(t, metadata.Name, "testsnapname")
+	assert.Equal(t, metadata.Apps["mybin"].Command, "mybin")
+	assert.Equal(t, metadata.Apps["testsnapname"].Command, "mybin")
 }
 
 func TestRunPipeMetadata(t *testing.T) {

--- a/www/content/snapcraft.md
+++ b/www/content/snapcraft.md
@@ -69,7 +69,7 @@ snapcraft:
   # you can declare extra details for those binaries. It is optional.
   apps:
 
-    # The name of the app must be the same name as the binary built.
+    # The name of the app must be the same name as the binary built or the snapcraft name.
     drumroll:
 
       # If your app requires extra permissions to work outside of its default


### PR DESCRIPTION
Hi there!

I have a snap, the name of which differs from the name of the binary build. So, I propose to use the snap name as the app name instead of the name of the binary build.