### PR TITLE
feat: copy all app metadata to default command

### DIFF
--- a/internal/pipeline/snapcraft/snapcraft.go
+++ b/internal/pipeline/snapcraft/snapcraft.go
@@ -162,9 +162,7 @@ func create(ctx *context.Context, arch string, binaries []artifact.Artifact) err
 	}
 
 	if _, ok := metadata.Apps[metadata.Name]; !ok {
-		metadata.Apps[metadata.Name] = AppMetadata{
-			Command: binaries[0].Name,
-		}
+		metadata.Apps[metadata.Name] = metadata.Apps[binaries[0].Name]
 	}
 
 	out, err := yaml.Marshal(metadata)

--- a/internal/pipeline/snapcraft/snapcraft_test.go
+++ b/internal/pipeline/snapcraft/snapcraft_test.go
@@ -119,7 +119,7 @@ func TestRunPipeMetadata(t *testing.T) {
 	assert.NoError(t, os.Mkdir(dist, 0755))
 	assert.NoError(t, err)
 	var ctx = context.New(config.Project{
-		ProjectName: "mybin",
+		ProjectName: "testprojectname",
 		Dist:        dist,
 		Snapcraft: config.Snapcraft{
 			NameTemplate: "foo_{{.Arch}}",
@@ -146,6 +146,9 @@ func TestRunPipeMetadata(t *testing.T) {
 	assert.Equal(t, metadata.Apps["mybin"].Plugs, []string{"home", "network"})
 	assert.Equal(t, metadata.Apps["mybin"].Daemon, "simple")
 	assert.Equal(t, metadata.Apps["mybin"].Command, "mybin --foo --bar")
+	assert.Equal(t, metadata.Apps["testprojectname"].Plugs, []string{"home", "network"})
+	assert.Equal(t, metadata.Apps["testprojectname"].Daemon, "simple")
+	assert.Equal(t, metadata.Apps["testprojectname"].Command, "mybin --foo --bar")
 }
 
 func TestNoSnapcraftInPath(t *testing.T) {


### PR DESCRIPTION
Hi there!

In my previous PR #749 I've added the default command for snapcraft pipeline. But I only copy the command without additional metadata. That solution doesn't work if we have additional metadata like `plugs`.