### PR TITLE
feat: Add url template to scoop pipeline

### DIFF
--- a/internal/pipeline/scoop/scoop.go
+++ b/internal/pipeline/scoop/scoop.go
@@ -10,6 +10,7 @@ import (
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/internal/client"
 	"github.com/goreleaser/goreleaser/internal/pipeline"
+	"github.com/goreleaser/goreleaser/internal/tmpl"
 	"github.com/goreleaser/goreleaser/pkg/context"
 )
 
@@ -109,13 +110,27 @@ func buildManifest(ctx *context.Context, artifacts []artifact.Artifact) (result 
 		Description:  ctx.Config.Scoop.Description,
 	}
 
+	var url string
+	if ctx.Config.Scoop.URLTemplate == "" {
+		ctx.Config.Scoop.URLTemplate = fmt.Sprintf("%s/%s/%s/releases/download/{{ .Tag }}/{{ .ArtifactName }}",
+			ctx.Config.GitHubURLs.Download,
+			ctx.Config.Release.GitHub.Owner,
+			ctx.Config.Release.GitHub.Name)
+	}
+
 	for _, artifact := range artifacts {
 		var arch = "64bit"
 		if artifact.Goarch == "386" {
 			arch = "32bit"
 		}
+
+		url, err = tmpl.New(ctx).WithArtifact(artifact, map[string]string{}).Apply(ctx.Config.Scoop.URLTemplate)
+		if err != nil {
+			return
+		}
+
 		manifest.Architecture[arch] = Resource{
-			URL: getDownloadURL(ctx, ctx.Config.GitHubURLs.Download, artifact.Name),
+			URL: url,
 			Bin: ctx.Config.Builds[0].Binary + ".exe",
 		}
 	}
@@ -126,15 +141,4 @@ func buildManifest(ctx *context.Context, artifacts []artifact.Artifact) (result 
 	}
 	_, err = result.Write(data)
 	return
-}
-
-func getDownloadURL(ctx *context.Context, githubURL, file string) string {
-	return fmt.Sprintf(
-		"%s/%s/%s/releases/download/%s/%s",
-		githubURL,
-		ctx.Config.Release.GitHub.Owner,
-		ctx.Config.Release.GitHub.Name,
-		ctx.Git.CurrentTag,
-		file,
-	)
 }

--- a/internal/pipeline/scoop/scoop_test.go
+++ b/internal/pipeline/scoop/scoop_test.go
@@ -370,115 +370,101 @@ func Test_doRun(t *testing.T) {
 }
 
 func Test_buildManifest(t *testing.T) {
-	var ctx = &context.Context{
-		Git: context.GitInfo{
-			CurrentTag: "v1.0.1",
-		},
-		Version:   "1.0.1",
-		Artifacts: artifact.New(),
-		Config: config.Project{
-			GitHubURLs: config.GitHubURLs{
-				Download: "https://github.com",
-			},
-			Builds: []config.Build{
-				{Binary: "test"},
-			},
-			Dist:        ".",
-			ProjectName: "run-pipe",
-			Archive: config.Archive{
-				Format: "tar.gz",
-			},
-			Release: config.Release{
-				GitHub: config.Repo{
-					Owner: "test",
-					Name:  "test",
-				},
-			},
-			Scoop: config.Scoop{
-				Bucket: config.Repo{
-					Owner: "test",
-					Name:  "test",
-				},
-				Description: "A run pipe test formula",
-				Homepage:    "https://github.com/goreleaser",
-			},
-		},
-	}
-	out, err := buildManifest(ctx, []artifact.Artifact{
-		{Name: "foo_1.0.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64"},
-		{Name: "foo_1.0.1_windows_386.tar.gz", Goos: "windows", Goarch: "386"},
-	})
-	assert.NoError(t, err)
-	var golden = "testdata/test_buildmanifest.json.golden"
-	if *update {
-		ioutil.WriteFile(golden, out.Bytes(), 0655)
-	}
-	bts, err := ioutil.ReadFile(golden)
-	assert.NoError(t, err)
-	assert.Equal(t, string(bts), out.String())
-}
-
-func Test_getDownloadURL(t *testing.T) {
-	type args struct {
-		ctx       *context.Context
-		githubURL string
-		file      string
-	}
 	tests := []struct {
-		name    string
-		args    args
-		wantURL string
+		filename string
+		ctx      *context.Context
 	}{
 		{
-			"simple",
-			args{
-				&context.Context{
-					Version: "1.0.0",
-					Git: context.GitInfo{
-						CurrentTag: "v1.0.0",
+			"testdata/test_buildmanifest.json.golden",
+			&context.Context{
+				Git: context.GitInfo{
+					CurrentTag: "v1.0.1",
+				},
+				Version:   "1.0.1",
+				Artifacts: artifact.New(),
+				Config: config.Project{
+					GitHubURLs: config.GitHubURLs{
+						Download: "https://github.com",
 					},
-					Config: config.Project{
-						Release: config.Release{
-							GitHub: config.Repo{
-								Owner: "user",
-								Name:  "repo",
-							},
+					Builds: []config.Build{
+						{Binary: "test"},
+					},
+					Dist:        ".",
+					ProjectName: "run-pipe",
+					Archive: config.Archive{
+						Format: "tar.gz",
+					},
+					Release: config.Release{
+						GitHub: config.Repo{
+							Owner: "test",
+							Name:  "test",
 						},
 					},
+					Scoop: config.Scoop{
+						Bucket: config.Repo{
+							Owner: "test",
+							Name:  "test",
+						},
+						Description: "A run pipe test formula",
+						Homepage:    "https://github.com/goreleaser",
+					},
 				},
-				"https://github.com",
-				"file.tar.gz",
 			},
-			"https://github.com/user/repo/releases/download/v1.0.0/file.tar.gz",
 		},
 		{
-			"custom",
-			args{
-				&context.Context{
-					Version: "1.0.0",
-					Git: context.GitInfo{
-						CurrentTag: "v1.0.0",
+			"testdata/test_buildmanifest_url_template.json.golden",
+			&context.Context{
+				Git: context.GitInfo{
+					CurrentTag: "v1.0.1",
+				},
+				Version:   "1.0.1",
+				Artifacts: artifact.New(),
+				Config: config.Project{
+					GitHubURLs: config.GitHubURLs{
+						Download: "https://github.com",
 					},
-					Config: config.Project{
-						Release: config.Release{
-							GitHub: config.Repo{
-								Owner: "user",
-								Name:  "repo",
-							},
+					Builds: []config.Build{
+						{Binary: "test"},
+					},
+					Dist:        ".",
+					ProjectName: "run-pipe",
+					Archive: config.Archive{
+						Format: "tar.gz",
+					},
+					Release: config.Release{
+						GitHub: config.Repo{
+							Owner: "test",
+							Name:  "test",
 						},
 					},
+					Scoop: config.Scoop{
+						Bucket: config.Repo{
+							Owner: "test",
+							Name:  "test",
+						},
+						Description: "A run pipe test formula",
+						Homepage:    "https://github.com/goreleaser",
+						URLTemplate: "http://github.mycompany.com/foo/bar/{{ .Tag }}/{{ .ArtifactName }}",
+					},
 				},
-				"https://git.my.company.com",
-				"file.tar.gz",
 			},
-			"https://git.my.company.com/user/repo/releases/download/v1.0.0/file.tar.gz",
 		},
 	}
+
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotURL := getDownloadURL(tt.args.ctx, tt.args.githubURL, tt.args.file)
-			assert.Equal(t, tt.wantURL, gotURL)
+		out, err := buildManifest(tt.ctx, []artifact.Artifact{
+			{Name: "foo_1.0.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64"},
+			{Name: "foo_1.0.1_windows_386.tar.gz", Goos: "windows", Goarch: "386"},
 		})
+
+		assert.NoError(t, err)
+
+		if *update {
+			ioutil.WriteFile(tt.filename, out.Bytes(), 0655)
+		}
+		bts, err := ioutil.ReadFile(tt.filename)
+		assert.NoError(t, err)
+		assert.Equal(t, string(bts), out.String())
 	}
 }
 

--- a/internal/pipeline/scoop/testdata/test_buildmanifest_url_template.json.golden
+++ b/internal/pipeline/scoop/testdata/test_buildmanifest_url_template.json.golden
@@ -1,0 +1,15 @@
+{
+    "version": "1.0.1",
+    "architecture": {
+        "32bit": {
+            "url": "http://github.mycompany.com/foo/bar/v1.0.1/foo_1.0.1_windows_386.tar.gz",
+            "bin": "test.exe"
+        },
+        "64bit": {
+            "url": "http://github.mycompany.com/foo/bar/v1.0.1/foo_1.0.1_windows_amd64.tar.gz",
+            "bin": "test.exe"
+        }
+    },
+    "homepage": "https://github.com/goreleaser",
+    "description": "A run pipe test formula"
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,6 +60,7 @@ type Scoop struct {
 	Homepage     string       `yaml:",omitempty"`
 	Description  string       `yaml:",omitempty"`
 	License      string       `yaml:",omitempty"`
+	URLTemplate  string       `yaml:"url_template,omitempty"`
 }
 
 // CommitAuthor is the author of a Git commit

--- a/www/content/scoop.md
+++ b/www/content/scoop.md
@@ -14,6 +14,10 @@ the commented example bellow:
 ```yml
 # .goreleaser.yml
 scoop:
+  # Template for the url.
+  # Default is "https://github.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+  url_template: "http://github.mycompany.com/foo/bar/releases/{{ .Tag }}/{{ .ArtifactName }}"
+
   # Repository to push the app manifest to.
   bucket:
     owner: user


### PR DESCRIPTION
Hi there!

I've added `url_template` to the scoop pipeline, as for [homebrew](https://github.com/goreleaser/goreleaser/pull/735).