### PR TITLE
fix: better dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM scratch
+FROM golang:1.10
+RUN apt-get update && \
+	apt-get install -y rpm git && \
+	rm -rf /var/lib/apt/lists/*
 COPY goreleaser /goreleaser
 ENTRYPOINT ["/goreleaser"]
 

--- a/www/content/introduction.md
+++ b/www/content/introduction.md
@@ -39,6 +39,25 @@ scoop install goreleaser
 > Check the [tap source](https://github.com/goreleaser/homebrew-tap) for
 > more details.
 
+### Using Docker
+
+You can use Docker to do simple releases. Currently, the provided docker
+image does not provide support for docker-in-docker and snapcraft.
+
+```console
+$ docker run \
+  -v $PWD:/go/src/github.com/user/repo \
+  -w /go/src/github.com/user/repo \
+  goreleaser/goreleaser --help
+```
+
+Note that the image will almost always have the last stable Go version.
+
+If you need more things, you are encouraged to have your own image. You can
+always use GoReleaser's [own Dockerfile][dockerfile] as an example though.
+
+[dockerfile]: https://github.com/goreleaser/goreleaser/blob/master/Dockerfile
+
 ## Manually
 
 Download your preferred flavor from the [releases page](https://github.com/goreleaser/goreleaser/releases/latest) and install


### PR DESCRIPTION
closes https://github.com/goreleaser/goreleaser/issues/606


I gave up trying to put everything inside the docker image, put only the basics - which is more than we had before. Should already be an improvement.

Will leave it as-is for now.