### PR TITLE
feat: Allow to get http username from env

### DIFF
--- a/internal/http/http_test.go
+++ b/internal/http/http_test.go
@@ -72,7 +72,6 @@ func TestCheckConfig(t *testing.T) {
 		{"ok", args{ctx, &config.Put{Name: "a", Target: "http://blabla", Username: "pepe", Mode: ModeArchive}, "test"}, false},
 		{"secret missing", args{ctx, &config.Put{Name: "b", Target: "http://blabla", Username: "pepe", Mode: ModeArchive}, "test"}, true},
 		{"target missing", args{ctx, &config.Put{Name: "a", Username: "pepe", Mode: ModeArchive}, "test"}, true},
-		{"username missing", args{ctx, &config.Put{Name: "a", Target: "http://blabla", Mode: ModeArchive}, "test"}, true},
 		{"name missing", args{ctx, &config.Put{Target: "http://blabla", Username: "pepe", Mode: ModeArchive}, "test"}, true},
 		{"mode missing", args{ctx, &config.Put{Name: "a", Target: "http://blabla", Username: "pepe"}, "test"}, true},
 		{"mode invalid", args{ctx, &config.Put{Name: "a", Target: "http://blabla", Username: "pepe", Mode: "blabla"}, "test"}, true},

--- a/www/content/artifactory.md
+++ b/www/content/artifactory.md
@@ -55,9 +55,27 @@ Supported variables:
 _Attention_: Variables _Os_, _Arch_ and _Arm_ are only supported in upload
 mode `binary`.
 
-### Password / API Key
+### Username
 
 Your configured username needs to be authenticated against your Artifactory.
+
+You can have the username set in the configuration file as shown above
+or you can have it read from an environment variable.
+The configured name of your Artifactory instance will be used to build
+the environment variable name.
+This way we support auth for multiple instances.
+This also means that the `name` per configured instance needs to be unique
+per goreleaser configuration.
+
+The name of the environment variable will be `ARTIFACTORY_NAME_USERNAME`.
+If your instance is named `production`, you can store the username in the
+environment variable `ARTIFACTORY_PRODUCTION_USERNAME`.
+The name will be transformed to uppercase.
+
+If a configured username is found in the configuration file, then the
+environment variable is not used at all.
+
+### Password / API Key
 
 The password or API key will be stored in a environment variable.
 The configured name of your Artifactory instance will be used.

--- a/www/content/put.md
+++ b/www/content/put.md
@@ -52,9 +52,27 @@ Supported variables:
 
 _Attention_: Variables _Os_, _Arch_ and _Arm_ are only supported in upload mode `binary`.
 
-### Password
+### Username
 
 Your configured username needs to be valid against your HTTP server.
+
+You can have the username set in the configuration file as shown above
+or you can have it read from and environment variable.
+The configured name of your HTTP server will be used to build the environment
+variable name.
+This way we support auth for multiple instances.
+This also means that the `name` per configured instance needs to be unique
+per goreleaser configuration.
+
+The name of the environment variable will be `PUT_NAME_USERNAME`.
+If your instance is named `production`, you can store the username in the
+environment variable `PUT_PRODUCTION_USERNAME`.
+The name will be transformed to uppercase.
+
+If a configured username is found in the configuration file, then the
+environment variable is not used at all.
+
+### Password
 
 The password will be stored in a environment variable.
 The configured name of your HTTP server will be used.
@@ -62,7 +80,7 @@ This way we support auth for multiple instances.
 This also means that the `name` per configured instance needs to be unique
 per goreleaser configuration.
 
-The name of the environment variable will be `PUT_<NAME>_SECRET`.
+The name of the environment variable will be `PUT_NAME_SECRET`.
 If your instance is named `production`, you need to store the secret in the
 environment variable `PUT_PRODUCTION_SECRET`.
 The name will be transformed to uppercase.


### PR DESCRIPTION
If applied, this commit will allow to get http username (used from "artifactory" and "put" pipelines) from env var if not configured in goreleaser configuration.

This change is useful to avoid committing to vcs the username in goreleaser configuration file when it needs to change based on the actual user which will run goreleaser to upload files.