### PR TITLE
feat: add hash to scoop manifest

### DIFF
--- a/internal/pipeline/scoop/scoop.go
+++ b/internal/pipeline/scoop/scoop.go
@@ -106,8 +106,9 @@ type Manifest struct {
 
 // Resource represents a combination of a url and a binary name for an architecture
 type Resource struct {
-	URL string `json:"url"` // URL to the archive
-	Bin string `json:"bin"` // name of binary inside the archive
+	URL  string `json:"url"`  // URL to the archive
+	Bin  string `json:"bin"`  // name of binary inside the archive
+	Hash string `json:"hash"` // the archive checksum
 }
 
 func buildManifest(ctx *context.Context, artifacts []artifact.Artifact) (bytes.Buffer, error) {
@@ -134,9 +135,15 @@ func buildManifest(ctx *context.Context, artifacts []artifact.Artifact) (bytes.B
 			return result, err
 		}
 
+		sum, err := artifact.Checksum()
+		if err != nil {
+			return result, err
+		}
+
 		manifest.Architecture[arch] = Resource{
-			URL: url,
-			Bin: ctx.Config.Builds[0].Binary + ".exe",
+			URL:  url,
+			Bin:  ctx.Config.Builds[0].Binary + ".exe",
+			Hash: sum,
 		}
 	}
 

--- a/internal/pipeline/scoop/scoop_test.go
+++ b/internal/pipeline/scoop/scoop_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"testing"
 
+	"path/filepath"
+
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/internal/client"
 	"github.com/goreleaser/goreleaser/internal/pipeline"
@@ -57,6 +59,11 @@ func TestDefault(t *testing.T) {
 }
 
 func Test_doRun(t *testing.T) {
+	folder, back := testlib.Mktmp(t)
+	defer back()
+	var file = filepath.Join(folder, "archive")
+	require.NoError(t, ioutil.WriteFile(file, []byte("lorem ipsum"), 0644))
+
 	type errChecker func(*testing.T, error)
 	var shouldErr = func(msg string) errChecker {
 		return func(t *testing.T, err error) {
@@ -114,8 +121,8 @@ func Test_doRun(t *testing.T) {
 				&DummyClient{},
 			},
 			[]artifact.Artifact{
-				{Name: "foo_1.0.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64"},
-				{Name: "foo_1.0.1_windows_386.tar.gz", Goos: "windows", Goarch: "386"},
+				{Name: "foo_1.0.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64", Path: file},
+				{Name: "foo_1.0.1_windows_386.tar.gz", Goos: "windows", Goarch: "386", Path: file},
 			},
 			shouldNotErr,
 		},
@@ -157,8 +164,8 @@ func Test_doRun(t *testing.T) {
 				&DummyClient{},
 			},
 			[]artifact.Artifact{
-				{Name: "foo_1.0.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64"},
-				{Name: "foo_1.0.1_windows_386.tar.gz", Goos: "windows", Goarch: "386"},
+				{Name: "foo_1.0.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64", Path: file},
+				{Name: "foo_1.0.1_windows_386.tar.gz", Goos: "windows", Goarch: "386", Path: file},
 			},
 			shouldNotErr,
 		},
@@ -276,8 +283,8 @@ func Test_doRun(t *testing.T) {
 				&DummyClient{},
 			},
 			[]artifact.Artifact{
-				{Name: "foo_1.0.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64"},
-				{Name: "foo_1.0.1_windows_386.tar.gz", Goos: "windows", Goarch: "386"},
+				{Name: "foo_1.0.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64", Path: file},
+				{Name: "foo_1.0.1_windows_386.tar.gz", Goos: "windows", Goarch: "386", Path: file},
 			},
 			shouldErr(pipeline.ErrSkipPublishEnabled.Error()),
 		},
@@ -315,8 +322,8 @@ func Test_doRun(t *testing.T) {
 				&DummyClient{},
 			},
 			[]artifact.Artifact{
-				{Name: "foo_1.0.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64"},
-				{Name: "foo_1.0.1_windows_386.tar.gz", Goos: "windows", Goarch: "386"},
+				{Name: "foo_1.0.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64", Path: file},
+				{Name: "foo_1.0.1_windows_386.tar.gz", Goos: "windows", Goarch: "386", Path: file},
 			},
 			shouldErr("release is marked as draft"),
 		},
@@ -373,6 +380,11 @@ func Test_doRun(t *testing.T) {
 }
 
 func Test_buildManifest(t *testing.T) {
+	folder, err := ioutil.TempDir("", "goreleasertest")
+	require.NoError(t, err)
+	var file = filepath.Join(folder, "archive")
+	require.NoError(t, ioutil.WriteFile(file, []byte("lorem ipsum"), 0644))
+
 	tests := []struct {
 		filename string
 		ctx      *context.Context
@@ -460,8 +472,8 @@ func Test_buildManifest(t *testing.T) {
 		var ctx = tt.ctx
 		Pipe{}.Default(ctx)
 		out, err := buildManifest(ctx, []artifact.Artifact{
-			{Name: "foo_1.0.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64"},
-			{Name: "foo_1.0.1_windows_386.tar.gz", Goos: "windows", Goarch: "386"},
+			{Name: "foo_1.0.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64", Path: file},
+			{Name: "foo_1.0.1_windows_386.tar.gz", Goos: "windows", Goarch: "386", Path: file},
 		})
 
 		require.NoError(t, err)

--- a/internal/pipeline/scoop/testdata/test_buildmanifest.json.golden
+++ b/internal/pipeline/scoop/testdata/test_buildmanifest.json.golden
@@ -3,11 +3,13 @@
     "architecture": {
         "32bit": {
             "url": "https://github.com/test/test/releases/download/v1.0.1/foo_1.0.1_windows_386.tar.gz",
-            "bin": "test.exe"
+            "bin": "test.exe",
+            "hash": "5e2bf57d3f40c4b6df69daf1936cb766f832374b4fc0259a7cbff06e2f70f269"
         },
         "64bit": {
             "url": "https://github.com/test/test/releases/download/v1.0.1/foo_1.0.1_windows_amd64.tar.gz",
-            "bin": "test.exe"
+            "bin": "test.exe",
+            "hash": "5e2bf57d3f40c4b6df69daf1936cb766f832374b4fc0259a7cbff06e2f70f269"
         }
     },
     "homepage": "https://github.com/goreleaser",

--- a/internal/pipeline/scoop/testdata/test_buildmanifest_url_template.json.golden
+++ b/internal/pipeline/scoop/testdata/test_buildmanifest_url_template.json.golden
@@ -3,11 +3,13 @@
     "architecture": {
         "32bit": {
             "url": "http://github.mycompany.com/foo/bar/v1.0.1/foo_1.0.1_windows_386.tar.gz",
-            "bin": "test.exe"
+            "bin": "test.exe",
+            "hash": "5e2bf57d3f40c4b6df69daf1936cb766f832374b4fc0259a7cbff06e2f70f269"
         },
         "64bit": {
             "url": "http://github.mycompany.com/foo/bar/v1.0.1/foo_1.0.1_windows_amd64.tar.gz",
-            "bin": "test.exe"
+            "bin": "test.exe",
+            "hash": "5e2bf57d3f40c4b6df69daf1936cb766f832374b4fc0259a7cbff06e2f70f269"
         }
     },
     "homepage": "https://github.com/goreleaser",

--- a/www/content/scoop.md
+++ b/www/content/scoop.md
@@ -59,12 +59,14 @@ the root of the repository specified in the `bucket` section.
     "64bit": {
       "url":
         "https://github.com/user/drumroll/releases/download/1.2.3/drumroll_1.2.3_windows_amd64.tar.gz",
-      "bin": "drumroll.exe"
+      "bin": "drumroll.exe",
+      "hash": "86920b1f04173ee08773136df31305c0dae2c9927248ac259e02aafd92b6008a"
     },
     "32bit": {
       "url":
         "https://github.com/user/drumroll/releases/download/1.2.3/drumroll_1.2.3_windows_386.tar.gz",
-      "bin": "drumroll.exe"
+      "bin": "drumroll.exe",
+      "hash": "283faa524ef41987e51c8786c61bb56658a489f63512b32139d222b3ee1d18e6"
     }
   },
   "homepage": "https://example.com/"


### PR DESCRIPTION
Hi there!

When I install an application via scoop I always see the warning:
> Warning: No hash in manifest...

So, I've added the hash key to the scoop manifest.