### PR TITLE
fix: remove location header requirement on http put responses

### DIFF
--- a/internal/http/http_test.go
+++ b/internal/http/http_test.go
@@ -222,11 +222,11 @@ func TestUpload(t *testing.T) {
 		}, nil
 	}
 	defer assetOpenReset()
-	var is2xx ResponseChecker = func(r *h.Response) (string, error) {
+	var is2xx ResponseChecker = func(r *h.Response) error {
 		if r.StatusCode/100 == 2 {
-			return r.Header.Get("Location"), nil
+			return nil
 		}
-		return "", errors.Errorf("unexpected http status code: %v", r.StatusCode)
+		return errors.Errorf("unexpected http status code: %v", r.StatusCode)
 	}
 	ctx := context.New(config.Project{ProjectName: "blah"})
 	ctx.Env["TEST_A_SECRET"] = "x"

--- a/internal/pipeline/artifactory/artifactory.go
+++ b/internal/pipeline/artifactory/artifactory.go
@@ -64,13 +64,13 @@ func (Pipe) Run(ctx *context.Context) error {
 		}
 	}
 
-	return http.Upload(ctx, ctx.Config.Artifactories, "artifactory", func(res *h.Response) (string, error) {
+	return http.Upload(ctx, ctx.Config.Artifactories, "artifactory", func(res *h.Response) error {
 		if err := checkResponse(res); err != nil {
-			return "", err
+			return err
 		}
 		var r artifactoryResponse
 		err := json.NewDecoder(res.Body).Decode(&r)
-		return r.DownloadURI, err
+		return err
 	})
 
 }

--- a/internal/pipeline/put/put.go
+++ b/internal/pipeline/put/put.go
@@ -38,15 +38,11 @@ func (Pipe) Run(ctx *context.Context) error {
 		}
 	}
 
-	return http.Upload(ctx, ctx.Config.Puts, "put", func(res *h.Response) (string, error) {
+	return http.Upload(ctx, ctx.Config.Puts, "put", func(res *h.Response) error {
 		if c := res.StatusCode; c < 200 || 299 < c {
-			return "", errors.Errorf("unexpected http response status: %s", res.Status)
+			return errors.Errorf("unexpected http response status: %s", res.Status)
 		}
-		loc, err := res.Location()
-		if err != nil {
-			return "", errors.Errorf("getting http response location: %s", err)
-		}
-		return loc.String(), err
+		return nil
 	})
 
 }


### PR DESCRIPTION
This PR removes the requirement for HTTP servers to return a Location header when are used as targets for publishing artifacts with the Put and Artifactory pipelines.

This is needed because Nexus repository server doesn't include a Location header on responses of PUT requests.

This change doesn't lose any functionality since the location wasn't used at all before the patch.