### PR TITLE
docs: Fix misplaced 'sort' for release

### DIFF
--- a/www/content/release.md
+++ b/www/content/release.md
@@ -48,6 +48,9 @@ You can customize how the changelog is generated using the
 ```yaml
 # .goreleaser.yml
 changelog:
+  # could either be asc, desc or empty
+  # Default is empty
+  sort: asc
   filters:
     # commit messages matching the regexp listed here will be removed from
     # the changelog
@@ -56,9 +59,6 @@ changelog:
       - '^docs:'
       - typo
       - (?i)foo
-    # could either be asc, desc or empty
-    # Default is empty
-    sort: asc
 ```
 
 ## Custom release notes


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->
The docs for `release` show that the `sort` field should a member of `filter`, which is incorrect syntax.

<!-- # Provide links to any relevant tickets, URLs or other resources -->
