### PR TITLE
Removed EOL'd CircleCI 1.0 instructions.

### DIFF
--- a/www/content/ci.md
+++ b/www/content/ci.md
@@ -7,9 +7,9 @@ weight: 140
 GoReleaser was built from the very first commit with the idea of
 running it as part of the CI pipeline in mind.
 
-Let's see how we can get it working on popular CI softwares.
+Let's see how we can get it working on popular CI software.
 
-## Travis
+## Travis CI
 
 You may want to setup your project to auto-deploy your new tags on
 [Travis](https://travis-ci.org), for example:
@@ -83,17 +83,6 @@ workflows:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
 ```
 
-For CircleCI 1.0:
-
-```yml
-# circle.yml
-deployment:
-  tag:
-    tag: /v[0-9]+(\.[0-9]+)*(-.*)*/
-    owner: user
-    commands:
-      - curl -sL https://git.io/goreleaser | bash
-```
 
 ## Drone
 


### PR DESCRIPTION
The main point of this PR is to remove the CI instructions for CircleCI 1.0.

Last month, CircleCI 1.0 [has been EOL'd](https://circleci.com/blog/sunsetting-1-0/). It doesn't work anymore for new projects, you have to use 2.0. Thus these instructions are useless now and should be removed.

Lastly, while I was in this file, I made some grammar corrections on lines 10 and 12.

- software is its own plural
- Travis CI is their correct name

Thanks!