### PR TITLE
fix github.com/Masterminds/semver import path

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -181,7 +181,7 @@
 
 [[projects]]
   digest = "1:b856d8248663c39265a764561c1a1a149783f6cc815feb54a1f3a591b91f6eca"
-  name = "github.com/masterminds/semver"
+  name = "github.com/Masterminds/semver"
   packages = ["."]
   pruneopts = ""
   revision = "c7af12943936e8c39859482e61f0574c2fd7fc75"
@@ -331,7 +331,7 @@
     "github.com/goreleaser/nfpm/deb",
     "github.com/goreleaser/nfpm/rpm",
     "github.com/imdario/mergo",
-    "github.com/masterminds/semver",
+    "github.com/Masterminds/semver",
     "github.com/mattn/go-zglob",
     "github.com/mitchellh/go-homedir",
     "github.com/pkg/errors",

--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/masterminds/semver"
+	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
 )
 


### PR DESCRIPTION
If applied, this commit will imports `github.com/Masterminds/semver` instead of `github.com/masterminds/semver`. This fixes case-sensitive collisions when other repos are also importing it but with a different report path.

`github.com/Masterminds/semver` seems to prefer the uppercase-leading one, see the usages in its readme.

https://raw.githubusercontent.com/Masterminds/semver/master/README.md
