### PR TITLE
feat: Adding GitLab support for releasing, homebrew, and scoop

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,7 +49,7 @@ brew:
   test: |
     system "#{bin}/goreleaser -v"
 scoop:
-  bucket:
+  github:
     owner: goreleaser
     name: scoop-bucket
   homepage:  https://goreleaser.com

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -18,7 +18,18 @@ type Info struct {
 
 // Client interface
 type Client interface {
-	CreateRelease(ctx *context.Context, body string) (releaseID int64, err error)
+	CreateRelease(ctx *context.Context, body string) (releaseID string, err error)
 	CreateFile(ctx *context.Context, commitAuthor config.CommitAuthor, repo config.Repo, content bytes.Buffer, path, message string) (err error)
-	Upload(ctx *context.Context, releaseID int64, name string, file *os.File) (err error)
+	Upload(ctx *context.Context, releaseID string, name string, file *os.File) (path string, err error)
+}
+
+func New(ctx *context.Context) (Client, error) {
+
+	if ctx.StorageType == context.StorageGitHub {
+		return NewGitHub(ctx)
+	}
+	if ctx.StorageType == context.StorageGitLab {
+		return NewGitLab(ctx)
+	}
+	return nil, nil
 }

--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -1,0 +1,328 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"sync"
+
+	"github.com/goreleaser/goreleaser/pkg/config"
+	"github.com/goreleaser/goreleaser/pkg/context"
+)
+
+type gitlabClient struct {
+	AccessToken string
+	BaseURL     string
+	HTTPClient  *http.Client
+	uploadLock  sync.Mutex
+}
+
+// NewGitLab returns a gitlab client implementation
+func NewGitLab(ctx *context.Context) (*gitlabClient, error) {
+	if ctx.Config.RepoURLs.API == "" {
+		ctx.Config.RepoURLs.API = "https://gitlab.com/api/v4"
+	}
+	if ctx.Config.RepoURLs.Download == "" {
+		ctx.Config.RepoURLs.Download = "https://gitlab.com/"
+	}
+
+	client := &gitlabClient{
+		AccessToken: ctx.StorageToken,
+		HTTPClient:  &http.Client{},
+	}
+	api, err := url.Parse(ctx.Config.RepoURLs.API)
+	if err != nil {
+		return &gitlabClient{}, err
+	}
+	client.BaseURL = api.String()
+
+	return client, nil
+}
+
+func (c *gitlabClient) CreateFile(
+	ctx *context.Context,
+	commitAuthor config.CommitAuthor,
+	repo config.Repo,
+	content bytes.Buffer,
+	p string,
+	message string,
+) error {
+
+	u := fmt.Sprintf(
+		"%s/projects/%s/repository/files/%s?ref=master",
+		c.BaseURL,
+		projectID(repo.Owner, repo.Name),
+		url.QueryEscape(p),
+	)
+
+	req, err := http.NewRequest(http.MethodHead, u, nil)
+	if err != nil {
+		return fmt.Errorf("gitlab get file: error creating new HTTP request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("PRIVATE-TOKEN", c.AccessToken)
+
+	resp, err := c.HTTPClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return fmt.Errorf("gitlab get file: error executing HTTP request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if err != nil && resp.StatusCode != http.StatusNotFound {
+		return err
+	}
+
+	opts := struct {
+		Branch        string `json:"branch"`
+		Content       string `json:"content"`
+		CommitMessage string `json:"commit_message"`
+	}{
+		Branch:        "master",
+		Content:       content.String(),
+		CommitMessage: message,
+	}
+	d, err := json.Marshal(opts)
+	if err != nil {
+		return fmt.Errorf("gitlab create/update file: error JSON marshaling options: %v", err)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+
+		req, err := http.NewRequest(http.MethodPost, u, bytes.NewReader(d))
+		if err != nil {
+			return fmt.Errorf("gitlab create file: error creating new HTTP request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("PRIVATE-TOKEN", c.AccessToken)
+
+		resp, err := c.HTTPClient.Do(req.WithContext(ctx))
+		if err != nil {
+			return fmt.Errorf("gitlab create file: error executing HTTP request: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("gitlab create file: unexpected HTTP status code: got %d; want %d", resp.StatusCode, http.StatusOK)
+		}
+	} else {
+
+		req, err := http.NewRequest(http.MethodPut, u, bytes.NewReader(d))
+		if err != nil {
+			return fmt.Errorf("gitlab update file: error creating new HTTP request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("PRIVATE-TOKEN", c.AccessToken)
+
+		resp, err := c.HTTPClient.Do(req.WithContext(ctx))
+		if err != nil {
+			return fmt.Errorf("gitlab update file: error executing HTTP request: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("gitlab update file: unexpected HTTP status code: got %d; want %d", resp.StatusCode, http.StatusOK)
+		}
+	}
+	return nil
+}
+
+func (c *gitlabClient) CreateRelease(ctx *context.Context, body string) (string, error) {
+
+	var method string
+	if _, err := c.getReleaseNotes(ctx, ctx.Git.CurrentTag); err == errReleaseNotFound {
+		method = http.MethodPost
+	} else {
+		method = http.MethodPut
+	}
+
+	return ctx.Git.CurrentTag, c.sendReleaseNotes(ctx, method, ctx.Git.CurrentTag, body)
+}
+
+func (c *gitlabClient) Upload(
+	ctx *context.Context,
+	releaseID string,
+	name string,
+	file *os.File,
+) (string, error) {
+	markdown, u, err := c.uploadFile(ctx, name, file)
+	if err != nil {
+		return "", err
+	}
+
+	// We lock the mutex so can append to the release description using a get and put
+	c.uploadLock.Lock()
+	defer c.uploadLock.Unlock()
+	notes, err := c.getReleaseNotes(ctx, releaseID)
+	if err != nil {
+		return "", err
+	}
+	notes = fmt.Sprintf("%s\n\n%s", notes, markdown)
+	if err := c.sendReleaseNotes(ctx, http.MethodPut, releaseID, notes); err != nil {
+		return "", err
+	}
+
+	return u, nil
+}
+
+func (c *gitlabClient) sendReleaseNotes(
+	ctx *context.Context,
+	method string,
+	releaseID string,
+	body string,
+) error {
+	u := fmt.Sprintf(
+		"%s/projects/%s/repository/tags/%s/release",
+		c.BaseURL,
+		projectID(ctx.Config.Release.Repo.Owner, ctx.Config.Release.Repo.Name),
+		releaseID,
+	)
+	opts := struct {
+		Description string `json:"description"`
+	}{
+		Description: body,
+	}
+	d, err := json.Marshal(opts)
+	if err != nil {
+		return fmt.Errorf("gitlab %s release: error JSON marshaling options: %v", method, err)
+	}
+
+	req, err := http.NewRequest(method, u, bytes.NewReader(d))
+	if err != nil {
+		return fmt.Errorf("gitlab %s release: error creating new HTTP request: %v", method, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("PRIVATE-TOKEN", c.AccessToken)
+
+	resp, err := c.HTTPClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return fmt.Errorf("gitlab %s release: error executing HTTP request: %v", method, err)
+	}
+	defer resp.Body.Close()
+
+	var statusCode int
+	if method == http.MethodPost {
+		statusCode = http.StatusCreated
+	} else {
+		statusCode = http.StatusOK
+	}
+
+	if resp.StatusCode != statusCode {
+		return fmt.Errorf("gitlab %s release: unexpected HTTP status code: got %d; want %d", method, resp.StatusCode, statusCode)
+	}
+	return nil
+}
+
+var errReleaseNotFound = errors.New("release not found")
+
+func (c *gitlabClient) getReleaseNotes(
+	ctx *context.Context,
+	releaseID string,
+) (string, error) {
+	u := fmt.Sprintf(
+		"%s/projects/%s/repository/tags/%s",
+		c.BaseURL,
+		projectID(ctx.Config.Release.Repo.Owner,
+			ctx.Config.Release.Repo.Name),
+		releaseID,
+	)
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return "", fmt.Errorf("gitlab release notes: error creating new HTTP request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("PRIVATE-TOKEN", c.AccessToken)
+
+	resp, err := c.HTTPClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return "", fmt.Errorf("gitlab release notes: error executing HTTP request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("gitlab release notes: unexpected HTTP status code: got %d; want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var respBody struct {
+		Release *struct {
+			Description string `json:"description"`
+		} `json:"release"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+		return "", fmt.Errorf("gitlab release notes: error JSON decoding HTTP response: %v", err)
+	}
+
+	if respBody.Release == nil {
+		return "", errReleaseNotFound
+	}
+
+	return respBody.Release.Description, nil
+}
+
+func (c *gitlabClient) uploadFile(
+	ctx *context.Context,
+	name string,
+	file *os.File,
+) (string, string, error) {
+	u := fmt.Sprintf(
+		"%s/projects/%s/uploads",
+		c.BaseURL,
+		projectID(ctx.Config.Release.Repo.Owner, ctx.Config.Release.Repo.Name),
+	)
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", file.Name())
+	if err != nil {
+		return "", "", err
+	}
+	_, err = io.Copy(part, file)
+
+	err = writer.Close()
+	if err != nil {
+		return "", "", err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, u, body)
+	if err != nil {
+		return "", "", fmt.Errorf("gitlab upload file: error creating new HTTP request: %v", err)
+	}
+	req.ContentLength = int64(body.Len())
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("PRIVATE-TOKEN", c.AccessToken)
+
+	resp, err := c.HTTPClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return "", "", fmt.Errorf("gitlab upload file: error executing HTTP request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return "", "", fmt.Errorf("gitlab upload file: unexpected HTTP status code: got %d; want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var respBody struct {
+		URL      string `json:"url"`
+		Markdown string `json:"markdown"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+		return "", "", fmt.Errorf("gitlab upload file: error JSON decoding HTTP response: %v", err)
+	}
+	downloadURL := path.Clean(
+		fmt.Sprintf(
+			"/%s/%s/%s",
+			ctx.Config.Release.Repo.Owner,
+			ctx.Config.Release.Repo.Name,
+			respBody.URL,
+		),
+	)
+	return respBody.Markdown, downloadURL, nil
+}
+
+func projectID(owner, name string) string {
+	return url.QueryEscape(fmt.Sprintf("%s/%s", owner, name))
+}

--- a/internal/pipe/defaults/defaults.go
+++ b/internal/pipe/defaults/defaults.go
@@ -63,9 +63,6 @@ func (Pipe) Run(ctx *context.Context) error {
 	if ctx.Config.Dist == "" {
 		ctx.Config.Dist = "dist"
 	}
-	if ctx.Config.GitHubURLs.Download == "" {
-		ctx.Config.GitHubURLs.Download = "https://github.com"
-	}
 	for _, defaulter := range defaulters {
 		log.Info(defaulter.String())
 		if err := defaulter.Default(ctx); err != nil {

--- a/internal/pipe/defaults/defaults_test.go
+++ b/internal/pipe/defaults/defaults_test.go
@@ -25,8 +25,8 @@ func TestFillBasicData(t *testing.T) {
 	}
 
 	assert.NoError(t, Pipe{}.Run(ctx))
-	assert.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Owner)
-	assert.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Name)
+	assert.Equal(t, "goreleaser", ctx.Config.Release.Repo.Owner)
+	assert.Equal(t, "goreleaser", ctx.Config.Release.Repo.Name)
 	assert.NotEmpty(t, ctx.Config.Builds)
 	assert.Equal(t, "goreleaser", ctx.Config.Builds[0].Binary)
 	assert.Equal(t, ".", ctx.Config.Builds[0].Main)
@@ -37,7 +37,6 @@ func TestFillBasicData(t *testing.T) {
 	assert.Equal(t, "tar.gz", ctx.Config.Archive.Format)
 	assert.Contains(t, ctx.Config.Brew.Install, "bin.install \"goreleaser\"")
 	assert.Empty(t, ctx.Config.Dockers)
-	assert.Equal(t, "https://github.com", ctx.Config.GitHubURLs.Download)
 	assert.NotEmpty(t, ctx.Config.Archive.NameTemplate)
 	assert.NotEmpty(t, ctx.Config.Builds[0].Ldflags)
 	assert.NotEmpty(t, ctx.Config.Archive.Files)
@@ -52,12 +51,12 @@ func TestFillPartial(t *testing.T) {
 
 	var ctx = &context.Context{
 		Config: config.Project{
-			GitHubURLs: config.GitHubURLs{
+			RepoURLs: config.RepoURLs{
 				Download: "https://github.company.com",
 			},
 			Dist: "disttt",
 			Release: config.Release{
-				GitHub: config.Repo{
+				Repo: config.Repo{
 					Owner: "goreleaser",
 					Name:  "test",
 				},
@@ -91,5 +90,5 @@ func TestFillPartial(t *testing.T) {
 	assert.NotEmpty(t, ctx.Config.Dockers[0].Dockerfile)
 	assert.Empty(t, ctx.Config.Dockers[0].Goarm)
 	assert.Equal(t, "disttt", ctx.Config.Dist)
-	assert.NotEqual(t, "https://github.com", ctx.Config.GitHubURLs.Download)
+	assert.NotEqual(t, "https://github.com", ctx.Config.RepoURLs.Download)
 }

--- a/internal/pipe/project/project.go
+++ b/internal/pipe/project/project.go
@@ -13,7 +13,7 @@ func (Pipe) String() string {
 // Default set project defaults
 func (Pipe) Default(ctx *context.Context) error {
 	if ctx.Config.ProjectName == "" {
-		ctx.Config.ProjectName = ctx.Config.Release.GitHub.Name
+		ctx.Config.ProjectName = ctx.Config.Release.Repo.Name
 	}
 	return nil
 }

--- a/internal/pipe/project/project_test.go
+++ b/internal/pipe/project/project_test.go
@@ -13,7 +13,7 @@ func TestCustomProjectName(t *testing.T) {
 	var ctx = context.New(config.Project{
 		ProjectName: "foo",
 		Release: config.Release{
-			GitHub: config.Repo{
+			Repo: config.Repo{
 				Owner: "bar",
 				Name:  "bar",
 			},
@@ -26,7 +26,7 @@ func TestCustomProjectName(t *testing.T) {
 func TestEmptyProjectName(t *testing.T) {
 	var ctx = context.New(config.Project{
 		Release: config.Release{
-			GitHub: config.Repo{
+			Repo: config.Repo{
 				Owner: "bar",
 				Name:  "bar",
 			},

--- a/internal/pipe/release/release.go
+++ b/internal/pipe/release/release.go
@@ -12,11 +12,16 @@ import (
 	"github.com/goreleaser/goreleaser/pkg/context"
 )
 
-// Pipe for github release
+const (
+	// ArtifactDownloadPath defines a string used to index into an artifact.Artifact's Extra k/v store to store a download path.
+	ArtifactDownloadPath = "release_artifact_download_path"
+)
+
+// Pipe for release
 type Pipe struct{}
 
 func (Pipe) String() string {
-	return "releasing to GitHub"
+	return "releasing"
 }
 
 // Default sets the pipe defaults
@@ -27,20 +32,20 @@ func (Pipe) Default(ctx *context.Context) error {
 	if ctx.Config.Release.NameTemplate == "" {
 		ctx.Config.Release.NameTemplate = "{{.Tag}}"
 	}
-	if ctx.Config.Release.GitHub.Name != "" {
+	if ctx.Config.Release.Repo.Name != "" {
 		return nil
 	}
 	repo, err := remoteRepo()
 	if err != nil && !ctx.Snapshot {
 		return err
 	}
-	ctx.Config.Release.GitHub = repo
+	ctx.Config.Release.Repo = repo
 	return nil
 }
 
 // Run the pipe
 func (Pipe) Run(ctx *context.Context) error {
-	c, err := client.NewGitHub(ctx)
+	c, err := client.New(ctx)
 	if err != nil {
 		return err
 	}
@@ -55,7 +60,7 @@ func doRun(ctx *context.Context, c client.Client) error {
 		return pipe.ErrSkipPublishEnabled
 	}
 	log.WithField("tag", ctx.Git.CurrentTag).
-		WithField("repo", ctx.Config.Release.GitHub.String()).
+		WithField("repo", ctx.Config.Release.Repo.String()).
 		Info("creating or updating release")
 	body, err := describeBody(ctx)
 	if err != nil {
@@ -83,12 +88,16 @@ func doRun(ctx *context.Context, c client.Client) error {
 	return g.Wait()
 }
 
-func upload(ctx *context.Context, c client.Client, releaseID int64, artifact artifact.Artifact) error {
+func upload(ctx *context.Context, c client.Client, releaseID string, artifact artifact.Artifact) error {
 	file, err := os.Open(artifact.Path)
 	if err != nil {
 		return err
 	}
 	defer file.Close() // nolint: errcheck
-	log.WithField("file", file.Name()).WithField("name", artifact.Name).Info("uploading to release")
-	return c.Upload(ctx, releaseID, artifact.Name, file)
+	log.WithField("file", file.Name()).WithField("name", artifact.Name).Infof("uploading to %s", ctx.StorageType)
+	path, err := c.Upload(ctx, releaseID, artifact.Name, file)
+	if err != nil {
+		return err
+	}
+	return ctx.Artifacts.SetExtra(artifact.ID(), ArtifactDownloadPath, path)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -15,6 +15,7 @@ import (
 
 func init() {
 	_ = os.Unsetenv("GITHUB_TOKEN")
+	_ = os.Unsetenv("GITLAB_TOKEN")
 }
 
 func TestReleaseProject(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -71,3 +71,112 @@ func TestConfigWithAnchors(t *testing.T) {
 	_, err := Load("testdata/anchor.yaml")
 	assert.NoError(t, err)
 }
+
+func TestHomebrewWithGithub(t *testing.T) {
+	prop, err := Load("testdata/homebrew_github.yaml")
+	assert.NoError(t, err)
+	assert.Equal(t, "homebrew with github", prop.ProjectName, "yaml did not load correctly")
+	assert.Equal(t, "brew project", prop.Brew.Name, "yaml did not load correctly")
+	assert.Equal(t, "foo", prop.Brew.Repo.Owner, "yaml repo did not load correctly")
+	assert.Equal(t, "bar", prop.Brew.Repo.Name, "yaml repo did not load correctly")
+}
+
+func TestHomebrewWithGitlab(t *testing.T) {
+	prop, err := Load("testdata/homebrew_gitlab.yaml")
+	assert.NoError(t, err)
+	assert.Equal(t, "homebrew with gitlab", prop.ProjectName, "yaml did not load correctly")
+	assert.Equal(t, "brew project", prop.Brew.Name, "yaml did not load correctly")
+	assert.Equal(t, "foo", prop.Brew.Repo.Owner, "yaml repo did not load correctly")
+	assert.Equal(t, "bar", prop.Brew.Repo.Name, "yaml repo did not load correctly")
+}
+
+func TestHomebrewWithGithubAndGitlab(t *testing.T) {
+	_, err := Load("testdata/homebrew_github_and_gitlab.yaml")
+	assert.EqualError(t, err, "homebrew: cannot define both github and gitlab")
+}
+
+func TestScoopWithBucket(t *testing.T) {
+	prop, err := Load("testdata/scoop_bucket.yaml")
+	assert.NoError(t, err)
+	assert.Equal(t, "scoop with bucket", prop.ProjectName, "yaml did not load correctly")
+	assert.Equal(t, "scoop homepage", prop.Scoop.Homepage, "yaml did not load correctly")
+	assert.Equal(t, "foo", prop.Scoop.Repo.Owner, "yaml repo did not load correctly")
+	assert.Equal(t, "bar", prop.Scoop.Repo.Name, "yaml repo did not load correctly")
+}
+
+func TestScoopWithGithub(t *testing.T) {
+	prop, err := Load("testdata/scoop_github.yaml")
+	assert.NoError(t, err)
+	assert.Equal(t, "scoop with github", prop.ProjectName, "yaml did not load correctly")
+	assert.Equal(t, "scoop homepage", prop.Scoop.Homepage, "yaml did not load correctly")
+	assert.Equal(t, "foo", prop.Scoop.Repo.Owner, "yaml repo did not load correctly")
+	assert.Equal(t, "bar", prop.Scoop.Repo.Name, "yaml repo did not load correctly")
+}
+
+func TestScoopWithGitlab(t *testing.T) {
+	prop, err := Load("testdata/scoop_gitlab.yaml")
+	assert.NoError(t, err)
+	assert.Equal(t, "scoop with gitlab", prop.ProjectName, "yaml did not load correctly")
+	assert.Equal(t, "scoop homepage", prop.Scoop.Homepage, "yaml did not load correctly")
+	assert.Equal(t, "foo", prop.Scoop.Repo.Owner, "yaml repo did not load correctly")
+	assert.Equal(t, "bar", prop.Scoop.Repo.Name, "yaml repo did not load correctly")
+}
+
+func TestScoopWithGithubAndBucket(t *testing.T) {
+	_, err := Load("testdata/scoop_github_and_bucket.yaml")
+	assert.EqualError(t, err, "scoop: cannot define multiple github, gitlab, and bucket")
+}
+
+func TestScoopWithGithubAndGitlab(t *testing.T) {
+	_, err := Load("testdata/scoop_github_and_gitlab.yaml")
+	assert.EqualError(t, err, "scoop: cannot define multiple github, gitlab, and bucket")
+}
+
+func TestScoopWithGitlabAndBucket(t *testing.T) {
+	_, err := Load("testdata/scoop_gitlab_and_bucket.yaml")
+	assert.EqualError(t, err, "scoop: cannot define multiple github, gitlab, and bucket")
+}
+
+func TestReleaseWithGithub(t *testing.T) {
+	prop, err := Load("testdata/release_github.yaml")
+	assert.NoError(t, err)
+	assert.Equal(t, "release with github", prop.ProjectName, "yaml did not load correctly")
+	assert.Equal(t, "foo", prop.Release.Repo.Owner, "yaml repo did not load correctly")
+	assert.Equal(t, "bar", prop.Release.Repo.Name, "yaml repo did not load correctly")
+}
+
+func TestReleaseWithGitlab(t *testing.T) {
+	prop, err := Load("testdata/release_gitlab.yaml")
+	assert.NoError(t, err)
+	assert.Equal(t, "release with gitlab", prop.ProjectName, "yaml did not load correctly")
+	assert.Equal(t, "foo", prop.Release.Repo.Owner, "yaml repo did not load correctly")
+	assert.Equal(t, "bar", prop.Release.Repo.Name, "yaml repo did not load correctly")
+}
+
+func TestReleaseWithGithubAndGitlab(t *testing.T) {
+	_, err := Load("testdata/release_github_and_gitlab.yaml")
+	assert.EqualError(t, err, "release: cannot define both github and gitlab")
+}
+
+func TestProjectWithGithub(t *testing.T) {
+	prop, err := Load("testdata/github_urls.yaml")
+	assert.NoError(t, err)
+	assert.Equal(t, "project with github urls", prop.ProjectName, "yaml did not load correctly")
+	assert.Equal(t, "https://git.company.com/api/v3/", prop.RepoURLs.API, "yaml urls did not load correctly")
+	assert.Equal(t, "https://git.company.com/api/uploads/", prop.RepoURLs.Upload, "yaml urls did not load correctly")
+	assert.Equal(t, "https://git.company.com/", prop.RepoURLs.Download, "yaml urls did not load correctly")
+}
+
+func TestProjectWithGitlab(t *testing.T) {
+	prop, err := Load("testdata/gitlab_urls.yaml")
+	assert.NoError(t, err)
+	assert.Equal(t, "project with gitlab urls", prop.ProjectName, "yaml did not load correctly")
+	assert.Equal(t, "https://git.company.com/api/v3/", prop.RepoURLs.API, "yaml urls did not load correctly")
+	assert.Equal(t, "https://git.company.com/api/uploads/", prop.RepoURLs.Upload, "yaml urls did not load correctly")
+	assert.Equal(t, "https://git.company.com/", prop.RepoURLs.Download, "yaml urls did not load correctly")
+}
+
+func TestProjectWithGithubAndGitlab(t *testing.T) {
+	_, err := Load("testdata/github_and_gitlab_urls.yaml")
+	assert.EqualError(t, err, "project: cannot define both github and gitlab urls")
+}

--- a/pkg/config/testdata/github_and_gitlab_urls.yaml
+++ b/pkg/config/testdata/github_and_gitlab_urls.yaml
@@ -1,0 +1,9 @@
+project_name: project with github and gitlab urls
+github_urls:
+  api: https://git.company.com/api/v3/
+  upload: https://git.company.com/api/uploads/
+  download: https://git.company.com/
+gitlab_urls:
+  api: https://git.company.com/api/v3/
+  upload: https://git.company.com/api/uploads/
+  download: https://git.company.com/

--- a/pkg/config/testdata/github_urls.yaml
+++ b/pkg/config/testdata/github_urls.yaml
@@ -1,0 +1,5 @@
+project_name: project with github urls
+github_urls:
+  api: https://git.company.com/api/v3/
+  upload: https://git.company.com/api/uploads/
+  download: https://git.company.com/

--- a/pkg/config/testdata/gitlab_urls.yaml
+++ b/pkg/config/testdata/gitlab_urls.yaml
@@ -1,0 +1,5 @@
+project_name: project with gitlab urls
+gitlab_urls:
+  api: https://git.company.com/api/v3/
+  upload: https://git.company.com/api/uploads/
+  download: https://git.company.com/

--- a/pkg/config/testdata/homebrew_github.yaml
+++ b/pkg/config/testdata/homebrew_github.yaml
@@ -1,0 +1,6 @@
+project_name: homebrew with github
+brew:
+  name: brew project
+  github:
+    owner: foo
+    name: bar

--- a/pkg/config/testdata/homebrew_github_and_gitlab.yaml
+++ b/pkg/config/testdata/homebrew_github_and_gitlab.yaml
@@ -1,0 +1,9 @@
+project_name: homebrew with github and gitlab
+brew:
+  name: brew project
+  github:
+    owner: foo
+    name: bar
+  gitlab:
+    owner: foo
+    name: bar

--- a/pkg/config/testdata/homebrew_gitlab.yaml
+++ b/pkg/config/testdata/homebrew_gitlab.yaml
@@ -1,0 +1,6 @@
+project_name: homebrew with gitlab
+brew:
+  name: brew project
+  github:
+    owner: foo
+    name: bar

--- a/pkg/config/testdata/release_github.yaml
+++ b/pkg/config/testdata/release_github.yaml
@@ -1,0 +1,5 @@
+project_name: release with github
+release:
+  github:
+    owner: foo
+    name: bar

--- a/pkg/config/testdata/release_github_and_gitlab.yaml
+++ b/pkg/config/testdata/release_github_and_gitlab.yaml
@@ -1,0 +1,8 @@
+project_name: release with github and gitlab
+release:
+  github:
+    owner: foo
+    name: bar
+  gitlab:
+    owner: foo
+    name: bar

--- a/pkg/config/testdata/release_gitlab.yaml
+++ b/pkg/config/testdata/release_gitlab.yaml
@@ -1,0 +1,5 @@
+project_name: release with gitlab
+release:
+  gitlab:
+    owner: foo
+    name: bar

--- a/pkg/config/testdata/scoop_bucket.yaml
+++ b/pkg/config/testdata/scoop_bucket.yaml
@@ -1,0 +1,6 @@
+project_name: scoop with bucket
+scoop:
+  homepage: scoop homepage
+  bucket:
+    owner: foo
+    name: bar

--- a/pkg/config/testdata/scoop_github.yaml
+++ b/pkg/config/testdata/scoop_github.yaml
@@ -1,0 +1,6 @@
+project_name: scoop with github
+scoop:
+  homepage: scoop homepage
+  bucket:
+    owner: foo
+    name: bar

--- a/pkg/config/testdata/scoop_github_and_bucket.yaml
+++ b/pkg/config/testdata/scoop_github_and_bucket.yaml
@@ -1,0 +1,9 @@
+project_name: scoop with github and bucket
+scoop:
+  homepage: scoop homepage
+  bucket:
+    owner: foo
+    name: bar
+  github:
+    owner: foo
+    name: bar

--- a/pkg/config/testdata/scoop_github_and_gitlab.yaml
+++ b/pkg/config/testdata/scoop_github_and_gitlab.yaml
@@ -1,0 +1,9 @@
+project_name: scoop with github and gitlab
+scoop:
+  homepage: scoop homepage
+  gitlab:
+    owner: foo
+    name: bar
+  github:
+    owner: foo
+    name: bar

--- a/pkg/config/testdata/scoop_gitlab.yaml
+++ b/pkg/config/testdata/scoop_gitlab.yaml
@@ -1,0 +1,6 @@
+project_name: scoop with gitlab
+scoop:
+  homepage: scoop homepage
+  bucket:
+    owner: foo
+    name: bar

--- a/pkg/config/testdata/scoop_gitlab_and_bucket.yaml
+++ b/pkg/config/testdata/scoop_gitlab_and_bucket.yaml
@@ -1,0 +1,9 @@
+project_name: scoop with gitlab and bucket
+scoop:
+  homepage: scoop homepage
+  gitlab:
+    owner: foo
+    name: bar
+  bucket:
+    owner: foo
+    name: bar

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -22,12 +22,20 @@ type GitInfo struct {
 	Commit     string
 }
 
+type storageType string
+
+const (
+	StorageGitHub storageType = "github"
+	StorageGitLab storageType = "gitlab"
+)
+
 // Context carries along some data through the pipes
 type Context struct {
 	ctx.Context
 	Config       config.Project
 	Env          map[string]string
-	Token        string
+	StorageToken string
+	StorageType  storageType
 	Git          GitInfo
 	Artifacts    artifact.Artifacts
 	ReleaseNotes string

--- a/www/content/deprecations.md
+++ b/www/content/deprecations.md
@@ -11,7 +11,39 @@ Deprecate code will be removed after ~6 months from the time it was deprecated.
 
 # Active deprecation notices
 
-No active deprecation notices at this time.
+## Scoop bucket
+
+> since 2018-09-20
+
+With the additional support of GitLab, a Scoop configuration should be explicit in whether or not a bucket is for GitHub or GitLab. The `bucket` key will continue be backwards until the next ~6 months.
+
+Change this:
+
+```yaml
+scoop:
+  bucket:
+	owner: foo
+	name: bar
+```
+
+to this:
+
+```yaml
+scoop:
+  github:
+	owner: foo
+	name: bar
+```
+
+or
+
+```yaml
+scoop:
+  gitlab:
+	owner: foo
+	name: bar
+```
+
 
 <!--
 

--- a/www/content/environment.md
+++ b/www/content/environment.md
@@ -4,23 +4,24 @@ weight: 20
 menu: true
 ---
 
-## GitHub Token
+## Storage Token
 
-GoReleaser requires a GitHub API token with the `repo` scope selected to
-deploy the artifacts to GitHub.
-You can create one [here](https://github.com/settings/tokens/new).
+GoReleaser requires a GitHub or GitLab API token with the `repo` scope selected to
+deploy the artifacts.
+You can create a [github one here](https://github.com/settings/tokens/new) or a [gitlab one here](https://gitlab.com/profile/personal_access_tokens)
 
-This token should be added to the environment variables as `GITHUB_TOKEN`.
+This token should be added to the environment variables as `GITHUB_TOKEN` or `GITLAB_TOKEN` respectively.
 Here is how to do it with Travis CI:
 [Defining Variables in Repository Settings](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings).
 
-Alternatively, you can provide the GitHub token in a file. GoReleaser will check `~/.config/goreleaser/github_token` by default, you can change that in
+Alternatively, you can provide the storage token in a file. GoReleaser will check `~/.config/goreleaser/github_token` and `~/.config/goreleaser/gitlab_token` by default, you can change that in
 the `.goreleaser.yml` file:
 
 ```yaml
 # .goreleaser.yml
 env_files:
-  github_token: ~/.path/to/my/token
+  github_token: ~/.path/to/my/github/token
+  gitlab_token: ~/.path/to/my/gitlab/token
 ```
 
 ## GitHub Enterprise
@@ -31,9 +32,9 @@ the `.goreleaser.yml` configuration file:
 ```yaml
 # .goreleaser.yml
 github_urls:
-  api: https://git.company.com/api/v3/
-  upload: https://git.company.com/api/uploads/
-  download: https://git.company.com/
+  api: https://github.company.com/api/v3/
+  upload: https://github.company.com/api/uploads/
+  download: https://github.company.com/
 ```
 
 If none are set, they default to GitHub's public URLs.
@@ -43,6 +44,21 @@ to another. If they are wrong, goreleaser will fail at some point, so, make
 sure they're right before opening an issue. See for example [#472][472].
 
 [472]: https://github.com/goreleaser/goreleaser/issues/472
+
+
+## Self-hosted GitLab
+
+You can use GoReleaser with Self-host GitLab by providing its URLs in
+the `.goreleaser.yml` configuration file:
+
+```yaml
+# .goreleaser.yml
+gitlab_urls:
+  api: https://gitlab.company.com/api/v3/
+  download: https://gitlab.company.com/
+```
+
+If none are set, they default to GitLab's public URLs. Not that unlike `github_urls` there is no `upload` key.
 
 ## The dist folder
 

--- a/www/content/homebrew.md
+++ b/www/content/homebrew.md
@@ -23,12 +23,13 @@ brew:
   name: myproject
 
   # Reporitory to push the tap to.
-  github:
+  github: # or gitlab
     owner: user
     name: homebrew-tap
 
   # Template for the url.
   # Default is "https://github.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+  # or for GitLab "https://gitlab.com/<repo_owner>/<repo_name>/uploads/<generated upload path>"
   url_template: "http://github.mycompany.com/foo/bar/releases/{{ .Tag }}/{{ .ArtifactName }}"
 
   # Allows you to set a custom download strategy.

--- a/www/content/release.md
+++ b/www/content/release.md
@@ -19,6 +19,10 @@ release:
   github:
     owner: user
     name: repo
+  # Or use gitlab
+  # github:
+  #  owner: user
+  #  name: repo
 
   # If set to true, will not auto-publish the release.
   # Default is false.

--- a/www/content/scoop.md
+++ b/www/content/scoop.md
@@ -19,7 +19,7 @@ scoop:
   url_template: "http://github.mycompany.com/foo/bar/releases/{{ .Tag }}/{{ .ArtifactName }}"
 
   # Repository to push the app manifest to.
-  bucket:
+  github: # or gitlab
     owner: user
     name: scoop-bucket
 


### PR DESCRIPTION
If applied, this commit will add support for GitLab see #110.

This change is being made to support talking to GitLab for releases, homebrew and scoop. It has several key changes to the internal design of goreleaser. Below is a list/summary of some of the changes you'll see in code:

- Artifacts now have an internal `id` and an `artifacts.SetExtra` function. This is so GitHub and GitLab clients can upload an artifact and then store the returned download URL on the artifact. The previous behavior was to build the download URL using a default template that uses the artifact name. Because [GitLab's uploads API](https://docs.gitlab.com/ce/api/projects.html#upload-a-file) generates a download URL rather than accepting a URL from the consumer (like [GitHub's release asset API](https://developer.github.com/v3/repos/releases/#upload-a-release-asset)) we cannot use the existing a template to build the URL, but have to store the returned download URL so we can use it later (used later in the brew and scoop pipelines).
- The `client.CreateRelease` method now returns a string for a release ID rather than an int64 since GitLab uses the tag string as the release ID when uploading a file to a project.
- Default `API` and `Download` URLs were previously set in `defaults.go` as the first default set, but at that point environment variables have not been set so it is unknown if a GitHub or GitLab token is set which determines which client to instantiate. The default `API` and `Download` URLs were deferred to when a client is instantiated.
- The `config` pkg now has custom YAML unmarshalers that will read in `github*` or `gitlab*` keys and store them in a agnostic `Repo` key on the config so code accessing the repo and URL information later doesn't need extra logic to determine whether or not to use GitLab or GitHub values. The config package will error if a `gorelease.yaml` file has both GitLab and GitHub options defined.
- A new `client.gitlabClient` exists for interacting with GitLab. Rather than importing another package (like `github.com/xanzy/go-gitlab`) the client uses the stdlib `http` package.
- The  `client.Upload` method returns a string in addition to an error where the string is the path to download the file. This is so homebrew and scoop pipelines can use that as a default URL.


This PR is large and I've tested my changes with a few use cases, but I'm not confident that it will work with other configurations. 



