### PR TITLE
fix customization link

### DIFF
--- a/www/content/introduction.md
+++ b/www/content/introduction.md
@@ -10,7 +10,7 @@ publish steps while providing variant customization options for all steps.
 
 GoReleaser is built for CI tools; you only need to
 [download and execute it](#ci_integration) in your build script.
-You can [customize](#customization) your release process by
+You can [customize](#Customization) your release process by
 creating a `.goreleaser.yml` file.
 
 The idea started with a


### PR DESCRIPTION
Repro:
 - Open https://goreleaser.com/ in Chrome or Firefox
 - Click on "customize" in the second paragraph
Expected:
 - The page jumps to "Customization"
Actual:
 - The page doesn't change because no matching `name` or `id` is found
