### PR TITLE
feat: Add support for docker build flags

### DIFF
--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -105,18 +105,12 @@ func process(ctx *context.Context, docker config.Docker, artifact artifact.Artif
 		return errors.Wrap(err, "failed to create temporaty dir")
 	}
 	log.Debug("tempdir: " + tmp)
-	// nolint:prealloc
-	var images []string
-	for _, tagTemplate := range docker.TagTemplates {
-		// TODO: add overrides support to config
-		tag, err := tmpl.New(ctx).
-			WithArtifact(artifact, map[string]string{}).
-			Apply(tagTemplate)
-		if err != nil {
-			return errors.Wrapf(err, "failed to execute tag template '%s'", tagTemplate)
-		}
-		images = append(images, fmt.Sprintf("%s:%s", docker.Image, tag))
+
+	images, err := processTagTemplates(ctx, docker, artifact)
+	if err != nil {
+		return err
 	}
+
 	if err := os.Link(docker.Dockerfile, filepath.Join(tmp, "Dockerfile")); err != nil {
 		return errors.Wrap(err, "failed to link dockerfile")
 	}
@@ -128,7 +122,13 @@ func process(ctx *context.Context, docker config.Docker, artifact artifact.Artif
 	if err := os.Link(artifact.Path, filepath.Join(tmp, filepath.Base(artifact.Path))); err != nil {
 		return errors.Wrap(err, "failed to link binary")
 	}
-	if err := dockerBuild(ctx, tmp, images[0], docker.BuildFlags); err != nil {
+
+	buildFlags, err := processBuildFlagTemplates(ctx, docker, artifact)
+	if err != nil {
+		return err
+	}
+
+	if err := dockerBuild(ctx, tmp, images[0], buildFlags); err != nil {
 		return err
 	}
 	for _, img := range images[1:] {
@@ -137,6 +137,37 @@ func process(ctx *context.Context, docker config.Docker, artifact artifact.Artif
 		}
 	}
 	return publish(ctx, docker, images)
+}
+
+func processTagTemplates(ctx *context.Context, docker config.Docker, artifact artifact.Artifact) ([]string, error) {
+	// nolint:prealloc
+	var images []string
+	for _, tagTemplate := range docker.TagTemplates {
+		// TODO: add overrides support to config
+		tag, err := tmpl.New(ctx).
+			WithArtifact(artifact, map[string]string{}).
+			Apply(tagTemplate)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to execute tag template '%s'", tagTemplate)
+		}
+		images = append(images, fmt.Sprintf("%s:%s", docker.Image, tag))
+	}
+	return images, nil
+}
+
+func processBuildFlagTemplates(ctx *context.Context, docker config.Docker, artifact artifact.Artifact) ([]string, error) {
+	// nolint:prealloc
+	var buildFlags []string
+	for _, buildFlagTemplate := range docker.BuildFlagTemplates {
+		buildFlag, err := tmpl.New(ctx).
+			WithArtifact(artifact, map[string]string{}).
+			Apply(buildFlagTemplate)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to process build flag template '%s'", buildFlagTemplate)
+		}
+		buildFlags = append(buildFlags, buildFlag)
+	}
+	return buildFlags, nil
 }
 
 // walks the src, recreating dirs and hard-linking files

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -238,16 +238,16 @@ type Checksum struct {
 
 // Docker image config
 type Docker struct {
-	Binary       string   `yaml:",omitempty"`
-	Goos         string   `yaml:",omitempty"`
-	Goarch       string   `yaml:",omitempty"`
-	Goarm        string   `yaml:",omitempty"`
-	Image        string   `yaml:",omitempty"`
-	Dockerfile   string   `yaml:",omitempty"`
-	SkipPush     bool     `yaml:"skip_push,omitempty"`
-	TagTemplates []string `yaml:"tag_templates,omitempty"`
-	Files        []string `yaml:"extra_files,omitempty"`
-	BuildFlags   []string `yaml:"build_flags,omitempty"`
+	Binary             string   `yaml:",omitempty"`
+	Goos               string   `yaml:",omitempty"`
+	Goarch             string   `yaml:",omitempty"`
+	Goarm              string   `yaml:",omitempty"`
+	Image              string   `yaml:",omitempty"`
+	Dockerfile         string   `yaml:",omitempty"`
+	SkipPush           bool     `yaml:"skip_push,omitempty"`
+	TagTemplates       []string `yaml:"tag_templates,omitempty"`
+	Files              []string `yaml:"extra_files,omitempty"`
+	BuildFlagTemplates []string `yaml:"build_flag_templates,omitempty"`
 }
 
 // Filters config

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -247,6 +247,7 @@ type Docker struct {
 	SkipPush     bool     `yaml:"skip_push,omitempty"`
 	TagTemplates []string `yaml:"tag_templates,omitempty"`
 	Files        []string `yaml:"extra_files,omitempty"`
+	BuildFlags   []string `yaml:"build_flags,omitempty"`
 }
 
 // Filters config

--- a/www/content/docker.md
+++ b/www/content/docker.md
@@ -66,6 +66,12 @@ dockers:
     - "{{ .Tag }}-{{ .Env.GO_VERSION }}"
     - "v{{ .Major }}"
     - latest
+    # Template of the docker build flags.
+    build_flag_templates:
+    - "--label=org.label-schema.schema-version=1.0"
+    - "--label=org.label-schema.version={{.Version}}"
+    - "--label=org.label-schema.name={{.ProjectName}}"
+    - "--build-arg=FOO={{.ENV.Bar}}"
     # If your Dockerfile copies files other than the binary itself,
     # you should list them here as well.
     extra_files:
@@ -106,3 +112,29 @@ This will build and publish the following images:
 
 With these settings you can hopefully push several different docker images
 with multiple tags.
+
+## Applying docker build flags
+
+Build flags can be applied using `build_flag_templates`. The flags must be
+valid docker build flags.
+
+```yaml
+# .goreleaser.yml
+dockers:
+  -
+    binary: mybinary
+    image: myuser/myimage
+    build_flag_templates:
+    - "--label=org.label-schema.schema-version=1.0"
+    - "--label=org.label-schema.version={{.Version}}"
+    - "--label=org.label-schema.name={{.ProjectName}}"
+```
+
+This will execute the following command:
+
+```bash
+docker build -t myuser/myimage . \
+  --label=org.label-schema.schema-version=1.0 \
+  --label=org.label-schema.version=1.6.4 \
+  --label=org.label-schema.name=mybinary"
+```


### PR DESCRIPTION
This adds support for building docker images with build flags through templates.

See #813

As an example, given this `.goreleaser.yml`

 ```yaml
# .goreleaser.yml
dockers:
  -
    binary: mybinary
    image: myuser/myimage
    build_flag_templates:
    - "--label=org.label-schema.schema-version=1.0"
    - "--label=org.label-schema.version={{.Version}}"
    - "--label=org.label-schema.name={{.ProjectName}}"
```

It will execute the following command:

 ```bash
docker build -t myuser/myimage . \
  --label=org.label-schema.schema-version=1.0 \
  --label=org.label-schema.version=1.6.4 \
  --label=org.label-schema.name=mybinary"
```