### PR TITLE
feat: git remote url in the template engine

### DIFF
--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -80,12 +80,17 @@ func getGitInfo(ctx *context.Context) (context.GitInfo, error) {
 	if ctx.Config.Git.ShortHash {
 		commit = short
 	}
+	url, err := getURL()
+	if err != nil {
+		return context.GitInfo{}, errors.Wrap(err, "couldn't get remote URL")
+	}
 	tag, err := getTag()
 	if err != nil {
 		return context.GitInfo{
 			Commit:      commit,
 			FullCommit:  full,
 			ShortCommit: short,
+			URL:         url,
 			CurrentTag:  "v0.0.0",
 		}, ErrNoTag
 	}
@@ -94,6 +99,7 @@ func getGitInfo(ctx *context.Context) (context.GitInfo, error) {
 		Commit:      commit,
 		FullCommit:  full,
 		ShortCommit: short,
+		URL:         url,
 	}, nil
 }
 
@@ -145,4 +151,8 @@ func getFullCommit() (string, error) {
 
 func getTag() (string, error) {
 	return git.Clean(git.Run("describe", "--tags", "--abbrev=0"))
+}
+
+func getURL() (string, error) {
+	return git.Clean(git.Run("ls-remote", "--get-url"))
 }

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -29,6 +29,7 @@ func TestSingleCommit(t *testing.T) {
 	_, back := testlib.Mktmp(t)
 	defer back()
 	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	testlib.GitCommit(t, "commit1")
 	testlib.GitTag(t, "v0.0.1")
 	var ctx = &context.Context{
@@ -53,6 +54,7 @@ func TestNoTagsSnapshot(t *testing.T) {
 	_, back := testlib.Mktmp(t)
 	defer back()
 	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	testlib.GitCommit(t, "first")
 	var ctx = context.New(config.Project{
 		Snapshot: config.Snapshot{
@@ -68,6 +70,7 @@ func TestNoTagsSnapshotInvalidTemplate(t *testing.T) {
 	_, back := testlib.Mktmp(t)
 	defer back()
 	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	testlib.GitCommit(t, "first")
 	var ctx = context.New(config.Project{
 		Snapshot: config.Snapshot{
@@ -85,6 +88,7 @@ func TestNoTagsNoSnapshot(t *testing.T) {
 	_, back := testlib.Mktmp(t)
 	defer back()
 	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	testlib.GitCommit(t, "first")
 	var ctx = context.New(config.Project{})
 	ctx.Snapshot = false
@@ -95,6 +99,7 @@ func TestInvalidTagFormat(t *testing.T) {
 	_, back := testlib.Mktmp(t)
 	defer back()
 	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	testlib.GitCommit(t, "commit2")
 	testlib.GitTag(t, "sadasd")
 	var ctx = context.New(config.Project{})
@@ -106,6 +111,7 @@ func TestDirty(t *testing.T) {
 	folder, back := testlib.Mktmp(t)
 	defer back()
 	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	dummy, err := os.Create(filepath.Join(folder, "dummy"))
 	assert.NoError(t, err)
 	testlib.GitAdd(t)
@@ -135,6 +141,7 @@ func TestTagIsNotLastCommit(t *testing.T) {
 	_, back := testlib.Mktmp(t)
 	defer back()
 	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	testlib.GitCommit(t, "commit3")
 	testlib.GitTag(t, "v0.0.1")
 	testlib.GitCommit(t, "commit4")
@@ -147,6 +154,7 @@ func TestValidState(t *testing.T) {
 	_, back := testlib.Mktmp(t)
 	defer back()
 	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	testlib.GitCommit(t, "commit3")
 	testlib.GitTag(t, "v0.0.1")
 	testlib.GitCommit(t, "commit4")
@@ -154,12 +162,14 @@ func TestValidState(t *testing.T) {
 	var ctx = context.New(config.Project{})
 	assert.NoError(t, Pipe{}.Run(ctx))
 	assert.Equal(t, "v0.0.2", ctx.Git.CurrentTag)
+	assert.Equal(t, "git@github.com:foo/bar.git", ctx.Git.URL)
 }
 
 func TestSnapshotNoTags(t *testing.T) {
 	_, back := testlib.Mktmp(t)
 	defer back()
 	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	testlib.GitAdd(t)
 	testlib.GitCommit(t, "whatever")
 	var ctx = context.New(config.Project{})
@@ -172,6 +182,7 @@ func TestSnapshotNoCommits(t *testing.T) {
 	_, back := testlib.Mktmp(t)
 	defer back()
 	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	var ctx = context.New(config.Project{})
 	ctx.Snapshot = true
 	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
@@ -191,6 +202,7 @@ func TestSnapshotDirty(t *testing.T) {
 	folder, back := testlib.Mktmp(t)
 	defer back()
 	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	testlib.GitAdd(t)
 	testlib.GitCommit(t, "whatever")
 	testlib.GitTag(t, "v0.0.1")
@@ -204,6 +216,7 @@ func TestShortCommitHash(t *testing.T) {
 	_, back := testlib.Mktmp(t)
 	defer back()
 	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	testlib.GitCommit(t, "first")
 	var ctx = context.New(config.Project{
 		Snapshot: config.Snapshot{

--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -27,6 +27,7 @@ const (
 	commit      = "Commit"
 	shortCommit = "ShortCommit"
 	fullCommit  = "FullCommit"
+	gitURL      = "GitURL"
 	major       = "Major"
 	minor       = "Minor"
 	patch       = "Patch"
@@ -52,6 +53,7 @@ func New(ctx *context.Context) *Template {
 			commit:      ctx.Git.Commit,
 			shortCommit: ctx.Git.ShortCommit,
 			fullCommit:  ctx.Git.FullCommit,
+			gitURL:      ctx.Git.URL,
 			env:         ctx.Env,
 			date:        time.Now().UTC().Format(time.RFC3339),
 			timestamp:   time.Now().UTC().Unix(),

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -22,6 +22,7 @@ type GitInfo struct {
 	Commit      string
 	ShortCommit string
 	FullCommit  string
+	URL         string
 }
 
 // Context carries along some data through the pipes

--- a/www/content/templates.md
+++ b/www/content/templates.md
@@ -21,6 +21,7 @@ On fields that support templating, this fields are always available:
 | `.ShortCommit` |            the git commit short hash             |
 | `.FullCommit`  |            the git commit full hash              |
 |   `.Commit`    |       the git commit hash (deprecated)           |
+|   `.GitURL`    |               the git remote url                 |
 |    `.Major`    |          the major part of the version           |
 |    `.Minor`    |          the minor part of the version           |
 |    `.Patch`    |          the patch part of the version           |


### PR DESCRIPTION
closes https://github.com/totvslabs/mdmdevops/pull/1087