### PR TITLE
fix: improve goreleaser init

### DIFF
--- a/main.go
+++ b/main.go
@@ -194,6 +194,12 @@ func loadConfig(path string) (config.Project, error) {
 
 var exampleConfig = `# This is an example goreleaser.yaml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
+before:
+   hooks:
+     # you may remove this if you don't use vgo
+     - go mod download
+     # you may remove this if you don't need go generate
+     - go generate ./...
 builds:
 - env:
   - CGO_ENABLED=0


### PR DESCRIPTION
adding some examples of commonly used hooks.