### PR TITLE
fix: docker: go1.11 and no-install-recommends

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM golang:1.10
+FROM golang:1.11
 RUN apt-get update && \
-	apt-get install -y rpm git apt-transport-https curl gnupg2 software-properties-common && \
+	apt-get install -y --no-install-recommends rpm git apt-transport-https curl gnupg2 software-properties-common && \
 	curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
 	add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
-	apt-get update && apt-get install -y docker-ce &&\
+	apt-get update && \
+	apt-get install -y --no-install-recommends docker-ce &&\
 	rm -rf /var/lib/apt/lists/*
 COPY goreleaser /bin/goreleaser
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
image now uses go 1.11 and do not installs recommended packages...