### PR TITLE
feat: image names can ontain template variables

### DIFF
--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -44,7 +44,7 @@ func (Pipe) Default(ctx *context.Context) error {
 			docker.Goarch = "amd64"
 		}
 	}
-	// only set defaults if there is exacly 1 docker setup in the config file.
+	// only set defaults if there is exactly 1 docker setup in the config file.
 	if len(ctx.Config.Dockers) != 1 {
 		return nil
 	}
@@ -102,7 +102,7 @@ func doRun(ctx *context.Context) error {
 func process(ctx *context.Context, docker config.Docker, artifact artifact.Artifact) error {
 	tmp, err := ioutil.TempDir(ctx.Config.Dist, "goreleaserdocker")
 	if err != nil {
-		return errors.Wrap(err, "failed to create temporaty dir")
+		return errors.Wrap(err, "failed to create temporary dir")
 	}
 	log.Debug("tempdir: " + tmp)
 
@@ -143,14 +143,15 @@ func processTagTemplates(ctx *context.Context, docker config.Docker, artifact ar
 	// nolint:prealloc
 	var images []string
 	for _, tagTemplate := range docker.TagTemplates {
+		imageTemplate := fmt.Sprintf("%s:%s", docker.Image, tagTemplate)
 		// TODO: add overrides support to config
-		tag, err := tmpl.New(ctx).
+		image, err := tmpl.New(ctx).
 			WithArtifact(artifact, map[string]string{}).
-			Apply(tagTemplate)
+			Apply(imageTemplate)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to execute tag template '%s'", tagTemplate)
 		}
-		images = append(images, fmt.Sprintf("%s:%s", docker.Image, tag))
+		images = append(images, image)
 	}
 	return images, nil
 }

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -384,7 +384,7 @@ func TestRunPipe(t *testing.T) {
 				},
 			},
 			assertImageLabels: noLabels,
-			assertError:       shouldErr(`template: tmpl:1:6: executing "tmpl" at <.Env.NOPE>: map has no entry for key "NOPE"`),
+			assertError:       shouldErr(`template: tmpl:1:46: executing "tmpl" at <.Env.NOPE>: map has no entry for key "NOPE"`),
 		},
 		"missing_env_on_build_flag_template": {
 			publish: true,
@@ -405,6 +405,36 @@ func TestRunPipe(t *testing.T) {
 			},
 			assertImageLabels: noLabels,
 			assertError:       shouldErr(`template: tmpl:1:19: executing "tmpl" at <.Env.NOPE>: map has no entry for key "NOPE"`),
+		},
+		"image_has_projectname_template_variable": {
+			publish: true,
+			dockers: []config.Docker{
+				{
+					Image:      registry + "goreleaser/{{.ProjectName}}",
+					Goos:       "linux",
+					Goarch:     "amd64",
+					Dockerfile: "testdata/Dockerfile",
+					Binary:     "mybin",
+					SkipPush:   true,
+					TagTemplates: []string{
+						"{{.Tag}}-{{.Env.FOO}}",
+						"v{{.Major}}",
+						"v{{.Major}}.{{.Minor}}",
+						"latest",
+					},
+					Files: []string{
+						"testdata/extra_file.txt",
+					},
+				},
+			},
+			expect: []string{
+				registry + "goreleaser/mybin:v1.0.0-123",
+				registry + "goreleaser/mybin:v1",
+				registry + "goreleaser/mybin:v1.0",
+				registry + "goreleaser/mybin:latest",
+			},
+			assertImageLabels: noLabels,
+			assertError:       shouldNotErr,
 		},
 		"no_permissions": {
 			publish: true,

--- a/www/content/docker.md
+++ b/www/content/docker.md
@@ -84,6 +84,23 @@ These settings should allow you to generate multiple Docker images,
 for example, using multiple `FROM` statements,
 as well as generate one image for each binary in your project.
 
+## Generic Image Names
+
+Some users might want to keep their image name as generic as possible.
+That can be accomplished simply by adding template language in the definition:
+
+```yaml
+# .goreleaser.yml
+dockers:
+  -
+    binary: mybinary
+    image: myuser/{{.ProjectName}}
+```
+
+This will build and public the following images:
+
+- `myuser/mybinary`
+
 ## Keeping docker images updated for current major
 
 Some users might want to when version to push docker tags `:v1`, `:v1.6`,


### PR DESCRIPTION
## If applied, this commit will...

Docker image names can now have template variables in them. This is super helpful for use cases where we want to reuse the same `.goreleaser.yml` file for all our builds so they all follow the same conventions.

## Why is this change being made?

Because convention > configuration

