### PR TITLE
improved logs related to archive and multiple builds

### DIFF
--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -63,7 +63,8 @@ func (Pipe) Default(ctx *context.Context) error {
 func (Pipe) Run(ctx *context.Context) error {
 	var g errgroup.Group
 	var filtered = ctx.Artifacts.Filter(artifact.ByType(artifact.Binary))
-	for _, artifacts := range filtered.GroupByPlatform() {
+	for group, artifacts := range filtered.GroupByPlatform() {
+		log.Debugf("group %s has %d binaries", group, len(artifacts))
 		artifacts := artifacts
 		g.Go(func() error {
 			if packageFormat(ctx, artifacts[0].Goos) == "binary" {

--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -89,7 +89,8 @@ func create(ctx *context.Context, binaries []artifact.Artifact) error {
 		return fmt.Errorf("failed to create directory %s: %s", archivePath, err.Error())
 	}
 	defer archiveFile.Close() // nolint: errcheck
-	log.WithField("archive", archivePath).Info("creating")
+	var log = log.WithField("archive", archivePath)
+	log.Info("creating")
 	var a = archive.New(archiveFile)
 	defer a.Close() // nolint: errcheck
 

--- a/internal/pipe/build/build.go
+++ b/internal/pipe/build/build.go
@@ -49,6 +49,9 @@ func (Pipe) Default(ctx *context.Context) error {
 			buildWithDefaults(ctx, ctx.Config.SingleBuild),
 		}
 	}
+	if len(ctx.Config.Builds) > 1 {
+		log.Warn("you have more than 1 build setup: please make sure it is a not a typo on your config")
+	}
 	return nil
 }
 


### PR DESCRIPTION
- add the `archive` field to subsequent logs
- log the number of binaries in a platform group
- warn if user has more than 1 build setup - while it is OK to have, most of the times its a type on the yaml file :/ 


refs https://github.com/goreleaser/goreleaser/issues/836