### PR TITLE
fix: Bring back docker release notes

### DIFF
--- a/internal/pipe/publish/publish.go
+++ b/internal/pipe/publish/publish.go
@@ -38,11 +38,13 @@ var publishers = []Publisher{
 	s3.Pipe{},
 	put.Pipe{},
 	artifactory.Pipe{},
-	release.Pipe{},
 	brew.Pipe{},
 	scoop.Pipe{},
 	docker.Pipe{},
 	snapcraft.Pipe{},
+	// This should be the last step in the pipeline to ensure that the
+	// release notes are complete.
+	release.Pipe{},
 }
 
 var bold = color.New(color.Bold)


### PR DESCRIPTION
Docker image names were not being added to the release notes
because the Github release step was happening earlier in the
pipeline than the docker release itself (so no artifacts had
been added to the context). This patch re-orders the pipeline
and adds a comment to warn against this happening again.

Fixes: #846

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->

<!-- # Provide links to any relevant tickets, URLs or other resources -->
