### PR TITLE
Add check if tag contains indicator for pre release

### DIFF
--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -94,12 +94,13 @@ func (c *githubClient) CreateRelease(ctx *context.Context, body string) (int64, 
 	if err != nil {
 		return 0, err
 	}
+
 	var data = &github.RepositoryRelease{
 		Name:       github.String(title),
 		TagName:    github.String(ctx.Git.CurrentTag),
 		Body:       github.String(body),
 		Draft:      github.Bool(ctx.Config.Release.Draft),
-		Prerelease: github.Bool(ctx.Config.Release.Prerelease),
+		Prerelease: github.Bool(ctx.PreRelease),
 	}
 	release, _, err = c.client.Repositories.GetReleaseByTag(
 		ctx,

--- a/internal/pipe/release/release_test.go
+++ b/internal/pipe/release/release_test.go
@@ -149,6 +149,35 @@ func TestDefault(t *testing.T) {
 	assert.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Owner)
 }
 
+func TestDefaultPreReleaseAuto(t *testing.T) {
+	_, back := testlib.Mktmp(t)
+	defer back()
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:goreleaser/goreleaser.git")
+
+	t.Run("auto-release", func(t *testing.T) {
+		var ctx = context.New(config.Project{
+			Release: config.Release{
+				Prerelease: "auto",
+			},
+		})
+		ctx.Git.CurrentTag = "v1.0.0"
+		assert.NoError(t, Pipe{}.Default(ctx))
+		assert.Equal(t, false, ctx.PreRelease)
+	})
+
+	t.Run("auto-rc", func(t *testing.T) {
+		var ctx = context.New(config.Project{
+			Release: config.Release{
+				Prerelease: "auto",
+			},
+		})
+		ctx.Git.CurrentTag = "v1.0.1-rc1"
+		assert.NoError(t, Pipe{}.Default(ctx))
+		assert.Equal(t, true, ctx.PreRelease)
+	})
+}
+
 func TestDefaultPipeDisabled(t *testing.T) {
 	_, back := testlib.Mktmp(t)
 	defer back()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -158,8 +158,8 @@ type Archive struct {
 type Release struct {
 	GitHub       Repo   `yaml:",omitempty"`
 	Draft        bool   `yaml:",omitempty"`
-	Prerelease   bool   `yaml:",omitempty"`
 	Disable      bool   `yaml:",omitempty"`
+	Prerelease   string `yaml:",omitempty"`
 	NameTemplate string `yaml:"name_template,omitempty"`
 }
 

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -41,6 +41,7 @@ type Context struct {
 	SkipValidate bool
 	RmDist       bool
 	Debug        bool
+	PreRelease   bool
 	Parallelism  int
 }
 

--- a/www/content/release.md
+++ b/www/content/release.md
@@ -24,9 +24,11 @@ release:
   # Default is false.
   draft: true
 
+  # If set to auto, will mark the release as not ready for production
+  # in case there is an indicator for this in the tag e.g. v1.0.0.-rc1
   # If set to true, will mark the release as not ready for production.
   # Default is false.
-  prerelease: true
+  prerelease: auto
 
   # You can change the name of the GitHub release.
   # Default is ``


### PR DESCRIPTION
This PR addresses #667 
It's not complete yet but with a draft for the implementation.

The changes enable `goreleaser` to automatically mark a release as a pre release when the tag contains an indicator for it. A tag that would lead to a pre release would be `0.0.1-rc1`. The requirement is basically that `-` followed by 1+ characters is present.
This can probably be tweaked and hardened a bit. I'm open for suggestions!

I'm also not 100% sure yet if this is the best location for the code.
`ctx.Config.Release.Prerelease` is not accessed anywhere else so the choice where to put the code is basically free. But since we change the datatype from `bool` to `string` and `Context` does not have a member for `Prerelease` we would have to carry the variable around otherwise.

So either we check quite late in the stack (as I did) or we could add a Member to `Context` and have the check after reading the config file. I think the latter would be a better way but to demo my idea I implemented the first choice.

Todo:
- [x] Add tests
- [x] Clarify when to check for pre release in tag
