### PR TITLE
feat: add custom_require to brew formula generation

### DIFF
--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -203,6 +203,7 @@ func dataFor(ctx *context.Context, artifact artifact.Artifact) (result templateD
 		Install:          split(cfg.Install),
 		Tests:            split(cfg.Test),
 		DownloadStrategy: cfg.DownloadStrategy,
+		CustomRequire:    cfg.CustomRequire,
 	}, nil
 }
 

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -101,6 +101,10 @@ func TestRunPipe(t *testing.T) {
 		"custom_download_strategy": func(ctx *context.Context) {
 			ctx.Config.Brew.DownloadStrategy = "GitHubPrivateRepositoryReleaseDownloadStrategy"
 		},
+		"custom_require": func(ctx *context.Context) {
+			ctx.Config.Brew.DownloadStrategy = "CustomDownloadStrategy"
+			ctx.Config.Brew.CustomRequire = "custom_download_strategy"
+		},
 		"binary_overridden": func(ctx *context.Context) {
 			ctx.Config.Archive.Format = "binary"
 			ctx.Config.Archive.FormatOverrides = []config.FormatOverride{

--- a/internal/pipe/brew/template.go
+++ b/internal/pipe/brew/template.go
@@ -14,9 +14,13 @@ type templateData struct {
 	Dependencies     []string
 	Conflicts        []string
 	Tests            []string
+	CustomRequire    string
 }
 
-const formulaTemplate = `class {{ .Name }} < Formula
+const formulaTemplate = `{{ if .CustomRequire -}}
+require_relative "{{ .CustomRequire }}"
+{{ end -}}
+class {{ .Name }} < Formula
   desc "{{ .Desc }}"
   homepage "{{ .Homepage }}"
   url "{{ .DownloadURL }}"

--- a/internal/pipe/brew/testdata/custom_require.rb.golden
+++ b/internal/pipe/brew/testdata/custom_require.rb.golden
@@ -1,0 +1,35 @@
+require_relative "custom_download_strategy"
+class CustomRequire < Formula
+  desc "A run pipe test formula"
+  homepage "https://github.com/goreleaser"
+  url "https://github.com/test/test/releases/download/v1.0.1/bin.tar.gz", :using => CustomDownloadStrategy
+  version "1.0.1"
+  sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  
+  depends_on "zsh"
+  depends_on "bash"
+  
+  conflicts_with "gtk+"
+  conflicts_with "qt"
+
+  def install
+    bin.install "foo"
+  end
+
+  def caveats; <<~EOS
+    don't do this
+  EOS
+  end
+
+  plist_options :startup => false
+
+  def plist; <<~EOS
+    <xml>whatever</xml>
+  EOS
+  end
+
+  test do
+    system "true"
+    system "#{bin}/foo -h"
+  end
+end

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,6 +51,7 @@ type Homebrew struct {
 	DownloadStrategy string       `yaml:"download_strategy,omitempty"`
 	SourceTarball    string       `yaml:"-"`
 	URLTemplate      string       `yaml:"url_template,omitempty"`
+	CustomRequire    string       `yaml:"custom_require,omitempty"`
 }
 
 // Scoop contains the scoop.sh section

--- a/www/content/homebrew.md
+++ b/www/content/homebrew.md
@@ -35,6 +35,10 @@ brew:
   # Default is empty.
   download_strategy: GitHubPrivateRepositoryReleaseDownloadStrategy
 
+  # Allows you to add a custom require_relative at the top of the formula template
+  # Default is empty
+  custom_require: custom_download_strategy 
+
   # Git author used to commit to the repository.
   # Defaults are shown.
   commit_author:


### PR DESCRIPTION
Due to the below linked changes in homebrew deprecating "unused" download
strategies and the suggested workaround of adding a custom
"require_relative" I have added the ability to specify a ruby filename
in the brew specification

My use case is to continue using the GitHubPrivateRepositoryDownloadStrategy
without deprecation warnings on every brew install.

brew deprecation:
https://github.com/Homebrew/brew/commit/599ecc9b5ad7951b8ddc51490ebe93a976d43b29#diff-ad9201cdd3b6f948345629ad812cd5bd

suggested workaround:
https://github.com/Homebrew/brew/issues/5074#issuecomment-429274286

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->

<!-- # Provide links to any relevant tickets, URLs or other resources -->
