### PR TITLE
Add a new future for builds section

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -134,6 +134,7 @@ type Build struct {
 	Lang     string         `yaml:",omitempty"`
 	Asmflags StringArray    `yaml:",omitempty"`
 	Gcflags  StringArray    `yaml:",omitempty"`
+	WorkPath string         `yaml:",omitempty"`
 }
 
 // FormatOverride is used to specify a custom format for a specific GOOS.


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->
Hi, every contributor.
I got a problem with my project when I using goreleaser. The corresponding on-disk structure of my project like this:
 project/
├── .goreleaser.yml
├── Makefile
├── subproject1
│   └── foodir
│   └── go.mod
│   └── main.go
└── subproject2
│   └── foodir
│   └── go.mod
│   └── main.go

Every subproject using go module, and every subproject have a binary file after the build. I found if the go build command is not running in the project folder, it does not run in go module mode, In my project, if go build command is not run in go module mode, something wrong will happened. So I add a field "**workpath**" to defined go build command running path, maybe there are other people who have similar needs like me.
<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->

<!-- # Provide links to any relevant tickets, URLs or other resources -->
