### PR TITLE
Add cgo image and cleanup existing dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,24 @@
 FROM golang:1.11
+
 RUN apt-get update && \
-	apt-get install -y --no-install-recommends rpm git apt-transport-https curl gnupg2 software-properties-common && \
-	curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
-	add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
-	apt-get update && \
-	apt-get install -y --no-install-recommends docker-ce &&\
-	rm -rf /var/lib/apt/lists/*
-COPY goreleaser /bin/goreleaser
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+    apt-get install -y --no-install-recommends apt-transport-https \
+                                               curl \
+                                               git \
+                                               gnupg2 \
+                                               rpm \
+                                               software-properties-common && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
+    apt-key fingerprint "9DC858229FC7DD38854AE2D88D81803C0EBFCD88" | grep "<docker@docker.com>" && \
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends docker-ce && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD [ "-h" ]
+
+COPY entrypoint.sh /entrypoint.sh
+COPY goreleaser /bin/goreleaser
+
+RUN chmod +x /entrypoint.sh

--- a/Dockerfile.cgo
+++ b/Dockerfile.cgo
@@ -1,0 +1,25 @@
+FROM golang:1.11
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends apt-transport-https \
+                                               build-essential \
+                                               curl \
+                                               git \
+                                               gnupg2 \
+                                               rpm \
+                                               software-properties-common && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
+    apt-key fingerprint "9DC858229FC7DD38854AE2D88D81803C0EBFCD88" | grep "<docker@docker.com>" && \
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends docker-ce && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD [ "-h" ]
+
+COPY entrypoint.sh /entrypoint.sh
+COPY goreleaser /bin/goreleaser
+
+RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
Added a CGO-capable Goreleaser image to repo and cleaned up layers
in exisitng Dockerfile.

Layers are ordered in a way to minimize breaking of the cache. Additional
Docker key fingerprint checking has been added to ensure that we get the
key we are expecting from Docker website.

https://github.com/goreleaser/goreleaser/issues/795
