### PR TITLE
Converted current docker images to Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,11 @@
-FROM golang:1.11
+FROM golang:1.11-alpine
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends apt-transport-https \
-                                               curl \
-                                               git \
-                                               gnupg2 \
-                                               rpm \
-                                               software-properties-common && \
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-    apt-key fingerprint "9DC858229FC7DD38854AE2D88D81803C0EBFCD88" | grep "<docker@docker.com>" && \
-    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends docker-ce && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache bash \
+                       curl \
+                       docker \
+                       git \
+                       mercurial \
+                       rpm
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD [ "-h" ]

--- a/Dockerfile.cgo
+++ b/Dockerfile.cgo
@@ -1,20 +1,12 @@
-FROM golang:1.11
+FROM golang:1.11-alpine
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends apt-transport-https \
-                                               build-essential \
-                                               curl \
-                                               git \
-                                               gnupg2 \
-                                               rpm \
-                                               software-properties-common && \
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-    apt-key fingerprint "9DC858229FC7DD38854AE2D88D81803C0EBFCD88" | grep "<docker@docker.com>" && \
-    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends docker-ce && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache bash \
+                       build-base \
+                       curl \
+                       docker \
+                       git \
+                       mercurial \
+                       rpm
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD [ "-h" ]


### PR DESCRIPTION
This should significantly reduce the image size of the Docker images
needed to use Goreleaser

```
Current:
goreleaser        1.15GB 
goreleaser-cgo    1.15GB

Alpine-based:
goreleaser        595MB
goreleaser-cgo    741MB
```

Resolves #882

I didn't have a big enough project to test everything that goreleaser supports in this manner but the medium-size one seems to work fine.

PS: `mercurial` is added since `go mod download` is supposed to support mercurial-backed plugins which some k8s go plugins use.
