### PR TITLE
fix: load env vars before running before hooks

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -33,13 +33,13 @@ type Piper interface {
 // Pipeline contains all pipe implementations in order
 // nolint: gochecknoglobals
 var Pipeline = []Piper{
+	env.Pipe{},             // load and validate environment variables
 	before.Pipe{},          // run global hooks before build
 	git.Pipe{},             // get and validate git repo state
 	defaults.Pipe{},        // load default configs
 	dist.Pipe{},            // ensure ./dist is clean
 	effectiveconfig.Pipe{}, // writes the actual config (with defaults et al set) to dist
 	changelog.Pipe{},       // builds the release changelog
-	env.Pipe{},             // load and validate environment variables
 	build.Pipe{},           // build
 	archive.Pipe{},         // archive in tar.gz, zip or binary (which does no archiving at all)
 	nfpm.Pipe{},            // archive via fpm (deb, rpm) using "native" go impl


### PR DESCRIPTION
If applied, this commit will set environment variables before running "before" hooks.

This change is needed when using go modules and running goreleaser inside a docker container. As the builds are run in parallel, the before hook `go mod download` is needed. However, as the build occurs inside `$GOPATH` the `go mod download` fails with the error:

    go: modules disabled inside GOPATH/src by GO111MODULE=auto; see 'go help modules'

Adding `GO111MODULE=on` to `builds.env` does not work because the hooks are run before the environment variable is set.

Setting the hook to be `GO111MODULE=on go mod download` fails with the error

    error=hook failed: GO111MODULE=on go mod download

possibly because `GO111MODULE=on` is interpreted as the name of the binary rather than setting a local environment variable.

This PR changes the order of actions to set environment variables first, before any `before.hooks` are run, so `GO111MODULES=on` can be set for `go mod download`. Of course, this equally applies to any hooks whose behavior is modified by environment variables.