### PR TITLE
fix: pass missing arg to log.Warnf

### DIFF
--- a/internal/pipe/release/release.go
+++ b/internal/pipe/release/release.go
@@ -52,7 +52,7 @@ func (Pipe) Default(ctx *context.Context) error {
 	case "false":
 		ctx.PreRelease = false
 	default:
-		log.Warnf("Invalid value %s for prerelease. Should be auto, true or false")
+		log.Warnf("Invalid value %s for prerelease. Should be auto, true or false", ctx.Config.Release.Prerelease)
 	}
 
 	return nil


### PR DESCRIPTION
If applied, this commit will fix a log message. At the moment, I see in the output of `goreleaser` I see:

```
   • SETTING DEFAULTS 
      • Invalid value %!s(MISSING) for prerelease. Should be auto, true or false
```

The `%!s(MISSING)` indicates a missing argument to (in this case) `log.Warnf`.

As I do not set `prerelease` in my config, it is also likely that the default value of `prerelease` is not being set correctly. Alternatively, if `prerelease` is empty is should perhaps be treated the same as `auto`.