### PR TITLE
feat: Allows pushing to private docker registry

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -2,7 +2,7 @@
 
 if [ -n "$DOCKER_USERNAME" ] && [ -n "$DOCKER_PASSWORD" ]; then
     echo "Login to the docker..."
-    docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+    docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD $DOCKER_REGISTRY
 fi
 
 goreleaser $@

--- a/www/content/install.md
+++ b/www/content/install.md
@@ -56,10 +56,14 @@ $ docker run --rm --privileged \
   -e GITHUB_TOKEN \
   -e DOCKER_USERNAME \
   -e DOCKER_PASSWORD \
+  -e DOCKER_REGISTRY \
   goreleaser/goreleaser release
 ```
 
 Note that the image will almost always have the last stable Go version.
+
+The `DOCKER_REGISTRY` environment variables can be left empty when you are
+releasing to the public docker registry.
 
 If you need more things, you are encouraged to have your own image. You can
 always use GoReleaser's [own Dockerfile][dockerfile] as an example though.


### PR DESCRIPTION
Allows pushing docker containers to a private docker registry.

When creating a docker image tagged for a private docker registry the [goreleaser docker container](https://hub.docker.com/r/goreleaser/goreleaser/) can optionally be configured to use a private docker registry by setting the `DOCKER_REGISTRY` command line environment variable.

This will allow you to, for example, push images to a `gitlab` docker registry.