### PR TITLE
Resolve error: Type.String redeclared in this block

### DIFF
--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -38,7 +38,7 @@ const (
 	Signature
 )
 
-func (t Type) String() string {
+func String(t Type) string {
 	switch t {
 	case UploadableArchive:
 		return "Archive"


### PR DESCRIPTION
Previous output:
```bash
~/go/src/github.com/goreleaser/goreleaser(master)$ make setup build
curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh
golangci/golangci-lint info checking GitHub for latest tag
golangci/golangci-lint info found version: 1.12.3 for v1.12.3/darwin/amd64
golangci/golangci-lint info installed ./bin/golangci-lint
curl -sfL https://install.goreleaser.com/github.com/gohugoio/hugo.sh | sh
gohugoio/hugo info checking GitHub for latest tag
gohugoio/hugo info found version: 0.52 for v0.52/macOS/64bit
gohugoio/hugo info installed ./bin/hugo
go mod download
go: finding github.com/apex/log v1.1.0
go: finding github.com/Masterminds/semver v1.4.2
go: finding github.com/davecgh/go-spew v1.1.1
go: finding github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e
go: finding github.com/alecthomas/kingpin v2.2.6+incompatible
go: finding github.com/mattn/go-colorable v0.0.9
go: finding github.com/google/go-querystring v1.0.0
go: finding github.com/google/go-github v17.0.0+incompatible
go: finding github.com/mattn/go-isatty v0.0.4
go: finding google.golang.org/appengine v1.2.0
go: finding github.com/fatih/color v1.7.0
go: finding github.com/imdario/mergo v0.3.6
go: finding github.com/goreleaser/nfpm v0.9.7
go: finding golang.org/x/sys v0.0.0-20181030150119-7e31e0c00fa0
go: finding github.com/pkg/errors v0.8.0
go: finding github.com/aws/aws-sdk-go v1.15.64
go: finding golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4
go: finding gopkg.in/yaml.v2 v2.2.1
go: finding github.com/mattn/go-zglob v0.0.0-20180803001819-2ea3427bfa53
go: finding github.com/mitchellh/go-homedir v1.0.0
go: finding golang.org/x/text v0.3.0
go: finding github.com/caarlos0/ctrlc v1.0.0
go: finding github.com/golang/protobuf v1.2.0
go: finding github.com/stretchr/testify v1.2.2
go: finding github.com/imdario/mergo v0.3.4
go: finding github.com/mattn/go-zglob v0.0.0-20171230104132-4959821b4817
go: finding github.com/davecgh/go-spew v1.1.0
go: finding github.com/pmezard/go-difflib v1.0.0
go: finding github.com/stretchr/testify v1.2.1
go: finding golang.org/x/net v0.0.0-20180724234803-3673e40ba225
go: finding gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
go: finding github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc
go: finding github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2
go: finding github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf
go: finding golang.org/x/net v0.0.0-20181023162649-9b4f9f5ad519
go: finding github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8
go build
# github.com/goreleaser/goreleaser/internal/artifact
internal/artifact/type_string.go:11:15: Type.String redeclared in this block
	previous declaration at internal/artifact/artifact.go:41:6
make: *** [build] Error 2
```

Output, after applying this 1 line change:
```bash
~/go/src/github.com/goreleaser/goreleaser(master)$ make setup build
curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh
golangci/golangci-lint info checking GitHub for latest tag
golangci/golangci-lint info found version: 1.12.3 for v1.12.3/darwin/amd64
golangci/golangci-lint info installed ./bin/golangci-lint
curl -sfL https://install.goreleaser.com/github.com/gohugoio/hugo.sh | sh
gohugoio/hugo info checking GitHub for latest tag
gohugoio/hugo info found version: 0.52 for v0.52/macOS/64bit
gohugoio/hugo info installed ./bin/hugo
go mod download
go build
```

Other details:
macOS Mojave 10.14.2
go version go1.11.4 darwin/amd64
[commit hash](https://github.com/goreleaser/goreleaser/blob/fac4b621b0d0db4e173cfa5688462f7ddcb6c153/internal/artifact/artifact.go#L41)