### PR TITLE
feat: allow skipping changelog generation

### DIFF
--- a/internal/pipe/changelog/changelog.go
+++ b/internal/pipe/changelog/changelog.go
@@ -29,6 +29,9 @@ func (Pipe) String() string {
 
 // Run the pipe
 func (Pipe) Run(ctx *context.Context) error {
+	if ctx.Config.Changelog.Skip {
+		return pipe.Skip("changelog should not be built")
+	}
 	if ctx.ReleaseNotes != "" {
 		return pipe.Skip("release notes already provided via --release-notes")
 	}

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -22,6 +22,12 @@ func TestChangelogProvidedViaFlag(t *testing.T) {
 	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
 }
 
+func TestChangelogSkip(t *testing.T) {
+	var ctx = context.New(config.Project{})
+	ctx.Config.Changelog.Skip = true
+	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
+}
+
 func TestSnapshot(t *testing.T) {
 	var ctx = context.New(config.Project{})
 	ctx.Snapshot = true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -262,6 +262,7 @@ type Filters struct {
 type Changelog struct {
 	Filters Filters `yaml:",omitempty"`
 	Sort    string  `yaml:",omitempty"`
+	Skip    bool    `yaml:",omitempty"`
 }
 
 // EnvFiles holds paths to files that contains environment variables


### PR DESCRIPTION
In some cases, changelog or release notes do not need to be compiled for
various reasons.
This commit adds an option to Skip building the changelog.

Fix #888