### PR TITLE
better retry upload

### DIFF
--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -134,18 +134,6 @@ func (c *githubClient) Upload(
 	name string,
 	file *os.File,
 ) error {
-	return c.uploadRetry(ctx, releaseID, name, file, 0)
-}
-
-const maxRetries = 10
-
-func (c *githubClient) uploadRetry(
-	ctx *context.Context,
-	releaseID int64,
-	name string,
-	file *os.File,
-	retry int,
-) error {
 	_, _, err := c.client.Repositories.UploadReleaseAsset(
 		ctx,
 		ctx.Config.Release.GitHub.Owner,
@@ -156,11 +144,5 @@ func (c *githubClient) uploadRetry(
 		},
 		file,
 	)
-	if err != nil {
-		if retry > maxRetries {
-			return err
-		}
-		return err
-	}
-	return c.uploadRetry(ctx, releaseID, name, file, retry+1)
+	return err
 }

--- a/internal/pipe/put/put.go
+++ b/internal/pipe/put/put.go
@@ -46,4 +46,3 @@ func (Pipe) Publish(ctx *context.Context) error {
 	})
 
 }
-

--- a/internal/pipe/put/put.go
+++ b/internal/pipe/put/put.go
@@ -46,3 +46,4 @@ func (Pipe) Publish(ctx *context.Context) error {
 	})
 
 }
+


### PR DESCRIPTION
current implementation on the client does not work well, as well its not the best place to do it, since we'll need to re-implement it on other clients when needed.

moved impl to the release pipe itself, also adding better tests for it.

refs #900 