### PR TITLE
feat: add custom_block to brew formula generation

### DIFF
--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -204,6 +204,7 @@ func dataFor(ctx *context.Context, artifact artifact.Artifact) (result templateD
 		Tests:            split(cfg.Test),
 		DownloadStrategy: cfg.DownloadStrategy,
 		CustomRequire:    cfg.CustomRequire,
+		CustomBlock:      split(cfg.CustomBlock),
 	}, nil
 }
 

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -58,6 +58,7 @@ func TestFullFormulae(t *testing.T) {
 	data.Dependencies = []string{"gtk+"}
 	data.Conflicts = []string{"svn"}
 	data.Plist = "it works"
+	data.CustomBlock = []string{"devel do", `  url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_x86_64.tar.gz"`, `  sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c68"`, "end"}
 	data.Install = []string{"custom install script", "another install script"}
 	data.Tests = []string{`system "#{bin}/foo -version"`}
 	out, err := doBuildFormula(data)
@@ -113,6 +114,9 @@ func TestRunPipe(t *testing.T) {
 					Format: "zip",
 				},
 			}
+		},
+		"custom_block": func(ctx *context.Context) {
+			ctx.Config.Brew.CustomBlock = `head "https://github.com/caarlos0/test.git"`
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/internal/pipe/brew/template.go
+++ b/internal/pipe/brew/template.go
@@ -15,6 +15,7 @@ type templateData struct {
 	Conflicts        []string
 	Tests            []string
 	CustomRequire    string
+	CustomBlock      []string
 }
 
 const formulaTemplate = `{{ if .CustomRequire -}}
@@ -27,6 +28,12 @@ class {{ .Name }} < Formula
   {{- if .DownloadStrategy }}, :using => {{ .DownloadStrategy }}{{- end }}
   version "{{ .Version }}"
   sha256 "{{ .SHA256 }}"
+
+  {{- with .CustomBlock }}
+  {{ range $index, $element := . }}
+  {{ . }}
+  {{- end }}
+  {{- end }}
 
   {{- with .Dependencies }}
   {{ range $index, $element := . }}

--- a/internal/pipe/brew/testdata/custom_block.rb.golden
+++ b/internal/pipe/brew/testdata/custom_block.rb.golden
@@ -1,0 +1,36 @@
+class CustomBlock < Formula
+  desc "A run pipe test formula"
+  homepage "https://github.com/goreleaser"
+  url "https://github.com/test/test/releases/download/v1.0.1/bin.tar.gz"
+  version "1.0.1"
+  sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  
+  head "https://github.com/caarlos0/test.git"
+  
+  depends_on "zsh"
+  depends_on "bash"
+  
+  conflicts_with "gtk+"
+  conflicts_with "qt"
+
+  def install
+    bin.install "foo"
+  end
+
+  def caveats; <<~EOS
+    don't do this
+  EOS
+  end
+
+  plist_options :startup => false
+
+  def plist; <<~EOS
+    <xml>whatever</xml>
+  EOS
+  end
+
+  test do
+    system "true"
+    system "#{bin}/foo -h"
+  end
+end

--- a/internal/pipe/brew/testdata/test.rb.golden
+++ b/internal/pipe/brew/testdata/test.rb.golden
@@ -5,6 +5,11 @@ class Test < Formula
   version "0.1.3"
   sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c68"
   
+  devel do
+    url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_x86_64.tar.gz"
+    sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c68"
+  end
+  
   depends_on "gtk+"
   
   conflicts_with "svn"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,6 +52,7 @@ type Homebrew struct {
 	SourceTarball    string       `yaml:"-"`
 	URLTemplate      string       `yaml:"url_template,omitempty"`
 	CustomRequire    string       `yaml:"custom_require,omitempty"`
+	CustomBlock      string       `yaml:"custom_block,omitempty"`
 }
 
 // Scoop contains the scoop.sh section

--- a/www/content/homebrew.md
+++ b/www/content/homebrew.md
@@ -67,6 +67,13 @@ brew:
   # Default is false.
   skip_upload: true
 
+  # Custom block for brew.
+  # Can be used to specify alternate downloads for devel or head releases.
+  # Default is empty.
+  custom_block: |
+    head "https://github.com/some/package.git"
+    ...
+
   # Packages your package depends on.
   dependencies:
     - git


### PR DESCRIPTION
<!-- If applied, this commit will... -->

This allow authors to specify things such as devel, head and more.

<!-- Why is this change being made? -->

I'm proposing this change so we can let users run projects from master.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

See https://github.com/Homebrew/brew/blob/master/docs/Formula-Cookbook.md#advanced-formula-tricks for details.