### PR TITLE
fix: support multiple binaries in scoop pipe

### DIFF
--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -159,6 +159,7 @@ func buildManifest(ctx *context.Context, artifacts []artifact.Artifact) (bytes.B
 }
 
 func binaries(a artifact.Artifact) []string {
+	// nolint: prealloc
 	var bins []string
 	for _, b := range a.ExtraOr("Builds", []artifact.Artifact{}).([]artifact.Artifact) {
 		bins = append(bins, b.ExtraOr("Binary", "").(string)+".exe")

--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -109,9 +109,9 @@ type Manifest struct {
 
 // Resource represents a combination of a url and a binary name for an architecture
 type Resource struct {
-	URL  string `json:"url"`  // URL to the archive
-	Bin  string `json:"bin"`  // name of binary inside the archive
-	Hash string `json:"hash"` // the archive checksum
+	URL  string   `json:"url"`  // URL to the archive
+	Bin  []string `json:"bin"`  // name of binary inside the archive
+	Hash string   `json:"hash"` // the archive checksum
 }
 
 func buildManifest(ctx *context.Context, artifacts []artifact.Artifact) (bytes.Buffer, error) {
@@ -145,7 +145,7 @@ func buildManifest(ctx *context.Context, artifacts []artifact.Artifact) (bytes.B
 
 		manifest.Architecture[arch] = Resource{
 			URL:  url,
-			Bin:  ctx.Config.Builds[0].Binary + ".exe", // TODO: this is wrong
+			Bin:  binaries(artifact),
 			Hash: sum,
 		}
 	}
@@ -156,4 +156,12 @@ func buildManifest(ctx *context.Context, artifacts []artifact.Artifact) (bytes.B
 	}
 	_, err = result.Write(data)
 	return result, err
+}
+
+func binaries(a artifact.Artifact) []string {
+	var bins []string
+	for _, b := range a.ExtraOr("Builds", []artifact.Artifact{}).([]artifact.Artifact) {
+		bins = append(bins, b.ExtraOr("Binary", "").(string)+".exe")
+	}
+	return bins
 }

--- a/internal/pipe/scoop/testdata/test_buildmanifest.json.golden
+++ b/internal/pipe/scoop/testdata/test_buildmanifest.json.golden
@@ -3,12 +3,18 @@
     "architecture": {
         "32bit": {
             "url": "https://github.com/test/test/releases/download/v1.0.1/foo_1.0.1_windows_386.tar.gz",
-            "bin": "test.exe",
+            "bin": [
+                "foo.exe",
+                "bar.exe"
+            ],
             "hash": "5e2bf57d3f40c4b6df69daf1936cb766f832374b4fc0259a7cbff06e2f70f269"
         },
         "64bit": {
             "url": "https://github.com/test/test/releases/download/v1.0.1/foo_1.0.1_windows_amd64.tar.gz",
-            "bin": "test.exe",
+            "bin": [
+                "foo.exe",
+                "bar.exe"
+            ],
             "hash": "5e2bf57d3f40c4b6df69daf1936cb766f832374b4fc0259a7cbff06e2f70f269"
         }
     },

--- a/internal/pipe/scoop/testdata/test_buildmanifest_url_template.json.golden
+++ b/internal/pipe/scoop/testdata/test_buildmanifest_url_template.json.golden
@@ -3,12 +3,18 @@
     "architecture": {
         "32bit": {
             "url": "http://github.mycompany.com/foo/bar/v1.0.1/foo_1.0.1_windows_386.tar.gz",
-            "bin": "test.exe",
+            "bin": [
+                "foo.exe",
+                "bar.exe"
+            ],
             "hash": "5e2bf57d3f40c4b6df69daf1936cb766f832374b4fc0259a7cbff06e2f70f269"
         },
         "64bit": {
             "url": "http://github.mycompany.com/foo/bar/v1.0.1/foo_1.0.1_windows_amd64.tar.gz",
-            "bin": "test.exe",
+            "bin": [
+                "foo.exe",
+                "bar.exe"
+            ],
             "hash": "5e2bf57d3f40c4b6df69daf1936cb766f832374b4fc0259a7cbff06e2f70f269"
         }
     },


### PR DESCRIPTION
now it should be able to support multiple builds and therefore multiple binaries.

refs https://github.com/goreleaser/goreleaser/issues/705