### PR TITLE
fix: improved semver parsing

### DIFF
--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -580,6 +580,11 @@ func TestRunPipe(t *testing.T) {
 				CurrentTag: "v1.0.0",
 				Commit:     "a1b2c3d4",
 			}
+			ctx.Semver = context.Semver{
+				Major: 1,
+				Minor: 0,
+				Patch: 0,
+			}
 			for _, os := range []string{"linux", "darwin"} {
 				for _, arch := range []string{"amd64", "386"} {
 					for _, bin := range []string{"mybin", "anotherbin"} {
@@ -817,6 +822,11 @@ func Test_processImageTemplates(t *testing.T) {
 	ctx.Git = context.GitInfo{
 		CurrentTag: "v1.0.0",
 		Commit:     "a1b2c3d4",
+	}
+	ctx.Semver = context.Semver{
+		Major: 1,
+		Minor: 0,
+		Patch: 0,
 	}
 
 	assert.NoError(t, Pipe{}.Default(ctx))

--- a/internal/pipe/git/errors.go
+++ b/internal/pipe/git/errors.go
@@ -5,15 +5,6 @@ import (
 	"fmt"
 )
 
-// ErrInvalidVersionFormat is return when the version isnt in a valid format
-type ErrInvalidVersionFormat struct {
-	version string
-}
-
-func (e ErrInvalidVersionFormat) Error() string {
-	return fmt.Sprintf("%v is not in a valid version format", e.version)
-}
-
 // ErrDirty happens when the repo has uncommitted/unstashed changes
 type ErrDirty struct {
 	status string

--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"os/exec"
-	"regexp"
 	"strings"
 
 	"github.com/apex/log"
@@ -111,9 +110,6 @@ func validate(ctx *context.Context) error {
 	out, err := git.Run("status", "--porcelain")
 	if strings.TrimSpace(out) != "" || err != nil {
 		return ErrDirty{status: out}
-	}
-	if !regexp.MustCompile("^[0-9.]+").MatchString(ctx.Version) {
-		return ErrInvalidVersionFormat{version: ctx.Version}
 	}
 	_, err = git.Clean(git.Run("describe", "--exact-match", "--tags", "--match", ctx.Git.CurrentTag))
 	if err != nil {

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -76,18 +76,6 @@ func TestNoTagsNoSnapshot(t *testing.T) {
 	assert.EqualError(t, Pipe{}.Run(ctx), `git doesn't contain any tags. Either add a tag or use --snapshot`)
 }
 
-func TestInvalidTagFormat(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
-	testlib.GitInit(t)
-	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
-	testlib.GitCommit(t, "commit2")
-	testlib.GitTag(t, "sadasd")
-	var ctx = context.New(config.Project{})
-	assert.EqualError(t, Pipe{}.Run(ctx), "sadasd is not in a valid version format")
-	assert.Equal(t, "sadasd", ctx.Git.CurrentTag)
-}
-
 func TestDirty(t *testing.T) {
 	folder, back := testlib.Mktmp(t)
 	defer back()

--- a/internal/pipe/release/release.go
+++ b/internal/pipe/release/release.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/Masterminds/semver"
 	"github.com/apex/log"
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/internal/client"
@@ -40,12 +39,7 @@ func (Pipe) Default(ctx *context.Context) error {
 	// Check if we have to check the git tag for an indicator to mark as pre release
 	switch ctx.Config.Release.Prerelease {
 	case "auto":
-		sv, err := semver.NewVersion(ctx.Git.CurrentTag)
-		if err != nil {
-			return errors.Wrapf(err, "failed to parse tag %s as semver", ctx.Git.CurrentTag)
-		}
-
-		if sv.Prerelease() != "" {
+		if ctx.Semver.Prerelease != "" {
 			ctx.PreRelease = true
 		}
 		log.Debugf("pre-release was detected for tag %s: %v", ctx.Git.CurrentTag, ctx.PreRelease)

--- a/internal/pipe/release/release_test.go
+++ b/internal/pipe/release/release_test.go
@@ -189,7 +189,11 @@ func TestDefaultPreReleaseAuto(t *testing.T) {
 				Prerelease: "auto",
 			},
 		})
-		ctx.Git.CurrentTag = "v1.0.0"
+		ctx.Semver = context.Semver{
+			Major: 1,
+			Minor: 0,
+			Patch: 0,
+		}
 		assert.NoError(t, Pipe{}.Default(ctx))
 		assert.Equal(t, false, ctx.PreRelease)
 	})
@@ -200,12 +204,17 @@ func TestDefaultPreReleaseAuto(t *testing.T) {
 				Prerelease: "auto",
 			},
 		})
-		ctx.Git.CurrentTag = "v1.0.1-rc1"
+		ctx.Semver = context.Semver{
+			Major:      1,
+			Minor:      0,
+			Patch:      0,
+			Prerelease: "rc1",
+		}
 		assert.NoError(t, Pipe{}.Default(ctx))
 		assert.Equal(t, true, ctx.PreRelease)
 	})
 
-	t.Run("auto-rc", func(t *testing.T) {
+	t.Run("auto-rc-github-setup", func(t *testing.T) {
 		var ctx = context.New(config.Project{
 			Release: config.Release{
 				GitHub: config.Repo{
@@ -215,7 +224,12 @@ func TestDefaultPreReleaseAuto(t *testing.T) {
 				Prerelease: "auto",
 			},
 		})
-		ctx.Git.CurrentTag = "v1.0.1-rc1"
+		ctx.Semver = context.Semver{
+			Major:      1,
+			Minor:      0,
+			Patch:      0,
+			Prerelease: "rc1",
+		}
 		assert.NoError(t, Pipe{}.Default(ctx))
 		assert.Equal(t, true, ctx.PreRelease)
 	})

--- a/internal/pipe/semver/semver.go
+++ b/internal/pipe/semver/semver.go
@@ -1,0 +1,41 @@
+package semver
+
+import (
+	"github.com/Masterminds/semver"
+	"github.com/apex/log"
+	"github.com/goreleaser/goreleaser/internal/pipe"
+	"github.com/goreleaser/goreleaser/pkg/context"
+	"github.com/pkg/errors"
+)
+
+// Pipe is a global hook pipe
+type Pipe struct{}
+
+// String is the name of this pipe
+func (Pipe) String() string {
+	return "Parsing tag"
+}
+
+// Run executes the hooks
+func (Pipe) Run(ctx *context.Context) error {
+	sv, err := semver.NewVersion(ctx.Git.CurrentTag)
+	if err != nil {
+		if ctx.Snapshot {
+			return pipe.ErrSnapshotEnabled
+		}
+		if ctx.SkipValidate {
+			log.WithError(err).
+				WithField("tag", ctx.Git.CurrentTag).
+				Warn("current tag is not a semantic tag")
+			return pipe.ErrSkipValidateEnabled
+		}
+		return errors.Wrapf(err, "failed to parse tag %s as semver", ctx.Git.CurrentTag)
+	}
+	ctx.Semver = context.Semver{
+		Major:      sv.Major(),
+		Minor:      sv.Minor(),
+		Patch:      sv.Patch(),
+		Prerelease: sv.Prerelease(),
+	}
+	return nil
+}

--- a/internal/pipe/semver/semver_test.go
+++ b/internal/pipe/semver/semver_test.go
@@ -1,0 +1,62 @@
+package semver
+
+import (
+	"testing"
+
+	"github.com/goreleaser/goreleaser/internal/pipe"
+
+	"github.com/goreleaser/goreleaser/pkg/config"
+	"github.com/goreleaser/goreleaser/pkg/context"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescription(t *testing.T) {
+	assert.NotEmpty(t, Pipe{}.String())
+}
+
+func TestValidSemver(t *testing.T) {
+	var ctx = context.New(config.Project{})
+	ctx.Git.CurrentTag = "v1.5.2-rc1"
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, context.Semver{
+		Major:      1,
+		Minor:      5,
+		Patch:      2,
+		Prerelease: "rc1",
+	}, ctx.Semver)
+}
+
+func TestInvalidSemver(t *testing.T) {
+	var ctx = context.New(config.Project{})
+	ctx.Git.CurrentTag = "aaaav1.5.2-rc1"
+	var err = Pipe{}.Run(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to parse tag aaaav1.5.2-rc1 as semver")
+}
+
+func TestInvalidSemverOnSnapshots(t *testing.T) {
+	var ctx = context.New(config.Project{})
+	ctx.Git.CurrentTag = "aaaav1.5.2-rc1"
+	ctx.Snapshot = true
+	require.EqualError(t, Pipe{}.Run(ctx), pipe.ErrSnapshotEnabled.Error())
+	require.Equal(t, context.Semver{
+		Major:      0,
+		Minor:      0,
+		Patch:      0,
+		Prerelease: "",
+	}, ctx.Semver)
+}
+
+func TestInvalidSemverSkipValidate(t *testing.T) {
+	var ctx = context.New(config.Project{})
+	ctx.Git.CurrentTag = "aaaav1.5.2-rc1"
+	ctx.SkipValidate = true
+	require.EqualError(t, Pipe{}.Run(ctx), pipe.ErrSkipValidateEnabled.Error())
+	require.Equal(t, context.Semver{
+		Major:      0,
+		Minor:      0,
+		Patch:      0,
+		Prerelease: "",
+	}, ctx.Semver)
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -4,6 +4,8 @@ package pipeline
 import (
 	"fmt"
 
+	"github.com/goreleaser/goreleaser/internal/pipe/semver"
+
 	"github.com/goreleaser/goreleaser/internal/pipe/archive"
 	"github.com/goreleaser/goreleaser/internal/pipe/before"
 	"github.com/goreleaser/goreleaser/internal/pipe/build"
@@ -36,6 +38,7 @@ type Piper interface {
 var Pipeline = []Piper{
 	before.Pipe{},          // run global hooks before build
 	git.Pipe{},             // get and validate git repo state
+	semver.Pipe{},          // parse current tag to a semver
 	defaults.Pipe{},        // load default configs
 	snapshot.Pipe{},        // snapshot version handling
 	dist.Pipe{},            // ensure ./dist is clean

--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -6,10 +6,8 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/Masterminds/semver"
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/pkg/errors"
 )
 
 // Template holds data that can be applied to a template string
@@ -57,6 +55,10 @@ func New(ctx *context.Context) *Template {
 			env:         ctx.Env,
 			date:        time.Now().UTC().Format(time.RFC3339),
 			timestamp:   time.Now().UTC().Unix(),
+			major:       ctx.Semver.Major,
+			minor:       ctx.Semver.Minor,
+			patch:       ctx.Semver.Patch,
+			// TODO: no reason not to add prerelease here too I guess
 		},
 	}
 }
@@ -89,14 +91,6 @@ func (t *Template) Apply(s string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-
-	sv, err := semver.NewVersion(t.fields[tag].(string))
-	if err != nil {
-		return "", errors.Wrap(err, "tmpl")
-	}
-	t.fields[major] = sv.Major()
-	t.fields[minor] = sv.Minor()
-	t.fields[patch] = sv.Patch()
 
 	err = tmpl.Execute(&out, t.fields)
 	return out.String(), err

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -43,6 +43,15 @@ type Context struct {
 	Debug        bool
 	PreRelease   bool
 	Parallelism  int
+	Semver       Semver
+}
+
+// Semver represents a semantic version
+type Semver struct {
+	Major      int64
+	Minor      int64
+	Patch      int64
+	Prerelease string
 }
 
 // New context


### PR DESCRIPTION
- get and parse semver in a single place
- semver now is available in the context 
- we may add prerelease to templates too
- simplified some docker checks that happened to fail here for some reason now
- removed extra semver checks
- fixed issue with skip validate and semver ( closes #928 )