### PR TITLE
clean: removed deprecated git.short_hash option

### DIFF
--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -49,7 +49,7 @@ func getInfo(ctx *context.Context) (context.GitInfo, error) {
 	if !git.IsRepo() {
 		return context.GitInfo{}, ErrNotRepository
 	}
-	info, err := getGitInfo(ctx)
+	info, err := getGitInfo()
 	if err != nil && ctx.Snapshot {
 		log.WithError(err).Warn("ignoring errors because this is a snapshot")
 		if info.Commit == "" {
@@ -60,7 +60,7 @@ func getInfo(ctx *context.Context) (context.GitInfo, error) {
 	return info, err
 }
 
-func getGitInfo(ctx *context.Context) (context.GitInfo, error) {
+func getGitInfo() (context.GitInfo, error) {
 	short, err := getShortCommit()
 	if err != nil {
 		return context.GitInfo{}, errors.Wrap(err, "couldn't get current commit")

--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/apex/log"
-	"github.com/goreleaser/goreleaser/internal/deprecate"
 	"github.com/goreleaser/goreleaser/internal/git"
 	"github.com/goreleaser/goreleaser/internal/pipe"
 	"github.com/goreleaser/goreleaser/pkg/context"
@@ -23,9 +22,6 @@ func (Pipe) String() string {
 func (Pipe) Run(ctx *context.Context) error {
 	if _, err := exec.LookPath("git"); err != nil {
 		return ErrNoGit
-	}
-	if ctx.Config.Git.ShortHash {
-		deprecate.Notice("git.short_hash")
 	}
 	info, err := getInfo(ctx)
 	if err != nil {
@@ -73,10 +69,6 @@ func getGitInfo(ctx *context.Context) (context.GitInfo, error) {
 	if err != nil {
 		return context.GitInfo{}, errors.Wrap(err, "couldn't get current commit")
 	}
-	var commit = full
-	if ctx.Config.Git.ShortHash {
-		commit = short
-	}
 	url, err := getURL()
 	if err != nil {
 		return context.GitInfo{}, errors.Wrap(err, "couldn't get remote URL")
@@ -84,7 +76,7 @@ func getGitInfo(ctx *context.Context) (context.GitInfo, error) {
 	tag, err := getTag()
 	if err != nil {
 		return context.GitInfo{
-			Commit:      commit,
+			Commit:      full,
 			FullCommit:  full,
 			ShortCommit: short,
 			URL:         url,
@@ -93,7 +85,7 @@ func getGitInfo(ctx *context.Context) (context.GitInfo, error) {
 	}
 	return context.GitInfo{
 		CurrentTag:  tag,
-		Commit:      commit,
+		Commit:      full,
 		FullCommit:  full,
 		ShortCommit: short,
 		URL:         url,

--- a/internal/pipe/snapshot/snapshot_test.go
+++ b/internal/pipe/snapshot/snapshot_test.go
@@ -34,20 +34,6 @@ func TestDefaultSet(t *testing.T) {
 	assert.Equal(t, "snap", ctx.Config.Snapshot.NameTemplate)
 }
 
-func TestSnapshotNameShortCommitHash(t *testing.T) {
-	var ctx = context.New(config.Project{
-		Snapshot: config.Snapshot{
-			NameTemplate: "{{.ShortCommit}}",
-		},
-	})
-	ctx.Snapshot = true
-	ctx.Config.Git.ShortHash = true
-	ctx.Git.CurrentTag = "v1.2.3"
-	ctx.Git.ShortCommit = "123"
-	assert.NoError(t, Pipe{}.Run(ctx))
-	assert.Equal(t, ctx.Version, "123")
-}
-
 func TestSnapshotInvalidNametemplate(t *testing.T) {
 	var ctx = context.New(config.Project{
 		Snapshot: config.Snapshot{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -273,11 +273,6 @@ type EnvFiles struct {
 	GitHubToken string `yaml:"github_token,omitempty"`
 }
 
-// Git config
-type Git struct {
-	ShortHash bool `yaml:"short_hash,omitempty"`
-}
-
 // Before config
 type Before struct {
 	Hooks []string `yaml:",omitempty"`
@@ -325,7 +320,6 @@ type Project struct {
 	Dist          string    `yaml:",omitempty"`
 	Sign          Sign      `yaml:",omitempty"`
 	EnvFiles      EnvFiles  `yaml:"env_files,omitempty"`
-	Git           Git       `yaml:",omitempty"`
 	Before        Before    `yaml:",omitempty"`
 
 	// this is a hack ¯\_(ツ)_/¯

--- a/www/content/deprecations.md
+++ b/www/content/deprecations.md
@@ -108,6 +108,8 @@ dockers:
 ## git.short_hash
 
 > since 2018-10-03
+>
+> removed 2019-01-19
 
 This property was being used to tell GoReleaser to use short git hashes
 instead of the full ones. This has been removed in favor of specific


### PR DESCRIPTION
Removed `git.short_commit` option, it has been deprecated for almost 1 year...