### PR TITLE
fix: do not override release notes

### DIFF
--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -128,6 +128,10 @@ func (c *githubClient) CreateRelease(ctx *context.Context, body string) (int64, 
 			data,
 		)
 	} else {
+		// keep the pre-existing release notes
+		if release.GetBody() != "" {
+			data.Body = release.Body
+		}
 		release, _, err = c.client.Repositories.EditRelease(
 			ctx,
 			ctx.Config.Release.GitHub.Owner,


### PR DESCRIPTION
this shall avoid overriding the release body if the release exists and the body is not empty...

refs #929 
closes #856