### PR TITLE
refactor/fix: improved CLI

### DIFF
--- a/internal/middleware/doc.go
+++ b/internal/middleware/doc.go
@@ -1,0 +1,2 @@
+// Package middleware define middlewares for Actions.
+package middleware

--- a/internal/middleware/error.go
+++ b/internal/middleware/error.go
@@ -1,0 +1,23 @@
+package middleware
+
+import (
+	"github.com/apex/log"
+	"github.com/goreleaser/goreleaser/internal/pipe"
+	"github.com/goreleaser/goreleaser/pkg/context"
+)
+
+// ErrHandler handles an action error, ignoring and logging pipe skipped
+// errors.
+func ErrHandler(action Action) Action {
+	return func(ctx *context.Context) error {
+		var err = action(ctx)
+		if err == nil {
+			return nil
+		}
+		if pipe.IsSkip(err) {
+			log.WithError(err).Warn("pipe skipped")
+			return nil
+		}
+		return err
+	}
+}

--- a/internal/middleware/error_test.go
+++ b/internal/middleware/error_test.go
@@ -1,0 +1,23 @@
+package middleware
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/goreleaser/goreleaser/internal/pipe"
+	"github.com/stretchr/testify/require"
+)
+
+func TestError(t *testing.T) {
+	t.Run("no errors", func(t *testing.T) {
+		require.NoError(t, ErrHandler(mockAction(nil))(ctx))
+	})
+
+	t.Run("pipe skipped", func(t *testing.T) {
+		require.NoError(t, ErrHandler(mockAction(pipe.ErrSkipValidateEnabled))(ctx))
+	})
+
+	t.Run("some err", func(t *testing.T) {
+		require.Error(t, ErrHandler(mockAction(fmt.Errorf("pipe errored")))(ctx))
+	})
+}

--- a/internal/middleware/logging.go
+++ b/internal/middleware/logging.go
@@ -1,0 +1,37 @@
+package middleware
+
+import (
+	"strings"
+
+	"github.com/apex/log"
+	"github.com/apex/log/handlers/cli"
+	"github.com/fatih/color"
+	"github.com/goreleaser/goreleaser/pkg/context"
+)
+
+// Padding is a logging initial padding.
+type Padding int
+
+// DefaultInitialPadding is the default padding in the log library.
+const DefaultInitialPadding Padding = 3
+
+// ExtraPadding is the double of the DefaultInitialPadding.
+const ExtraPadding Padding = DefaultInitialPadding * 2
+
+// Logging pretty prints the given action and its title.
+// You can have different padding levels by providing different initial
+// paddings. The middleware will print the title in the given padding and the
+// action logs in padding+default padding.
+// The default padding in the log library is 3.
+// The middleware always resets to the default padding.
+func Logging(title string, next Action, padding Padding) Action {
+	return func(ctx *context.Context) error {
+		defer func() {
+			cli.Default.Padding = int(DefaultInitialPadding)
+		}()
+		cli.Default.Padding = int(padding)
+		log.Infof(color.New(color.Bold).Sprint(strings.ToUpper(title)))
+		cli.Default.Padding = int(padding + DefaultInitialPadding)
+		return next(ctx)
+	}
+}

--- a/internal/middleware/logging_test.go
+++ b/internal/middleware/logging_test.go
@@ -1,0 +1,11 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogging(t *testing.T) {
+	require.NoError(t, Logging("foo", mockAction(nil), DefaultInitialPadding)(ctx))
+}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -1,0 +1,8 @@
+package middleware
+
+import "github.com/goreleaser/goreleaser/pkg/context"
+
+// Action is a function that takes a context and returns an error.
+// It is is used on Pipers, Defaulters and Publishers, although they are not
+// aware of this generalization.
+type Action func(ctx *context.Context) error

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -1,0 +1,11 @@
+package middleware
+
+import "github.com/goreleaser/goreleaser/pkg/context"
+
+var ctx = &context.Context{}
+
+func mockAction(err error) Action {
+	return func(ctx *context.Context) error {
+		return err
+	}
+}

--- a/internal/pipe/changelog/testdata/changes.md
+++ b/internal/pipe/changelog/testdata/changes.md
@@ -1,0 +1,1 @@
+c0ff33 coffeee

--- a/internal/pipe/defaults/defaults.go
+++ b/internal/pipe/defaults/defaults.go
@@ -3,7 +3,7 @@
 package defaults
 
 import (
-	"github.com/apex/log"
+	"github.com/goreleaser/goreleaser/internal/middleware"
 	"github.com/goreleaser/goreleaser/pkg/context"
 	"github.com/goreleaser/goreleaser/pkg/defaults"
 )
@@ -24,8 +24,11 @@ func (Pipe) Run(ctx *context.Context) error {
 		ctx.Config.GitHubURLs.Download = "https://github.com"
 	}
 	for _, defaulter := range defaults.Defaulters {
-		log.Debug(defaulter.String())
-		if err := defaulter.Default(ctx); err != nil {
+		if err := middleware.Logging(
+			defaulter.String(),
+			middleware.ErrHandler(defaulter.Default),
+			middleware.ExtraPadding,
+		)(ctx); err != nil {
 			return err
 		}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -127,7 +127,6 @@ func TestInitProjectDefaultPipeFails(t *testing.T) {
 
 func testParams() releaseOptions {
 	return releaseOptions{
-		Debug:       true,
 		Parallelism: 4,
 		Snapshot:    true,
 		Timeout:     time.Minute,

--- a/main_test.go
+++ b/main_test.go
@@ -33,6 +33,8 @@ func TestReleaseProjectSkipPublish(t *testing.T) {
 }
 
 func TestConfigFileIsSetAndDontExist(t *testing.T) {
+	_, back := setup(t)
+	defer back()
 	params := testParams()
 	params.Config = "/this/wont/exist"
 	assert.Error(t, releaseProject(params))
@@ -71,6 +73,8 @@ func TestConfigFileDoesntExist(t *testing.T) {
 }
 
 func TestReleaseNotesFileDontExist(t *testing.T) {
+	_, back := setup(t)
+	defer back()
 	params := testParams()
 	params.ReleaseNotes = "/this/also/wont/exist"
 	assert.Error(t, releaseProject(params))

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -40,7 +40,6 @@ type Context struct {
 	SkipSign     bool
 	SkipValidate bool
 	RmDist       bool
-	Debug        bool
 	PreRelease   bool
 	Parallelism  int
 	Semver       Semver


### PR DESCRIPTION
- moved changelog file load to the changelog pipe
- created middlewares for common abstractions on `Piper`, `Defaulter` and `Publisher` actions
- other smaller improvements