### PR TITLE
fix docker always push

### DIFF
--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -92,6 +92,9 @@ func (Pipe) Run(ctx *context.Context) error {
 
 // Publish the docker images
 func (Pipe) Publish(ctx *context.Context) error {
+	if ctx.SkipPublish {
+		return pipe.ErrSkipPublishEnabled
+	}
 	var images = ctx.Artifacts.Filter(artifact.ByType(artifact.PublishableDockerImage)).List()
 	for _, image := range images {
 		if err := dockerPush(ctx, image); err != nil {

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -71,6 +71,9 @@ func TestRunPipe(t *testing.T) {
 	var shouldNotErr = func(t *testing.T, err error) {
 		require.NoError(t, err)
 	}
+	var shouldNotPublish = func(t *testing.T, err error) {
+		require.EqualError(t, err, pipe.ErrSkipPublishEnabled.Error())
+	}
 	type imageLabelFinder func(*testing.T, int)
 	var shouldFindImagesWithLabels = func(image string, filters ...string) func(*testing.T, int) {
 		return func(t *testing.T, count int) {
@@ -276,7 +279,7 @@ func TestRunPipe(t *testing.T) {
 			},
 			assertImageLabels: noLabels,
 			assertError:       shouldNotErr,
-			pubAssertError:    shouldNotErr,
+			pubAssertError:    shouldNotPublish,
 		},
 		"valid build args": {
 			publish: false,
@@ -299,7 +302,7 @@ func TestRunPipe(t *testing.T) {
 			},
 			assertImageLabels: noLabels,
 			assertError:       shouldNotErr,
-			pubAssertError:    shouldNotErr,
+			pubAssertError:    shouldNotPublish,
 		},
 		"bad build args": {
 			publish: false,


### PR DESCRIPTION
Current docker implementation doesn't look at `ctx.SkipPublish`.

I also fix tests which was silently failing.