### PR TITLE
feat: ability to skip Homebrew Tap update for preleases

### DIFF
--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -122,7 +122,7 @@ func doRun(ctx *context.Context, client client.Client) error {
 		return err
 	}
 
-	if ctx.Config.Brew.SkipUpload {
+	if strings.TrimSpace(ctx.Config.Brew.SkipUpload) == "true" {
 		return pipe.Skip("brew.skip_upload is set")
 	}
 	if ctx.SkipPublish {
@@ -130,6 +130,9 @@ func doRun(ctx *context.Context, client client.Client) error {
 	}
 	if ctx.Config.Release.Draft {
 		return pipe.Skip("release is marked as draft")
+	}
+	if strings.TrimSpace(ctx.Config.Brew.SkipUpload) == "auto" && ctx.Semver.Prerelease != "" {
+		return pipe.Skip("prerelease detected with 'auto' upload, skipping homebrew publish")
 	}
 
 	var gpath = ghFormulaPath(ctx.Config.Brew.Folder, filename)

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -313,20 +313,32 @@ func TestRunPipeNoUpload(t *testing.T) {
 	}
 	t.Run("skip upload", func(tt *testing.T) {
 		ctx.Config.Release.Draft = false
-		ctx.Config.Brew.SkipUpload = true
+		ctx.Config.Brew.SkipUpload = "true"
 		ctx.SkipPublish = false
 		assertNoPublish(tt)
 	})
 	t.Run("skip publish", func(tt *testing.T) {
 		ctx.Config.Release.Draft = false
-		ctx.Config.Brew.SkipUpload = false
+		ctx.Config.Brew.SkipUpload = "false"
 		ctx.SkipPublish = true
 		assertNoPublish(tt)
 	})
 	t.Run("draft release", func(tt *testing.T) {
 		ctx.Config.Release.Draft = true
-		ctx.Config.Brew.SkipUpload = false
+		ctx.Config.Brew.SkipUpload = "false"
 		ctx.SkipPublish = false
+		assertNoPublish(tt)
+	})
+	t.Run("skip prerelease publish", func(tt *testing.T) {
+		ctx.Config.Release.Draft = false
+		ctx.Config.Brew.SkipUpload = "auto"
+		ctx.SkipPublish = false
+		ctx.Semver = context.Semver{
+			Major:      1,
+			Minor:      0,
+			Patch:      0,
+			Prerelease: "rc1",
+		}
 		assertNoPublish(tt)
 	})
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -48,7 +48,7 @@ type Homebrew struct {
 	Conflicts        []string     `yaml:",omitempty"`
 	Description      string       `yaml:",omitempty"`
 	Homepage         string       `yaml:",omitempty"`
-	SkipUpload       bool         `yaml:"skip_upload,omitempty"`
+	SkipUpload       string       `yaml:"skip_upload,omitempty"`
 	DownloadStrategy string       `yaml:"download_strategy,omitempty"`
 	SourceTarball    string       `yaml:"-"`
 	URLTemplate      string       `yaml:"url_template,omitempty"`

--- a/www/content/homebrew.md
+++ b/www/content/homebrew.md
@@ -37,7 +37,7 @@ brew:
 
   # Allows you to add a custom require_relative at the top of the formula template
   # Default is empty
-  custom_require: custom_download_strategy 
+  custom_require: custom_download_strategy
 
   # Git author used to commit to the repository.
   # Defaults are shown.
@@ -64,6 +64,8 @@ brew:
   # Setting this will prevent goreleaser to actually try to commit the updated
   # formula - instead, the formula file will be stored on the dist folder only,
   # leaving the responsibility of publishing it to the user.
+  # If set to auto, the release will not be uploaded to the homebrew tap
+  # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
   # Default is false.
   skip_upload: true
 


### PR DESCRIPTION
If applied, this commit will allow for pre-releases to not be pushed to a Homebrew tap.

 Why is this change being made? When working on a tool that uses a Homebrew tap it would be helpful to be able to upload new releases to GitHub so that others can pull these down and test them manually but to help us prevent breaking the usage by other users that just want the current working version of the tool.


- Updates Homebrew config to make "SkipUpload" a string so that it can
  contain more than true or false values. New available options are
  "true", "false" and "auto".
- Adds a new check in Homebrew publish to see if it should skip due to a
  prerelease and "SkipUpload" set to auto.
- Adds a new test to make sure that tap publishing is skipped when set
  to "auto" and a prerelease semver is provided.
- Updates documents to add information about the new "auto" option for
  "SkipUpload".