### PR TITLE
fix: parse commit hash of GPG signed commit

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -18,6 +18,10 @@ func IsRepo() bool {
 // Run runs a git command and returns its output or errors
 func Run(args ...string) (string, error) {
 	// TODO: use exex.CommandContext here and refactor.
+	var extraArgs = []string{
+		"-c", "log.showSignature=false",
+	}
+	args = append(extraArgs, args...)
 	/* #nosec */
 	var cmd = exec.Command("git", args...)
 	log.WithField("args", args).Debug("running git")

--- a/internal/testlib/git.go
+++ b/internal/testlib/git.go
@@ -48,6 +48,7 @@ func fakeGit(args ...string) (string, error) {
 		"-c", "user.name='GoReleaser'",
 		"-c", "user.email='test@goreleaser.github.com'",
 		"-c", "commit.gpgSign=false",
+		"-c", "log.showSignature=false",
 	}
 	allArgs = append(allArgs, args...)
 	return git.Run(allArgs...)


### PR DESCRIPTION
<!-- If applied, this commit will... -->
This change will support parsing the commit hash from GPG-signed commits. It does so by disabling signing output from the `git` CLI using `git -c log.showSignature=false` prior to the git subcommand.

<!-- Why is this change being made? -->
@controlplaneio security policy mandates GPG signed commits, and we'd like to use this tool.

Closes https://github.com/goreleaser/goreleaser/issues/952