### PR TITLE
Support custom file upload for S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage.txt
 goreleaser
 debug.test
 snap.login
+.vscode/

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -285,6 +285,8 @@ type S3 struct {
 	Region   string
 	Bucket   string
 	Folder   string
+	Path     string
+	Name     string
 	Profile  string
 	Endpoint string // used for minio for example
 	ACL      string

--- a/www/content/s3.md
+++ b/www/content/s3.md
@@ -30,6 +30,13 @@ s3:
     # Template for the path/name inside the bucket.
     # Default is `{{ .ProjectName }}/{{ .Tag }}`
     folder: "foo/bar/{{.Version}}"
+    # Set a name for what the asset should be called on S3. Use combined with `path`.
+    name: ""
+    # Set a path pointing to a local file to upload. Overrides build assets
+    # and explicitly instruct to upload a certain file. Useful when you want
+    # to upload install scripts, custom manifests, which don't directly relate to,
+    # and in addition to the build that was just uploaded.
+    path: "path/to/file"
     # Set a custom profile to use for this s3 config. If you have multiple
     # profiles setup in you ~/.aws config, this shall help defining which
     # profile to use in which s3 bucket.


### PR DESCRIPTION


Add support for custom S3 upload. This is useful when releasing to S3 and not Github. Github contains an implicit feature -- "latest release". When using S3 as a release destination, there is no way to express "this is the latest release version", unless you write a custom service to provide that by scanning S3 objects.

On the other hand, if we upload all assets, and then upload a custom-built manifest that states the latest build number (or in my case, an updated `install.sh` script), we have feature parity with releasing through Github in a sense.

Apologies for not adding tests. I set everything up, began writing them, and saw that the current test don't really test for correctness, just for failure. I assume testing is done manually, so saw no point in doing that (i'm using this feature in production on my product).

