### PR TITLE
Handle repository URLs without owner

### DIFF
--- a/internal/pipe/release/release.go
+++ b/internal/pipe/release/release.go
@@ -36,6 +36,11 @@ func (Pipe) Default(ctx *context.Context) error {
 		ctx.Config.Release.GitHub = repo
 	}
 
+	if (ctx.Config.Release.GitHub.Owner == "" || ctx.Config.Release.GitHub.Name == "") &&
+		!(ctx.Snapshot || ctx.Config.Release.Disable) {
+		return errors.New("Releases require a repository owner and name")
+	}
+
 	// Check if we have to check the git tag for an indicator to mark as pre release
 	switch ctx.Config.Release.Prerelease {
 	case "auto":

--- a/internal/pipe/release/release_test.go
+++ b/internal/pipe/release/release_test.go
@@ -314,6 +314,38 @@ func TestDefaultGitRepoWithoutRemote(t *testing.T) {
 	assert.Empty(t, ctx.Config.Release.GitHub.String())
 }
 
+func TestDefaultGitRepoWithoutSlash(t *testing.T) {
+	_, back := testlib.Mktmp(t)
+	defer back()
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "user@host:myrepo.git")
+
+	var ctx = context.New(config.Project{
+		Release: config.Release{},
+	})
+	assert.EqualError(t, Pipe{}.Default(ctx), "Releases require a repository owner and name")
+	assert.Equal(t, config.Repo{
+		Name: "myrepo",
+	}, ctx.Config.Release.GitHub)
+}
+
+func TestDefaultGitRepoWithoutSlashDisable(t *testing.T) {
+	_, back := testlib.Mktmp(t)
+	defer back()
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "user@host:myrepo.git")
+
+	var ctx = context.New(config.Project{
+		Release: config.Release{
+			Disable: true,
+		},
+	})
+	assert.NoError(t, Pipe{}.Default(ctx))
+	assert.Equal(t, config.Repo{
+		Name: "myrepo",
+	}, ctx.Config.Release.GitHub)
+}
+
 type DummyClient struct {
 	FailToCreateRelease bool
 	FailToUpload        bool

--- a/internal/pipe/release/remote.go
+++ b/internal/pipe/release/remote.go
@@ -35,8 +35,14 @@ func extractRepoFromURL(s string) config.Repo {
 	s = s[strings.LastIndex(s, ":")+1:]
 	// split by /, the last to parts should be the owner and name
 	ss := strings.Split(s, "/")
-	return config.Repo{
-		Owner: ss[len(ss)-2],
-		Name:  ss[len(ss)-1],
+
+	repo := config.Repo{
+		Name: ss[len(ss)-1],
 	}
+
+	if len(ss) > 1 {
+		repo.Owner = ss[len(ss)-2]
+	}
+
+	return repo
 }

--- a/internal/pipe/release/remote_test.go
+++ b/internal/pipe/release/remote_test.go
@@ -32,3 +32,20 @@ func TestExtractRepoFromURL(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractRepoFromNonURL(t *testing.T) {
+	for _, test := range []struct {
+		expected string
+		url      string
+	}{
+		{"", ""},
+		{"repo", "git@host:repo"},
+		{"repo", "git@host:repo.git"},
+		{"tmp/repo2", "file:///tmp/repo2.git"},
+	} {
+		t.Run(test.url, func(t *testing.T) {
+			repo := extractRepoFromURL(test.url)
+			assert.Equal(t, test.expected, repo.String())
+		})
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,10 +28,12 @@ type Repo struct {
 
 // String of the repo, e.g. owner/name
 func (r Repo) String() string {
-	if r.Owner == "" && r.Name == "" {
-		return ""
+	switch {
+	case r.Owner == "":
+		return r.Name
+	default:
+		return r.Owner + "/" + r.Name
 	}
-	return r.Owner + "/" + r.Name
 }
 
 // Homebrew contains the brew section

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -11,16 +11,30 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRepo(t *testing.T) {
-	assert.Equal(
-		t,
-		"goreleaser/godownloader",
-		Repo{Owner: "goreleaser", Name: "godownloader"}.String(),
-	)
-}
+func TestRepoString(t *testing.T) {
+	tests := []struct {
+		expected string
+		repo     Repo
+	}{
+		{
+			"",
+			Repo{},
+		},
+		{
+			"helloworld",
+			Repo{Name: "helloworld"},
+		},
+		{
+			"goreleaser/godownloader",
+			Repo{Owner: "goreleaser", Name: "godownloader"},
+		},
+	}
 
-func TestEmptyRepoNameAndOwner(t *testing.T) {
-	assert.Empty(t, Repo{}.String())
+	for _, test := range tests {
+		t.Run(test.expected, func(t *testing.T) {
+			assert.Equal(t, test.expected, test.repo.String())
+		})
+	}
 }
 
 func TestLoadReader(t *testing.T) {


### PR DESCRIPTION
When a repository has a remote URL such as "user@host:foobar.git" the
code extracting the owner panics. With this pull request such URLs are
handled more gracefully.