### PR TITLE
ability to skip Docker update for pre-releases (#977)

### DIFF
--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/internal/pipe"
+	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
 	"github.com/stretchr/testify/assert"
@@ -223,15 +224,14 @@ func TestRunPipe(t *testing.T) {
 					Goarch:     "amd64",
 					Dockerfile: "testdata/Dockerfile",
 					Binaries:   []string{"mybin"},
-					SkipPush:   true,
+					SkipPush:   "true",
 				},
 			},
 			expect: []string{
 				registry + "goreleaser/test_run_pipe:latest",
 			},
 			assertImageLabels: noLabels,
-			assertError:       shouldNotErr,
-			pubAssertError:    shouldNotErr,
+			assertError:       testlib.AssertSkipped,
 		},
 		"valid_no_latest": {
 			dockers: []config.Docker{
@@ -384,7 +384,7 @@ func TestRunPipe(t *testing.T) {
 					Goarch:     "amd64",
 					Dockerfile: "testdata/Dockerfile",
 					Binaries:   []string{"mybin"},
-					SkipPush:   true,
+					SkipPush:   "true",
 				},
 			},
 			env: map[string]string{
@@ -395,8 +395,7 @@ func TestRunPipe(t *testing.T) {
 				registry + "goreleaser/mybin:latest",
 			},
 			assertImageLabels: noLabels,
-			assertError:       shouldNotErr,
-			pubAssertError:    shouldNotErr,
+			assertError:       testlib.AssertSkipped,
 		},
 		"no_permissions": {
 			dockers: []config.Docker{
@@ -768,7 +767,7 @@ func Test_processImageTemplates(t *testing.T) {
 						"gcr.io/image:{{.Tag}}-{{.Env.FOO}}",
 						"gcr.io/image:v{{.Major}}.{{.Minor}}",
 					},
-					SkipPush: true,
+					SkipPush: "true",
 				},
 			},
 		},

--- a/internal/pipe/publish/publish_test.go
+++ b/internal/pipe/publish/publish_test.go
@@ -23,7 +23,7 @@ func TestPublish(t *testing.T) {
 	var ctx = context.New(config.Project{})
 	ctx.Config.Release.Disable = true
 	for i := range ctx.Config.Dockers {
-		ctx.Config.Dockers[i].SkipPush = true
+		ctx.Config.Dockers[i].SkipPush = "true"
 	}
 	require.NoError(t, Pipe{}.Run(ctx))
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -251,7 +251,7 @@ type Docker struct {
 	Image              string   `yaml:",omitempty"`
 	Dockerfile         string   `yaml:",omitempty"`
 	ImageTemplates     []string `yaml:"image_templates,omitempty"`
-	SkipPush           bool     `yaml:"skip_push,omitempty"`
+	SkipPush           string   `yaml:"skip_push,omitempty"`
 	TagTemplates       []string `yaml:"tag_templates,omitempty"`
 	Files              []string `yaml:"extra_files,omitempty"`
 	BuildFlagTemplates []string `yaml:"build_flag_templates,omitempty"`

--- a/www/content/docker.md
+++ b/www/content/docker.md
@@ -65,6 +65,8 @@ dockers:
     - "myuser/myimage:v{{ .Major }}"
     - "gcr.io/myuser/myimage:latest"
     # Skips the docker push. Could be useful if you also do draft releases.
+    # If set to auto, the release will not be pushed to the docker repository
+    # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
     # Defaults to false.
     skip_push: false
     # Path to the Dockerfile (from the project root).


### PR DESCRIPTION
If applied, this commit will skip docker pushes on `skip_publish` builds, draft builds and on pre-releases if `skip_push` is set to `auto`

Closes https://github.com/goreleaser/goreleaser/issues/977

I directly followed approach introduced in https://github.com/goreleaser/goreleaser/pull/943
So:
- Change `config.Docker.SkipPush` to `string`
- Respect `skip_publish` setting
- Respect `draft` setting
- Skip `docker push` if `skip_push` is set to `auto` and version is a pre-release