### PR TITLE
feat: added Plugs attribute to snapcraft.Metadata allowing plugs to b…

### DIFF
--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -39,6 +39,7 @@ type Metadata struct {
 	Confinement   string `yaml:",omitempty"`
 	Architectures []string
 	Apps          map[string]AppMetadata
+	Plugs         map[string]interface{} `yaml:",omitempty"`
 }
 
 // AppMetadata for the binaries that will be in the snap package
@@ -47,6 +48,10 @@ type AppMetadata struct {
 	Plugs   []string `yaml:",omitempty"`
 	Daemon  string   `yaml:",omitempty"`
 }
+
+// Plugs for configuring individual plugs
+// see: https://docs.snapcraft.io/snapcraft-yaml-reference/4276
+type Plugs map[string]interface{}
 
 const defaultNameTemplate = "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
 
@@ -143,6 +148,7 @@ func create(ctx *context.Context, arch string, binaries []artifact.Artifact) err
 		Confinement:   ctx.Config.Snapcraft.Confinement,
 		Architectures: []string{arch},
 		Apps:          map[string]AppMetadata{},
+		Plugs:		   Plugs{},
 	}
 
 	metadata.Name = ctx.Config.ProjectName
@@ -168,6 +174,7 @@ func create(ctx *context.Context, arch string, binaries []artifact.Artifact) err
 			}, " ")
 		}
 		metadata.Apps[binary.Name] = appMetadata
+		metadata.Plugs = ctx.Config.Snapcraft.Plugs
 
 		destBinaryPath := filepath.Join(primeDir, filepath.Base(binary.Path))
 		log.WithField("src", binary.Path).

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -228,6 +228,7 @@ type Snapcraft struct {
 	Grade       string                          `yaml:",omitempty"`
 	Confinement string                          `yaml:",omitempty"`
 	Apps        map[string]SnapcraftAppMetadata `yaml:",omitempty"`
+	Plugs       map[string]interface{}          `yaml:",omitempty"`
 }
 
 // Snapshot config


### PR DESCRIPTION
feat: added Plugs attribute to snapcraft.Metadata allowing plugs to b…

<!-- If applied, this commit will... -->
This commit will add the ability to confiture Plugs for Snapcraft. 

<!-- Why is this change being made? -->
Many Snapcraft Plugs such as "personal-files" and "system-files" require additional configuration. 

Example:
```
  apps:
    kubefwd:
      plugs: ["home", "network", "network-bind", "personal-files", "system-files"]

  plugs:
    personal-files:
      read: ["$HOME/.kube"]
    system-files:
      read: ["/etc/hosts"]
      write: ["/etc/hosts"]
```

<!-- # Provide links to any relevant tickets, URLs or other resources -->
https://docs.snapcraft.io/snapcraft-yaml-reference/4276