### PR TITLE
feat: added Plugs attribute to snapcraft.Metadata

### DIFF
--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -39,6 +39,7 @@ type Metadata struct {
 	Confinement   string `yaml:",omitempty"`
 	Architectures []string
 	Apps          map[string]AppMetadata
+	Plugs         map[string]interface{} `yaml:",omitempty"`
 }
 
 // AppMetadata for the binaries that will be in the snap package
@@ -47,6 +48,10 @@ type AppMetadata struct {
 	Plugs   []string `yaml:",omitempty"`
 	Daemon  string   `yaml:",omitempty"`
 }
+
+// Plugs for configuring individual plugs
+// see: https://docs.snapcraft.io/snapcraft-yaml-reference/4276
+type Plugs map[string]interface{}
 
 const defaultNameTemplate = "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
 
@@ -143,6 +148,7 @@ func create(ctx *context.Context, arch string, binaries []artifact.Artifact) err
 		Confinement:   ctx.Config.Snapcraft.Confinement,
 		Architectures: []string{arch},
 		Apps:          map[string]AppMetadata{},
+		Plugs:         Plugs{},
 	}
 
 	metadata.Name = ctx.Config.ProjectName
@@ -168,6 +174,7 @@ func create(ctx *context.Context, arch string, binaries []artifact.Artifact) err
 			}, " ")
 		}
 		metadata.Apps[binary.Name] = appMetadata
+		metadata.Plugs = ctx.Config.Snapcraft.Plugs
 
 		destBinaryPath := filepath.Join(primeDir, filepath.Base(binary.Path))
 		log.WithField("src", binary.Path).

--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -39,7 +39,7 @@ type Metadata struct {
 	Confinement   string `yaml:",omitempty"`
 	Architectures []string
 	Apps          map[string]AppMetadata
-	Plugs         map[string]interface{} `yaml:",omitempty"`
+	Plugs         Plugs `yaml:",omitempty"`
 }
 
 // AppMetadata for the binaries that will be in the snap package

--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -39,7 +39,7 @@ type Metadata struct {
 	Confinement   string `yaml:",omitempty"`
 	Architectures []string
 	Apps          map[string]AppMetadata
-	Plugs         Plugs `yaml:",omitempty"`
+	Plugs         map[string]interface{} `yaml:",omitempty"`
 }
 
 // AppMetadata for the binaries that will be in the snap package
@@ -48,10 +48,6 @@ type AppMetadata struct {
 	Plugs   []string `yaml:",omitempty"`
 	Daemon  string   `yaml:",omitempty"`
 }
-
-// Plugs for configuring individual plugs
-// see: https://docs.snapcraft.io/snapcraft-yaml-reference/4276
-type Plugs map[string]interface{}
 
 const defaultNameTemplate = "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
 
@@ -148,7 +144,6 @@ func create(ctx *context.Context, arch string, binaries []artifact.Artifact) err
 		Confinement:   ctx.Config.Snapcraft.Confinement,
 		Architectures: []string{arch},
 		Apps:          map[string]AppMetadata{},
-		Plugs:         Plugs{},
 	}
 
 	metadata.Name = ctx.Config.ProjectName

--- a/internal/pipe/snapcraft/snapcraft_test.go
+++ b/internal/pipe/snapcraft/snapcraft_test.go
@@ -129,10 +129,13 @@ func TestRunPipeMetadata(t *testing.T) {
 			Description:  "test description",
 			Apps: map[string]config.SnapcraftAppMetadata{
 				"mybin": {
-					Plugs:  []string{"home", "network"},
+					Plugs:  []string{"home", "network", "personal-files"},
 					Daemon: "simple",
 					Args:   "--foo --bar",
 				},
+			},
+			Plugs: Plugs{
+				"personal-files": []string{"$HOME/test"},
 			},
 		},
 	})
@@ -145,12 +148,13 @@ func TestRunPipeMetadata(t *testing.T) {
 	var metadata Metadata
 	err = yaml.Unmarshal(yamlFile, &metadata)
 	assert.NoError(t, err)
-	assert.Equal(t, metadata.Apps["mybin"].Plugs, []string{"home", "network"})
+	assert.Equal(t, metadata.Apps["mybin"].Plugs, []string{"home", "network", "personal-files"})
 	assert.Equal(t, metadata.Apps["mybin"].Daemon, "simple")
 	assert.Equal(t, metadata.Apps["mybin"].Command, "mybin --foo --bar")
-	assert.Equal(t, metadata.Apps["testprojectname"].Plugs, []string{"home", "network"})
+	assert.Equal(t, metadata.Apps["testprojectname"].Plugs, []string{"home", "network", "personal-files"})
 	assert.Equal(t, metadata.Apps["testprojectname"].Daemon, "simple")
 	assert.Equal(t, metadata.Apps["testprojectname"].Command, "mybin --foo --bar")
+	assert.Equal(t, metadata.Plugs["personal-files"], []interface{}([]interface{}{"$HOME/test"}))
 }
 
 func TestNoSnapcraftInPath(t *testing.T) {

--- a/internal/pipe/snapcraft/snapcraft_test.go
+++ b/internal/pipe/snapcraft/snapcraft_test.go
@@ -134,7 +134,7 @@ func TestRunPipeMetadata(t *testing.T) {
 					Args:   "--foo --bar",
 				},
 			},
-			Plugs: Plugs{
+			Plugs: map[string]interface{}{
 				"personal-files": []string{"$HOME/test"},
 			},
 		},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -228,6 +228,7 @@ type Snapcraft struct {
 	Grade       string                          `yaml:",omitempty"`
 	Confinement string                          `yaml:",omitempty"`
 	Apps        map[string]SnapcraftAppMetadata `yaml:",omitempty"`
+	Plugs       map[string]interface{}          `yaml:",omitempty"`
 }
 
 // Snapshot config


### PR DESCRIPTION
feat: added Plugs attribute to snapcraft.Metadata allowing plugs to be configured.

<!-- If applied, this commit will... -->
This commit will add the ability to confiture Plugs for Snapcraft. 

<!-- Why is this change being made? -->
Many Snapcraft Plugs such as "personal-files" and "system-files" require additional configuration. 

Example:
```
  apps:
    kubefwd:
      plugs: ["home", "network", "network-bind", "personal-files", "system-files"]

  plugs:
    personal-files:
      read: ["$HOME/.kube"]
    system-files:
      read: ["/etc/hosts"]
      write: ["/etc/hosts"]
```

<!-- # Provide links to any relevant tickets, URLs or other resources -->
https://docs.snapcraft.io/snapcraft-yaml-reference/4276