### PR TITLE
feat: linux compatible arch for ppc64/ppc64le

### DIFF
--- a/internal/linux/arch.go
+++ b/internal/linux/arch.go
@@ -16,6 +16,10 @@ func Arch(key string) string {
 		return "armel"
 	case strings.Contains(key, "arm7"):
 		return "armhf"
+	case strings.Contains(key, "ppc64le"):
+		return "ppc64le"
+	case strings.Contains(key, "ppc64"):
+		return "ppc64"
 	}
 	return key
 }


### PR DESCRIPTION
If applied, this commit will allow goreleaser to generate rpm packages for ppc64 and ppc64le targets which include the correct architecture in the SPEC definition.