### PR TITLE
test: validate arch map for linuxpp64/ppc64le

### DIFF
--- a/internal/linux/arch_test.go
+++ b/internal/linux/arch_test.go
@@ -14,6 +14,8 @@ func TestArch(t *testing.T) {
 		"linuxarm64": "arm64",
 		"linuxarm6":  "armel",
 		"linuxarm7":  "armhf",
+		"linuxppc64":  "ppc64",
+		"linuxppc64le":  "ppc64le",
 		"linuxwhat":  "what",
 	} {
 		t.Run(fmt.Sprintf("%s to %s", from, to), func(t *testing.T) {


### PR DESCRIPTION
If applied, this commit will validate the goarch to linux compatible architectures for the two ppc64 cases.

I didn't notice the go testing framework when I made the first pull
request so these were left out. Not a big deal either way but we might
as well have complete tests.

Related to #987.