### PR TITLE
Set GoCenter as GOPROXY to speed up go builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 env:
   - GO111MODULE=on
+  - GOPROXY=https://gocenter.io
 before:
   hooks:
     - go mod download

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ TEST_OPTIONS?=
 
 export PATH := ./bin:$(PATH)
 export GO111MODULE := on
+export GOPROXY := https://gocenter.io
 
 # Install all the build and lint dependencies
 setup:


### PR DESCRIPTION
Use https://gocenter.io as GOPROXY.

Using https://gocenter.io as GOPROXY will speed modules download and will ensure that modules referenced in go.mod are always the same, doesn't matter if some modules get deleted/changed/etc at source e.g. GitHub and etc, they get cached for live at https://gocenter.io  :-)
