### PR TITLE
feat: add flag to wrap binary in bin directory on archives for unix

### DIFF
--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -126,8 +126,12 @@ func create(ctx *context.Context, binaries []artifact.Artifact) error {
 		}
 	}
 	for _, binary := range binaries {
-		if err := a.Add(binary.Name, binary.Path); err != nil {
-			return fmt.Errorf("failed to add %s -> %s to the archive: %s", binary.Path, binary.Name, err.Error())
+		dest := binary.Name
+		if ctx.Config.Archive.BinDirectory {
+			dest = filepath.Join("bin", binary.Name)
+		}
+		if err := a.Add(dest, binary.Path); err != nil {
+			return fmt.Errorf("failed to add %s -> %s to the archive: %s", binary.Path, dest, err.Error())
 		}
 	}
 	ctx.Artifacts.Add(artifact.Artifact{

--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -49,9 +49,15 @@ func (Pipe) Default(ctx *context.Context) error {
 			if !isBrewBuild(build) {
 				continue
 			}
+
+			binaryPath := build.Binary
+			if ctx.Config.Archive.BinDirectory {
+				binaryPath = filepath.Join("bin", build.Binary)
+			}
+
 			installs = append(
 				installs,
-				fmt.Sprintf(`bin.install "%s"`, build.Binary),
+				fmt.Sprintf(`bin.install "%s"`, binaryPath),
 			)
 		}
 		ctx.Config.Brew.Install = strings.Join(installs, "\n")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -152,6 +152,7 @@ type Archive struct {
 
 	Format          string           `yaml:",omitempty"`
 	FormatOverrides []FormatOverride `yaml:"format_overrides,omitempty"`
+	BinDirectory    bool             `yaml:"bin_directory,omitempty"`
 	WrapInDirectory string           `yaml:"wrap_in_directory,omitempty"`
 	Files           []string         `yaml:",omitempty"`
 }


### PR DESCRIPTION
Add a flag to the archive configuration that makes it possible to add the binary in a bin directory.
<!-- If applied, this commit will... -->

This makes it possible to extract the archive in a location outside the `PATH` and add the `bin` directory to the `PATH`. We don't want to add the root of the archive, as we don't want the README, LICENSE and other included files to be in the `PATH`.
<!-- Why is this change being made? -->

This is also how [`Golang`](https://golang.org/dl/) structures their archive.

<!-- # Provide links to any relevant tickets, URLs or other resources -->
