### PR TITLE
fix: use the filename of the binary in snapcraft

### DIFF
--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -152,11 +152,12 @@ func create(ctx *context.Context, arch string, binaries []artifact.Artifact) err
 	}
 
 	for _, binary := range binaries {
+		_, name := filepath.Split(binary.Name)
 		log.WithField("path", binary.Path).
 			WithField("name", binary.Name).
 			Debug("passed binary to snapcraft")
 		appMetadata := AppMetadata{
-			Command: binary.Name,
+			Command: name,
 		}
 		if configAppMetadata, ok := ctx.Config.Snapcraft.Apps[binary.Name]; ok {
 			appMetadata.Plugs = configAppMetadata.Plugs
@@ -166,7 +167,7 @@ func create(ctx *context.Context, arch string, binaries []artifact.Artifact) err
 				configAppMetadata.Args,
 			}, " ")
 		}
-		metadata.Apps[binary.Name] = appMetadata
+		metadata.Apps[name] = appMetadata
 		metadata.Plugs = ctx.Config.Snapcraft.Plugs
 
 		destBinaryPath := filepath.Join(primeDir, filepath.Base(binary.Path))
@@ -182,7 +183,8 @@ func create(ctx *context.Context, arch string, binaries []artifact.Artifact) err
 	}
 
 	if _, ok := metadata.Apps[metadata.Name]; !ok {
-		metadata.Apps[metadata.Name] = metadata.Apps[binaries[0].Name]
+		_, name := filepath.Split(binaries[0].Name)
+		metadata.Apps[metadata.Name] = metadata.Apps[name]
 	}
 
 	out, err := yaml.Marshal(metadata)


### PR DESCRIPTION
When builds.binary is a path, only use the filename as the name
of the snapcraft app and as the command, instead of the full path.

As an alternative to #1000 we could have the binary field of the builds section be a path:

```yaml
builds:
  binary: bin/app
```

This works for most pipes, but fails on the snapcraft pipe. This PR fixes this usecase for the snapcraft pipe.