### PR TITLE
fix: use bin name instead of bin path to set snap app config

### DIFF
--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -159,7 +159,7 @@ func create(ctx *context.Context, arch string, binaries []artifact.Artifact) err
 		appMetadata := AppMetadata{
 			Command: name,
 		}
-		if configAppMetadata, ok := ctx.Config.Snapcraft.Apps[binary.Name]; ok {
+		if configAppMetadata, ok := ctx.Config.Snapcraft.Apps[name]; ok {
 			appMetadata.Plugs = configAppMetadata.Plugs
 			appMetadata.Daemon = configAppMetadata.Daemon
 			appMetadata.Command = strings.Join([]string{


### PR DESCRIPTION
@caarlos0 Sorry, missed one spot.

We should use the binary name to configure the snap app, not the binary path.

```yaml
builds:
  - binary: bin/hello-world
...
snapcraft:
  apps:
    hello-world:
      plugs:
```

instead of

```yaml
builds:
  - binary: bin/hello-world
...
snapcraft:
  apps:
    bin/hello-world:
      plugs:
```
