### PR TITLE
feat: build id

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -106,6 +106,7 @@ func (*Builder) Build(ctx *context.Context, build config.Build, options api.Opti
 		Extra: map[string]interface{}{
 			"Binary": build.Binary,
 			"Ext":    options.Ext,
+			"ID":     build.ID,
 		},
 	})
 	return nil

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -27,6 +27,7 @@ func TestWithDefaults(t *testing.T) {
 	}{
 		"full": {
 			build: config.Build{
+				ID:     "foo",
 				Binary: "foo",
 				Goos: []string{
 					"linux",
@@ -50,6 +51,7 @@ func TestWithDefaults(t *testing.T) {
 		},
 		"empty": {
 			build: config.Build{
+				ID:     "foo2",
 				Binary: "foo",
 			},
 			targets: []string{
@@ -81,6 +83,7 @@ func TestBuild(t *testing.T) {
 	var config = config.Project{
 		Builds: []config.Build{
 			{
+				ID:     "foo",
 				Env:    []string{"GO111MODULE=off"},
 				Binary: "foo",
 				Targets: []string{
@@ -122,6 +125,7 @@ func TestBuild(t *testing.T) {
 			Extra: map[string]interface{}{
 				"Ext":    "",
 				"Binary": "foo",
+				"ID":     "foo",
 			},
 		},
 		{
@@ -133,6 +137,7 @@ func TestBuild(t *testing.T) {
 			Extra: map[string]interface{}{
 				"Ext":    "",
 				"Binary": "foo",
+				"ID":     "foo",
 			},
 		},
 		{
@@ -145,6 +150,7 @@ func TestBuild(t *testing.T) {
 			Extra: map[string]interface{}{
 				"Ext":    "",
 				"Binary": "foo",
+				"ID":     "foo",
 			},
 		},
 		{
@@ -156,6 +162,7 @@ func TestBuild(t *testing.T) {
 			Extra: map[string]interface{}{
 				"Ext":    ".exe",
 				"Binary": "foo",
+				"ID":     "foo",
 			},
 		},
 	})
@@ -168,6 +175,7 @@ func TestBuildFailed(t *testing.T) {
 	var config = config.Project{
 		Builds: []config.Build{
 			{
+				ID:    "buildid",
 				Flags: []string{"-flag-that-dont-exists-to-force-failure"},
 				Targets: []string{
 					runtimeTarget,
@@ -192,6 +200,7 @@ func TestBuildInvalidTarget(t *testing.T) {
 	var config = config.Project{
 		Builds: []config.Build{
 			{
+				ID:      "foo",
 				Binary:  "foo",
 				Targets: []string{target},
 			},

--- a/internal/pipe/build/build.go
+++ b/internal/pipe/build/build.go
@@ -3,22 +3,21 @@
 package build
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/apex/log"
-	"github.com/pkg/errors"
-
 	"github.com/goreleaser/goreleaser/internal/semerrgroup"
 	"github.com/goreleaser/goreleaser/internal/tmpl"
 	builders "github.com/goreleaser/goreleaser/pkg/build"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
+	"github.com/pkg/errors"
 
 	// langs to init
-	"fmt"
 	_ "github.com/goreleaser/goreleaser/internal/builders/golang"
 )
 

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -218,16 +218,36 @@ func TestDefaultEmptyBuild(t *testing.T) {
 	assert.Equal(t, "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}", build.Ldflags[0])
 }
 
+func TestSeveralBuildsWithTheSameID(t *testing.T) {
+	var ctx = &context.Context{
+		Config: config.Project{
+			Builds: []config.Build{
+				{
+					ID:     "a",
+					Binary: "bar",
+				},
+				{
+					ID:     "a",
+					Binary: "foo",
+				},
+			},
+		},
+	}
+	assert.EqualError(t, Pipe{}.Default(ctx), "there are more than 2 builds with the ID 'a', please fix your config")
+}
+
 func TestDefaultPartialBuilds(t *testing.T) {
 	var ctx = &context.Context{
 		Config: config.Project{
 			Builds: []config.Build{
 				{
+					ID:     "build1",
 					Binary: "bar",
 					Goos:   []string{"linux"},
 					Main:   "./cmd/main.go",
 				},
 				{
+					ID:      "build2",
 					Binary:  "foo",
 					Ldflags: []string{"-s -w"},
 					Goarch:  []string{"386"},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -123,6 +123,7 @@ func (a *FlagArray) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // Build contains the build configuration section
 type Build struct {
+	ID       string         `yaml:",omitempty"`
 	Goos     []string       `yaml:",omitempty"`
 	Goarch   []string       `yaml:",omitempty"`
 	Goarm    []string       `yaml:",omitempty"`

--- a/www/content/build.md
+++ b/www/content/build.md
@@ -20,6 +20,7 @@ builds:
     # ID of the build.
     # Defaults to the binary name.
     id: "my-build"
+
     # Path to main.go file or main package.
     # Default is `.`.
     main: ./cmd/main.go

--- a/www/content/build.md
+++ b/www/content/build.md
@@ -17,6 +17,9 @@ Here is a commented `builds` section with all fields specified:
 builds:
   # You can have multiple builds defined as a yaml list
   -
+    # ID of the build.
+    # Defaults to the binary name.
+    id: "my-build"
     # Path to main.go file or main package.
     # Default is `.`.
     main: ./cmd/main.go


### PR DESCRIPTION
this is the first step to achieve multiple archives: we need to be able to identify builds.

The binary name alone is not a good idea, as the user may have different build configs depending on GOOS for example, so an `ID` field was added.

**This is a breaking change**: if the user has multiple builds with the same binary name the release will now fail.

refs #705 