### PR TITLE
fix: add env expansion within signage

### DIFF
--- a/internal/pipe/sign/sign.go
+++ b/internal/pipe/sign/sign.go
@@ -77,9 +77,8 @@ func sign(ctx *context.Context, artifacts []artifact.Artifact) error {
 func signone(ctx *context.Context, a artifact.Artifact) (*artifact.Artifact, error) {
 	cfg := ctx.Config.Sign
 
-	env := map[string]string{
-		"artifact": a.Path,
-	}
+	env := ctx.Env
+	env["artifact"] = a.Path
 	env["signature"] = expand(cfg.Signature, env)
 
 	// nolint:prealloc

--- a/internal/pipe/sign/sign_test.go
+++ b/internal/pipe/sign/sign_test.go
@@ -95,6 +95,29 @@ func TestSignArtifacts(t *testing.T) {
 			signaturePaths: []string{"checksum.sig"},
 			signatureNames: []string{"checksum.sig"},
 		},
+		{
+			desc: "sign all artifacts with env",
+			ctx: context.New(
+				config.Project{
+					Sign: config.Sign{
+						Artifacts: "all",
+						Args: []string{
+							"-u",
+							"${TEST_USER}",
+							"--output",
+							"${signature}",
+							"--detach-sign",
+							"${artifact}",
+						},
+					},
+					Env: []string{
+						fmt.Sprintf("TEST_USER=%s", user),
+					},
+				},
+			),
+			signaturePaths: []string{"artifact1.sig", "artifact2.sig", "artifact3.sig", "checksum.sig", "linux_amd64/artifact4.sig"},
+			signatureNames: []string{"artifact1.sig", "artifact2.sig", "artifact3_1.0.0_linux_amd64.sig", "checksum.sig", "artifact4_1.0.0_linux_amd64.sig"},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Add support for environment variables
within sign arguments. For e.g. the private key for signing.


Fixes #1009