### PR TITLE
Skip arm5 snaps

### DIFF
--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -120,7 +120,7 @@ func doRun(ctx *context.Context, snap config.Snapcraft) error {
 		),
 	).GroupByPlatform() {
 		arch := linux.Arch(platform)
-		if arch == "armel" {
+		if arch == "armel" || arch == "arm5" {
 			log.WithField("arch", arch).Warn("ignored unsupported arch")
 			continue
 		}


### PR DESCRIPTION
Skip arm5 snaps.

Snapcraft returns the following error when trying to upload arm5 snaps:
```
The store was unable to accept this snap.
  - architectures: Invalid architecture specified in the manifest: arm5.
```