### PR TITLE
docs: fix snap install command

### DIFF
--- a/www/content/install.md
+++ b/www/content/install.md
@@ -26,7 +26,7 @@ $ brew install goreleaser
 **snapcraft**:
 
 ```sh
-$ snap install goreleaser
+$ sudo snap install --classic goreleaser
 ```
 
 **scoop**:


### PR DESCRIPTION
This PR simply fixes the snapcraft install command listed on the website.

1. Almost always the user will need to prefix the command with `sudo`.
2. The GoReleaser snap is a classically confined snap which requires the flag `--classic` to install.