### PR TITLE
feat: Add support for specifying SSE on S3 objects

### DIFF
--- a/internal/pipe/s3/s3.go
+++ b/internal/pipe/s3/s3.go
@@ -130,7 +130,7 @@ func upload(ctx *context.Context, conf config.S3) error {
 						Key:   				  aws.String(filepath.Join(folder, artifact.Name)),
 						Body:  				  f,
 						ACL:   				  aws.String(conf.ACL),
-						ServerSideEncryption: aws.String("AES256"),
+						ServerSideEncryption: aws.String(conf.SSE),
 					})
 				}
 			} else {

--- a/internal/pipe/s3/s3.go
+++ b/internal/pipe/s3/s3.go
@@ -114,8 +114,8 @@ func upload(ctx *context.Context, conf config.S3) error {
 				"artifact": artifact.Name,
 			}).Info("uploading")
 
-			if conf.SSE {
-				if conf.KMSKey {
+			if conf.SSE != "" {
+				if conf.KMSKey != "" {
 					_, err = svc.PutObjectWithContext(ctx, &s3.PutObjectInput{
 						Bucket: 			  aws.String(bucket),
 						Key:    			  aws.String(filepath.Join(folder, artifact.Name)),

--- a/internal/pipe/s3/s3.go
+++ b/internal/pipe/s3/s3.go
@@ -117,19 +117,19 @@ func upload(ctx *context.Context, conf config.S3) error {
 			if conf.SSE != "" {
 				if conf.KMSKey != "" {
 					_, err = svc.PutObjectWithContext(ctx, &s3.PutObjectInput{
-						Bucket: 			  aws.String(bucket),
-						Key:    			  aws.String(filepath.Join(folder, artifact.Name)),
-						Body:   			  f,
-						ACL:    			  aws.String(conf.ACL),
+						Bucket:               aws.String(bucket),
+						Key:                  aws.String(filepath.Join(folder, artifact.Name)),
+						Body:                 f,
+						ACL:                  aws.String(conf.ACL),
 						ServerSideEncryption: aws.String("aws:kms"),
 						SSEKMSKeyId:          aws.String(conf.KMSKey),
 					})
 				} else {
 					_, err = svc.PutObjectWithContext(ctx, &s3.PutObjectInput{
-						Bucket:				  aws.String(bucket),
-						Key:   				  aws.String(filepath.Join(folder, artifact.Name)),
-						Body:  				  f,
-						ACL:   				  aws.String(conf.ACL),
+						Bucket:               aws.String(bucket),
+						Key:                  aws.String(filepath.Join(folder, artifact.Name)),
+						Body:                 f,
+						ACL:                  aws.String(conf.ACL),
 						ServerSideEncryption: aws.String(conf.SSE),
 					})
 				}

--- a/internal/pipe/snapcraft/snapcraft_test.go
+++ b/internal/pipe/snapcraft/snapcraft_test.go
@@ -245,7 +245,6 @@ func TestNoSnapcraftInPath(t *testing.T) {
 	assert.EqualError(t, Pipe{}.Run(ctx), ErrNoSnapcraft.Error())
 }
 
-
 func TestRunNoArguments(t *testing.T) {
 	folder, err := ioutil.TempDir("", "archivetest")
 	assert.NoError(t, err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -297,7 +297,7 @@ type S3 struct {
 	Profile  string
 	Endpoint string // used for minio for example
 	ACL      string
-	SSE      bool     `yaml:",omitempty"`
+	SSE      string   `yaml:",omitempty"`
 	KMSKey   string   `yaml:",omitempty"`
 	IDs      []string `yaml:"ids,omitempty"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -297,6 +297,8 @@ type S3 struct {
 	Profile  string
 	Endpoint string // used for minio for example
 	ACL      string
+	SSE      bool     `yaml:",omitempty"`
+	KMSKey   string   `yaml:",omitempty"`
 	IDs      []string `yaml:"ids,omitempty"`
 }
 


### PR DESCRIPTION
<!-- If applied, this commit will... -->
If applied, this commit will add support for specifying Server-Side Encryption (SSE) on uploaded S3 objects, both with default encryption and with custom-specified keys.

**Note**: I added this to the now-deprecated `s3` handler. I could not find a good example of how to set SSE for the `blob` handler.

<!-- Why is this change being made? -->
There is currently no support for SSE on uploaded S3 objects.

<!-- # Provide links to any relevant tickets, URLs or other resources -->
Closes #1045 