### PR TITLE
feat: add support for completer in snaps

### DIFF
--- a/internal/pipe/snapcraft/snapcraft_test.go
+++ b/internal/pipe/snapcraft/snapcraft_test.go
@@ -281,6 +281,44 @@ func TestRunNoArguments(t *testing.T) {
 	assert.Equal(t, "mybin", metadata.Apps["mybin"].Command)
 }
 
+func TestCompleter(t *testing.T) {
+	folder, err := ioutil.TempDir("", "archivetest")
+	require.NoError(t, err)
+	var dist = filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0755))
+	require.NoError(t, err)
+	var ctx = context.New(config.Project{
+		ProjectName: "testprojectname",
+		Dist:        dist,
+		Snapcrafts: []config.Snapcraft{
+			{
+				NameTemplate: "foo_{{.Arch}}",
+				Summary:      "test summary",
+				Description:  "test description",
+				Apps: map[string]config.SnapcraftAppMetadata{
+					"mybin": {
+						Daemon:    "simple",
+						Args:      "",
+						Completer: "mybin-completer.bash",
+					},
+				},
+				Builds: []string{"foo"},
+			},
+		},
+	})
+	ctx.Git.CurrentTag = "v1.2.3"
+	ctx.Version = "v1.2.3"
+	addBinaries(t, ctx, "foo", dist, "mybin")
+	require.NoError(t, Pipe{}.Run(ctx))
+	yamlFile, err := ioutil.ReadFile(filepath.Join(dist, "foo_amd64", "prime", "meta", "snap.yaml"))
+	require.NoError(t, err)
+	var metadata Metadata
+	err = yaml.Unmarshal(yamlFile, &metadata)
+	require.NoError(t, err)
+	assert.Equal(t, "mybin", metadata.Apps["mybin"].Command)
+	assert.Equal(t, "mybin-completer.bash", metadata.Apps["mybin"].Completer)
+}
+
 func TestDefault(t *testing.T) {
 	var ctx = context.New(config.Project{
 		Builds: []config.Build{

--- a/internal/pipe/snapcraft/snapcraft_test.go
+++ b/internal/pipe/snapcraft/snapcraft_test.go
@@ -245,7 +245,6 @@ func TestNoSnapcraftInPath(t *testing.T) {
 	assert.EqualError(t, Pipe{}.Run(ctx), ErrNoSnapcraft.Error())
 }
 
-
 func TestRunNoArguments(t *testing.T) {
 	folder, err := ioutil.TempDir("", "archivetest")
 	assert.NoError(t, err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -215,9 +215,10 @@ type Sign struct {
 
 // SnapcraftAppMetadata for the binaries that will be in the snap package
 type SnapcraftAppMetadata struct {
-	Plugs  []string
-	Daemon string
-	Args   string
+	Plugs     []string
+	Daemon    string
+	Args      string
+	Completer string `yaml:",omitempty"`
 }
 
 // Snapcraft config

--- a/www/content/snapcraft.md
+++ b/www/content/snapcraft.md
@@ -112,6 +112,11 @@ snapcrafts:
         # If you any to pass args to your binary, you can add them with the
         # args option.
         args: --foo
+
+        # Bash completion snippet. More information about completion here:
+        # https://docs.snapcraft.io/tab-completion-for-snaps.
+        completer: drumroll-completion.bash
+
     # Allows plugs to be configured. Plugs like system-files and personal-files
     # require this.
     # Default is empty.


### PR DESCRIPTION
If applied, this commit will add support for [snap bash tab completion](https://docs.snapcraft.io/tab-completion-for-snaps).

This change is being made because I would like to use this functionality in chezmoi (https://github.com/twpayne/chezmoi/issues/347). The change to `.goreleaser.yaml` is demonstrated in https://github.com/twpayne/chezmoi/pull/362.

I tested this using a local build of goreleaser to build a chezmoi snap package. It seems to work :)
