### PR TITLE
ci: use xenial instead of trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: required
 language: go
 go: '1.12.x'


### PR DESCRIPTION
should give us rpmbuild 4.12, maybe helps on https://github.com/goreleaser/goreleaser/issues/1033