### PR TITLE
ci: check for unnecessary packages during CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,14 @@ lint:
 	./bin/misspell -error **/*
 .PHONY: lint
 
+# Clean go.mod
+go-mod-tidy:
+	go mod tidy -v
+	git diff-index --quiet HEAD || echo "Go mod tidy failed. Please run it locally"
+.PHONY: go-mod-tidy
+
 # Run all the tests and code checks
-ci: build test lint
+ci: build test lint go-mod-tidy
 .PHONY: ci
 
 # Build a beta version of goreleaser


### PR DESCRIPTION
Adds step to Makefile `ci` step that diffs go.mod to help prevent garbage dependencies from getting in the commit.

Example where this could be useful: https://github.com/goreleaser/goreleaser/commit/c338cfb9a1db9922c40fa0149b7ae5c5ad0eabab

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->

<!-- # Provide links to any relevant tickets, URLs or other resources -->
