### PR TITLE
fix(nfpm): propagate epoch config to nfpm

### DIFF
--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -149,6 +149,7 @@ func create(ctx *context.Context, fpm config.NFPM, format, arch string, binaries
 		Version:     ctx.Git.CurrentTag,
 		Section:     "",
 		Priority:    "",
+		Epoch:       fpm.Epoch,
 		Maintainer:  fpm.Maintainer,
 		Description: fpm.Description,
 		Vendor:      fpm.Vendor,


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->
The `epoch` configuration is currently not propagated to nfpm, so setting `epoch` in `nfpms` config section currently has no effect on the epoch of the generated package. 

This can be easily reproduced by adding `epoch: 100` to the `.goreleaser.yml` `nfpms` section in this repo.
**Without this fix:**
```bash
$ rpm -qip dist/goreleaser_amd64.rpm
Name        : goreleaser
Version     : 0.112.1
Release     : 1
Architecture: x86_64
Install Date: (not installed)
Group       : Development/Tools
Size        : 23442528
License     : MIT
Signature   : (none)
Source RPM  : goreleaser-0.112.1-1.src.rpm
Build Date  : Tue 09 Jul 2019 10:53:37 AM CEST
Build Host  : e1-gostelit-alsu001.pnet.ch
Relocations : (not relocatable)
Packager    : Carlos Alexandro Becker <root@carlosbecker.com>
URL         : https://goreleaser.com
Summary     : Deliver Go binaries as fast and easily as possible
Description :
Deliver Go binaries as fast and easily as possible
```
_Please note there is no epoch set._

**With this fix:**
```bash
$ rpm -qip dist/goreleaser_amd64.rpm
Name        : goreleaser
Epoch       : 100
Version     : 0.112.1
Release     : 1
Architecture: x86_64
Install Date: (not installed)
Group       : Development/Tools
Size        : 23442528
License     : MIT
Signature   : (none)
Source RPM  : goreleaser-0.112.1-1.src.rpm
Build Date  : Tue 09 Jul 2019 10:55:51 AM CEST
Build Host  : e1-gostelit-alsu001.pnet.ch
Relocations : (not relocatable)
Packager    : Carlos Alexandro Becker <root@carlosbecker.com>
URL         : https://goreleaser.com
Summary     : Deliver Go binaries as fast and easily as possible
Description :
Deliver Go binaries as fast and easily as possible
```

_Epoch field is now set!_