### PR TITLE
feat: write brew formulae before publishing

### DIFF
--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -202,6 +202,9 @@ func TestRunPipe(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, string(bts), client.Content)
 
+			err = new(Pipe).Write(ctx)
+			assert.NoError(t, err)
+
 			distBts, err := ioutil.ReadFile(distFile)
 			assert.NoError(t, err)
 			assert.Equal(t, string(bts), string(distBts))

--- a/internal/pipe/publish/publish.go
+++ b/internal/pipe/publish/publish.go
@@ -51,6 +51,11 @@ var publishers = []Publisher{
 
 // Run the pipe
 func (Pipe) Run(ctx *context.Context) error {
+	err := new(brew.Pipe).Write(ctx)
+	if err != nil {
+		return err
+	}
+
 	if ctx.SkipPublish {
 		return pipe.ErrSkipPublishEnabled
 	}


### PR DESCRIPTION
I think it would be nice to be able to take a look at generated Homebrew Formulae without running actual publish task, for debugging purposes at least.

This commit changes the place where and when writing Formulae to file happens (before every publishing task + check if publishing is disabled).

Why is this change being made?
To be able to debug Formulae before actual publishing.
