### PR TITLE
chore: fix go-mod-tidy silent failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ lint:
 # Clean go.mod
 go-mod-tidy:
 	go mod tidy -v
-	git diff-index --quiet HEAD || echo "Go mod tidy failed. Please run it locally"
+	git diff-index --quiet HEAD
 .PHONY: go-mod-tidy
 
 # Run all the tests and code checks


### PR DESCRIPTION
- due to the `||` go-mod-tidy check will fail silently

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->

<!-- # Provide links to any relevant tickets, URLs or other resources -->
