### PR TITLE
fixes env usage description for docker images

### DIFF
--- a/www/content/docker.md
+++ b/www/content/docker.md
@@ -76,7 +76,7 @@ dockers:
     - "--label=org.label-schema.schema-version=1.0"
     - "--label=org.label-schema.version={{.Version}}"
     - "--label=org.label-schema.name={{.ProjectName}}"
-    - "--build-arg=FOO={{.ENV.Bar}}"
+    - "--build-arg=FOO={{.Env.Bar}}"
     # If your Dockerfile copies files other than the binary itself,
     # you should list them here as well.
     # Note that goreleaser will create the same structure inside the temporary


### PR DESCRIPTION
### If applied, this commit will...
fix the docs for using environment variables in the `.goreleaser.yml`

###  Why is this change being made?
I tested as described in the docs but the map does not have a key for `.ENV` but has for `.Env` as the case matters

### Provide links to any relevant tickets, URLs or other resources
See context struct:  https://github.com/goreleaser/goreleaser/blob/master/pkg/context/context.go#L55