### PR TITLE
docs: fix blob typo in deprecations doc

### DIFF
--- a/www/content/deprecations.md
+++ b/www/content/deprecations.md
@@ -72,7 +72,7 @@ s3:
 to this:
 
 ```yaml
-blobs:
+blob:
 -
   provider: s3
   # etc


### PR DESCRIPTION
https://github.com/goreleaser/goreleaser/blob/31e27e918dbdbec87e95ca4983944d963bb0768c/www/content/deprecations.md#s3

`blobs` is not working. 

```yml
# .goreleaser.yml
blobs:
-
  provider: s3
  # etc
```

```
$ goreleaser 

   • releasing using goreleaser dev...
   • loading config file       file=.goreleaser.yml
   ⨯ release failed after 0.00s error=yaml: unmarshal errors:
  line 31: field blobs not found in type config.Project
```

`blob` is working.

https://github.com/goreleaser/goreleaser/blob/31e27e918dbdbec87e95ca4983944d963bb0768c/pkg/config/config.go#L357
