### PR TITLE
fix: ldflags need to be a single string to apply

### DIFF
--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -467,6 +467,22 @@ func TestProcessFlagsInvalid(t *testing.T) {
 	assert.Nil(t, flags)
 }
 
+func TestJoinLdFlags(t *testing.T) {
+	tests := []struct {
+		input  []string
+		output string
+	}{
+		{[]string{"-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser"}, "-ldflags=-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser"},
+		{[]string{"-s -w", "-X main.version={{.Version}}"}, "-ldflags=-s -w -X main.version={{.Version}}"},
+	}
+
+	for _, test := range tests {
+		joinedLdFlags := joinLdFlags(test.input)
+
+		assert.Equal(t, joinedLdFlags, test.output)
+	}
+}
+
 //
 // Helpers
 //


### PR DESCRIPTION
- fixes a case where ldflags are set as array in config yaml, this causes only last one to apply

Fixes #911 

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->

<!-- # Provide links to any relevant tickets, URLs or other resources -->
