### PR TITLE
fix: if resp is nil avoid checking resp.StatusCode in Gitlab client (…

### DIFF
--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -68,7 +68,7 @@ func (c *gitlabClient) CreateRelease(ctx *context.Context, body string) (release
 	name := title
 	tagName := ctx.Git.CurrentTag
 	release, resp, err := c.client.Releases.GetRelease(projectID, tagName)
-	if err != nil && resp.StatusCode != 403 {
+	if err != nil && (resp == nil || resp.StatusCode != 403) {
 		return "", err
 	}
 


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

Fixes #1092 bug, issue with Gitlab client code that attempts to dereference nil (resp.StatusCode) on low-level IP, TCP or TLS/SSL errors that don't necessarily populate resp.

<!-- Why is this change being made? -->

This change is to avoid unnecessary panic/crash on network errors such as connectivity issues and/or Gitlab misconfiguration.

<!-- # Provide links to any relevant tickets, URLs or other resources -->