### PR TITLE
fix: pluralize blob in the config file

### DIFF
--- a/internal/pipe/blob/blob.go
+++ b/internal/pipe/blob/blob.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/goreleaser/goreleaser/internal/deprecate"
 	"github.com/goreleaser/goreleaser/internal/pipe"
 	"github.com/goreleaser/goreleaser/internal/semerrgroup"
 	"github.com/goreleaser/goreleaser/internal/tmpl"
@@ -21,6 +22,10 @@ func (Pipe) String() string {
 
 // Default sets the pipe defaults
 func (Pipe) Default(ctx *context.Context) error {
+	if len(ctx.Config.Blob) > 0 {
+		deprecate.Notice("blob")
+		ctx.Config.Blobs = append(ctx.Config.Blobs, ctx.Config.Blob...)
+	}
 	for i := range ctx.Config.Blobs {
 		blob := &ctx.Config.Blobs[i]
 

--- a/internal/pipe/blob/blob_test.go
+++ b/internal/pipe/blob/blob_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/goreleaser/goreleaser/pkg/config"
@@ -15,7 +17,7 @@ import (
 )
 
 func TestDescription(t *testing.T) {
-	assert.NotEmpty(t, Pipe{}.String())
+	require.NotEmpty(t, Pipe{}.String())
 }
 
 func TestNoBlob(t *testing.T) {
@@ -60,8 +62,13 @@ func TestDefaultsNoProvider(t *testing.T) {
 }
 
 func TestDefaults(t *testing.T) {
-	var assert = assert.New(t)
 	var ctx = context.New(config.Project{
+		Blob: []config.Blob{
+			{
+				Bucket:   "foobar",
+				Provider: "gcs",
+			},
+		},
 		Blobs: []config.Blob{
 			{
 				Bucket:   "foo",
@@ -70,13 +77,20 @@ func TestDefaults(t *testing.T) {
 			},
 		},
 	})
-	assert.NoError(Pipe{}.Default(ctx))
-	assert.Equal([]config.Blob{{
-		Bucket:   "foo",
-		Provider: "azblob",
-		Folder:   "{{ .ProjectName }}/{{ .Tag }}",
-		IDs:      []string{"foo", "bar"},
-	}}, ctx.Config.Blobs)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, []config.Blob{
+		{
+			Bucket:   "foo",
+			Provider: "azblob",
+			Folder:   "{{ .ProjectName }}/{{ .Tag }}",
+			IDs:      []string{"foo", "bar"},
+		},
+		{
+			Bucket:   "foobar",
+			Provider: "gcs",
+			Folder:   "{{ .ProjectName }}/{{ .Tag }}",
+		},
+	}, ctx.Config.Blobs)
 }
 
 func TestDefaultsWithProvider(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -354,7 +354,8 @@ type Project struct {
 	Artifactories []Put       `yaml:",omitempty"`
 	Puts          []Put       `yaml:",omitempty"`
 	S3            []S3        `yaml:"s3,omitempty"`
-	Blobs         []Blob      `yaml:"blob,omitempty"`
+	Blob          []Blob      `yaml:"blob,omitempty"` // TODO: remove this
+	Blobs         []Blob      `yaml:"blobs,omitempty"`
 	Changelog     Changelog   `yaml:",omitempty"`
 	Dist          string      `yaml:",omitempty"`
 	Sign          Sign        `yaml:",omitempty"` // TODO: remove this

--- a/www/content/blob.md
+++ b/www/content/blob.md
@@ -7,7 +7,7 @@ series: customization
 
 ```yaml
 # .goreleaser.yml
-blob:
+blobs:
   # You can have multiple blob configs
   -
     # Template for the cloud provider name
@@ -51,7 +51,7 @@ S3 provider support AWS [default credential provider](https://docs.aws.amazon.co
 
 - Shared credentials file.
 
-- If your application is running on an Amazon EC2 instance, IAM role for Amazon EC2. 
+- If your application is running on an Amazon EC2 instance, IAM role for Amazon EC2.
 
 ### Azure Blob Provider
 

--- a/www/content/deprecations.md
+++ b/www/content/deprecations.md
@@ -34,6 +34,28 @@ to this:
 -->
 
 
+### blob
+
+> since 2019-08-02
+
+Blob was deprecated in favor of its plural form.
+It was already accepting multiple inputs, but its pluralized now so its more
+clear.
+
+Change this:
+
+```yaml
+blob:
+  # etc
+```
+
+to this:
+
+```yaml
+blobs:
+  # etc
+```
+
 ### sign
 
 > since 2019-07-20
@@ -95,7 +117,7 @@ s3:
 to this:
 
 ```yaml
-blob:
+blobs:
 -
   provider: s3
   # etc


### PR DESCRIPTION
pluralizes `blob` to `blobs` so its more clear that it is a list.

fixes #1094