### PR TITLE
fix: honor order of functions in semerrgroup w/ parallelism == 1

### DIFF
--- a/internal/semerrgroup/sem.go
+++ b/internal/semerrgroup/sem.go
@@ -52,6 +52,9 @@ type serialGroup struct {
 
 // Go execs one function at a time.
 func (s *serialGroup) Go(fn func() error) {
+	if s.err != nil {
+		return
+	}
 	if err := fn(); err != nil {
 		s.err = err
 	}

--- a/internal/semerrgroup/sem.go
+++ b/internal/semerrgroup/sem.go
@@ -2,11 +2,7 @@
 // size, so you can control the number of tasks being executed simultaneously.
 package semerrgroup
 
-import (
-	"sync"
-
-	"golang.org/x/sync/errgroup"
-)
+import "golang.org/x/sync/errgroup"
 
 // Group is the Semphore ErrorGroup itself
 type Group interface {
@@ -51,22 +47,17 @@ func (s *parallelGroup) Wait() error {
 var _ Group = &serialGroup{}
 
 type serialGroup struct {
-	lock sync.Mutex
-	err  error
+	err error
 }
 
 // Go execs one function at a time.
 func (s *serialGroup) Go(fn func() error) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-	if err := fn(); err != nil && s.err == nil {
+	if err := fn(); err != nil {
 		s.err = err
 	}
 }
 
 // Wait waits for Go to complete and returns the first error encountered.
 func (s *serialGroup) Wait() error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
 	return s.err
 }

--- a/internal/semerrgroup/sem.go
+++ b/internal/semerrgroup/sem.go
@@ -50,14 +50,12 @@ type serialGroup struct {
 	err error
 }
 
-// Go execs one function at a time.
+// Go execs runs `fn` and saves the result if no error has been encountered.
 func (s *serialGroup) Go(fn func() error) {
 	if s.err != nil {
 		return
 	}
-	if err := fn(); err != nil {
-		s.err = err
-	}
+	s.err = fn()
 }
 
 // Wait waits for Go to complete and returns the first error encountered.

--- a/internal/semerrgroup/sem.go
+++ b/internal/semerrgroup/sem.go
@@ -20,8 +20,8 @@ func New(size int) *Group {
 
 // Go execs one function respecting the group and semaphore.
 func (s *Group) Go(fn func() error) {
+	s.ch <- true
 	s.g.Go(func() error {
-		s.ch <- true
 		defer func() {
 			<-s.ch
 		}()

--- a/internal/semerrgroup/sem_test.go
+++ b/internal/semerrgroup/sem_test.go
@@ -24,3 +24,23 @@ func TestSemaphore(t *testing.T) {
 	require.NoError(t, g.Wait())
 	require.Equal(t, counter, 10)
 }
+
+func TestSemaphoreOrder(t *testing.T) {
+	num := 10
+	var g = New(1)
+	output := make(chan int)
+	go func() {
+		for i := 0; i < num; i++ {
+			require.Equal(t, <-output, i)
+		}
+		require.NoError(t, g.Wait())
+	}()
+	for i := 0; i < num; i++ {
+		j := i
+		g.Go(func() error {
+			output <- j
+			return nil
+		})
+	}
+	require.NoError(t, g.Wait())
+}


### PR DESCRIPTION

<!-- If applied, this commit will... -->
## Overview
* Honor total order of methods added to `semerrgroup.Group` when `parallelism == 1`
* `semerrgroup.Group.Go(...)` will block if the number of concurrently executing goroutines in the group is at the maximum. 

<!-- Why is this change being made? -->
## Reason

This change is being made to so that project authors may include dependencies between build phases by ordering them in their project's `goreleaser.yml`

<!-- # Provide links to any relevant tickets, URLs or other resources -->
## Issues
* https://github.com/goreleaser/goreleaser/issues/1097
