### PR TITLE
&base always not nil

### DIFF
--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"reflect"
 	"strconv"
 
 	"github.com/apex/log"
@@ -27,7 +28,7 @@ func NewGitHub(ctx *context.Context) (Client, error) {
 	httpClient := oauth2.NewClient(ctx, ts)
 	base := httpClient.Transport.(*oauth2.Transport).Base
 	// nolint: govet
-	if &base != nil {
+	if reflect.ValueOf(base).IsNil() {
 		base = http.DefaultTransport
 	}
 	// nolint: gosec


### PR DESCRIPTION
Is it a bugs?

```go
type A interface {
	A()
}

func TestA(t *testing.T) {
	var a A
	assert.NotEqual(t, nil, &a)
	a = nil
	assert.NotEqual(t, nil, &a)
}
// this test is passed. So this pr is working?
```