### PR TITLE
Add a default value for the config file.

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func main() {
 
 	var app = kingpin.New("goreleaser", "Deliver Go binaries as fast and easily as possible")
 	var debug = app.Flag("debug", "Enable debug mode").Bool()
-	var config = app.Flag("config", "Load configuration from file").Short('c').Short('f').PlaceHolder(".goreleaser.yml").String()
+	var config = app.Flag("config", "Load configuration from file").Short('c').Short('f').PlaceHolder(".goreleaser.yml").Default(".goreleaser.yml").String()
 	var initCmd = app.Command("init", "Generates a .goreleaser.yml file").Alias("i")
 	var checkCmd = app.Command("check", "Checks if configuration is valid").Alias("c")
 	var releaseCmd = app.Command("release", "Releases the current project").Alias("r").Default()


### PR DESCRIPTION
Currently when you try to do a `goreleaser init` without specifying a `--config` you get the following error:
```
$ goreleaser init

   • Generating  file 
   ⨯ failed to init project    error=open : no such file or directory
```
There is currently no default on the config flag which leads to that error being raised.
If you add a `--config` it works so it would be really less confusing for newcomers if it had a default value IMHO.

Once that change has been made you can init without a `--config`:
```
$ goreleaser init

   • Generating .goreleaser.yml file
   • config created; please edit accordingly to your needs file=.goreleaser.yml
```


<!-- If applied, this commit will... -->

Add a default value to the config flag.

<!-- Why is this change being made? -->

To make it easier for newcomers to understand that this flag is mandatory apparently.
