### PR TITLE
feat: support arm for linuxbrew

### DIFF
--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -243,10 +243,23 @@ func dataFor(ctx *context.Context, cfg config.Homebrew, artifacts []*artifact.Ar
 			}
 			result.MacOS = down
 		} else if artifact.Goos == "linux" {
-			if result.Linux.DownloadURL != "" {
-				return result, ErrMultipleArchivesSameOS
+			switch artifact.Goarch {
+			case "386", "amd64":
+				if result.Linux.DownloadURL != "" {
+					return result, ErrMultipleArchivesSameOS
+				}
+				result.Linux = down
+			case "arm":
+				if result.Arm.DownloadURL != "" {
+					return result, ErrMultipleArchivesSameOS
+				}
+				result.Arm = down
+			case "arm64":
+				if result.Arm64.DownloadURL != "" {
+					return result, ErrMultipleArchivesSameOS
+				}
+				result.Arm64 = down
 			}
-			result.Linux = down
 		}
 	}
 

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -44,6 +44,14 @@ var defaultTemplateData = templateData{
 		DownloadURL: "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Linux_x86_64.tar.gz",
 		SHA256:      "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67",
 	},
+	Arm: downloadable{
+		DownloadURL: "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Arm.tar.gz",
+		SHA256:      "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67",
+	},
+	Arm64: downloadable{
+		DownloadURL: "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Arm64.tar.gz",
+		SHA256:      "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67",
+	},
 	Name:    "Test",
 	Version: "0.1.3",
 	Caveats: []string{},

--- a/internal/pipe/brew/template.go
+++ b/internal/pipe/brew/template.go
@@ -16,6 +16,8 @@ type templateData struct {
 	CustomBlock      []string
 	MacOS            downloadable
 	Linux            downloadable
+	Arm              downloadable
+	Arm64            downloadable
 }
 
 type downloadable struct {
@@ -36,15 +38,34 @@ class {{ .Name }} < Formula
   if OS.mac?
     {{- if .MacOS.DownloadURL }}
     url "{{ .MacOS.DownloadURL }}"
-	{{- if .DownloadStrategy }}, :using => {{ .DownloadStrategy }}{{- end }}
+    {{- if .DownloadStrategy }}, :using => {{ .DownloadStrategy }}{{- end }}
     sha256 "{{ .MacOS.SHA256 }}"
     {{- end }}
   elsif OS.linux?
     {{- if .Linux.DownloadURL }}
-    url "{{ .Linux.DownloadURL }}"
-	{{- if .DownloadStrategy }}, :using => {{ .DownloadStrategy }}{{- end }}
-    sha256 "{{ .Linux.SHA256 }}"
+    if Hardware::CPU.intel?
+      url "{{ .Linux.DownloadURL }}"
+      {{- if .DownloadStrategy }}, :using => {{ .DownloadStrategy }}{{- end }}
+      sha256 "{{ .Linux.SHA256 }}"
+    end
     {{- end }}
+	{{- if or .Arm.DownloadURL .Arm64.DownloadURL }}
+    if Hardware::CPU.arm?
+      if Hardware::CPU.is_64_bit?
+        {{- if .Arm64.DownloadURL }}
+        url "{{ .Arm64.DownloadURL }}"
+        {{- if .DownloadStrategy }}, :using => {{ .DownloadStrategy }}{{- end }}
+        sha256 "{{ .Arm64.SHA256 }}"
+        {{- end }}
+      else
+        {{- if .Arm.DownloadURL }}
+        url "{{ .Arm.DownloadURL }}"
+        {{- if .DownloadStrategy }}, :using => {{ .DownloadStrategy }}{{- end }}
+        sha256 "{{ .Arm.SHA256 }}"
+        {{- end }}
+      end
+    end
+	{{- end }}
   end
 
   {{- with .CustomBlock }}

--- a/internal/pipe/brew/testdata/test.rb.golden
+++ b/internal/pipe/brew/testdata/test.rb.golden
@@ -9,8 +9,19 @@ class Test < Formula
     url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_x86_64.tar.gz"
     sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c68"
   elsif OS.linux?
-    url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Linux_x86_64.tar.gz"
-    sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67"
+    if Hardware::CPU.intel?
+      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Linux_x86_64.tar.gz"
+      sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67"
+    end
+    if Hardware::CPU.arm?
+      if Hardware::CPU.is_64_bit?
+        url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Arm64.tar.gz"
+        sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67"
+      else
+        url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Arm.tar.gz"
+        sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67"
+      end
+    end
   end
   
   devel do


### PR DESCRIPTION
Hi there!

I've added support architecture arm for linuxbrew formulas.
I've used that formula as example https://github.com/Homebrew/linuxbrew-core/blob/c7f81028802006ba26b5e079556d1617b38ca495/Formula/openssl.rb#L58

/cc @caarlos0 @sethkor What do you think about it?

Close #1052 