### PR TITLE
docs: supported gitlab versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -28,6 +28,7 @@ A clear and concise description of what you expected to happen.
 - OS: [e.g. mac, linux]
 - OS version: [uname -a]
 - GoReleaser Version [goreleaser --version]
+- GitLab version (if using a private hosted one)
 
 **Additional context**
 Add any other context about the problem here. Full output log with debug on

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
-	github.com/xanzy/go-gitlab v0.18.0
+	github.com/xanzy/go-gitlab v0.19.0
 	gocloud.dev v0.15.0
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,6 @@ github.com/tidwall/pretty v0.0.0-20190325153808-1166b9ac2b65/go.mod h1:XNkn88O1C
 github.com/uber-go/atomic v1.3.2/go.mod h1:/Ct5t2lcmbJ4OSe/waGBoaVvVqtO0bmtfVNex1PFV8g=
 github.com/uber/jaeger-client-go v2.15.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v1.5.0/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
-github.com/xanzy/go-gitlab v0.18.0 h1:LybNSWSIw8BK+GnxuETAhUXEzzh5rHsHjopqVkGJXRE=
-github.com/xanzy/go-gitlab v0.18.0/go.mod h1:LSfUQ9OPDnwRqulJk2HcWaAiFfCzaknyeGvjQI67MbE=
 github.com/xanzy/go-gitlab v0.19.0 h1:WHw/JqUiQ82itbuB4IDS4AgTy8RQ0CBrbfljq65pJCo=
 github.com/xanzy/go-gitlab v0.19.0/go.mod h1:LSfUQ9OPDnwRqulJk2HcWaAiFfCzaknyeGvjQI67MbE=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=

--- a/go.sum
+++ b/go.sum
@@ -185,6 +185,8 @@ github.com/uber/jaeger-client-go v2.15.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMW
 github.com/uber/jaeger-lib v1.5.0/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/xanzy/go-gitlab v0.18.0 h1:LybNSWSIw8BK+GnxuETAhUXEzzh5rHsHjopqVkGJXRE=
 github.com/xanzy/go-gitlab v0.18.0/go.mod h1:LSfUQ9OPDnwRqulJk2HcWaAiFfCzaknyeGvjQI67MbE=
+github.com/xanzy/go-gitlab v0.19.0 h1:WHw/JqUiQ82itbuB4IDS4AgTy8RQ0CBrbfljq65pJCo=
+github.com/xanzy/go-gitlab v0.19.0/go.mod h1:LSfUQ9OPDnwRqulJk2HcWaAiFfCzaknyeGvjQI67MbE=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 go.mongodb.org/mongo-driver v1.0.1/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=

--- a/www/content/quick-start.md
+++ b/www/content/quick-start.md
@@ -96,6 +96,9 @@ The release should also look like this:
     src="https://user-images.githubusercontent.com/8409778/59390011-55fcdf80-8d70-11e9-840f-c568ddc0e965.png">
 </a>
 
+**Note:** Releasing to a private-hosted GitLab CE will only work for version `v11.7+`, because the release feature
+was introduced in this [version](https://docs.gitlab.com/ee/user/project/releases/index.html).
+
 ## Dry run
 
 If you want to test everything before doing a release "for real", you can

--- a/www/content/release.md
+++ b/www/content/release.md
@@ -41,7 +41,8 @@ release:
   disable: true
 ```
 
-Seconds let's see what can be customized in the `release` section for GitLab:
+Second, let's see what can be customized in the `release` section for GitLab.
+**Note** that only GitLab `v11.7+` are supported for releases:
 
 ```yml
 # .goreleaser.yml


### PR DESCRIPTION
### If applied, this commit will...
- update the docs and bug report template that only GitLab versions `11.7+` are supported 

### Why is this change being made?
- the docs were updated
- the gitlab sdk was updated to the latest version `go-gitlab v0.19.0`

### Provide links to any relevant tickets, URLs or other resources
- will close #1091
