### PR TITLE
fix: bzr required for some go modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:1.12-alpine
 
 RUN apk add --no-cache bash \
+                       bzr \
                        curl \
                        docker \
                        git \

--- a/Dockerfile.cgo
+++ b/Dockerfile.cgo
@@ -2,6 +2,7 @@ FROM golang:1.12-alpine
 
 RUN apk add --no-cache bash \
                        build-base \
+                       bzr \
                        curl \
                        docker \
                        git \


### PR DESCRIPTION
Subject says it all