### PR TITLE
fix brew and scoop for disabled release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/caarlos0/ctrlc v1.0.0
 	github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e
 	github.com/fatih/color v1.7.0
-	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/google/go-github/v25 v25.0.1
 	github.com/goreleaser/nfpm v0.12.0
 	github.com/imdario/mergo v0.3.6

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/caarlos0/ctrlc v1.0.0
 	github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e
 	github.com/fatih/color v1.7.0
+	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/google/go-github/v25 v25.0.1
 	github.com/goreleaser/nfpm v0.12.0
 	github.com/imdario/mergo v0.3.6

--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -119,11 +119,6 @@ func doRun(ctx *context.Context, brew config.Homebrew, client client.Client) err
 		return pipe.Skip("brew section is not configured")
 	}
 
-	// TODO mavogel: in another PR
-	// check if release pipe is not configured!
-	// if ctx.Config.Release.Disable {
-	// }
-
 	var filters = []artifact.Filter{
 		artifact.Or(
 			artifact.ByGoos("darwin"),
@@ -162,6 +157,9 @@ func doRun(ctx *context.Context, brew config.Homebrew, client client.Client) err
 	}
 	if ctx.Config.Release.Draft {
 		return pipe.Skip("release is marked as draft")
+	}
+	if ctx.Config.Release.Disable {
+		return pipe.Skip("release is disabled")
 	}
 	if strings.TrimSpace(brew.SkipUpload) == "auto" && ctx.Semver.Prerelease != "" {
 		return pipe.Skip("prerelease detected with 'auto' upload, skipping homebrew publish")

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -434,6 +434,12 @@ func TestRunPipeNoUpload(t *testing.T) {
 		ctx.SkipPublish = false
 		assertNoPublish(tt)
 	})
+	t.Run("release disabled", func(tt *testing.T) {
+		ctx.Config.Release.Disable = true
+		ctx.Config.Brews[0].SkipUpload = "false"
+		ctx.SkipPublish = false
+		assertNoPublish(tt)
+	})
 	t.Run("skip prerelease publish", func(tt *testing.T) {
 		ctx.Config.Release.Draft = false
 		ctx.Config.Brews[0].SkipUpload = "auto"

--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -88,6 +88,9 @@ func doRun(ctx *context.Context, client client.Client) error {
 	if ctx.Config.Release.Draft {
 		return pipe.Skip("release is marked as draft")
 	}
+	if ctx.Config.Release.Disable {
+		return pipe.Skip("release is disabled")
+	}
 	return client.CreateFile(
 		ctx,
 		ctx.Config.Scoop.CommitAuthor,

--- a/internal/pipe/scoop/scoop_test.go
+++ b/internal/pipe/scoop/scoop_test.go
@@ -496,6 +496,46 @@ func Test_doRun(t *testing.T) {
 			shouldErr("release is marked as draft"),
 		},
 		{
+			"release is disabled",
+			args{
+				&context.Context{
+					TokenType: context.TokenTypeGitHub,
+					Git: context.GitInfo{
+						CurrentTag: "v1.0.1",
+					},
+					Version:   "1.0.1",
+					Artifacts: artifact.New(),
+					Config: config.Project{
+						Builds: []config.Build{
+							{Binary: "test", Goarch: []string{"amd64"}, Goos: []string{"windows"}},
+						},
+						Dist:        ".",
+						ProjectName: "run-pipe",
+						Archive: config.Archive{
+							Format: "tar.gz",
+						},
+						Release: config.Release{
+							Disable: true,
+						},
+						Scoop: config.Scoop{
+							Bucket: config.Repo{
+								Owner: "test",
+								Name:  "test",
+							},
+							Description: "A run pipe test formula",
+							Homepage:    "https://github.com/goreleaser",
+						},
+					},
+				},
+				&DummyClient{},
+			},
+			[]*artifact.Artifact{
+				{Name: "foo_1.0.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64", Path: file},
+				{Name: "foo_1.0.1_windows_386.tar.gz", Goos: "windows", Goarch: "386", Path: file},
+			},
+			shouldErr("release is disabled"),
+		},
+		{
 			"no archive",
 			args{
 				&context.Context{


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

### If applied, this commit will...
... skip brew and scoop pipe if the release section is disabled and give an appropriate error message

### Why is this change being made?
- Users were confused because they got misleading error messages like in the liked issue
- We'd rather go further and add this to the `check` method to do a *semantic* validation of the config, but this would be a bigger change.

### Provide links to any relevant tickets, URLs or other resources
- #1119