### PR TITLE
fix: copy into DockerImage Artifact

### DIFF
--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -272,7 +272,13 @@ func dockerPush(ctx *context.Context, image *artifact.Artifact) error {
 		return errors.Wrapf(err, "failed to push docker image: \n%s", string(out))
 	}
 	log.Debugf("docker push output: \n%s", string(out))
-	image.Type = artifact.DockerImage
-	ctx.Artifacts.Add(image)
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Type:   artifact.DockerImage,
+		Name:   image.Name,
+		Path:   image.Path,
+		Goarch: image.Goarch,
+		Goos:   image.Goos,
+		Goarm:  image.Goarm,
+	})
 	return nil
 }


### PR DESCRIPTION
Since #1110 the artifacts are passed by reference, causing the previous
code to edit the Artifact in place, _and_ add it to the list.

Fixes: #1133