### PR TITLE
fix: install only docker-cli instead of docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.12-alpine
 RUN apk add --no-cache bash \
                        bzr \
                        curl \
-                       docker \
+                       docker-cli \
                        git \
                        mercurial \
                        rpm

--- a/Dockerfile.cgo
+++ b/Dockerfile.cgo
@@ -4,7 +4,7 @@ RUN apk add --no-cache bash \
                        build-base \
                        bzr \
                        curl \
-                       docker \
+                       docker-cli \
                        git \
                        mercurial \
                        rpm


### PR DESCRIPTION
While working on a GitLab CI setup I was copying the behavior of the Dockerfile and entrypoint.sh, so that I had control over the Go version used in CI, but still use goreleaser. When I was looking at the CI output I noticed there was 303 MB of packages installed when I did `apk add --no-cache bash curl docker git`. The list of packages included `containerd`, `libseccomp`, `docker-engine` and many more that seem unnecessary. When I changed it to `apk add --no-cache bash curl docker-cli git` it reduced this to 97 MB.

I think that's something the goreleaser/goreleaser Docker image can benefit from as well, so here's that same change. If there's a need for a full Docker engine instead of just the CLI, feel free to ignore this pull request.