### PR TITLE
fix: actually support arm

### DIFF
--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -122,7 +122,11 @@ func doRun(ctx *context.Context, brew config.Homebrew, client client.Client) err
 			artifact.ByGoos("linux"),
 		),
 		artifact.ByFormats("zip", "tar.gz"),
-		artifact.ByGoarch("amd64"),
+		artifact.Or(
+			artifact.ByGoarch("amd64"),
+			artifact.ByGoarch("arm64"),
+			artifact.ByGoarch("arm"),
+		),
 		artifact.ByType(artifact.UploadableArchive),
 	}
 	if len(brew.IDs) > 0 {


### PR DESCRIPTION
Without this change, formula is generated without arm support for linux.

See my last post here:
https://github.com/goreleaser/goreleaser/pull/1113

Repo made specifically for testing this (latest tag there is using this commit):
https://github.com/dawidd6/goreleaser-test


---
By the way I see that we can also support i386 architecture for linux in brew pipe as it seems to be simply omitted now, but idk if there is a demand for this.