### PR TITLE
feat: Use Version instead of Git tag to for .deb/.rpm

### DIFF
--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -146,7 +146,7 @@ func create(ctx *context.Context, fpm config.NFPM, format, arch string, binaries
 		Arch:        arch,
 		Platform:    "linux",
 		Name:        ctx.Config.ProjectName,
-		Version:     ctx.Git.CurrentTag,
+		Version:     ctx.Version,
 		Section:     "",
 		Priority:    "",
 		Epoch:       fpm.Epoch,

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -20,6 +20,7 @@ func TestDescription(t *testing.T) {
 
 func TestRunPipeNoFormats(t *testing.T) {
 	var ctx = &context.Context{
+		Version: "1.0.0",
 		Git: context.GitInfo{
 			CurrentTag: "v1.0.0",
 		},
@@ -45,6 +46,7 @@ func TestRunPipeInvalidFormat(t *testing.T) {
 			},
 		},
 	})
+	ctx.Version = "1.2.3"
 	ctx.Git = context.GitInfo{
 		CurrentTag: "v1.2.3",
 	}
@@ -211,6 +213,7 @@ func TestCreateFileDoesntExist(t *testing.T) {
 			},
 		},
 	})
+	ctx.Version = "1.2.3"
 	ctx.Git = context.GitInfo{
 		CurrentTag: "v1.2.3",
 	}


### PR DESCRIPTION
This commit will allow to build package from a snapshot without have a package version of "0.0.0". Instead of using ctx.Git.CurrentTag, it will use ctx.Version. During a release both are the same value (with prefix "v" removed if it exists), so release pipeline stay unchanged.

With this changes, we can build package from snapshot which is useful in our use-case where we built package after each commit to master. We don't want to tag each commit but still want to build usable packages (e.g. with a version - coming from snapshot pipe) and not "0.0.0").
In addition, is allow us to build package with version that does not match SemVer (like 19.06.27.084010 which is the date + time converted to a version).

The package version i'm talking is the one set in package metadata, not just filename. That is the one visible for deb package using:
```
$ dpkg-deb -I dist/myproject_1.0.0_linux_386.deb
 new Debian package, version 2.0.
 size 13657068 bytes: control archive=450 bytes.
       1 octets,     0 lignes      conffiles            
     397 octets,    15 lignes      control              
      50 octets,     1 lignes      md5sums              
 Package: myproject
 Version: 0.0.0
```
