### PR TITLE
ci: extend GOPROXY list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TEST_OPTIONS?=
 export PATH := ./bin:$(PATH)
 export GO111MODULE := on
 # enable consistent Go 1.12/1.13 GOPROXY behavior.
-export GOPROXY = https://proxy.golang.org
+export GOPROXY = https://proxy.golang.org,https://gocenter.io,direct
 
 # Install all the build and lint dependencies
 setup:


### PR DESCRIPTION
I just added `https://gocenter.io` as a reserve proxy because `https://proxy.golang.org` may not be available.

Any comments are welcome.

refs  #1155