### PR TITLE
feat: support additional GOOS/GOARCH targets

### DIFF
--- a/internal/builders/golang/targets.go
+++ b/internal/builders/golang/targets.go
@@ -93,7 +93,11 @@ func valid(target target) bool {
 // list from https://golang.org/doc/install/source#environment
 // nolint: gochecknoglobals
 var validTargets = []string{
+	"aixppc64",
+	"android386",
+	"androidamd64",
 	"androidarm",
+	"androidarm64",
 	"darwin386",
 	"darwinamd64",
 	// "darwinarm", - requires admin rights and other ios stuff
@@ -122,6 +126,7 @@ var validTargets = []string{
 	"openbsdarm",
 	"plan9386",
 	"plan9amd64",
+	"plan9arm",
 	"solarisamd64",
 	"windows386",
 	"windowsamd64",

--- a/internal/builders/golang/targets.go
+++ b/internal/builders/golang/targets.go
@@ -102,6 +102,7 @@ var validTargets = []string{
 	"freebsd386",
 	"freebsdamd64",
 	"freebsdarm",
+	"illumosamd64",
 	"linux386",
 	"linuxamd64",
 	"linuxarm",

--- a/internal/builders/golang/targets_test.go
+++ b/internal/builders/golang/targets_test.go
@@ -69,6 +69,7 @@ func TestGoosGoarchCombos(t *testing.T) {
 		{"freebsd", "386", true},
 		{"freebsd", "amd64", true},
 		{"freebsd", "arm", true},
+		{"illumos", "amd64", true},
 		{"linux", "386", true},
 		{"linux", "amd64", true},
 		{"linux", "arm", true},

--- a/internal/builders/golang/targets_test.go
+++ b/internal/builders/golang/targets_test.go
@@ -62,7 +62,11 @@ func TestGoosGoarchCombos(t *testing.T) {
 		valid bool
 	}{
 		// valid targets:
+		{"aix", "ppc64", true},
+		{"android", "386", true},
+		{"android", "amd64", true},
 		{"android", "arm", true},
+		{"android", "arm64", true},
 		{"darwin", "386", true},
 		{"darwin", "amd64", true},
 		{"dragonfly", "amd64", true},
@@ -89,6 +93,7 @@ func TestGoosGoarchCombos(t *testing.T) {
 		{"openbsd", "arm", true},
 		{"plan9", "386", true},
 		{"plan9", "amd64", true},
+		{"plan9", "arm", true},
 		{"solaris", "amd64", true},
 		{"windows", "386", true},
 		{"windows", "amd64", true},


### PR DESCRIPTION
Add support for additional targets:

GOOS=illumos GOARCH=amd64
GOOS=aix GOARCH=ppc64
GOOS=android GOARCH=386
GOOS=android GOARCH=amd64
GOOS=android GOARCH=arm64
GOOS=plan9 GOARCH=arm