### PR TITLE
fix: getTag return incorrect tag, if we have more than 1 tag for 1 commit

### DIFF
--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -74,7 +74,7 @@ func getGitInfo() (context.GitInfo, error) {
 		return context.GitInfo{}, errors.Wrap(err, "couldn't get remote URL")
 	}
 	tag, err := getTag()
-	if err != nil {
+	if err != nil || tag == "" {
 		return context.GitInfo{
 			Commit:      full,
 			FullCommit:  full,

--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -135,7 +135,7 @@ func getFullCommit() (string, error) {
 }
 
 func getTag() (string, error) {
-	return git.Clean(git.Run("tag", "-l", "--sort=-v:refname"))
+	return git.Clean(git.Run("-c", "versionsort.suffix=-", "tag", "-l", "--sort=-v:refname"))
 }
 
 func getURL() (string, error) {

--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -135,7 +135,7 @@ func getFullCommit() (string, error) {
 }
 
 func getTag() (string, error) {
-	return git.Clean(git.Run("describe", "--tags", "--abbrev=0"))
+	return git.Clean(git.Run("tag", "-l", "--sort=-v:refname"))
 }
 
 func getURL() (string, error) {

--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -135,6 +135,11 @@ func getFullCommit() (string, error) {
 }
 
 func getTag() (string, error) {
+	// Even when version sort is used in git-tag[1], tagnames with the same base version
+	// but different suffixes are still sorted lexicographically, resulting e.g. in prerelease tags
+	// appearing after the main release (e.g. "1.0-rc1" after "1.0").
+	// This variable can be specified to determine the sorting order of tags with different suffixes.
+	// https://git-scm.com/docs/git-config/2.19.2#git-config-versionsortsuffix
 	return git.Clean(git.Run("-c", "versionsort.suffix=-", "tag", "-l", "--sort=-v:refname"))
 }
 

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -73,9 +73,7 @@ func TestNoTagsNoSnapshot(t *testing.T) {
 	testlib.GitCommit(t, "first")
 	var ctx = context.New(config.Project{})
 	ctx.Snapshot = false
-	err := Pipe{}.Run(ctx)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "git tag  was not made against commit")
+	assert.EqualError(t, Pipe{}.Run(ctx), `git doesn't contain any tags. Either add a tag or use --snapshot`)
 }
 
 func TestDirty(t *testing.T) {

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -73,7 +73,9 @@ func TestNoTagsNoSnapshot(t *testing.T) {
 	testlib.GitCommit(t, "first")
 	var ctx = context.New(config.Project{})
 	ctx.Snapshot = false
-	assert.EqualError(t, Pipe{}.Run(ctx), `git doesn't contain any tags. Either add a tag or use --snapshot`)
+	err := Pipe{}.Run(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "git tag  was not made against commit")
 }
 
 func TestDirty(t *testing.T) {


### PR DESCRIPTION
Possible fix of https://github.com/goreleaser/goreleaser/issues/1163
