### PR TITLE
fix: reject docker.files as . or inside dist

### DIFF
--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -40,6 +40,11 @@ func (Pipe) Default(ctx *context.Context) error {
 		if docker.Goarch == "" {
 			docker.Goarch = "amd64"
 		}
+		for _, f := range docker.Files {
+			if f == "." || filepath.HasPrefix(f, ctx.Config.Dist) {
+				return fmt.Errorf("invalid docker.files: can't be . or inside dist folder: %s", f)
+			}
+		}
 	}
 	// only set defaults if there is exactly 1 docker setup in the config file.
 	if len(ctx.Config.Dockers) != 1 {

--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -41,7 +41,7 @@ func (Pipe) Default(ctx *context.Context) error {
 			docker.Goarch = "amd64"
 		}
 		for _, f := range docker.Files {
-			if f == "." || filepath.HasPrefix(f, ctx.Config.Dist) {
+			if f == "." || strings.HasPrefix(f, ctx.Config.Dist) {
 				return fmt.Errorf("invalid docker.files: can't be . or inside dist folder: %s", f)
 			}
 		}

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -702,6 +702,34 @@ func TestDefaultNoDockers(t *testing.T) {
 	assert.Empty(t, ctx.Config.Dockers)
 }
 
+func TestDefaultFilesDot(t *testing.T) {
+	var ctx = &context.Context{
+		Config: config.Project{
+			Dist: "/tmp/distt",
+			Dockers: []config.Docker{
+				{
+					Files: []string{"./lala", "./lolsob", "."},
+				},
+			},
+		},
+	}
+	assert.EqualError(t, Pipe{}.Default(ctx), `invalid docker.files: can't be . or inside dist folder: .`)
+}
+
+func TestDefaultFilesDis(t *testing.T) {
+	var ctx = &context.Context{
+		Config: config.Project{
+			Dist: "/tmp/dist",
+			Dockers: []config.Docker{
+				{
+					Files: []string{"./fooo", "/tmp/dist/asdasd/asd", "./bar"},
+				},
+			},
+		},
+	}
+	assert.EqualError(t, Pipe{}.Default(ctx), `invalid docker.files: can't be . or inside dist folder: /tmp/dist/asdasd/asd`)
+}
+
 func TestDefaultSet(t *testing.T) {
 	var ctx = &context.Context{
 		Config: config.Project{


### PR DESCRIPTION
<!-- If applied, this commit will... -->

prevent setting `docker.files` to `.` or something inside `./dist`, hence not allowing "infinite path loops"

<!-- Why is this change being made? -->

<!-- # Provide links to any relevant tickets, URLs or other resources -->

closes #1117