### PR TITLE
feat: git diff when dirty

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -316,6 +316,7 @@ github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jW
 github.com/steveyen/gtreap v0.0.0-20150807155958-0abe01ef9be2/go.mod h1:mjqs7N0Q6m5HpR7QfXVBZXZWSqTjQLeTujjA/xUp2uw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -91,6 +91,7 @@ func TestDirty(t *testing.T) {
 		err = Pipe{}.Run(context.New(config.Project{}))
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "git is currently in a dirty state")
+		assert.Contains(t, err.Error(), "+lorem ipsum")
 	})
 	t.Run("skip validate is set", func(t *testing.T) {
 		ctx := context.New(config.Project{})


### PR DESCRIPTION
prints the `git diff` output when the branch is dirty, helping debug things on CI (maybe)

closes #1005