### PR TITLE
ci: add golangci-lint configuration file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,14 @@
+# This file contains all available configuration options
+# with their default values.
+
+# options for analysis running
+run:
+  tests: false
+
+linters:
+  enable-all: true
+  disable:
+    - wsl
+    - lll
+    - funlen
+    - godox

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ lint:
 	# TODO: fix funlen issues
 	# TODO: fix godox issues
 	# TODO: fix wsl issues
-	./bin/golangci-lint run --tests=false --enable-all --disable wsl --disable lll --disable funlen --disable godox ./...
+	./bin/golangci-lint run ./...
 	./bin/misspell -error **/*
 .PHONY: lint
 


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->
This commit adds  a configuration for `golangci-lint` to not need to add a bunch of cli parameters.

closes #1185 

<!-- Why is this change being made? -->

<!-- # Provide links to any relevant tickets, URLs or other resources -->
