### PR TITLE
Revert "feat: git diff when dirty (#1178)"

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -328,7 +328,6 @@ github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jW
 github.com/steveyen/gtreap v0.0.0-20150807155958-0abe01ef9be2/go.mod h1:mjqs7N0Q6m5HpR7QfXVBZXZWSqTjQLeTujjA/xUp2uw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -99,10 +99,11 @@ func validate(ctx *context.Context) error {
 	if ctx.SkipValidate {
 		return pipe.ErrSkipValidateEnabled
 	}
-	if hasDiff() {
-		return diffErr()
+	out, err := git.Run("status", "--porcelain")
+	if strings.TrimSpace(out) != "" || err != nil {
+		return ErrDirty{status: out}
 	}
-	_, err := git.Clean(git.Run("describe", "--exact-match", "--tags", "--match", ctx.Git.CurrentTag))
+	_, err = git.Clean(git.Run("describe", "--exact-match", "--tags", "--match", ctx.Git.CurrentTag))
 	if err != nil {
 		return ErrWrongRef{
 			commit: ctx.Git.Commit,
@@ -110,20 +111,6 @@ func validate(ctx *context.Context) error {
 		}
 	}
 	return nil
-}
-
-func diffErr() error {
-	out, err := git.Run("diff")
-	if err != nil {
-		// in theory this will never happen...
-		return ErrDirty{status: err.Error()}
-	}
-	return ErrDirty{status: out}
-}
-
-func hasDiff() bool {
-	out, err := git.Run("status", "--porcelain")
-	return strings.TrimSpace(out) != "" || err != nil
 }
 
 func getShortCommit() (string, error) {

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -91,7 +91,6 @@ func TestDirty(t *testing.T) {
 		err = Pipe{}.Run(context.New(config.Project{}))
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "git is currently in a dirty state")
-		assert.Contains(t, err.Error(), "+lorem ipsum")
 	})
 	t.Run("skip validate is set", func(t *testing.T) {
 		ctx := context.New(config.Project{})


### PR DESCRIPTION
`git diff` does not work when we have untracked files.