### PR TITLE
docs: add GITHUB_TOKEN env to github action file

### DIFF
--- a/www/content/actions.md
+++ b/www/content/actions.md
@@ -32,6 +32,8 @@ jobs:
         with:
           version: latest
           args: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 > For detailed intructions please follow GitHub Actions [workflow syntax][syntax].


### PR DESCRIPTION
We will get the following error without it: `error=missing GITHUB_TOKEN, GITLAB_TOKEN and GITEA_TOKEN`, and the release action will be failed.