### PR TITLE
feat: add Include Changelog filter

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -286,6 +286,7 @@ type Docker struct {
 // Filters config
 type Filters struct {
 	Exclude []string `yaml:",omitempty"`
+	Include []string `yaml:",omitempty"`
 }
 
 // Changelog Config


### PR DESCRIPTION
The Include filter allows you to include commit messages to the CHANGELOG
that matches the given regexp.

This has been implemented since negative look-ahead is not available in
package regexp.