### PR TITLE
feat: add basic string function to template

### DIFF
--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -108,9 +108,13 @@ func (t *Template) Apply(s string) (string, error) {
 	tmpl, err := template.New("tmpl").
 		Option("missingkey=error").
 		Funcs(template.FuncMap{
+			"replace": strings.ReplaceAll,
 			"time": func(s string) string {
 				return time.Now().UTC().Format(s)
 			},
+			"tolower": strings.ToLower,
+			"toupper": strings.ToUpper,
+			"trim":    strings.TrimSpace,
 		}).
 		Parse(s)
 	if err != nil {

--- a/internal/tmpl/tmpl_test.go
+++ b/internal/tmpl/tmpl_test.go
@@ -154,23 +154,48 @@ func TestFuncMap(t *testing.T) {
 	for _, tc := range []struct {
 		Template string
 		Name     string
+		Expected string
 	}{
 		{
+			Template: `{{ replace "v1.24" "v" "" }}`,
+			Name:     "replace",
+			Expected: "1.24",
+		},
+		{
 			Template: `{{ time "2006-01-02" }}`,
-			Name:     "YYYY-MM-DD",
+			Name:     "time YYYY-MM-DD",
 		},
 		{
 			Template: `{{ time "01/02/2006" }}`,
-			Name:     "MM/DD/YYYY",
+			Name:     "time MM/DD/YYYY",
 		},
 		{
 			Template: `{{ time "01/02/2006" }}`,
-			Name:     "MM/DD/YYYY",
+			Name:     "time MM/DD/YYYY",
+		},
+		{
+			Template: `{{ tolower "TEST" }}`,
+			Name:     "tolower",
+			Expected: "test",
+		},
+		{
+			Template: `{{ toupper "test" }}`,
+			Name:     "toupper",
+			Expected: "TEST",
+		},
+		{
+			Template: `{{ trim " test " }}`,
+			Name:     "trim",
+			Expected: "test",
 		},
 	} {
 		out, err := New(ctx).Apply(tc.Template)
 		assert.NoError(t, err)
-		assert.NotEmpty(t, out)
+		if tc.Expected != "" {
+			assert.Equal(t, tc.Expected, out)
+		} else {
+			assert.NotEmpty(t, out)
+		}
 	}
 }
 

--- a/www/content/templates.md
+++ b/www/content/templates.md
@@ -42,15 +42,19 @@ may have some extra fields:
 
 On all fields, you have these available functions:
 
-|        Usage        |               Description                |
-| :-----------------: | :--------------------------------------: |
-| `time "01/02/2006"` | current UTC time in the specified format |
+|        Usage            |               Description                                                                                |
+| :--------------------:  | :----------------------------------------------------------------------------------:                     |
+| `replace "v1.2" "v" ""` | replaces all macthes. See [ReplaceAll](https://golang.org/pkg/strings/#ReplaceAll)                       |
+| `time "01/02/2006"`     | current UTC time in the specified format                                                                 |
+| `tolower "V1.2"`        | makes input string lowercase. See [ToLower](https://golang.org/pkg/strings/#ToLower)                     |
+| `toupper "v1.2"`        | makes input string uppercase. See [ToUpper](https://golang.org/pkg/strings/#ToUpper)                     |
+| `trim " v1.2  "`        | removes all leading and trailing white space. See [TrimSpace](https://golang.org/pkg/strings/#TrimSpace) |
 
 With all those fields, you may be able to compose the name of your artifacts
 pretty much the way you want:
 
 ```yaml
-example_template: '{{ .ProjectName }}_{{ .Env.USER }}_{{ time "2006" }}'
+example_template: '{{ tolower .ProjectName }}_{{ .Env.USER }}_{{ time "2006" }}'
 ```
 
 For example, if you want to add the go version to some artifact:


### PR DESCRIPTION
This commit introduces a set of functions from the `strings` package to the templates.

It might be useful to modify the available template predefined variables.

In my case, the version format we use for tags is not compatible with docker tag format so I needed to modify it a bit