### PR TITLE
feat: filter by id on sign pipe

### DIFF
--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -211,7 +211,8 @@ func ByIDs(ids ...string) Filter {
 	for _, id := range ids {
 		id := id
 		filters = append(filters, func(a *Artifact) bool {
-			return a.ExtraOr("ID", "") == id
+			// checksum are allways for all artifacts, so return always true.
+			return a.Type == Checksum || a.ExtraOr("ID", "") == id
 		})
 	}
 	return Or(filters...)

--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -222,15 +222,19 @@ func TestByIDs(t *testing.T) {
 				"ID": "check",
 			},
 		},
+		{
+			Name: "checksum",
+			Type: Checksum,
+		},
 	}
 	var artifacts = New()
 	for _, a := range data {
 		artifacts.Add(a)
 	}
 
-	require.Len(t, artifacts.Filter(ByIDs("check")).items, 1)
-	require.Len(t, artifacts.Filter(ByIDs("foo")).items, 2)
-	require.Len(t, artifacts.Filter(ByIDs("foo", "bar")).items, 3)
+	require.Len(t, artifacts.Filter(ByIDs("check")).items, 2)
+	require.Len(t, artifacts.Filter(ByIDs("foo")).items, 3)
+	require.Len(t, artifacts.Filter(ByIDs("foo", "bar")).items, 4)
 }
 
 func TestByFormats(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -230,6 +230,7 @@ type Sign struct {
 	Args      []string `yaml:"args,omitempty"`
 	Signature string   `yaml:"signature,omitempty"`
 	Artifacts string   `yaml:"artifacts,omitempty"`
+	IDs       []string `yaml:"ids,omitempty"`
 }
 
 // SnapcraftAppMetadata for the binaries that will be in the snap package

--- a/www/content/sign.md
+++ b/www/content/sign.md
@@ -56,4 +56,11 @@ signs:
     #
     # defaults to `none`
     artifacts: all
+
+    # IDs of the artifacts to sign.
+    # Defaults to all.
+    # If `artifacts` is checksum, this fields has no effect.
+    ids:
+      - foo
+      - bar
 ```


### PR DESCRIPTION
ads the hability to filter by id on the sign pipe.

with this, the user can have multiple build configs, say, one specifically for macos, then one archive config specifically for it, and finally a sign config for it, signing it with `gon`, so it macOS won't complain when the user tries to run it.

refs https://github.com/goreleaser/goreleaser/issues/1227

