### PR TITLE
feat: Add support for c-shared and c-archive build modes in windows

### DIFF
--- a/internal/pipe/build/build.go
+++ b/internal/pipe/build/build.go
@@ -132,7 +132,8 @@ func extFor(target string, flags config.FlagArray) string {
 		for _, s := range flags {
 			if s == "-buildmode=c-shared" {
 				return ".dll"
-			} else if s == "-buildmode=c-archive" {
+			}
+			if s == "-buildmode=c-archive" {
 				return ".lib"
 			}
 		}

--- a/internal/pipe/build/build.go
+++ b/internal/pipe/build/build.go
@@ -104,7 +104,7 @@ func runHook(ctx *context.Context, env []string, hook string) error {
 }
 
 func doBuild(ctx *context.Context, build config.Build, target string) error {
-	var ext = extFor(target)
+	var ext = extFor(target, build.Flags)
 
 	binary, err := tmpl.New(ctx).Apply(build.Binary)
 	if err != nil {
@@ -127,8 +127,15 @@ func doBuild(ctx *context.Context, build config.Build, target string) error {
 	})
 }
 
-func extFor(target string) string {
+func extFor(target string, flags config.FlagArray) string {
 	if strings.Contains(target, "windows") {
+		for _, s := range flags {
+			if s == "-buildmode=c-shared" {
+				return ".dll"
+			} else if s == "-buildmode=c-archive" {
+				return ".lib"
+			}
+		}
 		return ".exe"
 	}
 	if target == "js_wasm" {

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -336,18 +336,23 @@ func TestDefaultFillSingleBuild(t *testing.T) {
 }
 
 func TestExtWindows(t *testing.T) {
-	assert.Equal(t, ".exe", extFor("windows_amd64"))
-	assert.Equal(t, ".exe", extFor("windows_386"))
+	assert.Equal(t, ".exe", extFor("windows_amd64", config.FlagArray{}))
+	assert.Equal(t, ".exe", extFor("windows_386", config.FlagArray{}))
+	assert.Equal(t, ".exe", extFor("windows_amd64", config.FlagArray{"-tags=dev", "-v"}))
+	assert.Equal(t, ".dll", extFor("windows_amd64", config.FlagArray{"-tags=dev", "-v", "-buildmode=c-shared"}))
+	assert.Equal(t, ".dll", extFor("windows_386", config.FlagArray{"-buildmode=c-shared"}))
+	assert.Equal(t, ".lib", extFor("windows_amd64", config.FlagArray{"-buildmode=c-archive"}))
+	assert.Equal(t, ".lib", extFor("windows_386", config.FlagArray{"-tags=dev", "-v", "-buildmode=c-archive"}))
 }
 
 func TestExtWasm(t *testing.T) {
-	assert.Equal(t, ".wasm", extFor("js_wasm"))
+	assert.Equal(t, ".wasm", extFor("js_wasm", config.FlagArray{}))
 }
 
 func TestExtOthers(t *testing.T) {
-	assert.Empty(t, "", extFor("linux_amd64"))
-	assert.Empty(t, "", extFor("linuxwin_386"))
-	assert.Empty(t, "", extFor("winasdasd_sad"))
+	assert.Empty(t, "", extFor("linux_amd64", config.FlagArray{}))
+	assert.Empty(t, "", extFor("linuxwin_386", config.FlagArray{}))
+	assert.Empty(t, "", extFor("winasdasd_sad", config.FlagArray{}))
 }
 
 func TestTemplate(t *testing.T) {


### PR DESCRIPTION
This PR modifies the default extension of windows that are build using the flag `-buildmode=c-shared` and `-buildmode=c-archive` from `.exe` to `.dll` and `.lib`, respectively.

Even though go allows other non-`.exe` build modes (archive, shared, pie and plugin), these are not supported in windows.

More info about build modes: https://golang.org/cmd/go/#hdr-Build_modes

This commit is based on this issue:
#1221 