### PR TITLE
refactor: remove some deprecated options

### DIFF
--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -343,9 +343,9 @@ func resolveTargetTemplate(ctx *context.Context, put *config.Put, artifact *arti
 
 	if put.Mode == ModeBinary {
 		// TODO: multiple archives here
-		data.Os = replace(ctx.Config.Archive.Replacements, artifact.Goos)
-		data.Arch = replace(ctx.Config.Archive.Replacements, artifact.Goarch)
-		data.Arm = replace(ctx.Config.Archive.Replacements, artifact.Goarm)
+		data.Os = replace(ctx.Config.Archives[0].Replacements, artifact.Goos)
+		data.Arch = replace(ctx.Config.Archives[0].Replacements, artifact.Goarch)
+		data.Arm = replace(ctx.Config.Archives[0].Replacements, artifact.Goarm)
 	}
 
 	var out bytes.Buffer

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -341,7 +341,7 @@ func resolveTargetTemplate(ctx *context.Context, put *config.Put, artifact *arti
 		ProjectName: ctx.Config.ProjectName,
 	}
 
-	if put.Mode == ModeBinary {
+	if put.Mode == ModeBinary && len(ctx.Config.Archives) > 0 {
 		// TODO: multiple archives here
 		data.Os = replace(ctx.Config.Archives[0].Replacements, artifact.Goos)
 		data.Arch = replace(ctx.Config.Archives[0].Replacements, artifact.Goarch)

--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -7,14 +7,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"sync"
 
 	"github.com/apex/log"
 	"github.com/campoy/unique"
 	"github.com/goreleaser/goreleaser/internal/artifact"
-	"github.com/goreleaser/goreleaser/internal/deprecate"
 	"github.com/goreleaser/goreleaser/internal/ids"
 	"github.com/goreleaser/goreleaser/internal/semerrgroup"
 	"github.com/goreleaser/goreleaser/internal/tmpl"
@@ -44,10 +42,7 @@ func (Pipe) String() string {
 func (Pipe) Default(ctx *context.Context) error {
 	var ids = ids.New("archives")
 	if len(ctx.Config.Archives) == 0 {
-		ctx.Config.Archives = append(ctx.Config.Archives, ctx.Config.Archive)
-		if !reflect.DeepEqual(ctx.Config.Archive, config.Archive{}) {
-			deprecate.Notice("archive")
-		}
+		ctx.Config.Archives = append(ctx.Config.Archives, config.Archive{})
 	}
 	for i := range ctx.Config.Archives {
 		var archive = &ctx.Config.Archives[i]

--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 
 	"github.com/apex/log"
 	"github.com/goreleaser/goreleaser/internal/artifact"
@@ -35,12 +34,6 @@ func (Pipe) String() string {
 
 // Default sets the pipe defaults
 func (Pipe) Default(ctx *context.Context) error {
-	if len(ctx.Config.NFPMs) == 0 {
-		ctx.Config.NFPMs = append(ctx.Config.NFPMs, ctx.Config.NFPM)
-		if !reflect.DeepEqual(ctx.Config.NFPM, config.NFPM{}) {
-			deprecate.Notice("nfpm")
-		}
-	}
 	var ids = ids.New("nfpms")
 	for i := range ctx.Config.NFPMs {
 		var fpm = &ctx.Config.NFPMs[i]

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -24,7 +24,11 @@ func TestRunPipeNoFormats(t *testing.T) {
 		Git: context.GitInfo{
 			CurrentTag: "v1.0.0",
 		},
-		Config:      config.Project{},
+		Config: config.Project{
+			NFPMs: []config.NFPM{
+				{},
+			},
+		},
 		Parallelism: runtime.NumCPU(),
 	}
 	require.NoError(t, Pipe{}.Default(ctx))
@@ -270,7 +274,9 @@ func TestDefault(t *testing.T) {
 	var ctx = &context.Context{
 		Config: config.Project{
 			ProjectName: "foobar",
-			NFPMs:       []config.NFPM{},
+			NFPMs: []config.NFPM{
+				{},
+			},
 			Builds: []config.Build{
 				{ID: "foo"},
 				{ID: "bar"},
@@ -284,26 +290,7 @@ func TestDefault(t *testing.T) {
 	require.Equal(t, ctx.Config.ProjectName, ctx.Config.NFPMs[0].PackageName)
 }
 
-func TestDefaultDeprecate(t *testing.T) {
-	var ctx = &context.Context{
-		Config: config.Project{
-			NFPM: config.NFPM{
-				Formats: []string{"deb"},
-			},
-			Builds: []config.Build{
-				{ID: "foo"},
-				{ID: "bar"},
-			},
-		},
-	}
-	require.NoError(t, Pipe{}.Default(ctx))
-	require.Equal(t, "/usr/local/bin", ctx.Config.NFPMs[0].Bindir)
-	require.Equal(t, []string{"deb"}, ctx.Config.NFPMs[0].Formats)
-	require.Equal(t, []string{"foo", "bar"}, ctx.Config.NFPMs[0].Builds)
-	require.Equal(t, defaultNameTemplate, ctx.Config.NFPMs[0].FileNameTemplate)
-}
-
-func TestDefaultDeprecated(t *testing.T) {
+func TestDefaultNotEmpty(t *testing.T) {
 	var ctx = &context.Context{
 		Config: config.Project{
 			Builds: []config.Build{

--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -56,12 +56,14 @@ func doRun(ctx *context.Context, client client.Client) error {
 		return pipe.Skip("scoop section is not configured")
 	}
 
-	// TODO mavogel: in another PR
+	// TODO: mavogel: in another PR
 	// check if release pipe is not configured!
 	// if ctx.Config.Release.Disable {
 	// }
 
-	if ctx.Config.Archive.Format == "binary" {
+	// TODO: caarlos0: need to add the filter for archives on this pipe and
+	// improve this.
+	if ctx.Config.Archives[0].Format == "binary" {
 		return pipe.Skip("archive format is binary")
 	}
 

--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -63,7 +63,7 @@ func doRun(ctx *context.Context, client client.Client) error {
 
 	// TODO: caarlos0: need to add the filter for archives on this pipe and
 	// improve this.
-	if ctx.Config.Archives[0].Format == "binary" {
+	if len(ctx.Config.Archives) > 0 && ctx.Config.Archives[0].Format == "binary" {
 		return pipe.Skip("archive format is binary")
 	}
 

--- a/internal/pipe/scoop/scoop_test.go
+++ b/internal/pipe/scoop/scoop_test.go
@@ -101,8 +101,10 @@ func Test_doRun(t *testing.T) {
 						},
 						Dist:        ".",
 						ProjectName: "run-pipe",
-						Archive: config.Archive{
-							Format: "tar.gz",
+						Archives: []config.Archive{
+							{
+								Format: "tar.gz",
+							},
 						},
 						Release: config.Release{
 							GitHub: config.Repo{
@@ -145,8 +147,10 @@ func Test_doRun(t *testing.T) {
 						},
 						Dist:        ".",
 						ProjectName: "run-pipe",
-						Archive: config.Archive{
-							Format: "tar.gz",
+						Archives: []config.Archive{
+							{
+								Format: "tar.gz",
+							},
 						},
 						Release: config.Release{
 							GitHub: config.Repo{
@@ -188,8 +192,10 @@ func Test_doRun(t *testing.T) {
 						},
 						Dist:        ".",
 						ProjectName: "run-pipe",
-						Archive: config.Archive{
-							Format: "tar.gz",
+						Archives: []config.Archive{
+							{
+								Format: "tar.gz",
+							},
 						},
 						Release: config.Release{
 							GitLab: config.Repo{
@@ -248,8 +254,10 @@ func Test_doRun(t *testing.T) {
 						},
 						Dist:        ".",
 						ProjectName: "run-pipe",
-						Archive: config.Archive{
-							Format: "tar.gz",
+						Archives: []config.Archive{
+							{
+								Format: "tar.gz",
+							},
 						},
 						Release: config.Release{
 							GitHub: config.Repo{
@@ -306,8 +314,10 @@ func Test_doRun(t *testing.T) {
 						},
 						Dist:        ".",
 						ProjectName: "run-pipe",
-						Archive: config.Archive{
-							Format: "tar.gz",
+						Archives: []config.Archive{
+							{
+								Format: "tar.gz",
+							},
 						},
 						Release: config.Release{
 							GitHub: config.Repo{
@@ -349,8 +359,10 @@ func Test_doRun(t *testing.T) {
 						},
 						Dist:        ".",
 						ProjectName: "run-pipe",
-						Archive: config.Archive{
-							Format: "tar.gz",
+						Archives: []config.Archive{
+							{
+								Format: "tar.gz",
+							},
 						},
 						Release: config.Release{
 							GitHub: config.Repo{
@@ -392,8 +404,10 @@ func Test_doRun(t *testing.T) {
 						},
 						Dist:        ".",
 						ProjectName: "run-pipe",
-						Archive: config.Archive{
-							Format: "tar.gz",
+						Archives: []config.Archive{
+							{
+								Format: "tar.gz",
+							},
 						},
 						Release: config.Release{
 							GitHub: config.Repo{
@@ -427,8 +441,10 @@ func Test_doRun(t *testing.T) {
 						},
 						Dist:        ".",
 						ProjectName: "run-pipe",
-						Archive: config.Archive{
-							Format: "tar.gz",
+						Archives: []config.Archive{
+							{
+								Format: "tar.gz",
+							},
 						},
 						Release: config.Release{
 							GitHub: config.Repo{
@@ -471,8 +487,10 @@ func Test_doRun(t *testing.T) {
 						},
 						Dist:        ".",
 						ProjectName: "run-pipe",
-						Archive: config.Archive{
-							Format: "tar.gz",
+						Archives: []config.Archive{
+							{
+								Format: "tar.gz",
+							},
 						},
 						Release: config.Release{
 							Draft: true,
@@ -511,8 +529,10 @@ func Test_doRun(t *testing.T) {
 						},
 						Dist:        ".",
 						ProjectName: "run-pipe",
-						Archive: config.Archive{
-							Format: "tar.gz",
+						Archives: []config.Archive{
+							{
+								Format: "tar.gz",
+							},
 						},
 						Release: config.Release{
 							Disable: true,
@@ -551,8 +571,10 @@ func Test_doRun(t *testing.T) {
 						},
 						Dist:        ".",
 						ProjectName: "run-pipe",
-						Archive: config.Archive{
-							Format: "binary",
+						Archives: []config.Archive{
+							{
+								Format: "binary",
+							},
 						},
 						Release: config.Release{
 							Draft: true,
@@ -613,8 +635,10 @@ func Test_buildManifest(t *testing.T) {
 					},
 					Dist:        ".",
 					ProjectName: "run-pipe",
-					Archive: config.Archive{
-						Format: "tar.gz",
+					Archives: []config.Archive{
+						{
+							Format: "tar.gz",
+						},
 					},
 					Release: config.Release{
 						GitHub: config.Repo{
@@ -652,8 +676,10 @@ func Test_buildManifest(t *testing.T) {
 					},
 					Dist:        ".",
 					ProjectName: "run-pipe",
-					Archive: config.Archive{
-						Format: "tar.gz",
+					Archives: []config.Archive{
+						{
+							Format: "tar.gz",
+						},
 					},
 					Release: config.Release{
 						GitHub: config.Repo{
@@ -692,8 +718,10 @@ func Test_buildManifest(t *testing.T) {
 					},
 					Dist:        ".",
 					ProjectName: "run-pipe",
-					Archive: config.Archive{
-						Format: "tar.gz",
+					Archives: []config.Archive{
+						{
+							Format: "tar.gz",
+						},
 					},
 					Release: config.Release{
 						GitHub: config.Repo{

--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -7,12 +7,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"reflect"
 	"strings"
 
 	"github.com/apex/log"
 	"github.com/goreleaser/goreleaser/internal/artifact"
-	"github.com/goreleaser/goreleaser/internal/deprecate"
 	"github.com/goreleaser/goreleaser/internal/ids"
 	"github.com/goreleaser/goreleaser/internal/linux"
 	"github.com/goreleaser/goreleaser/internal/pipe"
@@ -67,12 +65,6 @@ func (Pipe) String() string {
 
 // Default sets the pipe defaults
 func (Pipe) Default(ctx *context.Context) error {
-	if len(ctx.Config.Snapcrafts) == 0 {
-		ctx.Config.Snapcrafts = append(ctx.Config.Snapcrafts, ctx.Config.Snapcraft)
-		if !reflect.DeepEqual(ctx.Config.Snapcraft, config.Snapcraft{}) {
-			deprecate.Notice("snapcraft")
-		}
-	}
 	var ids = ids.New("snapcrafts")
 	for i := range ctx.Config.Snapcrafts {
 		var snap = &ctx.Config.Snapcrafts[i]

--- a/internal/pipe/snapcraft/snapcraft_test.go
+++ b/internal/pipe/snapcraft/snapcraft_test.go
@@ -326,6 +326,9 @@ func TestDefault(t *testing.T) {
 				ID: "foo",
 			},
 		},
+		Snapcrafts: []config.Snapcraft{
+			{},
+		},
 	})
 	assert.NoError(t, Pipe{}.Default(ctx))
 	assert.Equal(t, defaultNameTemplate, ctx.Config.Snapcrafts[0].NameTemplate)
@@ -351,16 +354,6 @@ func TestDefaultSet(t *testing.T) {
 			{
 				NameTemplate: "foo",
 			},
-		},
-	})
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Equal(t, "foo", ctx.Config.Snapcrafts[0].NameTemplate)
-}
-
-func TestDefaultDeprecate(t *testing.T) {
-	var ctx = context.New(config.Project{
-		Snapcraft: config.Snapcraft{
-			NameTemplate: "foo",
 		},
 	})
 	assert.NoError(t, Pipe{}.Default(ctx))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -353,11 +353,8 @@ type Project struct {
 	Brews         []Homebrew  `yaml:",omitempty"`
 	Scoop         Scoop       `yaml:",omitempty"`
 	Builds        []Build     `yaml:",omitempty"`
-	Archive       Archive     `yaml:",omitempty"` // TODO: remove this
 	Archives      []Archive   `yaml:",omitempty"`
-	NFPM          NFPM        `yaml:",omitempty"` // TODO: remove this
 	NFPMs         []NFPM      `yaml:"nfpms,omitempty"`
-	Snapcraft     Snapcraft   `yaml:",omitempty"` // TODO: remove this
 	Snapcrafts    []Snapcraft `yaml:",omitempty"`
 	Snapshot      Snapshot    `yaml:",omitempty"`
 	Checksum      Checksum    `yaml:",omitempty"`

--- a/www/content/deprecations.md
+++ b/www/content/deprecations.md
@@ -150,9 +150,15 @@ blobs:
   # etc
 ```
 
+---
+
+# Expired deprecation notices
+
+The following options were deprecated for ~6 months and are now fully removed.
+
 ### snapcraft
 
-> since 2019-05-39
+> since 2019-05-27
 
 We now allow multiple Snapcraft configs, so the `snapcraft` statement will be removed.
 
@@ -216,10 +222,6 @@ archives:
   - id: foo
     format: zip
 ```
-
-## Expired deprecation notices
-
-The following options were deprecated for ~6 months and are now fully removed.
 
 ### docker.binary
 


### PR DESCRIPTION
removed some options that were deprecated for 6 months or more:

- singular nfpm
- singular archive
- singular snapcraft

on the next few months a few more will be removed.

Make sure to run `goreleaser check` every now and then to ensure your config is still valid.

We try hard to avoid those changes, but sometimes we can't help it. Some things must change so the project can continue to evolve.