### PR TITLE
feat: change default snapshot version template

### DIFF
--- a/internal/pipe/snapshot/snapshot.go
+++ b/internal/pipe/snapshot/snapshot.go
@@ -20,7 +20,7 @@ func (Pipe) String() string {
 // Default sets the pipe defaults
 func (Pipe) Default(ctx *context.Context) error {
 	if ctx.Config.Snapshot.NameTemplate == "" {
-		ctx.Config.Snapshot.NameTemplate = "SNAPSHOT-{{ .ShortCommit }}"
+		ctx.Config.Snapshot.NameTemplate = "{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}"
 	}
 	return nil
 }

--- a/internal/pipe/snapshot/snapshot_test.go
+++ b/internal/pipe/snapshot/snapshot_test.go
@@ -19,7 +19,7 @@ func TestDefault(t *testing.T) {
 		},
 	}
 	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Equal(t, "SNAPSHOT-{{ .ShortCommit }}", ctx.Config.Snapshot.NameTemplate)
+	assert.Equal(t, "{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}", ctx.Config.Snapshot.NameTemplate)
 }
 
 func TestDefaultSet(t *testing.T) {

--- a/www/content/snapshots.md
+++ b/www/content/snapshots.md
@@ -15,8 +15,12 @@ and also with the `snapshot` customization section:
 # .goreleaser.yml
 snapshot:
   # Allows you to change the name of the generated snapshot
-  # Default is `SNAPSHOT-{{.ShortCommit}}`.
-  name_template: SNAPSHOT-{{.Commit}}
+  #
+  # Note that some pipes require this to be semantic version compliant (nfpm,
+  # for example).
+  #
+  # Default is `{{ .Tag }}-SNAPSHOT-{{.ShortCommit}}`.
+  name_template: 1.2.3-SNAPSHOT-{{.Commit}}
 ```
 
 > Learn more about the [name template engine](/templates).


### PR DESCRIPTION
both deb and rpm requires that the version is somewhat semantic, so this is a way to make that work as expected.

closes https://github.com/goreleaser/goreleaser/issues/1236