### PR TITLE
fix: brew: do not really depends on release

### DIFF
--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -162,12 +162,6 @@ func doRun(ctx *context.Context, brew config.Homebrew, client client.Client) err
 	if ctx.SkipPublish {
 		return pipe.ErrSkipPublishEnabled
 	}
-	if ctx.Config.Release.Draft {
-		return pipe.Skip("release is marked as draft")
-	}
-	if ctx.Config.Release.Disable {
-		return pipe.Skip("release is disabled")
-	}
 	if strings.TrimSpace(brew.SkipUpload) == "auto" && ctx.Semver.Prerelease != "" {
 		return pipe.Skip("prerelease detected with 'auto' upload, skipping homebrew publish")
 	}

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -641,30 +641,6 @@ func TestRunPipeNoUpload(t *testing.T) {
 		ctx.SkipPublish = true
 		assertNoPublish(tt)
 	})
-	t.Run("draft release", func(tt *testing.T) {
-		ctx.Config.Release.Draft = true
-		ctx.Config.Brews[0].SkipUpload = "false"
-		ctx.SkipPublish = false
-		assertNoPublish(tt)
-	})
-	t.Run("release disabled", func(tt *testing.T) {
-		ctx.Config.Release.Disable = true
-		ctx.Config.Brews[0].SkipUpload = "false"
-		ctx.SkipPublish = false
-		assertNoPublish(tt)
-	})
-	t.Run("skip prerelease publish", func(tt *testing.T) {
-		ctx.Config.Release.Draft = false
-		ctx.Config.Brews[0].SkipUpload = "auto"
-		ctx.SkipPublish = false
-		ctx.Semver = context.Semver{
-			Major:      1,
-			Minor:      0,
-			Patch:      0,
-			Prerelease: "rc1",
-		}
-		assertNoPublish(tt)
-	})
 }
 
 func TestRunTokenTypeNotImplementedForBrew(t *testing.T) {


### PR DESCRIPTION
The user might provide another `url_template`.

This is not ideal, but I guess its OK for now.

closes https://github.com/goreleaser/goreleaser/issues/1237