### PR TITLE
Support for running a subset of builds, targets, archives

### DIFF
--- a/internal/pipe/pipe.go
+++ b/internal/pipe/pipe.go
@@ -17,6 +17,10 @@ var ErrSkipSignEnabled = Skip("artifact signing is disabled")
 // It means that the part of a Piper that validates some things was not run.
 var ErrSkipValidateEnabled = Skip("validation is disabled")
 
+// ErrSkipArchiveEnabled happens if --skip-archive is set.
+// It means that the part of a Piper that validates some things was not run.
+var ErrSkipArchiveEnabled = Skip("archiving is disabled")
+
 // IsSkip returns true if the error is an ErrSkip
 func IsSkip(err error) bool {
 	_, ok := err.(ErrSkip)

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -53,24 +53,28 @@ const (
 // Context carries along some data through the pipes
 type Context struct {
 	ctx.Context
-	Config        config.Project
-	Env           Env
-	Token         string
-	TokenType     TokenType
-	Git           GitInfo
-	Artifacts     artifact.Artifacts
-	ReleaseNotes  string
-	ReleaseHeader string
-	ReleaseFooter string
-	Version       string
-	Snapshot      bool
-	SkipPublish   bool
-	SkipSign      bool
-	SkipValidate  bool
-	RmDist        bool
-	PreRelease    bool
-	Parallelism   int
-	Semver        Semver
+	Config         config.Project
+	Env            Env
+	Token          string
+	TokenType      TokenType
+	Git            GitInfo
+	Artifacts      artifact.Artifacts
+	ReleaseNotes   string
+	ReleaseHeader  string
+	ReleaseFooter  string
+	Version        string
+	Snapshot       bool
+	SkipPublish    bool
+	SkipSign       bool
+	SkipValidate   bool
+	SkipArchive    bool
+	RmDist         bool
+	PreRelease     bool
+	Parallelism    int
+	Semver         Semver
+	OnlyBuildIDs   []string
+	OnlyTargets    []string
+	OnlyArchiveIDs []string
 }
 
 // Semver represents a semantic version


### PR DESCRIPTION
I'm not sure if this is the best approach to accomplish what I am hoping for but I figured I'd open this PR to get some feedback.

<!-- If applied, this commit will... -->
Add support for running a subset of builds, targets, and archives configured in a goreleaser config. It also adds support for skipping archives all together.

<!-- Why is this change being made? -->
We're using goreleaser as a primary source for both releases & building development binaries across our organization. For example:

* The docker containers that our web developers trigger a goreleaser build with `--no-publish --skip-validate` each time the containers are rebuilt -- the containers only need `linux/amd64` binaries however.

* We build our Windows MSI packages on AppVeyor and we only need to produce the `windows/386` and `windows/amd64` binaries as a result. We're currently maintaining two goreleaser configs, one for Windows and one for our other platforms to solve this for now.

These changes will significantly cut down time spent where goreleaser is building binaries for every platform we support when we only need one or two.