### PR TITLE
docs: fix default ldflag template

### DIFF
--- a/www/content/build.md
+++ b/www/content/build.md
@@ -49,7 +49,7 @@ builds:
       - ./dontoptimizeme=-N
 
     # Custom ldflags templates.
-    # Default is `-s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.builtBy=goreleaser`.
+    # Default is `-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser`.
     ldflags:
      - -s -w -X main.build={{.Version}}
      - ./usemsan=-msan


### PR DESCRIPTION
### What

Change the default ldflags template that is displayed in the build docs to
show that the default sets `main.commit` to `Commit` instead of
`ShortCommit`.

### Why

The docs state that the default ldflags includes the ShortCommit but in
reality the code uses the longer Commit value instead. This behavior has
existed since the defaults were introduced ~3 years ago in commit
4af2cb0 so even if short commit was the intended behavior, after 3 years
of it working this way we should probably just update the docs to reflect
the actual default.

Fixes #1264