### PR TITLE
feat: specify (sub)directory with go code when building

### DIFF
--- a/internal/pipe/build/build.go
+++ b/internal/pipe/build/build.go
@@ -113,11 +113,16 @@ func doBuild(ctx *context.Context, build config.Build, target string) error {
 
 	build.Binary = binary
 	var name = build.Binary + ext
-	var path = filepath.Join(
-		ctx.Config.Dist,
-		fmt.Sprintf("%s_%s", build.ID, target),
-		name,
+	path, err := filepath.Abs(
+		filepath.Join(
+			ctx.Config.Dist,
+			fmt.Sprintf("%s_%s", build.ID, target),
+			name,
+		),
 	)
+	if err != nil {
+		return err
+	}
 	log.WithField("binary", path).Info("building")
 	return builders.For(build.Lang).Build(ctx, build, builders.Options{
 		Target: target,

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -231,6 +231,7 @@ func TestDefaultEmptyBuild(t *testing.T) {
 	var build = ctx.Config.Builds[0]
 	assert.Equal(t, ctx.Config.ProjectName, build.ID)
 	assert.Equal(t, ctx.Config.ProjectName, build.Binary)
+	assert.Equal(t, ".", build.Dir)
 	assert.Equal(t, ".", build.Main)
 	assert.Equal(t, []string{"linux", "darwin"}, build.Goos)
 	assert.Equal(t, []string{"amd64", "386"}, build.Goarch)
@@ -289,6 +290,7 @@ func TestDefaultPartialBuilds(t *testing.T) {
 				{
 					ID:      "build2",
 					Binary:  "foo",
+					Dir:     "baz",
 					Ldflags: []string{"-s -w"},
 					Goarch:  []string{"386"},
 				},
@@ -299,6 +301,7 @@ func TestDefaultPartialBuilds(t *testing.T) {
 	t.Run("build0", func(t *testing.T) {
 		var build = ctx.Config.Builds[0]
 		assert.Equal(t, "bar", build.Binary)
+		assert.Equal(t, ".", build.Dir)
 		assert.Equal(t, "./cmd/main.go", build.Main)
 		assert.Equal(t, []string{"linux"}, build.Goos)
 		assert.Equal(t, []string{"amd64", "386"}, build.Goarch)
@@ -310,6 +313,7 @@ func TestDefaultPartialBuilds(t *testing.T) {
 		var build = ctx.Config.Builds[1]
 		assert.Equal(t, "foo", build.Binary)
 		assert.Equal(t, ".", build.Main)
+		assert.Equal(t, "baz", build.Dir)
 		assert.Equal(t, []string{"linux", "darwin"}, build.Goos)
 		assert.Equal(t, []string{"386"}, build.Goarch)
 		assert.Equal(t, []string{"6"}, build.Goarm)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -144,6 +144,7 @@ type Build struct {
 	Goarm    []string       `yaml:",omitempty"`
 	Targets  []string       `yaml:",omitempty"`
 	Ignore   []IgnoredBuild `yaml:",omitempty"`
+	Dir      string         `yaml:",omitempty"`
 	Main     string         `yaml:",omitempty"`
 	Ldflags  StringArray    `yaml:",omitempty"`
 	Flags    FlagArray      `yaml:",omitempty"`

--- a/www/content/build.md
+++ b/www/content/build.md
@@ -21,6 +21,11 @@ builds:
     # Defaults to the project name.
     id: "my-build"
 
+    # Path to project's (sub)directory containing Go code.
+    # This is the working directory for the Go build command(s).
+    # Default is `.`.
+    dir: go
+
     # Path to main.go file or main package.
     # Default is `.`.
     main: ./cmd/main.go


### PR DESCRIPTION
This will enable using GoReleaser in multi-language projects where Go code (and `go.mod`/`go.sum`) is not in project's root directory.

An example of such project is [Oasis Core](https://github.com/oasislabs/oasis-core) (where we are planning on using GoReleaser to do releases).