### PR TITLE
feat: docker builds filter

### DIFF
--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -55,6 +55,11 @@ func (Pipe) Default(ctx *context.Context) error {
 			ctx.Config.Builds[0].Binary,
 		}
 	}
+	if len(ctx.Config.Dockers[0].Builds) == 0 {
+		ctx.Config.Dockers[0].Builds = []string{
+			ctx.Config.Builds[0].ID,
+		}
+	}
 	if ctx.Config.Dockers[0].Dockerfile == "" {
 		ctx.Config.Dockers[0].Dockerfile = "Dockerfile"
 	}
@@ -98,22 +103,24 @@ func doRun(ctx *context.Context) error {
 				}
 				binaryNames[i] = bin
 			}
-			var binaries = ctx.Artifacts.Filter(
-				artifact.And(
-					artifact.ByGoos(docker.Goos),
-					artifact.ByGoarch(docker.Goarch),
-					artifact.ByGoarm(docker.Goarm),
-					artifact.ByType(artifact.Binary),
-					func(a *artifact.Artifact) bool {
-						for _, bin := range binaryNames {
-							if a.ExtraOr("Binary", "").(string) == bin {
-								return true
-							}
+			var filters = []artifact.Filter{
+				artifact.ByGoos(docker.Goos),
+				artifact.ByGoarch(docker.Goarch),
+				artifact.ByGoarm(docker.Goarm),
+				artifact.ByType(artifact.Binary),
+				func(a *artifact.Artifact) bool {
+					for _, bin := range binaryNames {
+						if a.ExtraOr("Binary", "").(string) == bin {
+							return true
 						}
-						return false
-					},
-				),
-			).List()
+					}
+					return false
+				},
+			}
+			if len(docker.Builds) > 0 {
+				filters = append(filters, artifact.ByIDs(docker.Builds...))
+			}
+			var binaries = ctx.Artifacts.Filter(artifact.And(filters...)).List()
 			// TODO: not so good of a check, if one binary match multiple
 			// binaries and the other match none, this will still pass...
 			if len(binaries) != len(docker.Binaries) {

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -153,6 +153,26 @@ func TestRunPipe(t *testing.T) {
 			assertError:    shouldNotErr,
 			pubAssertError: shouldNotErr,
 		},
+		"valid-with-builds": {
+			dockers: []config.Docker{
+				{
+					ImageTemplates: []string{
+						registry + "goreleaser/test_run_pipe_build:latest",
+					},
+					Goos:       "linux",
+					Goarch:     "amd64",
+					Dockerfile: "testdata/Dockerfile",
+					Binaries:   []string{"mybin"},
+					Builds:     []string{"mybin"},
+				},
+			},
+			expect: []string{
+				registry + "goreleaser/test_run_pipe_build:latest",
+			},
+			assertImageLabels: noLabels,
+			assertError:       shouldNotErr,
+			pubAssertError:    shouldNotErr,
+		},
 		"multiple images with same extra file": {
 			dockers: []config.Docker{
 				{
@@ -583,6 +603,7 @@ func TestRunPipe(t *testing.T) {
 							Type:   artifact.Binary,
 							Extra: map[string]interface{}{
 								"Binary": bin,
+								"ID":     bin,
 							},
 						})
 					}

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -728,6 +728,11 @@ func TestDefault(t *testing.T) {
 func TestDefaultBinaries(t *testing.T) {
 	var ctx = &context.Context{
 		Config: config.Project{
+			Builds: []config.Build{
+				{
+					ID: "foo",
+				},
+			},
 			Dockers: []config.Docker{
 				{
 					Binaries: []string{"foo"},
@@ -736,7 +741,7 @@ func TestDefaultBinaries(t *testing.T) {
 		},
 	}
 	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Len(t, ctx.Config.Dockers, 1)
+	require.Len(t, ctx.Config.Dockers, 1)
 	var docker = ctx.Config.Dockers[0]
 	assert.Equal(t, "linux", docker.Goos)
 	assert.Equal(t, "amd64", docker.Goarch)
@@ -786,6 +791,7 @@ func TestDefaultSet(t *testing.T) {
 		Config: config.Project{
 			Dockers: []config.Docker{
 				{
+					Builds:     []string{"foo"},
 					Goos:       "windows",
 					Goarch:     "i386",
 					Binaries:   []string{"bar"},
@@ -800,6 +806,7 @@ func TestDefaultSet(t *testing.T) {
 	assert.Equal(t, "windows", docker.Goos)
 	assert.Equal(t, "i386", docker.Goarch)
 	assert.Equal(t, "bar", docker.Binaries[0])
+	assert.Equal(t, "foo", docker.Builds[0])
 	assert.Equal(t, "Dockerfile.foo", docker.Dockerfile)
 }
 

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -813,6 +813,11 @@ func TestDefaultSet(t *testing.T) {
 func Test_processImageTemplates(t *testing.T) {
 	var ctx = &context.Context{
 		Config: config.Project{
+			Builds: []config.Build{
+				{
+					ID: "default",
+				},
+			},
 			Dockers: []config.Docker{
 				{
 					Binaries:   []string{"foo"},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -276,6 +276,7 @@ type Checksum struct {
 // Docker image config
 type Docker struct {
 	Binaries           []string `yaml:",omitempty"`
+	Builds             []string `yaml:",omitempty"`
 	Goos               string   `yaml:",omitempty"`
 	Goarch             string   `yaml:",omitempty"`
 	Goarm              string   `yaml:",omitempty"`

--- a/www/content/docker.md
+++ b/www/content/docker.md
@@ -50,13 +50,21 @@ dockers:
   -
     # GOOS of the built binary that should be used.
     goos: linux
+
     # GOARCH of the built binary that should be used.
     goarch: amd64
+
     # GOARM of the built binary that should be used.
     goarm: ''
+
     # Name templates of the built binaries that should be used.
     binaries:
     - mybinary
+
+    # Build IDs to gather the binaries from.
+    builds:
+    - mybuild
+
     # Templates of the Docker image names.
     image_templates:
     - "myuser/myimage:latest"
@@ -64,19 +72,23 @@ dockers:
     - "myuser/myimage:{{ .Tag }}-{{ .Env.GO_VERSION }}"
     - "myuser/myimage:v{{ .Major }}"
     - "gcr.io/myuser/myimage:latest"
+
     # Skips the docker push. Could be useful if you also do draft releases.
     # If set to auto, the release will not be pushed to the docker repository
     # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
     # Defaults to false.
     skip_push: false
+
     # Path to the Dockerfile (from the project root).
     dockerfile: Dockerfile
+
     # Template of the docker build flags.
     build_flag_templates:
     - "--label=org.label-schema.schema-version=1.0"
     - "--label=org.label-schema.version={{.Version}}"
     - "--label=org.label-schema.name={{.ProjectName}}"
     - "--build-arg=FOO={{.Env.Bar}}"
+
     # If your Dockerfile copies files other than the binary itself,
     # you should list them here as well.
     # Note that goreleaser will create the same structure inside the temporary


### PR DESCRIPTION
Tested it with a config like this, worked like a charm:

```yaml
builds:
- id: build1
  binary: foo
  env:
  - CGO_ENABLED=0
  main: ./main.go
  goos:
  - darwin
  goarch:
  - amd64
- id: build2
  binary: foo
  env:
  - CGO_ENABLED=0
  main: ./foo/main.go
  goos:
  - linux
  goarch:
  - amd64
dockers:
- image_templates:
  - caarlos0/foo
  binaries:
  - foo
  builds:
  - build2
  dockerfile: Dockerfile.foo

```

closes #1241
