### PR TITLE
feat: remove singular archive config

### DIFF
--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -372,9 +372,9 @@ func resolveTargetTemplate(ctx *context.Context, upload *config.Upload, artifact
 
 	if upload.Mode == ModeBinary {
 		// TODO: multiple archives here
-		data.Os = replace(ctx.Config.Archive.Replacements, artifact.Goos)
-		data.Arch = replace(ctx.Config.Archive.Replacements, artifact.Goarch)
-		data.Arm = replace(ctx.Config.Archive.Replacements, artifact.Goarm)
+		data.Os = replace(ctx.Config.Archives[0].Replacements, artifact.Goos)
+		data.Arch = replace(ctx.Config.Archives[0].Replacements, artifact.Goarch)
+		data.Arm = replace(ctx.Config.Archives[0].Replacements, artifact.Goarm)
 	}
 
 	var out bytes.Buffer

--- a/internal/http/http_test.go
+++ b/internal/http/http_test.go
@@ -205,7 +205,12 @@ func TestUpload(t *testing.T) {
 		}
 		return errors.Errorf("unexpected http status code: %v", r.StatusCode)
 	}
-	ctx := context.New(config.Project{ProjectName: "blah"})
+	ctx := context.New(config.Project{
+		ProjectName: "blah",
+		Archives: []config.Archive{
+			{},
+		},
+	})
 	ctx.Env["TEST_A_SECRET"] = "x"
 	ctx.Env["TEST_A_USERNAME"] = "u2"
 	ctx.Version = "2.1.0"

--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -7,14 +7,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"sync"
 
 	"github.com/apex/log"
 	"github.com/campoy/unique"
+	"github.com/mattn/go-zglob"
+
 	"github.com/goreleaser/goreleaser/internal/artifact"
-	"github.com/goreleaser/goreleaser/internal/deprecate"
 	"github.com/goreleaser/goreleaser/internal/ids"
 	"github.com/goreleaser/goreleaser/internal/semerrgroup"
 	"github.com/goreleaser/goreleaser/internal/tmpl"
@@ -22,7 +22,6 @@ import (
 	archivelib "github.com/goreleaser/goreleaser/pkg/archive"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	zglob "github.com/mattn/go-zglob"
 )
 
 const (
@@ -44,10 +43,7 @@ func (Pipe) String() string {
 func (Pipe) Default(ctx *context.Context) error {
 	var ids = ids.New("archives")
 	if len(ctx.Config.Archives) == 0 {
-		ctx.Config.Archives = append(ctx.Config.Archives, ctx.Config.Archive)
-		if !reflect.DeepEqual(ctx.Config.Archive, config.Archive{}) {
-			deprecate.Notice("archive")
-		}
+		ctx.Config.Archives = append(ctx.Config.Archives, config.Archive{})
 	}
 	for i := range ctx.Config.Archives {
 		var archive = &ctx.Config.Archives[i]

--- a/internal/pipe/artifactory/artifactory_test.go
+++ b/internal/pipe/artifactory/artifactory_test.go
@@ -188,6 +188,9 @@ func TestRunPipe_ModeBinary(t *testing.T) {
 				Username: "productionuser",
 			},
 		},
+		Archives: []config.Archive{
+			{},
+		},
 	})
 	ctx.Env = map[string]string{
 		"ARTIFACTORY_PRODUCTION-US_SECRET": "deployuser-secret",
@@ -228,6 +231,9 @@ func TestRunPipe_ModeArchive(t *testing.T) {
 				Target:   fmt.Sprintf("%s/example-repo-local/{{ .ProjectName }}/{{ .Version }}/", server.URL),
 				Username: "deployuser",
 			},
+		},
+		Archives: []config.Archive{
+			{},
 		},
 	})
 	ctx.Env = map[string]string{
@@ -361,6 +367,9 @@ func TestRunPipe_TargetTemplateError(t *testing.T) {
 				Username: "deployuser",
 			},
 		},
+		Archives: []config.Archive{
+			{},
+		},
 	})
 	ctx.Env = map[string]string{
 		"ARTIFACTORY_PRODUCTION_SECRET": "deployuser-secret",
@@ -417,6 +426,9 @@ func TestRunPipe_BadCredentials(t *testing.T) {
 				Target:   fmt.Sprintf("%s/example-repo-local/{{ .ProjectName }}/{{ .Os }}/{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}", server.URL),
 				Username: "deployuser",
 			},
+		},
+		Archives: []config.Archive{
+			{},
 		},
 	})
 	ctx.Env = map[string]string{
@@ -476,6 +488,9 @@ func TestRunPipe_UnparsableErrorResponse(t *testing.T) {
 				Username: "deployuser",
 			},
 		},
+		Archives: []config.Archive{
+			{},
+		},
 	})
 	ctx.Env = map[string]string{
 		"ARTIFACTORY_PRODUCTION_SECRET": "deployuser-secret",
@@ -531,6 +546,9 @@ func TestRunPipe_UnparsableResponse(t *testing.T) {
 				Username: "deployuser",
 			},
 		},
+		Archives: []config.Archive{
+			{},
+		},
 	})
 	ctx.Env = map[string]string{
 		"ARTIFACTORY_PRODUCTION_SECRET": "deployuser-secret",
@@ -558,6 +576,9 @@ func TestRunPipe_FileNotFound(t *testing.T) {
 				Target:   "http://artifacts.company.com/example-repo-local/{{ .ProjectName }}/{{ .Os }}/{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}",
 				Username: "deployuser",
 			},
+		},
+		Archives: []config.Archive{
+			{},
 		},
 	})
 	ctx.Env = map[string]string{
@@ -597,6 +618,9 @@ func TestRunPipe_UnparsableTarget(t *testing.T) {
 				Username: "deployuser",
 			},
 		},
+		Archives: []config.Archive{
+			{},
+		},
 	})
 	ctx.Env = map[string]string{
 		"ARTIFACTORY_PRODUCTION_SECRET": "deployuser-secret",
@@ -622,6 +646,9 @@ func TestRunPipe_SkipWhenPublishFalse(t *testing.T) {
 				Target:   "http://artifacts.company.com/example-repo-local/{{ .ProjectName }}/{{ .Os }}/{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}",
 				Username: "deployuser",
 			},
+		},
+		Archives: []config.Archive{
+			{},
 		},
 	})
 	ctx.Env = map[string]string{
@@ -653,6 +680,9 @@ func TestRunPipe_DirUpload(t *testing.T) {
 				Target:   "http://artifacts.company.com/example-repo-local/{{ .ProjectName }}/{{ .Os }}/{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}",
 				Username: "deployuser",
 			},
+		},
+		Archives: []config.Archive{
+			{},
 		},
 	})
 	ctx.Env = map[string]string{

--- a/internal/pipe/defaults/defaults_test.go
+++ b/internal/pipe/defaults/defaults_test.go
@@ -63,9 +63,11 @@ func TestFillPartial(t *testing.T) {
 					Name:  "test",
 				},
 			},
-			Archive: config.Archive{
-				Files: []string{
-					"glob/*",
+			Archives: []config.Archive{
+				{
+					Files: []string{
+						"glob/*",
+					},
 				},
 			},
 			Builds: []config.Build{
@@ -90,7 +92,7 @@ func TestFillPartial(t *testing.T) {
 		},
 	}
 	assert.NoError(t, Pipe{}.Run(ctx))
-	assert.Len(t, ctx.Config.Archive.Files, 1)
+	assert.Len(t, ctx.Config.Archives[0].Files, 1)
 	assert.Equal(t, `bin.install "testreleaser"`, ctx.Config.Brews[0].Install)
 	assert.NotEmpty(t, ctx.Config.Dockers[0].Binaries)
 	assert.NotEmpty(t, ctx.Config.Dockers[0].Goos)

--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -61,7 +61,8 @@ func doRun(ctx *context.Context, client client.Client) error {
 	// if ctx.Config.Release.Disable {
 	// }
 
-	if ctx.Config.Archive.Format == "binary" {
+	// TODO: multiple archives
+	if ctx.Config.Archives[0].Format == "binary" {
 		return pipe.Skip("archive format is binary")
 	}
 

--- a/internal/pipe/scoop/scoop_test.go
+++ b/internal/pipe/scoop/scoop_test.go
@@ -101,8 +101,8 @@ func Test_doRun(t *testing.T) {
 						},
 						Dist:        ".",
 						ProjectName: "run-pipe",
-						Archive: config.Archive{
-							Format: "tar.gz",
+						Archives: []config.Archive{
+							{Format: "tar.gz"},
 						},
 						Release: config.Release{
 							GitHub: config.Repo{
@@ -145,8 +145,8 @@ func Test_doRun(t *testing.T) {
 						},
 						Dist:        ".",
 						ProjectName: "run-pipe",
-						Archive: config.Archive{
-							Format: "tar.gz",
+						Archives: []config.Archive{
+							{Format: "tar.gz"},
 						},
 						Release: config.Release{
 							GitHub: config.Repo{
@@ -188,8 +188,8 @@ func Test_doRun(t *testing.T) {
 						},
 						Dist:        ".",
 						ProjectName: "run-pipe",
-						Archive: config.Archive{
-							Format: "tar.gz",
+						Archives: []config.Archive{
+							{Format: "tar.gz"},
 						},
 						Release: config.Release{
 							GitLab: config.Repo{
@@ -248,8 +248,8 @@ func Test_doRun(t *testing.T) {
 						},
 						Dist:        ".",
 						ProjectName: "run-pipe",
-						Archive: config.Archive{
-							Format: "tar.gz",
+						Archives: []config.Archive{
+							{Format: "tar.gz"},
 						},
 						Release: config.Release{
 							GitHub: config.Repo{
@@ -306,8 +306,8 @@ func Test_doRun(t *testing.T) {
 						},
 						Dist:        ".",
 						ProjectName: "run-pipe",
-						Archive: config.Archive{
-							Format: "tar.gz",
+						Archives: []config.Archive{
+							{Format: "tar.gz"},
 						},
 						Release: config.Release{
 							GitHub: config.Repo{
@@ -349,8 +349,8 @@ func Test_doRun(t *testing.T) {
 						},
 						Dist:        ".",
 						ProjectName: "run-pipe",
-						Archive: config.Archive{
-							Format: "tar.gz",
+						Archives: []config.Archive{
+							{Format: "tar.gz"},
 						},
 						Release: config.Release{
 							GitHub: config.Repo{
@@ -392,8 +392,8 @@ func Test_doRun(t *testing.T) {
 						},
 						Dist:        ".",
 						ProjectName: "run-pipe",
-						Archive: config.Archive{
-							Format: "tar.gz",
+						Archives: []config.Archive{
+							{Format: "tar.gz"},
 						},
 						Release: config.Release{
 							GitHub: config.Repo{
@@ -427,8 +427,8 @@ func Test_doRun(t *testing.T) {
 						},
 						Dist:        ".",
 						ProjectName: "run-pipe",
-						Archive: config.Archive{
-							Format: "tar.gz",
+						Archives: []config.Archive{
+							{Format: "tar.gz"},
 						},
 						Release: config.Release{
 							GitHub: config.Repo{
@@ -471,8 +471,8 @@ func Test_doRun(t *testing.T) {
 						},
 						Dist:        ".",
 						ProjectName: "run-pipe",
-						Archive: config.Archive{
-							Format: "tar.gz",
+						Archives: []config.Archive{
+							{Format: "tar.gz"},
 						},
 						Release: config.Release{
 							Draft: true,
@@ -511,8 +511,8 @@ func Test_doRun(t *testing.T) {
 						},
 						Dist:        ".",
 						ProjectName: "run-pipe",
-						Archive: config.Archive{
-							Format: "tar.gz",
+						Archives: []config.Archive{
+							{Format: "tar.gz"},
 						},
 						Release: config.Release{
 							Disable: true,
@@ -551,8 +551,8 @@ func Test_doRun(t *testing.T) {
 						},
 						Dist:        ".",
 						ProjectName: "run-pipe",
-						Archive: config.Archive{
-							Format: "binary",
+						Archives: []config.Archive{
+							{Format: "binary"},
 						},
 						Release: config.Release{
 							Draft: true,
@@ -613,8 +613,8 @@ func Test_buildManifest(t *testing.T) {
 					},
 					Dist:        ".",
 					ProjectName: "run-pipe",
-					Archive: config.Archive{
-						Format: "tar.gz",
+					Archives: []config.Archive{
+						{Format: "tar.gz"},
 					},
 					Release: config.Release{
 						GitHub: config.Repo{
@@ -652,8 +652,8 @@ func Test_buildManifest(t *testing.T) {
 					},
 					Dist:        ".",
 					ProjectName: "run-pipe",
-					Archive: config.Archive{
-						Format: "tar.gz",
+					Archives: []config.Archive{
+						{Format: "tar.gz"},
 					},
 					Release: config.Release{
 						GitHub: config.Repo{
@@ -692,8 +692,8 @@ func Test_buildManifest(t *testing.T) {
 					},
 					Dist:        ".",
 					ProjectName: "run-pipe",
-					Archive: config.Archive{
-						Format: "tar.gz",
+					Archives: []config.Archive{
+						{Format: "tar.gz"},
 					},
 					Release: config.Release{
 						GitHub: config.Repo{

--- a/internal/pipe/upload/upload_test.go
+++ b/internal/pipe/upload/upload_test.go
@@ -123,6 +123,9 @@ func TestRunPipe_ModeBinary(t *testing.T) {
 				Username: "productionuser",
 			},
 		},
+		Archives: []config.Archive{
+			{},
+		},
 	})
 	ctx.Env = map[string]string{
 		"UPLOAD_PRODUCTION-US_SECRET": "deployuser-secret",
@@ -163,6 +166,9 @@ func TestRunPipe_ModeArchive(t *testing.T) {
 				Target:   fmt.Sprintf("%s/example-repo-local/{{ .ProjectName }}/{{ .Version }}/", server.URL),
 				Username: "deployuser",
 			},
+		},
+		Archives: []config.Archive{
+			{},
 		},
 	})
 	ctx.Env = map[string]string{
@@ -261,6 +267,9 @@ func TestRunPipe_TargetTemplateError(t *testing.T) {
 				Username: "deployuser",
 			},
 		},
+		Archives: []config.Archive{
+			{},
+		},
 	})
 	ctx.Env = map[string]string{
 		"UPLOAD_PRODUCTION_SECRET": "deployuser-secret",
@@ -313,6 +322,9 @@ func TestRunPipe_BadCredentials(t *testing.T) {
 				Username: "deployuser",
 			},
 		},
+		Archives: []config.Archive{
+			{},
+		},
 	})
 	ctx.Env = map[string]string{
 		"UPLOAD_PRODUCTION_SECRET": "deployuser-secret",
@@ -342,6 +354,9 @@ func TestRunPipe_FileNotFound(t *testing.T) {
 				Target:   "http://artifacts.company.com/example-repo-local/{{ .ProjectName }}/{{ .Os }}/{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}",
 				Username: "deployuser",
 			},
+		},
+		Archives: []config.Archive{
+			{},
 		},
 	})
 	ctx.Env = map[string]string{
@@ -381,6 +396,9 @@ func TestRunPipe_UnparsableTarget(t *testing.T) {
 				Username: "deployuser",
 			},
 		},
+		Archives: []config.Archive{
+			{},
+		},
 	})
 	ctx.Env = map[string]string{
 		"UPLOAD_PRODUCTION_SECRET": "deployuser-secret",
@@ -405,6 +423,9 @@ func TestRunPipe_SkipWhenPublishFalse(t *testing.T) {
 				Target:   "http://artifacts.company.com/example-repo-local/{{ .ProjectName }}/{{ .Os }}/{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}",
 				Username: "deployuser",
 			},
+		},
+		Archives: []config.Archive{
+			{},
 		},
 	})
 	ctx.Env = map[string]string{
@@ -436,6 +457,9 @@ func TestRunPipe_DirUpload(t *testing.T) {
 				Target:   "http://artifacts.company.com/example-repo-local/{{ .ProjectName }}/{{ .Os }}/{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}",
 				Username: "deployuser",
 			},
+		},
+		Archives: []config.Archive{
+			{},
 		},
 	})
 	ctx.Env = map[string]string{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -358,7 +358,6 @@ type Project struct {
 	Brews         []Homebrew  `yaml:",omitempty"`
 	Scoop         Scoop       `yaml:",omitempty"`
 	Builds        []Build     `yaml:",omitempty"`
-	Archive       Archive     `yaml:",omitempty"` // TODO: remove this
 	Archives      []Archive   `yaml:",omitempty"`
 	NFPMs         []NFPM      `yaml:"nfpms,omitempty"`
 	Snapcrafts    []Snapcraft `yaml:",omitempty"`

--- a/www/content/deprecations.md
+++ b/www/content/deprecations.md
@@ -175,9 +175,13 @@ blobs:
   # etc
 ```
 
+## Expired deprecation notices
+
+The following options were deprecated for ~6 months and are now fully removed.
+
 ### archive
 
-> since 2019-04-16
+> since 2019-04-16, removed 2019-12-27
 
 We now allow multiple archives, so the `archive` statement will be removed.
 
@@ -195,11 +199,6 @@ archives:
   - id: foo
     format: zip
 ```
-
-## Expired deprecation notices
-
-The following options were deprecated for ~6 months and are now fully removed.
-
 
 ### snapcraft
 


### PR DESCRIPTION
removed singular `archive` config in favor of its plural form, `archives`.