### PR TITLE
docs: remove reference to deprecated download strategy

### DIFF
--- a/www/content/homebrew.md
+++ b/www/content/homebrew.md
@@ -60,9 +60,9 @@ brews:
 
     # Allows you to set a custom download strategy. Note that you'll need
     # to implement the strategy and add it to your tap repository.
-    # Example: http://lessthanhero.io/post/homebrew-with-private-repo-releases/
+    # Example: https://docs.brew.sh/Formula-Cookbook#specifying-the-download-strategy-explicitly
     # Default is empty.
-    download_strategy: GitHubPrivateRepositoryReleaseDownloadStrategy
+    download_strategy: CurlDownloadStrategy.
 
     # Allows you to add a custom require_relative at the top of the formula template
     # Default is empty


### PR DESCRIPTION
This just updates the Hombrew documentation to reference the official managed list of download strategies. Making this change as I was bit by the example provided. 

Referenced by this issue https://github.com/goreleaser/goreleaser/issues/967
