### PR TITLE
docs: invite people to use docker --pull

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,9 +36,10 @@ dockers:
   - goreleaser
   build_flag_templates:
   - "--pull"
-  - "--label=org.label-schema.schema-version=1.0"
-  - "--label=org.label-schema.version={{.Version}}"
-  - "--label=org.label-schema.name={{.ProjectName}}"
+  - "--label=org.opencontainers.image.created={{.Date}}"
+  - "--label=org.opencontainers.image.name={{.ProjectName}}"
+  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  - "--label=org.opencontainers.image.version={{.Version}}"
   extra_files:
   - scripts/entrypoint.sh
 - image_templates:
@@ -50,9 +51,11 @@ dockers:
   - goreleaser
   build_flag_templates:
   - "--pull"
-  - "--label=org.label-schema.schema-version=1.0"
-  - "--label=org.label-schema.version={{.Version}}"
-  - "--label=org.label-schema.name={{.ProjectName}}"
+  - "--label=org.opencontainers.image.created={{.Date}}"
+  - "--label=org.opencontainers.image.name={{.ProjectName}}"
+  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  - "--label=org.opencontainers.image.version={{.Version}}"
+  - "--label=org.opencontainers.image.source=http://github.com/goreleaser/goreleaser"
   - "--label=com.github.actions.name={{.ProjectName}}"
   - "--label=com.github.actions.description=Deliver Go binaries as fast and easily as possible"
   - "--label=com.github.actions.icon=terminal"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,7 +55,7 @@ dockers:
   - "--label=org.opencontainers.image.name={{.ProjectName}}"
   - "--label=org.opencontainers.image.revision={{.FullCommit}}"
   - "--label=org.opencontainers.image.version={{.Version}}"
-  - "--label=org.opencontainers.image.source=http://github.com/goreleaser/goreleaser"
+  - "--label=org.opencontainers.image.source={{.GitURL}}"
   - "--label=com.github.actions.name={{.ProjectName}}"
   - "--label=com.github.actions.description=Deliver Go binaries as fast and easily as possible"
   - "--label=com.github.actions.icon=terminal"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,6 +35,7 @@ dockers:
   binaries:
   - goreleaser
   build_flag_templates:
+  - "--pull"
   - "--label=org.label-schema.schema-version=1.0"
   - "--label=org.label-schema.version={{.Version}}"
   - "--label=org.label-schema.name={{.ProjectName}}"
@@ -48,6 +49,7 @@ dockers:
   binaries:
   - goreleaser
   build_flag_templates:
+  - "--pull"
   - "--label=org.label-schema.schema-version=1.0"
   - "--label=org.label-schema.version={{.Version}}"
   - "--label=org.label-schema.name={{.ProjectName}}"

--- a/www/content/docker.md
+++ b/www/content/docker.md
@@ -85,9 +85,10 @@ dockers:
     # Template of the docker build flags.
     build_flag_templates:
     - "--pull"
-    - "--label=org.label-schema.schema-version=1.0"
-    - "--label=org.label-schema.version={{.Version}}"
-    - "--label=org.label-schema.name={{.ProjectName}}"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.name={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
     - "--build-arg=FOO={{.Env.Bar}}"
 
     # If your Dockerfile copies files other than the binary itself,
@@ -199,18 +200,22 @@ dockers:
     image_templates:
     - "myuser/myimage"
     build_flag_templates:
-    - "--label=org.label-schema.schema-version=1.0"
-    - "--label=org.label-schema.version={{.Version}}"
-    - "--label=org.label-schema.name={{.ProjectName}}"
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.name={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
 ```
 
 This will execute the following command:
 
 ```bash
 docker build -t myuser/myimage . \
-  --label=org.label-schema.schema-version=1.0 \
-  --label=org.label-schema.version=1.6.4 \
-  --label=org.label-schema.name=mybinary"
+  --pull \
+  --label=org.opencontainers.image.created=2020-01-19T15:58:07Z" \
+  --label=org.opencontainers.image.name=mybinary" \
+  --label=org.opencontainers.image.revision=da39a3ee5e6b4b0d3255bfef95601890afd80709" \
+  --label=org.opencontainers.image.version=1.6.4
 ```
 
 > Learn more about the [name template engine](/templates).

--- a/www/content/docker.md
+++ b/www/content/docker.md
@@ -84,6 +84,7 @@ dockers:
 
     # Template of the docker build flags.
     build_flag_templates:
+    - "--pull"
     - "--label=org.label-schema.schema-version=1.0"
     - "--label=org.label-schema.version={{.Version}}"
     - "--label=org.label-schema.name={{.ProjectName}}"


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

Add the flag `--pull` to the `goreleaser` releaser process itself as well as the Docker documentation.

<!-- Why is this change being made? -->

By default, docker won't refresh the images when performing a `docker build`, thus when building new releases, it might reuse an old base image, e.g. `alpine:3` (in my case) or `golang:1.13-alpine` in this case.

<!-- # Provide links to any relevant tickets, URLs or other resources -->
