### PR TITLE
fix(ci): install snapcraft

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-dist: trusty
-sudo: required
+dist: bionic
 language: go
 go: '1.13.x'
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,9 @@ services:
 addons:
   apt:
     packages:
-    - snapd
-env:
-  - PATH=/snap/bin:$PATH
+    - snapcraft
 install:
   - make setup
-  - sudo snap install snapcraft --classic
 script:
   - make ci
   - test -n "$TRAVIS_TAG" || ./goreleaser --snapshot


### PR DESCRIPTION
fixed the CI pipeline

we needed trusty because we needed sudo to install snapcraft... turns out there is now a package for it on apt, so, no need for any of that anymore... 

plus, upgraded infrastructure!

🚀
