### PR TITLE
fix: Use long git arg for quiet

### DIFF
--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -114,11 +114,11 @@ func validate(ctx *context.Context) error {
 }
 
 func getShortCommit() (string, error) {
-	return git.Clean(git.Run("show", "--format='%h'", "HEAD", "-q"))
+	return git.Clean(git.Run("show", "--format='%h'", "HEAD", "--quiet"))
 }
 
 func getFullCommit() (string, error) {
-	return git.Clean(git.Run("show", "--format='%H'", "HEAD", "-q"))
+	return git.Clean(git.Run("show", "--format='%H'", "HEAD", "--quiet"))
 }
 
 func getTag() (string, error) {


### PR DESCRIPTION
With older versions of git (such as 1.8.x which I have to use for reasons), the `-q` switch is invalid, which results in this error message:

```
• releasing using goreleaser 0.124.1...
   • loading config file       file=.goreleaser.yml
   • RUNNING BEFORE HOOKS     
   • LOADING ENVIRONMENT VARIABLES
   • GETTING AND VALIDATING GIT STATE
   ⨯ release failed after 0.01s error=couldn't get current commit: fatal: unrecognized argument: -q
```

Using the longer form `--quiet` works on both newer and older versions of git.