### PR TITLE
Use CI environment variables to figure out tag

### DIFF
--- a/internal/pipe/changelog/changelog.go
+++ b/internal/pipe/changelog/changelog.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -189,6 +190,10 @@ func gitLog(refs ...string) (string, error) {
 }
 
 func previous(tag string) (result string, err error) {
+	if tag := os.Getenv("GORELEASER_PREVIOUS_TAG"); tag != "" {
+		return tag, nil
+	}
+
 	result, err = git.Clean(git.Run("describe", "--tags", "--abbrev=0", fmt.Sprintf("tags/%s^", tag)))
 	if err != nil {
 		result, err = git.Clean(git.Run("rev-list", "--max-parents=0", "HEAD"))

--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -1,14 +1,16 @@
 package git
 
 import (
+	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/apex/log"
+	"github.com/pkg/errors"
+
 	"github.com/goreleaser/goreleaser/internal/git"
 	"github.com/goreleaser/goreleaser/internal/pipe"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/pkg/errors"
 )
 
 // Pipe that sets up git state
@@ -122,6 +124,10 @@ func getFullCommit() (string, error) {
 }
 
 func getTag() (string, error) {
+	if tag := os.Getenv("GORELEASER_CURRENT_TAG"); tag != "" {
+		return tag, nil
+	}
+
 	return git.Clean(git.Run("describe", "--tags", "--abbrev=0"))
 }
 

--- a/www/content/build.md
+++ b/www/content/build.md
@@ -152,6 +152,6 @@ GOVERSION=$(go version) goreleaser
 
 ## Define Build Tag
 
-Goreleaser uses `git describe` to get the build tag. You can set
+GoReleaser uses `git describe` to get the build tag. You can set
 a different build tag using the environment variable `GORELEASER_CURRENT_TAG`.
 This is useful in scenarios where two tags point to the same commit.

--- a/www/content/build.md
+++ b/www/content/build.md
@@ -149,3 +149,9 @@ GOVERSION=$(go version) goreleaser
  ```
 
  [hook]: /hooks
+
+## Define Build Tag
+
+Goreleaser uses `git describe` to get the build tag. You can set
+a different build tag using the environment variable `GORELEASER_CURRENT_TAG`.
+This is useful in scenarios where two tags point to the same commit.

--- a/www/content/environment.md
+++ b/www/content/environment.md
@@ -117,3 +117,7 @@ func main() {
 ```
 
 You can override this by changing the `ldflags` option in the `build` section.
+
+## Overriding Git Tags
+
+You can force the [build tag](/build#define-build-tag) and [previous changelog tag](/release#define-previous-tag) using environment variables. This is useful in cases where one git commit is referenced by multiple git tags.

--- a/www/content/release.md
+++ b/www/content/release.md
@@ -137,6 +137,12 @@ changelog:
       - (?i)foo
 ```
 
+### Define Previos Tag
+
+Goreleaser uses `git describe` to get the previous tag used for generating the Changelog.
+. You can set a different build tag using the environment variable `GORELEASER_PREVIOUS_TAG`.
+This is useful in scenarios where two tags point to the same commit.
+
 ## Custom release notes
 
 You can specify a file containing your custom release notes, and

--- a/www/content/release.md
+++ b/www/content/release.md
@@ -140,7 +140,7 @@ changelog:
 ### Define Previous Tag
 
 GoReleaser uses `git describe` to get the previous tag used for generating the Changelog.
-. You can set a different build tag using the environment variable `GORELEASER_PREVIOUS_TAG`.
+You can set a different build tag using the environment variable `GORELEASER_PREVIOUS_TAG`.
 This is useful in scenarios where two tags point to the same commit.
 
 ## Custom release notes

--- a/www/content/release.md
+++ b/www/content/release.md
@@ -137,7 +137,7 @@ changelog:
       - (?i)foo
 ```
 
-### Define Previos Tag
+### Define Previous Tag
 
 Goreleaser uses `git describe` to get the previous tag used for generating the Changelog.
 . You can set a different build tag using the environment variable `GORELEASER_PREVIOUS_TAG`.

--- a/www/content/release.md
+++ b/www/content/release.md
@@ -139,7 +139,7 @@ changelog:
 
 ### Define Previous Tag
 
-Goreleaser uses `git describe` to get the previous tag used for generating the Changelog.
+GoReleaser uses `git describe` to get the previous tag used for generating the Changelog.
 . You can set a different build tag using the environment variable `GORELEASER_PREVIOUS_TAG`.
 This is useful in scenarios where two tags point to the same commit.
 


### PR DESCRIPTION
This patch detects CI environments and uses the available tag information when
collecting the git tag.

This resolves issues where one commit has multiple tags.

Closes #1163
Closes #1311

