### PR TITLE
feat: add ability to skip uploads for prereleases

### DIFF
--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/internal/client"
@@ -85,6 +86,14 @@ func doRun(ctx *context.Context, client client.Client) error {
 
 	if ctx.SkipPublish {
 		return pipe.ErrSkipPublishEnabled
+
+	}
+	if strings.TrimSpace(ctx.Config.Scoop.SkipUpload) == "true" {
+		return pipe.Skip("scoop.skip_upload is true")
+	} else if strings.TrimSpace(ctx.Config.Scoop.SkipUpload) == "auto" {
+		if ctx.Semver.Prerelease != "" {
+			return pipe.Skip("release is prerelease")
+		}
 	}
 	if ctx.Config.Release.Draft {
 		return pipe.Skip("release is marked as draft")

--- a/internal/pipe/scoop/scoop_test.go
+++ b/internal/pipe/scoop/scoop_test.go
@@ -496,6 +496,100 @@ func Test_doRun(t *testing.T) {
 			shouldErr("release is marked as draft"),
 		},
 		{
+			"is prerelease and skip upload set to auto",
+			args{
+				&context.Context{
+					TokenType: context.TokenTypeGitHub,
+					Git: context.GitInfo{
+						CurrentTag: "v1.0.1-pre.1",
+					},
+					Semver: context.Semver{
+						Major:      1,
+						Minor:      0,
+						Patch:      1,
+						Prerelease: "-pre.1",
+					},
+					Version:   "1.0.1-pre.1",
+					Artifacts: artifact.New(),
+					Config: config.Project{
+						Builds: []config.Build{
+							{Binary: "test", Goarch: []string{"amd64"}, Goos: []string{"windows"}},
+						},
+						Dist:        ".",
+						ProjectName: "run-pipe",
+						Archives: []config.Archive{
+							{Format: "tar.gz"},
+						},
+						Release: config.Release{
+							GitHub: config.Repo{
+								Owner: "test",
+								Name:  "test",
+							},
+						},
+						Scoop: config.Scoop{
+							SkipUpload: "auto",
+							Bucket: config.Repo{
+								Owner: "test",
+								Name:  "test",
+							},
+							Description: "A run pipe test formula",
+							Homepage:    "https://github.com/goreleaser",
+						},
+					},
+				},
+				&DummyClient{},
+			},
+			[]*artifact.Artifact{
+				{Name: "foo_1.0.1-pre.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64", Path: file},
+				{Name: "foo_1.0.1-pre.1_windows_386.tar.gz", Goos: "windows", Goarch: "386", Path: file},
+			},
+			shouldErr("release is prerelease"),
+		},
+		{
+			"skip upload set to true",
+			args{
+				&context.Context{
+					TokenType: context.TokenTypeGitHub,
+					Git: context.GitInfo{
+						CurrentTag: "v1.0.1",
+					},
+					Version:   "1.0.1",
+					Artifacts: artifact.New(),
+					Config: config.Project{
+						Builds: []config.Build{
+							{Binary: "test", Goarch: []string{"amd64"}, Goos: []string{"windows"}},
+						},
+						Dist:        ".",
+						ProjectName: "run-pipe",
+						Archives: []config.Archive{
+							{Format: "tar.gz"},
+						},
+						Release: config.Release{
+							GitHub: config.Repo{
+								Owner: "test",
+								Name:  "test",
+							},
+						},
+						Scoop: config.Scoop{
+							SkipUpload: "true",
+							Bucket: config.Repo{
+								Owner: "test",
+								Name:  "test",
+							},
+							Description: "A run pipe test formula",
+							Homepage:    "https://github.com/goreleaser",
+						},
+					},
+				},
+				&DummyClient{},
+			},
+			[]*artifact.Artifact{
+				{Name: "foo_1.0.1-pre.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64", Path: file},
+				{Name: "foo_1.0.1-pre.1_windows_386.tar.gz", Goos: "windows", Goarch: "386", Path: file},
+			},
+			shouldErr("scoop.skip_upload is true"),
+		},
+		{
 			"release is disabled",
 			args{
 				&context.Context{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -81,6 +81,7 @@ type Scoop struct {
 	License      string       `yaml:",omitempty"`
 	URLTemplate  string       `yaml:"url_template,omitempty"`
 	Persist      []string     `yaml:"persist,omitempty"`
+	SkipUpload   string       `yaml:"skip_upload,omitempty"`
 }
 
 // CommitAuthor is the author of a Git commit


### PR DESCRIPTION
## If applied, this commit will...

Expose a new config option for `scoop`, `skip_upload`, that behaves like `brew.skip_upload`

## Why is this change being made?

We make heavy use of prereleases over at https://github.com/cli/cli and have come to rely on the
brew pipeline's `skip_upload` setting to avoid shipping prereleases. We were surprised that the
scoop pipeline didn't seem to support a similar feature, so this PR adds it. Please let me know if
there is existing support for this that I just missed!

## Provide links to any relevant tickets, URLs or other resources

[the existing brew feature](https://github.com/goreleaser/goreleaser/blob/479798126ea3d066f11fbd9ab67c21aa057ce204/internal/pipe/brew/brew.go#L157)
