### PR TITLE
fix: Use go mod download

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ env:
   - GOPROXY=https://gocenter.io
 before:
   hooks:
-    - go mod tidy
+    - go mod download
 builds:
 - env:
     - CGO_ENABLED=0

--- a/internal/static/config.go
+++ b/internal/static/config.go
@@ -6,8 +6,8 @@ const ExampleConfig = `# This is an example goreleaser.yaml file with some sane 
 # Make sure to check the documentation at http://goreleaser.com
 before:
   hooks:
-    # you may remove this if you don't use vgo
-    - go mod tidy
+    # You may remove this if you don't use go modules.
+    - go mod download
     # you may remove this if you don't need go generate
     - go generate ./...
 builds:

--- a/www/content/build.md
+++ b/www/content/build.md
@@ -138,13 +138,13 @@ GOVERSION=$(go version) goreleaser
  try to download the dependencies. Since several builds run in parallel, it is
  very likely to fail.
 
- You can solve this by running `go mod tidy` before calling `goreleaser` or
+ You can solve this by running `go mod download` before calling `goreleaser` or
  by adding a [hook][] doing that on your `.goreleaser.yaml` file:
 
  ```yaml
  before:
    hooks:
-   - go mod tidy
+   - go mod download
  # rest of the file...
  ```
 

--- a/www/content/env.md
+++ b/www/content/env.md
@@ -16,11 +16,11 @@ env:
   - GO111MODULE=on
 before:
   hooks:
-    - go mod tidy
+    - go mod download
 builds:
 - binary: program
 ```
 
-This way, both `go mod tidy` and the underlying `go build` will have
+This way, both `go mod download` and the underlying `go build` will have
 `GO111MODULE` set to `on`.
 

--- a/www/content/hooks.md
+++ b/www/content/hooks.md
@@ -18,7 +18,7 @@ before:
   hooks:
   - make clean
   - go generate ./...
-  - go mod tidy
+  - go mod download
   - touch {{ .Env.FILE_TO_TOUCH }}
 ```
 


### PR DESCRIPTION
Recommend using `go mod download` rather than `go mod tidy` for fetching
dependencies. The `tidy` function is used to update things and chagnes
the dependency graph. Using the `download` function avoids any changes.

Signed-off-by: Ben Kochie <superq@gmail.com>
