### PR TITLE
feat: support variable substitution in archive.files

### DIFF
--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -215,7 +215,7 @@ func findFiles(template *tmpl.Template, archive config.Archive) (result []string
 	for _, glob := range archive.Files {
 		replaced, err := template.Apply(glob)
 		if err != nil {
-			return result, fmt.Errorf("Variable substitution failed for pattern %s: %s", glob, err.Error())
+			return result, errors.Wrapf(err, "failed to apply template %s", glob)
 		}
 		files, err := zglob.Glob(replaced)
 		if err != nil {


### PR DESCRIPTION
If applied, this commit will allow template variables like {{.Os}} to appear in the archive.files field. 

It can be useful to include different files in an archive depending on os and arch. This will be especially useful if names of files can be customized – I'll push up another PR shortly to get your thoughts on an approach there.

Fixes https://github.com/goreleaser/goreleaser/issues/1347
