### PR TITLE
feat: add archive.rewrite_paths option [WIP]

### DIFF
--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -146,7 +146,7 @@ func create(ctx *context.Context, archive config.Archive, binaries []*artifact.A
 		return fmt.Errorf("failed to find files to archive: %s", err.Error())
 	}
 	for _, f := range files {
-		if err = a.Add(f, f); err != nil {
+		if err = a.Add(rewritePath(archive, f), f); err != nil {
 			return fmt.Errorf("failed to add %s to the archive: %s", f, err.Error())
 		}
 	}
@@ -181,6 +181,22 @@ func wrapFolder(a config.Archive) string {
 	default:
 		return a.WrapInDirectory
 	}
+}
+
+func rewritePath(a config.Archive, oldpath string) string {
+	for _, rewrite := range a.RewritePaths {
+		relative, err := filepath.Rel(rewrite.Source, oldpath)
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
+		if strings.HasPrefix(relative, "..") {
+			continue
+		} else {
+			return filepath.Join(rewrite.Dest, relative)
+		}
+	}
+	return oldpath
 }
 
 func skip(ctx *context.Context, archive config.Archive, binaries []*artifact.Artifact) error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -164,6 +164,12 @@ type FormatOverride struct {
 	Format string `yaml:",omitempty"`
 }
 
+// RewritePath determines the ultimate path of a file in the archive.
+type RewritePath struct {
+	Source string `yaml:",omitempty"`
+	Dest   string `yaml:",omitempty"`
+}
+
 // Archive config used for the archive
 type Archive struct {
 	ID              string            `yaml:",omitempty"`
@@ -174,6 +180,7 @@ type Archive struct {
 	FormatOverrides []FormatOverride  `yaml:"format_overrides,omitempty"`
 	WrapInDirectory string            `yaml:"wrap_in_directory,omitempty"`
 	Files           []string          `yaml:",omitempty"`
+	RewritePaths    []RewritePath     `yaml:"rewrite_paths,omitempty"`
 }
 
 // Release config used for the GitHub/GitLab release


### PR DESCRIPTION
Allow a user to specify a `source` and `dest` for some (list of) files in the archive
and name the archived file at `source`, `dest`.

If applied, this commit will add a new `archive.rewrite_paths` option to the yaml config. This is a list of `source`, `dest` pairs where `source`s are files that are to be added to the archive, and `dest`s are what we want them to be called within the archive.

This change pairs with 
https://github.com/goreleaser/goreleaser/pull/1350 as it allows you to do something like include a different file per-OS, but called the same thing

and also fixes https://github.com/goreleaser/goreleaser/issues/679.

This is one of many ways that this feature could be implemented. If you're interested in including this, I still need to 

- [ ] write docs for the new feature
- [ ] add tests, especially around moving whole directories
- [ ] determine what should happen if the source doesn't exist
- [ ] improve various error conditions

