### PR TITLE
docs: Clarify usage of --snapshot in quick start

### DIFF
--- a/www/content/quick-start.md
+++ b/www/content/quick-start.md
@@ -72,8 +72,12 @@ $ git push origin v0.1.0
 
 > **Attention**: Check if your tag adheres to [semantic versioning](/semver).
 
-If you don't want to create a tag yet, you can also create a release
-based on the latest commit by using the `--snapshot` flag. (*Note*: only GitHub supports snapshots)
+If you don't want to create a tag yet, you can also run GoReleaser without publishing
+based on the latest commit by using the `--snapshot` flag:
+
+```sh
+$ goreleaser --snapshot
+```
 
 Now you can run GoReleaser at the root of your repository:
 


### PR DESCRIPTION
The docs for `--snapshot` in the quick start are confusing, especially since they mention Github releases and `--snapshot` doesn't create releases at all.
