### PR TITLE
feat: add filter artifacts by name in uploads

### DIFF
--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -13,6 +13,7 @@ import (
 	"hash/crc32"
 	"io"
 	"os"
+	"regexp"
 	"sync"
 
 	"github.com/apex/log"
@@ -219,6 +220,13 @@ func ByIDs(ids ...string) Filter {
 		})
 	}
 	return Or(filters...)
+}
+
+func ByNamePattern(pattern string) Filter {
+	return func(a *Artifact) bool {
+		ok, _ := regexp.MatchString(pattern, a.Name)
+		return ok
+	}
 }
 
 // Or performs an OR between all given filters

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -183,6 +183,9 @@ func Upload(ctx *context.Context, uploads []config.Upload, kind string, check Re
 		if len(upload.IDs) > 0 {
 			filter = artifact.And(filter, artifact.ByIDs(upload.IDs...))
 		}
+		if upload.Pattern != "" {
+			filter = artifact.And(filter, artifact.ByNamePattern(upload.Pattern))
+		}
 		if err := uploadWithFilter(ctx, &upload, filter, kind, check); err != nil {
 			return err
 		}

--- a/internal/pipe/upload/upload_test.go
+++ b/internal/pipe/upload/upload_test.go
@@ -282,6 +282,81 @@ func TestRunPipe_ModeBinary_CustomArtifactName(t *testing.T) {
 	assert.NoError(t, Pipe{}.Publish(ctx))
 }
 
+func TestRunPipe_FilterByName(t *testing.T) {
+	setup()
+	defer teardown()
+
+	folder, err := ioutil.TempDir("", "archivetest")
+	assert.NoError(t, err)
+	var dist = filepath.Join(folder, "dist")
+	assert.NoError(t, os.Mkdir(dist, 0755))
+	assert.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
+	var binPath = filepath.Join(dist, "mybin", "mybin")
+	d1 := []byte("hello\ngo\n")
+	err = ioutil.WriteFile(binPath, d1, 0666)
+	assert.NoError(t, err)
+
+	// Dummy http server
+	mux.HandleFunc("/example-repo-local/mybin/darwin/amd64/mybin;deb.distribution=xenial", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPut)
+		testHeader(t, r, "Content-Length", "9")
+		// Basic auth of user "deployuser" with secret "deployuser-secret"
+		testHeader(t, r, "Authorization", "Basic ZGVwbG95dXNlcjpkZXBsb3l1c2VyLXNlY3JldA==")
+
+		w.Header().Set("Location", "/production-repo-remote/mybin/linux/amd64/mybin;deb.distribution=xenial")
+		w.WriteHeader(http.StatusCreated)
+	})
+	mux.HandleFunc("/example-repo-local/mybin/linux/amd64/mybin;deb.distribution=xenial", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPut)
+		testHeader(t, r, "Content-Length", "9")
+		// Basic auth of user "deployuser" with secret "deployuser-secret"
+		testHeader(t, r, "Authorization", "Basic ZGVwbG95dXNlcjpkZXBsb3l1c2VyLXNlY3JldA==")
+
+		w.Header().Set("Location", "/example-repo-local/mybin/linux/amd64/mybin;deb.distribution=xenial")
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	var ctx = context.New(config.Project{
+		ProjectName: "mybin",
+		Dist:        dist,
+		Uploads: []config.Upload{
+			{
+				Method:             h.MethodPut,
+				Name:               "production-us",
+				Mode:               "binary",
+				Target:             fmt.Sprintf("%s/example-repo-local/{{ .ProjectName }}/{{ .Os }}/{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}/{{ .ArtifactName }};deb.distribution=xenial", server.URL),
+				Username:           "deployuser",
+				CustomArtifactName: true,
+				Pattern:            "^mybin$",
+			},
+		},
+		Archives: []config.Archive{
+			{},
+		},
+	})
+	ctx.Env = map[string]string{
+		"UPLOAD_PRODUCTION-US_SECRET": "deployuser-secret",
+	}
+	for _, goos := range []string{"linux", "darwin"} {
+		ctx.Artifacts.Add(&artifact.Artifact{
+			Name:   "mybin",
+			Path:   binPath,
+			Goarch: "amd64",
+			Goos:   goos,
+			Type:   artifact.UploadableBinary,
+		})
+		ctx.Artifacts.Add(&artifact.Artifact{
+			Name:   "nothing",
+			Path:   binPath,
+			Goarch: "amd64",
+			Goos:   goos,
+			Type:   artifact.UploadableBinary,
+		})
+	}
+
+	assert.NoError(t, Pipe{}.Publish(ctx))
+}
+
 func TestRunPipe_ModeArchive_CustomArtifactName(t *testing.T) {
 	setup()
 	defer teardown()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -347,6 +347,7 @@ type Upload struct {
 	Checksum           bool     `yaml:",omitempty"`
 	Signature          bool     `yaml:",omitempty"`
 	CustomArtifactName bool     `yaml:"custom_artifact_name,omitempty"`
+	Pattern            string   `yaml:",omitempty"` // filter artifact by name pattern - should regular expression
 }
 
 // Project includes all project configuration

--- a/www/content/upload.md
+++ b/www/content/upload.md
@@ -138,6 +138,9 @@ uploads:
     - foo
     - bar
 
+    # Filter artifacts by name using regular expression (disabled by default)
+    pattern: '.*?\\.tar\\.gz'
+
     # Upload mode. Valid options are `binary` and `archive`.
     # If mode is `archive`, variables _Os_, _Arch_ and _Arm_ for target name are not supported.
     # In that case these variables are empty.


### PR DESCRIPTION
This commit adds filtering artifacts by name using regular expression for `uploads` section.

It could useful for uploading to servers only selected files (like only `.deb` to debian repo)

It is partially relevant to #1202, #15 