### PR TITLE
fix: infer project name from GitLab/Gitea release

### DIFF
--- a/internal/pipe/project/project.go
+++ b/internal/pipe/project/project.go
@@ -13,7 +13,14 @@ func (Pipe) String() string {
 // Default set project defaults
 func (Pipe) Default(ctx *context.Context) error {
 	if ctx.Config.ProjectName == "" {
-		ctx.Config.ProjectName = ctx.Config.Release.GitHub.Name
+		switch {
+		case ctx.Config.Release.GitHub.Name != "":
+			ctx.Config.ProjectName = ctx.Config.Release.GitHub.Name
+		case ctx.Config.Release.GitLab.Name != "":
+			ctx.Config.ProjectName = ctx.Config.Release.GitLab.Name
+		case ctx.Config.Release.Gitea.Name != "":
+			ctx.Config.ProjectName = ctx.Config.Release.Gitea.Name
+		}
 	}
 	return nil
 }

--- a/internal/pipe/project/project_test.go
+++ b/internal/pipe/project/project_test.go
@@ -23,10 +23,36 @@ func TestCustomProjectName(t *testing.T) {
 	require.Equal(t, "foo", ctx.Config.ProjectName)
 }
 
-func TestEmptyProjectName(t *testing.T) {
+func TestEmptyProjectName_DefaultsToGitHubRelease(t *testing.T) {
 	var ctx = context.New(config.Project{
 		Release: config.Release{
 			GitHub: config.Repo{
+				Owner: "bar",
+				Name:  "bar",
+			},
+		},
+	})
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, "bar", ctx.Config.ProjectName)
+}
+
+func TestEmptyProjectName_DefaultsToGitLabRelease(t *testing.T) {
+	var ctx = context.New(config.Project{
+		Release: config.Release{
+			GitLab: config.Repo{
+				Owner: "bar",
+				Name:  "bar",
+			},
+		},
+	})
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, "bar", ctx.Config.ProjectName)
+}
+
+func TestEmptyProjectName_DefaultsToGiteaRelease(t *testing.T) {
+	var ctx = context.New(config.Project{
+		Release: config.Release{
+			Gitea: config.Repo{
 				Owner: "bar",
 				Name:  "bar",
 			},

--- a/www/content/project.md
+++ b/www/content/project.md
@@ -6,7 +6,8 @@ weight: 10
 ---
 
 The project name is used in the name of the Brew formula, archives, etc.
-If none is given, it will be inferred from the name of the Git project.
+If none is given, it will be inferred from the name of the GitHub, GitLab, or
+Gitea release.
 
 ```yaml
 # .goreleaser.yml


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->

<!-- # Provide links to any relevant tickets, URLs or other resources -->

When a GitLab release is configured, the project name will default to the repository name, if not set explicitly. This is already the behaviour with GitHub releases.

This should fix https://github.com/goreleaser/goreleaser/issues/1337.