### PR TITLE
fix: http.target template

### DIFF
--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -350,20 +350,6 @@ func executeHTTPRequest(ctx *context.Context, upload *config.Upload, req *h.Requ
 	return resp, err
 }
 
-// targetData is used as a template struct for
-// Artifactory.Target
-type targetData struct {
-	Version      string
-	Tag          string
-	ProjectName  string
-	ArtifactName string
-
-	// Only supported in mode binary
-	Os   string
-	Arch string
-	Arm  string
-}
-
 // resolveTargetTemplate returns the resolved target template with replaced variables
 // Those variables can be replaced by the given context, goos, goarch, goarm and more
 func resolveTargetTemplate(ctx *context.Context, upload *config.Upload, artifact *artifact.Artifact) (string, error) {

--- a/internal/pipe/artifactory/artifactory_test.go
+++ b/internal/pipe/artifactory/artifactory_test.go
@@ -383,7 +383,7 @@ func TestRunPipe_TargetTemplateError(t *testing.T) {
 	})
 
 	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.EqualError(t, Pipe{}.Publish(ctx), `artifactory: error while building the target url: template: mybin:1: unexpected "/" in operand`)
+	assert.EqualError(t, Pipe{}.Publish(ctx), `artifactory: error while building the target url: template: tmpl:1: unexpected "/" in operand`)
 }
 
 func TestRunPipe_BadCredentials(t *testing.T) {
@@ -634,7 +634,7 @@ func TestRunPipe_UnparsableTarget(t *testing.T) {
 	})
 
 	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.EqualError(t, Pipe{}.Publish(ctx), `artifactory: upload failed: parse ://artifacts.company.com/example-repo-local/mybin/darwin/amd64/mybin: missing protocol scheme`)
+	assert.EqualError(t, Pipe{}.Publish(ctx), `artifactory: upload failed: parse "://artifacts.company.com/example-repo-local/mybin/darwin/amd64/mybin": missing protocol scheme`)
 }
 
 func TestRunPipe_SkipWhenPublishFalse(t *testing.T) {

--- a/internal/pipe/upload/upload_test.go
+++ b/internal/pipe/upload/upload_test.go
@@ -422,7 +422,7 @@ func TestRunPipe_TargetTemplateError(t *testing.T) {
 	})
 	err = Pipe{}.Publish(ctx)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), `upload: error while building the target url: template: mybin:1: unexpected "/" in operand`)
+	assert.Contains(t, err.Error(), `upload: error while building the target url: template: tmpl:1: unexpected "/" in operand`)
 }
 
 func TestRunPipe_BadCredentials(t *testing.T) {
@@ -550,7 +550,7 @@ func TestRunPipe_UnparsableTarget(t *testing.T) {
 		Type:   artifact.UploadableBinary,
 	})
 
-	assert.EqualError(t, Pipe{}.Publish(ctx), `upload: upload failed: parse ://artifacts.company.com/example-repo-local/mybin/darwin/amd64/mybin: missing protocol scheme`)
+	assert.EqualError(t, Pipe{}.Publish(ctx), `upload: upload failed: parse "://artifacts.company.com/example-repo-local/mybin/darwin/amd64/mybin": missing protocol scheme`)
 }
 
 func TestRunPipe_SkipWhenPublishFalse(t *testing.T) {

--- a/www/content/upload.md
+++ b/www/content/upload.md
@@ -30,7 +30,7 @@ Prerequisites:
 
 ### Target
 
-The `target` is the URL to upload the artifacts to (_without_ the name of the artifact).
+The `target` is the template of the URL to upload the artifacts to (_without_ the name of the artifact).
 
 An example configuration for `goreleaser` in upload mode `binary` with the target can look like
 
@@ -66,7 +66,7 @@ The configured name of your HTTP server will be used to build the environment
 variable name.
 This way we support auth for multiple instances.
 This also means that the `name` per configured instance needs to be unique
-per goreleaser configuration.
+per GoReleaser configuration.
 
 The name of the environment variable will be `UPLOAD_NAME_USERNAME`.
 If your instance is named `production`, you can store the username in the
@@ -82,7 +82,7 @@ The password will be stored in a environment variable.
 The configured name of your HTTP server will be used.
 This way we support auth for multiple instances.
 This also means that the `name` per configured instance needs to be unique
-per goreleaser configuration.
+per GoReleaser configuration.
 
 The name of the environment variable will be `UPLOAD_NAME_SECRET`.
 If your instance is named `production`, you need to store the secret in the
@@ -144,7 +144,7 @@ uploads:
     # Default is `archive`.
     mode: archive
 
-    # URL to be used as target of the HTTP request
+    # Template of the URL to be used as target of the HTTP request
     target: https://some.server/some/path/example-repo-local/{{ .ProjectName }}/{{ .Version }}/
 
     # Custom artifact name (defaults to false)
@@ -178,3 +178,5 @@ uploads:
 ```
 
 These settings should allow you to push your artifacts into multiple HTTP servers.
+
+> Learn more about the [name template engine](/templates).


### PR DESCRIPTION
<!-- If applied, this commit will... -->

Use the standard template package on the http upload pipe.

<!-- Why is this change being made? -->

This way, users can have more fields available on the template, as for instance, the `Os` or `Arch`.

<!-- Provide links to any relevant tickets, URLs or other resources -->

refs #1357