### PR TITLE
fix: snapcraft: do not push when skip publish

### DIFF
--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -141,6 +141,9 @@ func isValidArch(arch string) bool {
 
 // Publish packages
 func (Pipe) Publish(ctx *context.Context) error {
+	if ctx.SkipPublish {
+		return pipe.ErrSkipPublishEnabled
+	}
 	snaps := ctx.Artifacts.Filter(artifact.ByType(artifact.PublishableSnapcraft)).List()
 	var g = semerrgroup.New(ctx.Parallelism)
 	for _, snap := range snaps {

--- a/internal/pipe/snapcraft/snapcraft_test.go
+++ b/internal/pipe/snapcraft/snapcraft_test.go
@@ -7,10 +7,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/goreleaser/goreleaser/internal/testlib"
-
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/internal/pipe"
+	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
 	"github.com/stretchr/testify/assert"

--- a/internal/pipe/snapcraft/snapcraft_test.go
+++ b/internal/pipe/snapcraft/snapcraft_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/goreleaser/goreleaser/internal/testlib"
+
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/internal/pipe"
 	"github.com/goreleaser/goreleaser/pkg/config"
@@ -353,6 +355,19 @@ func TestPublish(t *testing.T) {
 	})
 	err := Pipe{}.Publish(ctx)
 	assert.Contains(t, err.Error(), "failed to push nope.snap package")
+}
+
+func TestPublishSkip(t *testing.T) {
+	var ctx = context.New(config.Project{})
+	ctx.SkipPublish = true
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name:   "mybin",
+		Path:   "nope.snap",
+		Goarch: "amd64",
+		Goos:   "linux",
+		Type:   artifact.PublishableSnapcraft,
+	})
+	testlib.AssertSkipped(t, Pipe{}.Publish(ctx))
 }
 
 func TestDefaultSet(t *testing.T) {


### PR DESCRIPTION
fixes #1365

do not push snaps if skip-publish is set