### PR TITLE
fix: fail if cant guess project name

### DIFF
--- a/internal/pipe/project/project.go
+++ b/internal/pipe/project/project.go
@@ -1,7 +1,11 @@
 // Package project sets "high level" defaults related to the project.
 package project
 
-import "github.com/goreleaser/goreleaser/pkg/context"
+import (
+	"fmt"
+
+	"github.com/goreleaser/goreleaser/pkg/context"
+)
 
 // Pipe implemens defaulter to set the project name
 type Pipe struct{}
@@ -20,6 +24,8 @@ func (Pipe) Default(ctx *context.Context) error {
 			ctx.Config.ProjectName = ctx.Config.Release.GitLab.Name
 		case ctx.Config.Release.Gitea.Name != "":
 			ctx.Config.ProjectName = ctx.Config.Release.Gitea.Name
+		default:
+			return fmt.Errorf("couldn't guess project_name, please add it to your config")
 		}
 	}
 	return nil

--- a/internal/pipe/project/project_test.go
+++ b/internal/pipe/project/project_test.go
@@ -61,3 +61,12 @@ func TestEmptyProjectName_DefaultsToGiteaRelease(t *testing.T) {
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "bar", ctx.Config.ProjectName)
 }
+
+func TestEmptyProjectNameAndRelease(t *testing.T) {
+	var ctx = context.New(config.Project{
+		Release: config.Release{
+			GitHub: config.Repo{},
+		},
+	})
+	require.EqualError(t, Pipe{}.Default(ctx), "couldn't guess project_name, please add it to your config")
+}


### PR DESCRIPTION
if we can't get the project name from the release settings, fail the whole thing, as things will eventually get broken anyway.

closes #1367