### PR TITLE
fix: build.binary and artifact.extra.binary

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -81,7 +81,7 @@ func (*Builder) Build(ctx *context.Context, build config.Build, options api.Opti
 		Goarm:  target.arm,
 		Gomips: target.mips,
 		Extra: map[string]interface{}{
-			"Binary": build.Binary,
+			"Binary": filepath.Base(build.Binary),
 			"Ext":    options.Ext,
 			"ID":     build.ID,
 		},

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -91,7 +91,7 @@ func TestBuild(t *testing.T) {
 			{
 				ID:     "foo",
 				Env:    []string{"GO111MODULE=off"},
-				Binary: "foo",
+				Binary: "bin/foo",
 				Targets: []string{
 					"linux_amd64",
 					"darwin_amd64",
@@ -129,8 +129,8 @@ func TestBuild(t *testing.T) {
 	}
 	assert.ElementsMatch(t, ctx.Artifacts.List(), []*artifact.Artifact{
 		{
-			Name:   "foo",
-			Path:   filepath.Join(folder, "dist", "linux_amd64", "foo"),
+			Name:   "bin/foo",
+			Path:   filepath.Join(folder, "dist", "linux_amd64", "bin", "foo"),
 			Goos:   "linux",
 			Goarch: "amd64",
 			Type:   artifact.Binary,
@@ -141,8 +141,8 @@ func TestBuild(t *testing.T) {
 			},
 		},
 		{
-			Name:   "foo",
-			Path:   filepath.Join(folder, "dist", "linux_mips_softfloat", "foo"),
+			Name:   "bin/foo",
+			Path:   filepath.Join(folder, "dist", "linux_mips_softfloat", "bin", "foo"),
 			Goos:   "linux",
 			Goarch: "mips",
 			Gomips: "softfloat",
@@ -154,8 +154,8 @@ func TestBuild(t *testing.T) {
 			},
 		},
 		{
-			Name:   "foo",
-			Path:   filepath.Join(folder, "dist", "linux_mips64le_softfloat", "foo"),
+			Name:   "bin/foo",
+			Path:   filepath.Join(folder, "dist", "linux_mips64le_softfloat", "bin", "foo"),
 			Goos:   "linux",
 			Goarch: "mips64le",
 			Gomips: "softfloat",
@@ -167,8 +167,8 @@ func TestBuild(t *testing.T) {
 			},
 		},
 		{
-			Name:   "foo",
-			Path:   filepath.Join(folder, "dist", "darwin_amd64", "foo"),
+			Name:   "bin/foo",
+			Path:   filepath.Join(folder, "dist", "darwin_amd64", "bin", "foo"),
 			Goos:   "darwin",
 			Goarch: "amd64",
 			Type:   artifact.Binary,
@@ -179,8 +179,8 @@ func TestBuild(t *testing.T) {
 			},
 		},
 		{
-			Name:   "foo",
-			Path:   filepath.Join(folder, "dist", "linux_arm_6", "foo"),
+			Name:   "bin/foo",
+			Path:   filepath.Join(folder, "dist", "linux_arm_6", "bin", "foo"),
 			Goos:   "linux",
 			Goarch: "arm",
 			Goarm:  "6",
@@ -192,8 +192,8 @@ func TestBuild(t *testing.T) {
 			},
 		},
 		{
-			Name:   "foo",
-			Path:   filepath.Join(folder, "dist", "windows_amd64", "foo"),
+			Name:   "bin/foo",
+			Path:   filepath.Join(folder, "dist", "windows_amd64", "bin", "foo"),
 			Goos:   "windows",
 			Goarch: "amd64",
 			Type:   artifact.Binary,
@@ -204,8 +204,8 @@ func TestBuild(t *testing.T) {
 			},
 		},
 		{
-			Name:   "foo",
-			Path:   filepath.Join(folder, "dist", "js_wasm", "foo"),
+			Name:   "bin/foo",
+			Path:   filepath.Join(folder, "dist", "js_wasm", "bin", "foo"),
 			Goos:   "js",
 			Goarch: "wasm",
 			Type:   artifact.Binary,

--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -118,6 +118,7 @@ func create(ctx *context.Context, archive config.Archive, binaries []*artifact.A
 	archivePath := filepath.Join(ctx.Config.Dist, folder+"."+format)
 	lock.Lock()
 	if err := os.MkdirAll(filepath.Dir(archivePath), 0755|os.ModeDir); err != nil {
+		lock.Unlock()
 		return err
 	}
 	if _, err = os.Stat(archivePath); !os.IsNotExist(err) {

--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -117,6 +117,9 @@ func create(ctx *context.Context, archive config.Archive, binaries []*artifact.A
 	}
 	archivePath := filepath.Join(ctx.Config.Dist, folder+"."+format)
 	lock.Lock()
+	if err := os.MkdirAll(filepath.Dir(archivePath), 0755|os.ModeDir); err != nil {
+		return err
+	}
 	if _, err = os.Stat(archivePath); !os.IsNotExist(err) {
 		lock.Unlock()
 		return fmt.Errorf("archive named %s already exists. Check your archive name template", archivePath)

--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -196,7 +196,7 @@ func binaries(a *artifact.Artifact) []string {
 	// nolint: prealloc
 	var bins []string
 	for _, b := range a.ExtraOr("Builds", []*artifact.Artifact{}).([]*artifact.Artifact) {
-		bins = append(bins, b.ExtraOr("Binary", "").(string)+".exe")
+		bins = append(bins, b.Name+".exe")
 	}
 	return bins
 }

--- a/internal/pipe/scoop/scoop_test.go
+++ b/internal/pipe/scoop/scoop_test.go
@@ -825,14 +825,10 @@ func Test_buildManifest(t *testing.T) {
 						"ArtifactUploadHash": "820ead5d9d2266c728dce6d4d55b6460",
 						"Builds": []*artifact.Artifact{
 							{
-								Extra: map[string]interface{}{
-									"Binary": "foo",
-								},
+								Name: "foo",
 							},
 							{
-								Extra: map[string]interface{}{
-									"Binary": "bar",
-								},
+								Name: "bar",
 							},
 						},
 					},
@@ -846,14 +842,10 @@ func Test_buildManifest(t *testing.T) {
 						"ArtifactUploadHash": "820ead5d9d2266c728dce6d4d55b6460",
 						"Builds": []*artifact.Artifact{
 							{
-								Extra: map[string]interface{}{
-									"Binary": "foo",
-								},
+								Name: "foo",
 							},
 							{
-								Extra: map[string]interface{}{
-									"Binary": "bar",
-								},
+								Name: "bar",
 							},
 						},
 					},


### PR DESCRIPTION
closes https://github.com/goreleaser/goreleaser/issues/1398

3 things:

1. make archive pipe work when `build.binary` is a path
2. `artifact.extra[binary]` should not have the path to the binary, just its name...
3. scoop pipe was using the `artifact.extra[binary]` field instead of just `artifact.name`