### PR TITLE
docs: a name key is required

### DIFF
--- a/www/content/upload.md
+++ b/www/content/upload.md
@@ -32,10 +32,11 @@ Prerequisites:
 
 The `target` is the template of the URL to upload the artifacts to (_without_ the name of the artifact).
 
-An example configuration for `goreleaser` in upload mode `binary` with the target can look like
+An example configuration for `goreleaser` in upload mode `binary` with the target can look like:
 
 ```yaml
-- mode: binary
+- name: production
+  mode: binary
   target: 'http://some.server/some/path/example-repo-local/{{ .ProjectName }}/{{ .Version }}/{{ .Os }}/{{ .Arch }}{{ if .Arm }}{{ .Arm }}{{ end }}'
 ```
 


### PR DESCRIPTION
Change the HTTP upload example to include the `name` key.

<!-- If applied, this commit will... -->

I banged my head on it for a while when trying to upload to Nexus using archive, then binary. Apparently it wants to use GET for some reasons.

<!-- Why is this change being made? -->

#1404

<!-- # Provide links to any relevant tickets, URLs or other resources -->