### PR TITLE
feat(pipe/build): Add support for flexible build hooks

### DIFF
--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -400,7 +400,7 @@ func TestRunPipeWithoutMainFunc(t *testing.T) {
 		Builds: []config.Build{
 			{
 				Binary: "no-main",
-				Hooks:  config.Hooks{},
+				Hooks:  config.HookConfig{},
 				Targets: []string{
 					runtimeTarget,
 				},
@@ -448,7 +448,7 @@ func TestRunPipeWithMainFuncNotInMainGoFile(t *testing.T) {
 			{
 				Env:    []string{"GO111MODULE=off"},
 				Binary: "foo",
-				Hooks:  config.Hooks{},
+				Hooks:  config.HookConfig{},
 				Targets: []string{
 					runtimeTarget,
 				},

--- a/internal/pipe/build/build.go
+++ b/internal/pipe/build/build.go
@@ -76,43 +76,84 @@ func buildWithDefaults(ctx *context.Context, build config.Build) config.Build {
 }
 
 func runPipeOnBuild(ctx *context.Context, build config.Build) error {
-	if err := runHook(ctx, build.Env, build.Hooks.Pre); err != nil {
-		return errors.Wrap(err, "pre hook failed")
-	}
 	var g = semerrgroup.New(ctx.Parallelism)
 	for _, target := range build.Targets {
 		target := target
 		build := build
 		g.Go(func() error {
-			return doBuild(ctx, build, target)
+			opts, err := buildOptionsForTarget(ctx, build, target)
+			if err != nil {
+				return err
+			}
+
+			if err := runHook(ctx, *opts, build.Env, build.Hooks.Pre); err != nil {
+				return errors.Wrap(err, "pre hook failed")
+			}
+			if err := doBuild(ctx, build, *opts); err != nil {
+				return err
+			}
+			if err := runHook(ctx, *opts, build.Env, build.Hooks.Post); err != nil {
+				return errors.Wrap(err, "post hook failed")
+			}
+			return nil
 		})
 	}
-	if err := g.Wait(); err != nil {
-		return err
-	}
-	return errors.Wrap(runHook(ctx, build.Env, build.Hooks.Post), "post hook failed")
+
+	return g.Wait()
 }
 
-func runHook(ctx *context.Context, env []string, hook string) error {
-	if hook == "" {
+func runHook(ctx *context.Context, opts builders.Options, buildEnv []string, hooks config.BuildHooks) error {
+	if len(hooks) == 0 {
 		return nil
 	}
-	sh, err := tmpl.New(ctx).WithEnvS(env).Apply(hook)
-	if err != nil {
-		return err
+
+	for _, hook := range hooks {
+		var env []string
+
+		env = append(env, ctx.Env.Strings()...)
+		env = append(env, buildEnv...)
+
+		for _, rawEnv := range hook.Env {
+			e, err := tmpl.New(ctx).WithBuildOptions(opts).Apply(rawEnv)
+			if err != nil {
+				return err
+			}
+			env = append(env, e)
+		}
+
+		dir, err := tmpl.New(ctx).WithBuildOptions(opts).Apply(hook.Dir)
+		if err != nil {
+			return err
+		}
+
+		sh, err := tmpl.New(ctx).WithBuildOptions(opts).
+			WithEnvS(env).
+			Apply(hook.Cmd)
+		if err != nil {
+			return err
+		}
+
+		log.WithField("hook", sh).Info("running hook")
+		cmd := strings.Fields(sh)
+
+		if err := run(ctx, dir, cmd, env); err != nil {
+			return err
+		}
 	}
-	log.WithField("hook", sh).Info("running hook")
-	cmd := strings.Fields(sh)
-	env = append(env, ctx.Env.Strings()...)
-	return run(ctx, cmd, env)
+
+	return nil
 }
 
-func doBuild(ctx *context.Context, build config.Build, target string) error {
+func doBuild(ctx *context.Context, build config.Build, opts builders.Options) error {
+	return builders.For(build.Lang).Build(ctx, build, opts)
+}
+
+func buildOptionsForTarget(ctx *context.Context, build config.Build, target string) (*builders.Options, error) {
 	var ext = extFor(target, build.Flags)
 
 	binary, err := tmpl.New(ctx).Apply(build.Binary)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	build.Binary = binary
@@ -125,15 +166,15 @@ func doBuild(ctx *context.Context, build config.Build, target string) error {
 		),
 	)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	log.WithField("binary", path).Info("building")
-	return builders.For(build.Lang).Build(ctx, build, builders.Options{
+	return &builders.Options{
 		Target: target,
 		Name:   name,
 		Path:   path,
 		Ext:    ext,
-	})
+	}, nil
 }
 
 func extFor(target string, flags config.FlagArray) string {
@@ -154,11 +195,14 @@ func extFor(target string, flags config.FlagArray) string {
 	return ""
 }
 
-func run(ctx *context.Context, command, env []string) error {
+func run(ctx *context.Context, dir string, command, env []string) error {
 	/* #nosec */
 	var cmd = exec.CommandContext(ctx, command[0], command[1:]...)
 	var log = log.WithField("env", env).WithField("cmd", command)
 	cmd.Env = env
+	if dir != "" {
+		cmd.Dir = dir
+	}
 	log.Debug("running")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		log.WithError(err).Debug("failed")

--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -3,11 +3,13 @@ package tmpl
 
 import (
 	"bytes"
+	"path/filepath"
 	"strings"
 	"text/template"
 	"time"
 
 	"github.com/goreleaser/goreleaser/internal/artifact"
+	"github.com/goreleaser/goreleaser/pkg/build"
 	"github.com/goreleaser/goreleaser/pkg/context"
 )
 
@@ -42,8 +44,15 @@ const (
 	mips         = "Mips"
 	binary       = "Binary"
 	artifactName = "ArtifactName"
+
 	// gitlab only
 	artifactUploadHash = "ArtifactUploadHash"
+
+	// build keys
+	name   = "Name"
+	ext    = "Ext"
+	path   = "Path"
+	target = "Target"
 )
 
 // New Template
@@ -114,6 +123,19 @@ func (t *Template) WithArtifact(a *artifact.Artifact, replacements map[string]st
 	return t
 }
 
+func (t *Template) WithBuildOptions(opts build.Options) *Template {
+	return t.WithExtraFields(buildOptsToFields(opts))
+}
+
+func buildOptsToFields(opts build.Options) Fields {
+	return Fields{
+		target: opts.Target,
+		ext:    opts.Ext,
+		name:   opts.Name,
+		path:   opts.Path,
+	}
+}
+
 // Apply applies the given string against the Fields stored in the template.
 func (t *Template) Apply(s string) (string, error) {
 	var out bytes.Buffer
@@ -127,6 +149,7 @@ func (t *Template) Apply(s string) (string, error) {
 			"tolower": strings.ToLower,
 			"toupper": strings.ToUpper,
 			"trim":    strings.TrimSpace,
+			"dir":     filepath.Dir,
 		}).
 		Parse(s)
 	if err != nil {

--- a/pkg/config/config_build_hook_test.go
+++ b/pkg/config/config_build_hook_test.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func TestBuildHook_justString(t *testing.T) {
+	var actual HookConfig
+
+	err := yaml.UnmarshalStrict([]byte(`pre: ./script.sh`), &actual)
+	assert.NoError(t, err)
+	assert.Equal(t, BuildHook{
+		Cmd: "./script.sh",
+		Env: nil,
+	}, actual.Pre[0])
+}
+
+func TestBuildHook_stringCmds(t *testing.T) {
+	var actual HookConfig
+
+	err := yaml.UnmarshalStrict([]byte(`pre:
+ - ./script.sh
+ - second-script.sh
+`), &actual)
+	assert.NoError(t, err)
+
+	assert.Equal(t, BuildHooks{
+		{
+			Cmd: "./script.sh",
+			Env: nil,
+		},
+		{
+			Cmd: "second-script.sh",
+			Env: nil,
+		},
+	}, actual.Pre)
+}
+
+func TestBuildHook_complex(t *testing.T) {
+	var actual HookConfig
+
+	err := yaml.UnmarshalStrict([]byte(`pre:
+ - cmd: ./script.sh
+   env:
+    - TEST=value
+`), &actual)
+	assert.NoError(t, err)
+	assert.Equal(t, BuildHook{
+		Cmd: "./script.sh",
+		Env: []string{"TEST=value"},
+	}, actual.Pre[0])
+}

--- a/www/content/templates.md
+++ b/www/content/templates.md
@@ -57,6 +57,7 @@ On all fields, you have these available functions:
 | `tolower "V1.2"`        | makes input string lowercase. See [ToLower](https://golang.org/pkg/strings/#ToLower)                     |
 | `toupper "v1.2"`        | makes input string uppercase. See [ToUpper](https://golang.org/pkg/strings/#ToUpper)                     |
 | `trim " v1.2  "`        | removes all leading and trailing white space. See [TrimSpace](https://golang.org/pkg/strings/#TrimSpace) |
+| `dir .Path`             | returns all but the last element of path, typically the path's directory. See [Dir](https://golang.org/pkg/path/filepath/#Dir)
 
 With all those fields, you may be able to compose the name of your artifacts
 pretty much the way you want:


### PR DESCRIPTION
This is an early prototype of a solution for #1328 to solicit early feedback.

### Usage

```yml
builds:
  -
    env:
      - CGO_ENABLED=0
    targets:
      - darwin_amd64
      - windows_386
      - windows_amd64
    after:
      all:
        hooks:
          - zip ./signable_binaries.zip {{ range .Builds }} {{ .Path }}{{ end }}
          - echo "Signing every eligible binary..."
          - cmd: ./codesign.sh
            env:
              - ZIP_FILE={{ .ProjectName }}_{{ .Version }}_{{ .Target }}.zip
      each:
        default_dir: "{{ .Path }}"
        hooks:
          - upx {{ .Name }}
```

--- 

I would be happy to add some tests, perhaps some more logging and docs if we agree on the rough direction.
