### PR TITLE
feat: use maximum compression for gzip and zip archives

### DIFF
--- a/pkg/archive/gzip/gzip.go
+++ b/pkg/archive/gzip/gzip.go
@@ -21,7 +21,7 @@ func (a Archive) Close() error {
 
 // New gz archive
 func New(target io.Writer) Archive {
-	gw := gzip.NewWriter(target)
+	gw, _ := gzip.NewWriterLevel(target, gzip.BestCompression)
 	return Archive{
 		gw: gw,
 	}

--- a/pkg/archive/gzip/gzip.go
+++ b/pkg/archive/gzip/gzip.go
@@ -21,6 +21,7 @@ func (a Archive) Close() error {
 
 // New gz archive
 func New(target io.Writer) Archive {
+	// the error will be nil since the compression level is valid
 	gw, _ := gzip.NewWriterLevel(target, gzip.BestCompression)
 	return Archive{
 		gw: gw,

--- a/pkg/archive/targz/targz.go
+++ b/pkg/archive/targz/targz.go
@@ -25,6 +25,7 @@ func (a Archive) Close() error {
 
 // New tar.gz archive
 func New(target io.Writer) Archive {
+	// the error will be nil since the compression level is valid
 	gw, _ := gzip.NewWriterLevel(target, gzip.BestCompression)
 	tw := tar.NewWriter(gw)
 	return Archive{

--- a/pkg/archive/targz/targz.go
+++ b/pkg/archive/targz/targz.go
@@ -25,7 +25,7 @@ func (a Archive) Close() error {
 
 // New tar.gz archive
 func New(target io.Writer) Archive {
-	gw := gzip.NewWriter(target)
+	gw, _ := gzip.NewWriterLevel(target, gzip.BestCompression)
 	tw := tar.NewWriter(gw)
 	return Archive{
 		gw: gw,

--- a/pkg/archive/zip/zip.go
+++ b/pkg/archive/zip/zip.go
@@ -4,6 +4,7 @@ package zip
 
 import (
 	"archive/zip"
+	"compress/flate"
 	"io"
 	"os"
 )
@@ -20,8 +21,12 @@ func (a Archive) Close() error {
 
 // New zip archive
 func New(target io.Writer) Archive {
+	compressor := zip.NewWriter(target)
+	compressor.RegisterCompressor(zip.Deflate, func(out io.Writer) (io.WriteCloser, error) {
+		return flate.NewWriter(out, flate.BestCompression)
+	})
 	return Archive{
-		z: zip.NewWriter(target),
+		z: compressor,
 	}
 }
 


### PR DESCRIPTION
I have read the CONTRIBUTING guide.

If applied, this commit will use maximum compression levels for gzip and zip archives instead of the default compression level.

This change will speed up uploading archive files created by goreleaser to GitHub and also consume less disk space.

