### PR TITLE
feat: build.skip option, support for library projects

### DIFF
--- a/internal/pipe/build/build.go
+++ b/internal/pipe/build/build.go
@@ -32,6 +32,10 @@ func (Pipe) String() string {
 // Run the pipe
 func (Pipe) Run(ctx *context.Context) error {
 	for _, build := range ctx.Config.Builds {
+		if build.Skip {
+			log.WithField("id", build.ID).Info("skip is set")
+			continue
+		}
 		log.WithField("build", build).Debug("building")
 		if err := runPipeOnBuild(ctx, build); err != nil {
 			return err

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -339,6 +339,23 @@ func TestDefaultFillSingleBuild(t *testing.T) {
 	assert.Equal(t, ctx.Config.Builds[0].Binary, "foo")
 }
 
+func TestSkipBuild(t *testing.T) {
+	folder, back := testlib.Mktmp(t)
+	defer back()
+	var config = config.Project{
+		Dist: folder,
+		Builds: []config.Build{
+			{
+				Skip: true,
+			},
+		},
+	}
+	var ctx = context.New(config)
+	ctx.Git.CurrentTag = "2.4.5"
+	assert.NoError(t, Pipe{}.Run(ctx))
+	assert.Len(t, ctx.Artifacts.List(), 0)
+}
+
 func TestExtWindows(t *testing.T) {
 	assert.Equal(t, ".exe", extFor("windows_amd64", config.FlagArray{}))
 	assert.Equal(t, ".exe", extFor("windows_386", config.FlagArray{}))

--- a/internal/pipe/checksums/checksums_test.go
+++ b/internal/pipe/checksums/checksums_test.go
@@ -131,6 +131,12 @@ func TestPipeCouldNotOpenChecksumsTxt(t *testing.T) {
 	assert.Contains(t, err.Error(), "/checksums.txt: permission denied")
 }
 
+func TestPipeWhenNoArtifacts(t *testing.T) {
+	var ctx = &context.Context{}
+	assert.NoError(t, Pipe{}.Run(ctx))
+	assert.Len(t, ctx.Artifacts.List(), 0)
+}
+
 func TestDefault(t *testing.T) {
 	var ctx = &context.Context{
 		Config: config.Project{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -156,6 +156,7 @@ type Build struct {
 	Lang     string         `yaml:",omitempty"`
 	Asmflags StringArray    `yaml:",omitempty"`
 	Gcflags  StringArray    `yaml:",omitempty"`
+	Skip     bool           `yaml:",omitempty"`
 }
 
 // FormatOverride is used to specify a custom format for a specific GOOS.

--- a/www/content/build.md
+++ b/www/content/build.md
@@ -111,6 +111,11 @@ builds:
     hooks:
       pre: rice embed-go
       post: ./script.sh
+
+    # If true, skip the build.
+    # Useful for library projects.
+    # Default is false
+    skip: false
 ```
 
 > Learn more about the [name template engine](/templates).


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->

This PR introduces the `skip` option to the build configuration. That is mainly relevant for a library project which would need the changelog generation and creating the release, but not the building step.

With this feature, also simple library projects can benefit from `goreleaser`. 

Configuration example for a library project:
```yaml
project_name: mylib-go
build:
  skip: true
release:
  github:
  prerelease: auto
```

<!-- # Provide links to any relevant tickets, URLs or other resources -->

Fixes #981 