### PR TITLE
fix: scoop binary names

### DIFF
--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -196,7 +196,7 @@ func binaries(a *artifact.Artifact) []string {
 	// nolint: prealloc
 	var bins []string
 	for _, b := range a.ExtraOr("Builds", []*artifact.Artifact{}).([]*artifact.Artifact) {
-		bins = append(bins, b.Name+".exe")
+		bins = append(bins, b.Name)
 	}
 	return bins
 }

--- a/internal/pipe/scoop/scoop_test.go
+++ b/internal/pipe/scoop/scoop_test.go
@@ -825,10 +825,10 @@ func Test_buildManifest(t *testing.T) {
 						"ArtifactUploadHash": "820ead5d9d2266c728dce6d4d55b6460",
 						"Builds": []*artifact.Artifact{
 							{
-								Name: "foo",
+								Name: "foo.exe",
 							},
 							{
-								Name: "bar",
+								Name: "bar.exe",
 							},
 						},
 					},
@@ -842,10 +842,10 @@ func Test_buildManifest(t *testing.T) {
 						"ArtifactUploadHash": "820ead5d9d2266c728dce6d4d55b6460",
 						"Builds": []*artifact.Artifact{
 							{
-								Name: "foo",
+								Name: "foo.exe",
 							},
 							{
-								Name: "bar",
+								Name: "bar.exe",
 							},
 						},
 					},


### PR DESCRIPTION
Since v1.30.X the scoop manifest `bin` field always ends with `exe.exe`.
Check out the official goreleaser scoop-bucket [commit](https://github.com/goreleaser/scoop-bucket/commit/e820896a5ef81374aa05e5e8c109b1542d659c89). 

The cause is [this](https://github.com/goreleaser/goreleaser/commit/fa608c302efac346ea198f193a5d284bafa63fce#diff-01ec4399097caf1adca54769f5d1e7c9R199) change. `Artifact.Name` already contains an extension.