### PR TITLE
feat(pipe/build): Report hook error in addition to stdout

### DIFF
--- a/internal/pipe/build/build.go
+++ b/internal/pipe/build/build.go
@@ -162,7 +162,7 @@ func run(ctx *context.Context, command, env []string) error {
 	log.Debug("running")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		log.WithError(err).Debug("failed")
-		return errors.New(string(out))
+		return errors.Wrapf(err, "%q", string(out))
 	}
 	return nil
 }

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -182,14 +182,14 @@ func TestRunPipeFailingHooks(t *testing.T) {
 		ctx.Git.CurrentTag = "2.3.4"
 		ctx.Config.Builds[0].Hooks.Pre = "exit 1"
 		ctx.Config.Builds[0].Hooks.Post = "echo post"
-		assert.EqualError(t, Pipe{}.Run(ctx), `pre hook failed: `)
+		assert.EqualError(t, Pipe{}.Run(ctx), `pre hook failed: "": exec: "exit": executable file not found in $PATH`)
 	})
 	t.Run("post-hook", func(t *testing.T) {
 		var ctx = context.New(config)
 		ctx.Git.CurrentTag = "2.3.4"
 		ctx.Config.Builds[0].Hooks.Pre = "echo pre"
 		ctx.Config.Builds[0].Hooks.Post = "exit 1"
-		assert.EqualError(t, Pipe{}.Run(ctx), `post hook failed: `)
+		assert.EqualError(t, Pipe{}.Run(ctx), `post hook failed: "": exec: "exit": executable file not found in $PATH`)
 	})
 }
 


### PR DESCRIPTION
This helps in situations where hook couldn't run at all, e.g. because of insufficient permissions.

Previously such failure would only be reported as empty stdout/stderr output - this allows exposure of the real root cause.

This PR is currently part of https://github.com/goreleaser/goreleaser/pull/1414 but I think the change is small enough in scope it could be merged separately and the PR can then be rebased.