### PR TITLE
fix: brew no token

### DIFF
--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -274,7 +274,6 @@ func dataFor(ctx *context.Context, cfg config.Homebrew, tokenType context.TokenT
 					ctx.Config.Release.GitLab.Name,
 				)
 			default:
-				log.WithField("type", tokenType).Info("here")
 				return result, ErrTokenTypeNotImplementedForBrew
 			}
 		}

--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -267,6 +267,7 @@ func dataFor(ctx *context.Context, cfg config.Homebrew, tokenType context.TokenT
 					ctx.Config.Release.GitLab.Name,
 				)
 			default:
+				log.Warn("no url_template set and not github/gitlab/gitea token found, defaulting to github url template")
 				cfg.URLTemplate = fmt.Sprintf(
 					"%s/%s/%s/releases/download/{{ .Tag }}/{{ .ArtifactName }}",
 					ctx.Config.GitHubURLs.Download,

--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -259,13 +259,6 @@ func dataFor(ctx *context.Context, cfg config.Homebrew, tokenType context.TokenT
 
 		if cfg.URLTemplate == "" {
 			switch tokenType {
-			case context.TokenTypeGitHub:
-				cfg.URLTemplate = fmt.Sprintf(
-					"%s/%s/%s/releases/download/{{ .Tag }}/{{ .ArtifactName }}",
-					ctx.Config.GitHubURLs.Download,
-					ctx.Config.Release.GitHub.Owner,
-					ctx.Config.Release.GitHub.Name,
-				)
 			case context.TokenTypeGitLab:
 				cfg.URLTemplate = fmt.Sprintf(
 					"%s/%s/%s/uploads/{{ .ArtifactUploadHash }}/{{ .ArtifactName }}",
@@ -274,7 +267,12 @@ func dataFor(ctx *context.Context, cfg config.Homebrew, tokenType context.TokenT
 					ctx.Config.Release.GitLab.Name,
 				)
 			default:
-				return result, ErrTokenTypeNotImplementedForBrew
+				cfg.URLTemplate = fmt.Sprintf(
+					"%s/%s/%s/releases/download/{{ .Tag }}/{{ .ArtifactName }}",
+					ctx.Config.GitHubURLs.Download,
+					ctx.Config.Release.GitHub.Owner,
+					ctx.Config.Release.GitHub.Name,
+				)
 			}
 		}
 		url, err := tmpl.New(ctx).WithArtifact(artifact, map[string]string{}).Apply(cfg.URLTemplate)

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -660,42 +660,6 @@ func TestRunPipeNoUpload(t *testing.T) {
 	})
 }
 
-func TestRunTokenTypeNotImplementedForBrew(t *testing.T) {
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	assert.NoError(t, err)
-	var ctx = context.New(config.Project{
-		Dist:        folder,
-		ProjectName: "foo",
-		Release:     config.Release{},
-		Brews: []config.Homebrew{
-			{
-				GitHub: config.Repo{
-					Owner: "test",
-					Name:  "test",
-				},
-			},
-		},
-	})
-	ctx.Git = context.GitInfo{CurrentTag: "v1.0.1"}
-	var path = filepath.Join(folder, "whatever.tar.gz")
-	_, err = os.Create(path)
-	assert.NoError(t, err)
-	ctx.Artifacts.Add(&artifact.Artifact{
-		Name:   "bin",
-		Path:   path,
-		Goos:   "darwin",
-		Goarch: "amd64",
-		Type:   artifact.UploadableArchive,
-		Extra: map[string]interface{}{
-			"ID":     "foo",
-			"Format": "tar.gz",
-		},
-	})
-	client := &DummyClient{}
-	require.Equal(t, ErrTokenTypeNotImplementedForBrew, Pipe{}.Run(ctx))
-	testlib.AssertSkipped(t, doPublish(ctx, client))
-}
-
 func TestDefault(t *testing.T) {
 	_, back := testlib.Mktmp(t)
 	defer back()


### PR DESCRIPTION
refs #1425

basically, we don't need to fail at that time if the token is not there... it will still fail on publish time if at that time there is none.

for now, while building the brew file, assume github unless a gitlab token is provided, this should prevent failures on snapshot mode when no token is available.