### PR TITLE
feat: improve check command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -97,7 +97,7 @@ scoop:
   description: Deliver Go binaries as fast and easily as possible
   license: MIT
 nfpms:
-  - name_template: '{{ .ProjectName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+  - file_name_template: '{{ .ProjectName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     homepage:  https://goreleaser.com
     description: Deliver Go binaries as fast and easily as possible
     maintainer: Carlos Alexandro Becker <root@carlosbecker.com>

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   - make setup
 script:
   - make ci
+  - ./goreleaser check
   - test -n "$TRAVIS_TAG" || ./goreleaser --snapshot --parallelism 2
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/internal/deprecate/deprecate.go
+++ b/internal/deprecate/deprecate.go
@@ -8,12 +8,14 @@ import (
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/cli"
 	"github.com/fatih/color"
+	"github.com/goreleaser/goreleaser/pkg/context"
 )
 
 const baseURL = "https://goreleaser.com/deprecations#"
 
 // Notice warns the user about the deprecation of the given property
-func Notice(property string) {
+func Notice(ctx *context.Context, property string) {
+	ctx.Deprecated = true
 	cli.Default.Padding += 3
 	defer func() {
 		cli.Default.Padding -= 3

--- a/internal/deprecate/deprecate_test.go
+++ b/internal/deprecate/deprecate_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/cli"
 	"github.com/fatih/color"
+	"github.com/goreleaser/goreleaser/pkg/config"
+	"github.com/goreleaser/goreleaser/pkg/context"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,8 +23,10 @@ func TestNotice(t *testing.T) {
 	log.SetHandler(cli.New(f))
 
 	log.Info("first")
-	Notice("foo.bar.whatever")
+	var ctx = context.New(config.Project{})
+	Notice(ctx, "foo.bar.whatever")
 	log.Info("last")
+	require.True(t, ctx.Deprecated)
 
 	require.NoError(t, f.Close())
 

--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -48,7 +48,7 @@ func (Pipe) Default(ctx *context.Context) error {
 			fpm.PackageName = ctx.Config.ProjectName
 		}
 		if fpm.NameTemplate != "" && fpm.FileNameTemplate == "" {
-			deprecate.Notice("nfpms.name_template")
+			deprecate.Notice(ctx, "nfpms.name_template")
 			fpm.FileNameTemplate = fpm.NameTemplate
 		}
 		if fpm.FileNameTemplate == "" {

--- a/internal/pipe/upload/upload.go
+++ b/internal/pipe/upload/upload.go
@@ -23,7 +23,7 @@ func (Pipe) String() string {
 // Default sets the pipe defaults
 func (Pipe) Default(ctx *context.Context) error {
 	if len(ctx.Config.Puts) > 0 {
-		deprecate.Notice("puts")
+		deprecate.Notice(ctx,"puts")
 		ctx.Config.Uploads = append(ctx.Config.Uploads, ctx.Config.Puts...)
 	}
 	return http.Defaults(ctx.Config.Uploads)

--- a/internal/pipe/upload/upload.go
+++ b/internal/pipe/upload/upload.go
@@ -23,7 +23,7 @@ func (Pipe) String() string {
 // Default sets the pipe defaults
 func (Pipe) Default(ctx *context.Context) error {
 	if len(ctx.Config.Puts) > 0 {
-		deprecate.Notice(ctx,"puts")
+		deprecate.Notice(ctx, "puts")
 		ctx.Config.Uploads = append(ctx.Config.Uploads, ctx.Config.Puts...)
 	}
 	return http.Defaults(ctx.Config.Uploads)

--- a/main_test.go
+++ b/main_test.go
@@ -22,13 +22,15 @@ func init() {
 func TestReleaseProject(t *testing.T) {
 	_, back := setup(t)
 	defer back()
-	assert.NoError(t, releaseProject(testParams()))
+	_, err := releaseProject(testParams())
+	assert.NoError(t, err)
 }
 
 func TestCheckConfig(t *testing.T) {
 	_, back := setup(t)
 	defer back()
-	assert.NoError(t, checkConfig(testParams().Config))
+	_, err := checkConfig(testParams().Config)
+	assert.NoError(t, err)
 }
 
 func TestCheckConfigFails(t *testing.T) {
@@ -36,7 +38,8 @@ func TestCheckConfigFails(t *testing.T) {
 	defer back()
 	var filename = "fail.yaml"
 	assert.NoError(t, ioutil.WriteFile(filename, []byte("nope: 1"), 0644))
-	assert.Error(t, checkConfig(filename))
+	_, err := checkConfig(filename)
+	assert.NoError(t, err)
 }
 
 func TestReleaseProjectSkipPublish(t *testing.T) {
@@ -45,7 +48,8 @@ func TestReleaseProjectSkipPublish(t *testing.T) {
 	params := testParams()
 	params.Snapshot = true
 	params.SkipPublish = true
-	assert.NoError(t, releaseProject(params))
+	_, err := releaseProject(params)
+	assert.NoError(t, err)
 }
 
 func TestConfigFileIsSetAndDontExist(t *testing.T) {
@@ -53,7 +57,8 @@ func TestConfigFileIsSetAndDontExist(t *testing.T) {
 	defer back()
 	params := testParams()
 	params.Config = "/this/wont/exist"
-	assert.Error(t, releaseProject(params))
+	_, err := releaseProject(params)
+	assert.NoError(t, err)
 }
 
 func TestConfigFlagNotSetButExists(t *testing.T) {
@@ -93,7 +98,8 @@ func TestReleaseNotesFileDontExist(t *testing.T) {
 	defer back()
 	params := testParams()
 	params.ReleaseNotes = "/this/also/wont/exist"
-	assert.Error(t, releaseProject(params))
+	_, err := releaseProject(params)
+	assert.NoError(t, err)
 }
 
 func TestCustomReleaseNotesFile(t *testing.T) {
@@ -104,7 +110,8 @@ func TestCustomReleaseNotesFile(t *testing.T) {
 	createFile(t, releaseNotes.Name(), "nothing important at all")
 	var params = testParams()
 	params.ReleaseNotes = releaseNotes.Name()
-	assert.NoError(t, releaseProject(params))
+	_, err := releaseProject(params)
+	assert.NoError(t, err)
 }
 
 func TestCustomReleaseHeaderFileDontExist(t *testing.T) {
@@ -113,7 +120,8 @@ func TestCustomReleaseHeaderFileDontExist(t *testing.T) {
 	params := testParams()
 	params.ReleaseHeader = "/header/that/dont/exist"
 	params.Snapshot = false
-	assert.Error(t, releaseProject(params))
+	_, err := releaseProject(params)
+	assert.NoError(t, err)
 }
 
 func TestCustomReleaseHeaderFile(t *testing.T) {
@@ -126,7 +134,8 @@ func TestCustomReleaseHeaderFile(t *testing.T) {
 	params.ReleaseHeader = releaseHeader.Name()
 	params.Snapshot = false
 	params.SkipPublish = true
-	assert.NoError(t, releaseProject(params))
+	_, err := releaseProject(params)
+	assert.NoError(t, err)
 }
 
 func TestCustomReleaseFooterFileDontExist(t *testing.T) {
@@ -135,7 +144,8 @@ func TestCustomReleaseFooterFileDontExist(t *testing.T) {
 	params := testParams()
 	params.ReleaseFooter = "/footer/that/dont/exist"
 	params.Snapshot = false
-	assert.Error(t, releaseProject(params))
+	_, err := releaseProject(params)
+	assert.NoError(t, err)
 }
 
 func TestCustomReleaseFooterFile(t *testing.T) {
@@ -148,14 +158,16 @@ func TestCustomReleaseFooterFile(t *testing.T) {
 	params.ReleaseFooter = releaseFooter.Name()
 	params.Snapshot = false
 	params.SkipPublish = true
-	assert.NoError(t, releaseProject(params))
+	_, err := releaseProject(params)
+	assert.NoError(t, err)
 }
 
 func TestBrokenPipe(t *testing.T) {
 	_, back := setup(t)
 	defer back()
 	createFile(t, "main.go", "not a valid go file")
-	assert.Error(t, releaseProject(testParams()))
+	_, err := releaseProject(testParams())
+	assert.NoError(t, err)
 }
 
 func TestInitProject(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -39,7 +39,7 @@ func TestCheckConfigFails(t *testing.T) {
 	var filename = "fail.yaml"
 	assert.NoError(t, ioutil.WriteFile(filename, []byte("nope: 1"), 0644))
 	_, err := checkConfig(filename)
-	assert.NoError(t, err)
+	assert.Error(t, err)
 }
 
 func TestReleaseProjectSkipPublish(t *testing.T) {
@@ -58,7 +58,7 @@ func TestConfigFileIsSetAndDontExist(t *testing.T) {
 	params := testParams()
 	params.Config = "/this/wont/exist"
 	_, err := releaseProject(params)
-	assert.NoError(t, err)
+	assert.Error(t, err)
 }
 
 func TestConfigFlagNotSetButExists(t *testing.T) {
@@ -99,7 +99,7 @@ func TestReleaseNotesFileDontExist(t *testing.T) {
 	params := testParams()
 	params.ReleaseNotes = "/this/also/wont/exist"
 	_, err := releaseProject(params)
-	assert.NoError(t, err)
+	assert.Error(t, err)
 }
 
 func TestCustomReleaseNotesFile(t *testing.T) {
@@ -121,7 +121,7 @@ func TestCustomReleaseHeaderFileDontExist(t *testing.T) {
 	params.ReleaseHeader = "/header/that/dont/exist"
 	params.Snapshot = false
 	_, err := releaseProject(params)
-	assert.NoError(t, err)
+	assert.Error(t, err)
 }
 
 func TestCustomReleaseHeaderFile(t *testing.T) {
@@ -145,7 +145,7 @@ func TestCustomReleaseFooterFileDontExist(t *testing.T) {
 	params.ReleaseFooter = "/footer/that/dont/exist"
 	params.Snapshot = false
 	_, err := releaseProject(params)
-	assert.NoError(t, err)
+	assert.Error(t, err)
 }
 
 func TestCustomReleaseFooterFile(t *testing.T) {
@@ -167,7 +167,7 @@ func TestBrokenPipe(t *testing.T) {
 	defer back()
 	createFile(t, "main.go", "not a valid go file")
 	_, err := releaseProject(testParams())
-	assert.NoError(t, err)
+	assert.Error(t, err)
 }
 
 func TestInitProject(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -110,7 +110,7 @@ func TestCustomReleaseNotesFile(t *testing.T) {
 	createFile(t, releaseNotes.Name(), "nothing important at all")
 	var params = testParams()
 	params.ReleaseNotes = releaseNotes.Name()
-	_, err := releaseProject(params)
+	_, err = releaseProject(params)
 	assert.NoError(t, err)
 }
 
@@ -134,7 +134,7 @@ func TestCustomReleaseHeaderFile(t *testing.T) {
 	params.ReleaseHeader = releaseHeader.Name()
 	params.Snapshot = false
 	params.SkipPublish = true
-	_, err := releaseProject(params)
+	_, err = releaseProject(params)
 	assert.NoError(t, err)
 }
 
@@ -158,7 +158,7 @@ func TestCustomReleaseFooterFile(t *testing.T) {
 	params.ReleaseFooter = releaseFooter.Name()
 	params.Snapshot = false
 	params.SkipPublish = true
-	_, err := releaseProject(params)
+	_, err = releaseProject(params)
 	assert.NoError(t, err)
 }
 
@@ -181,8 +181,7 @@ func TestInitProject(t *testing.T) {
 	out, err := ioutil.ReadAll(file)
 	assert.NoError(t, err)
 
-	var config = config.Project{}
-	assert.NoError(t, yaml.Unmarshal(out, &config))
+	assert.NoError(t, yaml.Unmarshal(out, &config.Project{}))
 }
 
 func TestInitProjectFileExist(t *testing.T) {

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -78,9 +78,9 @@ type Context struct {
 	SkipValidate  bool
 	RmDist        bool
 	PreRelease    bool
+	Deprecated    bool
 	Parallelism   int
 	Semver        Semver
-	Deprecated    bool
 }
 
 // Semver represents a semantic version

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -80,6 +80,7 @@ type Context struct {
 	PreRelease    bool
 	Parallelism   int
 	Semver        Semver
+	Deprecated    bool
 }
 
 // Semver represents a semantic version

--- a/www/content/ci.md
+++ b/www/content/ci.md
@@ -18,15 +18,19 @@ You may want to setup your project to auto-deploy your new tags on
 # .travis.yml
 language: go
 
+# needed only if you use the snap pipe:
 addons:
   apt:
     packages:
-    # needed only if you use the snap pipe:
     - snapcraft
 
-# needed for the docker pipe
+# needed only if you use the docker pipe
 services:
 - docker
+
+script:
+  - go test ./... # replace this with your test script
+  - curl -sfL https://git.io/goreleaser | sh -s -- check # check goreleaser config for deprecations
 
 after_success:
 # docker login is required if you want to push docker images.


### PR DESCRIPTION
- instruct to run `goreleaser check` on CI
- actually fail if deprecated properties are being used
- warn in the end of a release as well if deprecated properties are being used

closes https://github.com/goreleaser/goreleaser/issues/1289