### PR TITLE
feat: remove deprecated nfpm options and puts

### DIFF
--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/goreleaser/goreleaser/internal/artifact"
-	"github.com/goreleaser/goreleaser/internal/deprecate"
 	"github.com/goreleaser/goreleaser/internal/ids"
 	"github.com/goreleaser/goreleaser/internal/linux"
 	"github.com/goreleaser/goreleaser/internal/pipe"
@@ -46,10 +45,6 @@ func (Pipe) Default(ctx *context.Context) error {
 		}
 		if fpm.PackageName == "" {
 			fpm.PackageName = ctx.Config.ProjectName
-		}
-		if fpm.NameTemplate != "" && fpm.FileNameTemplate == "" {
-			deprecate.Notice(ctx, "nfpms.name_template")
-			fpm.FileNameTemplate = fpm.NameTemplate
 		}
 		if fpm.FileNameTemplate == "" {
 			fpm.FileNameTemplate = defaultNameTemplate

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -327,11 +327,11 @@ func TestOverrides(t *testing.T) {
 				{
 					Bindir: "/bin",
 					NFPMOverridables: config.NFPMOverridables{
-						NameTemplate: "foo",
+						FileNameTemplate: "foo",
 					},
 					Overrides: map[string]config.NFPMOverridables{
 						"deb": {
-							NameTemplate: "bar",
+							FileNameTemplate: "bar",
 						},
 					},
 				},
@@ -342,9 +342,9 @@ func TestOverrides(t *testing.T) {
 	merged, err := mergeOverrides(ctx.Config.NFPMs[0], "deb")
 	require.NoError(t, err)
 	require.Equal(t, "/bin", ctx.Config.NFPMs[0].Bindir)
-	require.Equal(t, "foo", ctx.Config.NFPMs[0].NameTemplate)
-	require.Equal(t, "bar", ctx.Config.NFPMs[0].Overrides["deb"].NameTemplate)
-	require.Equal(t, "bar", merged.NameTemplate)
+	require.Equal(t, "foo", ctx.Config.NFPMs[0].FileNameTemplate)
+	require.Equal(t, "bar", ctx.Config.NFPMs[0].Overrides["deb"].FileNameTemplate)
+	require.Equal(t, "bar", merged.FileNameTemplate)
 }
 
 func TestSeveralNFPMsWithTheSameID(t *testing.T) {

--- a/internal/pipe/upload/upload.go
+++ b/internal/pipe/upload/upload.go
@@ -4,8 +4,6 @@ package upload
 import (
 	h "net/http"
 
-	"github.com/goreleaser/goreleaser/internal/deprecate"
-
 	"github.com/goreleaser/goreleaser/internal/http"
 	"github.com/goreleaser/goreleaser/internal/pipe"
 	"github.com/goreleaser/goreleaser/pkg/context"
@@ -22,10 +20,6 @@ func (Pipe) String() string {
 
 // Default sets the pipe defaults
 func (Pipe) Default(ctx *context.Context) error {
-	if len(ctx.Config.Puts) > 0 {
-		deprecate.Notice(ctx, "puts")
-		ctx.Config.Uploads = append(ctx.Config.Uploads, ctx.Config.Puts...)
-	}
 	return http.Defaults(ctx.Config.Uploads)
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -271,7 +271,6 @@ type NFPMScripts struct {
 type NFPMOverridables struct {
 	FileNameTemplate string            `yaml:"file_name_template,omitempty"`
 	PackageName      string            `yaml:"package_name,omitempty"`
-	NameTemplate     string            `yaml:"name_template,omitempty"` // deprecated
 	Epoch            string            `yaml:"epoch,omitempty"`
 	Release          string            `yaml:"release,omitempty"`
 	Replacements     map[string]string `yaml:",omitempty"`
@@ -422,7 +421,6 @@ type Project struct {
 	Dockers       []Docker    `yaml:",omitempty"`
 	Artifactories []Upload    `yaml:",omitempty"`
 	Uploads       []Upload    `yaml:",omitempty"`
-	Puts          []Upload    `yaml:",omitempty"` // TODO: remove this
 	Blobs         []Blob      `yaml:"blobs,omitempty"`
 	Changelog     Changelog   `yaml:",omitempty"`
 	Dist          string      `yaml:",omitempty"`

--- a/www/content/deprecations.md
+++ b/www/content/deprecations.md
@@ -39,10 +39,13 @@ to this:
 
 -->
 
+## Expired deprecation notices
+
+The following options were deprecated for ~6 months and are now fully removed.
 
 ### puts
 
-> since 2019-11-15
+> since 2019-11-15, removed 2020-04-14 (v0.132.0)
 
 The HTTP upload support was extended to also accept `POST` as a method,
 so the name `puts` kind of lost its meaning.
@@ -66,7 +69,7 @@ Also note that secrets environment variable name prefixes have changed from
 
 ### nfpms.name_template
 
-> since 2019-11-15
+> since 2019-11-15, removed 2020-04-14 (v0.132.0)
 
 The `name_template` field was deprecated in favor of a more clear one,
 `file_name_template`.
@@ -85,13 +88,9 @@ nfpms:
   - file_name_template: foo
 ```
 
-## Expired deprecation notices
-
-The following options were deprecated for ~6 months and are now fully removed.
-
 ### blob
 
-> since 2019-08-02, removed 2020-03-22
+> since 2019-08-02, removed 2020-03-22 (v0.130.0)
 
 Blob was deprecated in favor of its plural form.
 It was already accepting multiple inputs, but its pluralized now so its more
@@ -113,7 +112,7 @@ blobs:
 
 ### sign
 
-> since 2019-07-20, removed 2020-03-22
+> since 2019-07-20, removed 2020-03-22 (v0.130.0)
 
 Sign was deprecated in favor of its plural form.
 
@@ -134,7 +133,7 @@ signs:
 
 ### brew
 
-> since 2019-06-09, removed 2020-01-26
+> since 2019-06-09, removed 2020-01-26 (v0.125.0)
 
 Brew was deprecated in favor of its plural form.
 
@@ -155,7 +154,7 @@ brews:
 
 ### s3
 
-> since 2019-06-09, removed 2020-01-07
+> since 2019-06-09, removed 2020-01-07 (v0.125.0)
 
 S3 was deprecated in favor of the new `blob`, which supports S3, Azure Blob and
 GCS.
@@ -181,7 +180,7 @@ ACLs should be set on the bucket, the `acl` option does not exist anymore.
 
 ### archive
 
-> since 2019-04-16, removed 2019-12-27
+> since 2019-04-16, removed 2019-12-27 (v0.124.0)
 
 We now allow multiple archives, so the `archive` statement will be removed.
 
@@ -202,7 +201,7 @@ archives:
 
 ### snapcraft
 
-> since 2019-05-27, removed 2019-12-27
+> since 2019-05-27, removed 2019-12-27 (v0.124.0)
 
 We now allow multiple Snapcraft configs, so the `snapcraft` statement will be removed.
 
@@ -225,7 +224,7 @@ snapcrafts:
 
 ### nfpm
 
-> since 2019-05-07, removed 2019-12-27
+> since 2019-05-07, removed 2019-12-27 (v0.124.0)
 
 We now allow multiple NFPM config, so the `nfpm` statement will be removed.
 
@@ -248,7 +247,7 @@ nfpms:
 
 ### docker.binary
 
-> since 2018-10-01, removed 2019-08-02
+> since 2018-10-01, removed 2019-08-02 (v0.114.0)
 
 You can now create a Docker image with multiple binaries.
 
@@ -271,7 +270,7 @@ dockers:
 
 ### docker.image
 
-> since 2018-10-20, removed 2019-08-02
+> since 2018-10-20, removed 2019-08-02 (v0.114.0)
 
 This property was deprecated in favor of more flexible `image_templates`.
 The idea is to be able to define several images and tags using templates instead of just one image with tag templates.
@@ -296,7 +295,7 @@ dockers:
 
 ### docker.tag_templates
 
-> since 2018-10-20, removed 2019-08-02
+> since 2018-10-20, removed 2019-08-02 (v0.114.0)
 
 This property was deprecated in favor of more flexible `image_templates`.
 The idea is to be able to define several images and tags using templates instead of just one image with tag templates.
@@ -320,7 +319,7 @@ dockers:
 
 ### git.short_hash
 
-> since 2018-10-03, removed 2019-01-19
+> since 2018-10-03, removed 2019-01-19 (v0.98.0)
 
 This property was being used to tell GoReleaser to use short git hashes
 instead of the full ones. This has been removed in favor of specific
@@ -345,7 +344,7 @@ fake:
 
 ### fpm
 
-> since 2018-02-17, removed 2017-08-15
+> since 2018-02-17, removed 2017-08-15 (v0.83.0)
 
 FPM is deprecated in favor of nfpm, which is a simpler alternative written
 in Go. The objective is to remove the ruby dependency thus simplify the
@@ -369,7 +368,7 @@ nfpm:
 
 ### docker.tag_template
 
-> since 2018-01-19, removed 2017-08-15
+> since 2018-01-19, removed 2017-08-15 (v0.83.0)
 
 This property was deprecated in favor of the pluralized `tag_templates`.
 The idea is to be able to define several tags instead of just one.
@@ -393,7 +392,7 @@ dockers:
 
 ### docker.latest
 
-> since 2018-01-19, removed 2017-08-15
+> since 2018-01-19, removed 2017-08-15 (v0.83.0)
 
 The `latest` field in Docker config is deprecated in favor of the newer
 `tag_templates` field.


### PR DESCRIPTION
- removed the deprecated `puts` pipe from config (replaced with `uploads`)
- removed the deprecated `nfpm.file_name_template` option in favor of `nfpms.file_name_template`
- updated deprecations page, also adding the versions in which something was removed