### PR TITLE
fix: snap package apps with multiple binaries

### DIFF
--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -228,12 +228,14 @@ func create(ctx *context.Context, snap config.Snapcraft, arch string, binaries [
 		// setup the apps: directive for each binary
 		for name, config := range snap.Apps {
 			log.WithField("path", binary.Path).
-				WithField("name", binary.Name).
+				WithField("name", name).
 				Debug("passed binary to snapcraft")
 
+			// TODO: test that the correct binary is used in Command
+			// See https://github.com/goreleaser/goreleaser/pull/1449
 			appMetadata := AppMetadata{
 				Command: strings.TrimSpace(strings.Join([]string{
-					binary.Name,
+					name,
 					config.Args,
 				}, " ")),
 				Plugs:  config.Plugs,


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

This is a proposal fix for #1448. Fixes the issue for us, and relevant tests pass. This should probably be tested as well, but I cannot add a relevant unit test.

Given that the tests pass, it should not break existing behaviour either. Yet, if you think a more elaborate solution is required, feel free to close this.

<!-- If applied, this commit will... -->

Change snap app metadata command generation, using app name instead of binary name.

<!-- Why is this change being made? -->

Snap packages with multiple apps are not built correctly.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

Closes #1448