### PR TITLE
fix: correct the spelling of "snapshotting"

### DIFF
--- a/internal/pipe/snapshot/snapshot.go
+++ b/internal/pipe/snapshot/snapshot.go
@@ -1,4 +1,4 @@
-// Package snapshot provides the snapshoting functionality to goreleaser.
+// Package snapshot provides the snapshotting functionality to goreleaser.
 package snapshot
 
 import (
@@ -14,7 +14,7 @@ import (
 type Pipe struct{}
 
 func (Pipe) String() string {
-	return "snapshoting"
+	return "snapshotting"
 }
 
 // Default sets the pipe defaults


### PR DESCRIPTION
Small and relatively insignificant change, but the correct spelling is
with two "t's"


<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->

<!-- # Provide links to any relevant tickets, URLs or other resources -->