### PR TITLE
fix: scoop wrap_in_directory

### DIFF
--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -170,9 +170,10 @@ func create(ctx *context.Context, archive config.Archive, binaries []*artifact.A
 		Goarm:  binaries[0].Goarm,
 		Gomips: binaries[0].Gomips,
 		Extra: map[string]interface{}{
-			"Builds": binaries,
-			"ID":     archive.ID,
-			"Format": archive.Format,
+			"Builds":    binaries,
+			"ID":        archive.ID,
+			"Format":    archive.Format,
+			"WrappedIn": wrap,
 		},
 	})
 	return nil

--- a/internal/pipe/archive/archive_test.go
+++ b/internal/pipe/archive/archive_test.go
@@ -494,6 +494,10 @@ func TestRunPipeWrap(t *testing.T) {
 	})
 	require.NoError(t, Pipe{}.Run(ctx))
 
+	var archives = ctx.Artifacts.Filter(artifact.ByType(artifact.UploadableArchive)).List()
+	require.Len(t, archives, 1)
+	require.Equal(t, "foo_macOS", archives[0].ExtraOr("WrappedIn", ""))
+
 	// Check archive contents
 	f, err := os.Open(filepath.Join(dist, "foo.tar.gz"))
 	require.NoError(t, err)
@@ -648,11 +652,12 @@ func TestBinaryOverride(t *testing.T) {
 			darwin := archives.Filter(artifact.ByGoos("darwin")).List()[0]
 			require.Equal(tt, "foobar_0.0.1_darwin_amd64."+format, darwin.Name)
 			require.Equal(tt, format, darwin.ExtraOr("Format", ""))
+			require.Empty(tt, darwin.ExtraOr("WrappedIn", ""))
 
 			archives = ctx.Artifacts.Filter(artifact.ByType(artifact.UploadableBinary))
 			windows := archives.Filter(artifact.ByGoos("windows")).List()[0]
 			require.Equal(tt, "foobar_0.0.1_windows_amd64.exe", windows.Name)
-			require.Equal(tt, format, windows.ExtraOr("Format", ""))
+			require.Empty(tt, windows.ExtraOr("WrappedIn", ""))
 		})
 	}
 }

--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/goreleaser/goreleaser/internal/artifact"
@@ -196,8 +197,9 @@ func buildManifest(ctx *context.Context, artifacts []*artifact.Artifact) (bytes.
 func binaries(a *artifact.Artifact) []string {
 	// nolint: prealloc
 	var bins []string
+	var wrap = a.ExtraOr("WrappedIn", "").(string)
 	for _, b := range a.ExtraOr("Builds", []*artifact.Artifact{}).([]*artifact.Artifact) {
-		bins = append(bins, b.Name)
+		bins = append(bins, filepath.Join(wrap, b.Name))
 	}
 	return bins
 }

--- a/internal/pipe/scoop/testdata/test_buildmanifest_wrap.json.golden
+++ b/internal/pipe/scoop/testdata/test_buildmanifest_wrap.json.golden
@@ -1,0 +1,19 @@
+{
+    "version": "1.0.1",
+    "architecture": {
+        "64bit": {
+            "url": "http://gitlab.mycompany.com/foo/bar/uploads/820ead5d9d2266c728dce6d4d55b6460/foo_1.0.1_windows_amd64.tar.gz",
+            "bin": [
+                "foo_1.0.1_windows_amd64/foo.exe",
+                "foo_1.0.1_windows_amd64/bar.exe"
+            ],
+            "hash": "5e2bf57d3f40c4b6df69daf1936cb766f832374b4fc0259a7cbff06e2f70f269"
+        }
+    },
+    "homepage": "https://gitlab.com/goreleaser",
+    "description": "A run pipe test formula",
+    "persist": [
+        "data.cfg",
+        "etc"
+    ]
+}


### PR DESCRIPTION
takes into account `wrap_in_directory` when building the scoop manifest.

closes #1447