### PR TITLE
fix: brew gitlab url templating

### DIFF
--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -280,6 +280,12 @@ func dataFor(ctx *context.Context, cfg config.Homebrew, tokenType context.TokenT
 		if err != nil {
 			return result, err
 		}
+		log.WithFields(log.Fields{
+			"artifact":         artifact,
+			"fromURLTemplate":  cfg.URLTemplate,
+			"templatedBrewURL": url,
+			"sum":              sum,
+		}).Debug("extracted file hash")
 		var down = downloadable{
 			DownloadURL: url,
 			SHA256:      sum,

--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -281,11 +281,11 @@ func dataFor(ctx *context.Context, cfg config.Homebrew, tokenType context.TokenT
 			return result, err
 		}
 		log.WithFields(log.Fields{
-			"artifact":         artifact,
+			"artifactExtras":   artifact.Extra,
 			"fromURLTemplate":  cfg.URLTemplate,
 			"templatedBrewURL": url,
 			"sum":              sum,
-		}).Debug("extracted file hash")
+		}).Debug("brew url templating")
 		var down = downloadable{
 			DownloadURL: url,
 			SHA256:      sum,

--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/apex/log"
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/internal/client"
 	"github.com/goreleaser/goreleaser/internal/pipe"
@@ -178,6 +179,12 @@ func buildManifest(ctx *context.Context, artifacts []*artifact.Artifact) (bytes.
 		if err != nil {
 			return result, err
 		}
+		log.WithFields(log.Fields{
+			"artifactExtras":   artifact.Extra,
+			"fromURLTemplate":  ctx.Config.Scoop.URLTemplate,
+			"templatedBrewURL": url,
+			"sum":              sum,
+		}).Debug("scoop url templating")
 
 		manifest.Architecture[arch] = Resource{
 			URL:  url,


### PR DESCRIPTION
### If applied, this commit will...
Fix #1463 and template the gitlab URL correctly

### Why is this change being made?
To fix broken formulas like https://gitlab.com/mavogel/scoop-bucket/-/commit/0689e8a54ec22a903d9b41b82d46b28aac017b9c

### Provide links to any relevant tickets, URLs or other resources
Issue #1463
