### PR TITLE
feat(scoop): provide config option to change commit message

### DIFF
--- a/internal/pipe/scoop/scoop_test.go
+++ b/internal/pipe/scoop/scoop_test.go
@@ -57,6 +57,7 @@ func TestDefault(t *testing.T) {
 	assert.Equal(t, ctx.Config.ProjectName, ctx.Config.Scoop.Name)
 	assert.NotEmpty(t, ctx.Config.Scoop.CommitAuthor.Name)
 	assert.NotEmpty(t, ctx.Config.Scoop.CommitAuthor.Email)
+	assert.NotEmpty(t, ctx.Config.Scoop.CommitMessageTemplate)
 }
 
 func Test_doRun(t *testing.T) {
@@ -736,6 +737,7 @@ func Test_doRun(t *testing.T) {
 				ctx.Artifacts.Add(a)
 			}
 			require.NoError(t, Pipe{}.Default(ctx))
+
 			tt.assertError(t, doRun(ctx, tt.args.client))
 		})
 	}
@@ -819,10 +821,11 @@ func Test_buildManifest(t *testing.T) {
 							Owner: "test",
 							Name:  "test",
 						},
-						Description: "A run pipe test formula",
-						Homepage:    "https://github.com/goreleaser",
-						URLTemplate: "http://github.mycompany.com/foo/bar/{{ .Tag }}/{{ .ArtifactName }}",
-						Persist:     []string{"data.cfg", "etc"},
+						Description:           "A run pipe test formula",
+						Homepage:              "https://github.com/goreleaser",
+						URLTemplate:           "http://github.mycompany.com/foo/bar/{{ .Tag }}/{{ .ArtifactName }}",
+						CommitMessageTemplate: "chore(scoop): update {{ .ProjectName }} version {{ .Tag }}",
+						Persist:               []string{"data.cfg", "etc"},
 					},
 				},
 			},
@@ -859,10 +862,11 @@ func Test_buildManifest(t *testing.T) {
 							Owner: "test",
 							Name:  "test",
 						},
-						Description: "A run pipe test formula",
-						Homepage:    "https://gitlab.com/goreleaser",
-						URLTemplate: "http://gitlab.mycompany.com/foo/bar/uploads/{{ .ArtifactUploadHash }}/{{ .ArtifactName }}",
-						Persist:     []string{"data.cfg", "etc"},
+						Description:           "A run pipe test formula",
+						Homepage:              "https://gitlab.com/goreleaser",
+						URLTemplate:           "http://gitlab.mycompany.com/foo/bar/uploads/{{ .ArtifactUploadHash }}/{{ .ArtifactName }}",
+						CommitMessageTemplate: "chore(scoop): update {{ .ProjectName }} version {{ .Tag }}",
+						Persist:               []string{"data.cfg", "etc"},
 					},
 				},
 			},
@@ -958,10 +962,11 @@ func TestWrapInDirectory(t *testing.T) {
 					Owner: "test",
 					Name:  "test",
 				},
-				Description: "A run pipe test formula",
-				Homepage:    "https://gitlab.com/goreleaser",
-				URLTemplate: "http://gitlab.mycompany.com/foo/bar/uploads/{{ .ArtifactUploadHash }}/{{ .ArtifactName }}",
-				Persist:     []string{"data.cfg", "etc"},
+				Description:           "A run pipe test formula",
+				Homepage:              "https://gitlab.com/goreleaser",
+				URLTemplate:           "http://gitlab.mycompany.com/foo/bar/uploads/{{ .ArtifactUploadHash }}/{{ .ArtifactName }}",
+				CommitMessageTemplate: "chore(scoop): update {{ .ProjectName }} version {{ .Tag }}",
+				Persist:               []string{"data.cfg", "etc"},
 			},
 		},
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -73,15 +73,16 @@ type Homebrew struct {
 
 // Scoop contains the scoop.sh section
 type Scoop struct {
-	Name         string       `yaml:",omitempty"`
-	Bucket       Repo         `yaml:",omitempty"`
-	CommitAuthor CommitAuthor `yaml:"commit_author,omitempty"`
-	Homepage     string       `yaml:",omitempty"`
-	Description  string       `yaml:",omitempty"`
-	License      string       `yaml:",omitempty"`
-	URLTemplate  string       `yaml:"url_template,omitempty"`
-	Persist      []string     `yaml:"persist,omitempty"`
-	SkipUpload   string       `yaml:"skip_upload,omitempty"`
+	Name                  string       `yaml:",omitempty"`
+	Bucket                Repo         `yaml:",omitempty"`
+	CommitAuthor          CommitAuthor `yaml:"commit_author,omitempty"`
+	CommitMessageTemplate string       `yaml:"commit_msg_template,omitempty"`
+	Homepage              string       `yaml:",omitempty"`
+	Description           string       `yaml:",omitempty"`
+	License               string       `yaml:",omitempty"`
+	URLTemplate           string       `yaml:"url_template,omitempty"`
+	Persist               []string     `yaml:"persist,omitempty"`
+	SkipUpload            string       `yaml:"skip_upload,omitempty"`
 }
 
 // CommitAuthor is the author of a Git commit

--- a/www/content/scoop.md
+++ b/www/content/scoop.md
@@ -31,6 +31,9 @@ scoop:
     name: goreleaserbot
     email: goreleaser@carlosbecker.com
 
+  # The project name and current git tag are used in the format string.
+  commit_msg_template: "Scoop update for {{ .ProjectName }} version {{ .Tag }}"
+
   # Your app's homepage.
   # Default is empty.
   homepage: "https://example.com/"


### PR DESCRIPTION
Without this change, users unable to control the resulting commit message of the
scoop update.  In some environments this may present an issue with commit
linters that require a specific commit message format in order to build proper
change logs and make decisions.  Here we include a Scoop config option to use a
format string provided by the user during the commit.

resolves: https://github.com/goreleaser/goreleaser/issues/1468