### PR TITLE
feat: Add Windows ARM64 support

### DIFF
--- a/internal/builders/golang/targets.go
+++ b/internal/builders/golang/targets.go
@@ -150,4 +150,5 @@ var validTargets = []string{
 	"solarisamd64",
 	"windows386",
 	"windowsamd64",
+	"windowsarm64",
 }

--- a/internal/builders/golang/targets_test.go
+++ b/internal/builders/golang/targets_test.go
@@ -122,12 +122,12 @@ func TestGoosGoarchCombos(t *testing.T) {
 		{"solaris", "amd64", true},
 		{"windows", "386", true},
 		{"windows", "amd64", true},
+		{"windows", "arm64", true},
 		{"js", "wasm", true},
 		// invalid targets
 		{"darwin", "arm", false},
 		{"darwin", "arm64", false},
 		{"windows", "arm", false},
-		{"windows", "arm64", false},
 	}
 	for _, p := range platforms {
 		t.Run(fmt.Sprintf("%v %v valid=%v", p.os, p.arch, p.valid), func(t *testing.T) {


### PR DESCRIPTION
<!-- If applied, this commit will... -->
This will add Windows ARM64 to the valid target list.

<!-- Why is this change being made? -->
Laptops exist running [Windows on ARM64](https://www.microsoft.com/en-us/surface/business/surface-pro-x/processor).

