### PR TITLE
feat: allow to template signs.args

### DIFF
--- a/internal/pipe/sign/sign_test.go
+++ b/internal/pipe/sign/sign_test.go
@@ -102,6 +102,24 @@ func TestSignArtifacts(t *testing.T) {
 			),
 		},
 		{
+			desc:           "invalid args template",
+			expectedErrMsg: `sign failed: ${FOO}-{{ .foo }{{}}{: invalid template: template: tmpl:1: unexpected "}" in operand`,
+			ctx: context.New(
+				config.Project{
+					Signs: []config.Sign{
+						{
+							Artifacts: "all",
+							Cmd:       "exit",
+							Args:      []string{"${FOO}-{{ .foo }{{}}{"},
+						},
+					},
+					Env: []string{
+						"FOO=BAR",
+					},
+				},
+			),
+		},
+		{
 			desc: "sign single",
 			ctx: context.New(
 				config.Project{
@@ -220,6 +238,31 @@ func TestSignArtifacts(t *testing.T) {
 					},
 					Env: []string{
 						fmt.Sprintf("TEST_USER=%s", user),
+					},
+				},
+			),
+			signaturePaths: []string{"artifact1.sig", "artifact2.sig", "artifact3.sig", "checksum.sig", "checksum2.sig", "linux_amd64/artifact4.sig"},
+			signatureNames: []string{"artifact1.sig", "artifact2.sig", "artifact3_1.0.0_linux_amd64.sig", "checksum.sig", "checksum2.sig", "artifact4_1.0.0_linux_amd64.sig"},
+		},
+		{
+			desc: "sign all artifacts with template",
+			ctx: context.New(
+				config.Project{
+					Signs: []config.Sign{
+						{
+							Artifacts: "all",
+							Args: []string{
+								"-u",
+								"{{ .Env.SOME_TEST_USER }}",
+								"--output",
+								"${signature}",
+								"--detach-sign",
+								"${artifact}",
+							},
+						},
+					},
+					Env: []string{
+						fmt.Sprintf("SOME_TEST_USER=%s", user),
 					},
 				},
 			),

--- a/www/content/sign.md
+++ b/www/content/sign.md
@@ -47,13 +47,13 @@ signs:
     # defaults to `gpg`
     cmd: gpg2
 
-    # command line arguments for the command
+    # command line templateable arguments for the command
     #
     # to sign with a specific key use
     # args: ["-u", "<key id, fingerprint, email, ...>", "--output", "${signature}", "--detach-sign", "${artifact}"]
     #
     # defaults to `["--output", "${signature}", "--detach-sign", "${artifact}"]`
-    args: ["--output", "${signature}", "${artifact}"]
+    args: ["--output", "${signature}", "${artifact}", "{{ .ProjectName }}"]
 
 
     # which artifacts to sign


### PR DESCRIPTION
allow to use templates in `signs.args`