### PR TITLE
feat: run hooks as last step in the release pipeline

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -4,6 +4,7 @@ package pipeline
 import (
 	"fmt"
 
+	"github.com/goreleaser/goreleaser/internal/pipe/after"
 	"github.com/goreleaser/goreleaser/internal/pipe/semver"
 	"github.com/goreleaser/goreleaser/internal/pipe/sourcearchive"
 
@@ -61,4 +62,5 @@ var Pipeline = append(
 	sign.Pipe{},          // sign artifacts
 	docker.Pipe{},        // create and push docker images
 	publish.Pipe{},       // publishes artifacts
+	after.Pipe{},         // run global hooks as last step before ending a release
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -372,6 +372,11 @@ type Before struct {
 	Hooks []string `yaml:",omitempty"`
 }
 
+// After config
+type After struct {
+	Hooks []string `yaml:",omitempty"`
+}
+
 // Blob contains config for GO CDK blob
 type Blob struct {
 	Bucket     string   `yaml:",omitempty"`
@@ -440,6 +445,7 @@ type Project struct {
 	Signs         []Sign      `yaml:",omitempty"`
 	EnvFiles      EnvFiles    `yaml:"env_files,omitempty"`
 	Before        Before      `yaml:",omitempty"`
+	After         After       `yaml:",omitempty"`
 	Source        Source      `yaml:",omitempty"`
 
 	// this is a hack ¯\_(ツ)_/¯


### PR DESCRIPTION
Hello, my goreleaser friends!

!!! I would like to make this PR better (will explain what I mean
later), it is here to gather feedback about the feature itself.

I asked about running some custom code at the end of the release cycle
on Gopher Slack today.

I would like to manipulate the manifest for a bunch of Docker
images I create during the release life cycle.

My build generates docker images for multiple architectures
and in order to teach the registry about that, you are supposed to
generate or updated a manifest.

You have to do it when the images are pushed to the registry.

It looks like a custom publisher won't work because it runs before
the docker one.

This PR proposes the same approach we use for the `before` feature, but
it runs at the end of the release workflow, as the last step.

---

As I said, I just copy-pasted and hooked a bunch of code. If this has
sense, I think I would like to write a pipe called `HookRunner` in order to reuse
it for Before and After.

---

- [ ] Add documentation
- [ ] Add tests
