### PR TITLE
fix(ci): htmltest failing checks

### DIFF
--- a/www/htmltest.yml
+++ b/www/htmltest.yml
@@ -3,6 +3,7 @@ IgnoreURLs:
 - www.google-analytics.com
 - fonts.gstatic.com
 - opencollective.com
+- https://gitlab.com/profile/personal_access_tokens
 IgnoreDirs:
 - overrides
 IgnoreDirectoryMissingTrailingSlash: true


### PR DESCRIPTION
this always fails with 503 because it requires auth... ignore it.