### PR TITLE
fix: cgo docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ RUN apk add --no-cache bash \
                        curl \
                        docker-cli \
                        git \
-                       mercurial \
-                       rpm
+                       mercurial
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD [ "-h" ]

--- a/Dockerfile.cgo
+++ b/Dockerfile.cgo
@@ -7,7 +7,7 @@ RUN apk add --no-cache bash \
                        docker-cli \
                        git \
                        mercurial \
-                       rpm
+                       build-base
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD [ "-h" ]


### PR DESCRIPTION
closes https://github.com/goreleaser/goreleaser/issues/1526

also removes `rpm` which is not required anymore.