### PR TITLE
fix: include go as a dependency of the brew tap

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -89,6 +89,8 @@ brews:
     description: Deliver Go binaries as fast and easily as possible
     test: |
       system "#{bin}/goreleaser -v"
+    dependencies:
+    - go
 scoop:
   bucket:
     owner: goreleaser


### PR DESCRIPTION
closes https://github.com/goreleaser/goreleaser/discussions/1484