### PR TITLE
fix: include golang as a dependency of deb/rpms

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -108,6 +108,7 @@ nfpms:
     - rpm
     dependencies:
     - git
+    - golang
 snapcrafts:
   - name_template: '{{ .ProjectName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     summary: Deliver Go binaries as fast and easily as possible

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -108,7 +108,7 @@ nfpms:
     - rpm
     dependencies:
     - git
-    recommend:
+    recommends:
     - golang
 snapcrafts:
   - name_template: '{{ .ProjectName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -108,6 +108,7 @@ nfpms:
     - rpm
     dependencies:
     - git
+    recommend:
     - golang
 snapcrafts:
   - name_template: '{{ .ProjectName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'


### PR DESCRIPTION
having in mind #1542, maybe we should add `golang` as a dependency of the rpm and deb packages as well?

tested on both ubuntu and fedora (latests) and it works, although by default ubuntu install golang 1.10 and fedora golang 1.13 (but I think if any other package provides `golang` it will work as well).

what are your thoughts on this?