### PR TITLE
fix(ci): Fix invalid cross-device link

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
       -
         name: Prepare
         run: |
+          sudo df -h
+          sudo mount
           mkdir -p $TMPDIR
       -
         name: Unshallow

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
       - 'v*'
   pull_request:
 
+env:
+  TMPDIR: /home/runner/.tmp
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -15,6 +18,10 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v2
+      -
+        name: Prepare
+        run: |
+          mkdir -p $TMPDIR
       -
         name: Unshallow
         run: git fetch --prune --unshallow

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,10 @@ jobs:
       -
         name: Prepare
         run: |
-          mkdir -p $TMPDIR
+          # TODO: Workaround for invalid cross-device link
+          # https://github.com/goreleaser/goreleaser/pull/1545
+          sudo mkdir -p $TMPDIR
+          sudo chown $(id -u):$(id -g) $TMPDIR
       -
         name: Unshallow
         run: git fetch --prune --unshallow

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       -
         name: Prepare
         run: |
-          # TODO: Workaround for invalid cross-device link
+          # FIXME: Workaround for invalid cross-device link
           # https://github.com/goreleaser/goreleaser/pull/1545
           mkdir -p $TMPDIR
       -

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 env:
-  TMPDIR: /home/runner/.tmp
+  TMPDIR: /mnt/.tmp
 
 jobs:
   goreleaser:
@@ -21,8 +21,6 @@ jobs:
       -
         name: Prepare
         run: |
-          sudo df -h
-          sudo mount
           mkdir -p $TMPDIR
       -
         name: Unshallow

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 env:
-  TMPDIR: /mnt/.tmp
+  TMPDIR: /home/runner/work/.tmp
 
 jobs:
   goreleaser:
@@ -23,8 +23,7 @@ jobs:
         run: |
           # TODO: Workaround for invalid cross-device link
           # https://github.com/goreleaser/goreleaser/pull/1545
-          sudo mkdir -p $TMPDIR
-          sudo chown $(id -u):$(id -g) $TMPDIR
+          mkdir -p $TMPDIR
       -
         name: Unshallow
         run: git fetch --prune --unshallow

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 env:
-  TMPDIR: /home/runner/work/.tmp
+  TMPDIR: /home/runner/work/_temp/tmp
 
 jobs:
   goreleaser:


### PR DESCRIPTION
```
--- FAIL: TestRunPipe/multiple_images_with_same_extra_file (0.05s)
        docker_test.go:73: 
            	Error Trace:	docker_test.go:73
            	            				docker_test.go:619
            	Error:      	Received unexpected error:
            	            	link testdata/Dockerfile /tmp/dockertest722218777/dist/goreleaserdocker676008868/Dockerfile: invalid cross-device link
            	            	failed to link dockerfile
            	            	github.com/goreleaser/goreleaser/internal/pipe/docker.process
```
> https://github.com/goreleaser/goreleaser/runs/698224308#step:8:40

Since virtual environment `ubuntu-18.04` (20200518.1), `/home/runner/work` is on another partition `/dev/sdb1`, so rename or link returns this kind of error.

To workaround this, override `TMPDIR` env var with `/home/runner/work/_temp/tmp`

```
$ df -h
Filesystem      Size  Used Avail Use% Mounted on
udev            3.4G     0  3.4G   0% /dev
tmpfs           693M  960K  692M   1% /run
/dev/sda1        84G   66G   18G  80% /
tmpfs           3.4G  8.0K  3.4G   1% /dev/shm
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs           3.4G     0  3.4G   0% /sys/fs/cgroup
/dev/loop0       40M   40M     0 100% /snap/hub/43
/dev/loop1       94M   94M     0 100% /snap/core/9066
/dev/sda15      105M  3.6M  101M   4% /boot/efi
/dev/sdb1        14G   48M   13G   1% /mnt

$ mount
sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime)
proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
udev on /dev type devtmpfs (rw,nosuid,relatime,size=3528460k,nr_inodes=882115,mode=755)
devpts on /dev/pts type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000)
tmpfs on /run type tmpfs (rw,nosuid,noexec,relatime,size=709352k,mode=755)
/dev/sda1 on / type ext4 (rw,relatime,discard)
securityfs on /sys/kernel/security type securityfs (rw,nosuid,nodev,noexec,relatime)
tmpfs on /dev/shm type tmpfs (rw,nosuid,nodev)
tmpfs on /run/lock type tmpfs (rw,nosuid,nodev,noexec,relatime,size=5120k)
tmpfs on /sys/fs/cgroup type tmpfs (ro,nosuid,nodev,noexec,mode=755)
cgroup on /sys/fs/cgroup/unified type cgroup2 (rw,nosuid,nodev,noexec,relatime)
cgroup on /sys/fs/cgroup/systemd type cgroup (rw,nosuid,nodev,noexec,relatime,xattr,name=systemd)
pstore on /sys/fs/pstore type pstore (rw,nosuid,nodev,noexec,relatime)
cgroup on /sys/fs/cgroup/cpu,cpuacct type cgroup (rw,nosuid,nodev,noexec,relatime,cpu,cpuacct)
cgroup on /sys/fs/cgroup/memory type cgroup (rw,nosuid,nodev,noexec,relatime,memory)
cgroup on /sys/fs/cgroup/rdma type cgroup (rw,nosuid,nodev,noexec,relatime,rdma)
cgroup on /sys/fs/cgroup/devices type cgroup (rw,nosuid,nodev,noexec,relatime,devices)
cgroup on /sys/fs/cgroup/net_cls,net_prio type cgroup (rw,nosuid,nodev,noexec,relatime,net_cls,net_prio)
cgroup on /sys/fs/cgroup/blkio type cgroup (rw,nosuid,nodev,noexec,relatime,blkio)
cgroup on /sys/fs/cgroup/freezer type cgroup (rw,nosuid,nodev,noexec,relatime,freezer)
cgroup on /sys/fs/cgroup/hugetlb type cgroup (rw,nosuid,nodev,noexec,relatime,hugetlb)
cgroup on /sys/fs/cgroup/pids type cgroup (rw,nosuid,nodev,noexec,relatime,pids)
cgroup on /sys/fs/cgroup/perf_event type cgroup (rw,nosuid,nodev,noexec,relatime,perf_event)
cgroup on /sys/fs/cgroup/cpuset type cgroup (rw,nosuid,nodev,noexec,relatime,cpuset)
systemd-1 on /proc/sys/fs/binfmt_misc type autofs (rw,relatime,fd=25,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=24677)
mqueue on /dev/mqueue type mqueue (rw,relatime)
hugetlbfs on /dev/hugepages type hugetlbfs (rw,relatime,pagesize=2M)
debugfs on /sys/kernel/debug type debugfs (rw,relatime)
/var/lib/snapd/snaps/hub_43.snap on /snap/hub/43 type squashfs (ro,nodev,relatime,x-gdu.hide)
/var/lib/snapd/snaps/core_9066.snap on /snap/core/9066 type squashfs (ro,nodev,relatime,x-gdu.hide)
configfs on /sys/kernel/config type configfs (rw,relatime)
fusectl on /sys/fs/fuse/connections type fusectl (rw,relatime)
/dev/sda15 on /boot/efi type vfat (rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro,discard)
binfmt_misc on /proc/sys/fs/binfmt_misc type binfmt_misc (rw,relatime)
/dev/sdb1 on /mnt type ext4 (rw,relatime,x-systemd.requires=cloud-init.service)
lxcfs on /var/lib/lxcfs type fuse.lxcfs (rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other)
/dev/sdb1 on /home/runner/work type ext4 (rw,relatime)
```

See also actions/virtual-environments#922