### PR TITLE
chore(deps): bump code.gitea.io/sdk/gitea from v0.11.3 to v0.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/goreleaser/goreleaser
 go 1.14
 
 require (
-	code.gitea.io/sdk/gitea v0.11.3
+	code.gitea.io/sdk/gitea v0.12.0
 	github.com/Masterminds/semver/v3 v3.1.0
 	github.com/apex/log v1.1.4
 	github.com/aws/aws-sdk-go v1.25.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6A
 cloud.google.com/go v0.44.3 h1:0sMegbmn/8uTwpNkB0q9cLEpZ2W5a6kl+wtBQgPWBJQ=
 cloud.google.com/go v0.44.3/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
-code.gitea.io/sdk/gitea v0.11.3 h1:CdI3J82Mqn0mElyEKa5DUSr3Wi2R+qm/6uVtCkSSqSM=
-code.gitea.io/sdk/gitea v0.11.3/go.mod h1:z3uwDV/b9Ls47NGukYM9XhnHtqPh/J+t40lsUrR6JDY=
+code.gitea.io/sdk/gitea v0.12.0 h1:hvDCz4wtFvo7rf5Ebj8tGd4aJ4wLPKX3BKFX9Dk1Pgs=
+code.gitea.io/sdk/gitea v0.12.0/go.mod h1:z3uwDV/b9Ls47NGukYM9XhnHtqPh/J+t40lsUrR6JDY=
 contrib.go.opencensus.io/exporter/aws v0.0.0-20181029163544-2befc13012d0/go.mod h1:uu1P0UCM/6RbsMrgPa98ll8ZcHM858i/AD06a9aLRCA=
 contrib.go.opencensus.io/exporter/ocagent v0.5.0 h1:TKXjQSRS0/cCDrP7KvkgU6SmILtF/yV2TOs/02K/WZQ=
 contrib.go.opencensus.io/exporter/ocagent v0.5.0/go.mod h1:ImxhfLRpxoYiSq891pBrLVhN+qmP8BTVvdH2YLs7Gl0=

--- a/internal/client/gitea.go
+++ b/internal/client/gitea.go
@@ -91,7 +91,7 @@ func (c *giteaClient) createRelease(ctx *context.Context, title, body string) (*
 }
 
 func (c *giteaClient) getExistingRelease(owner, repoName, tagName string) (*gitea.Release, error) {
-	releases, err := c.client.ListReleases(owner, repoName)
+	releases, err := c.client.ListReleases(owner, repoName, gitea.ListReleasesOptions{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Migrate gitea client sdk

for more info look at https://gitea.com/gitea/go-sdk/src/branch/master/docs/migrate-v0.11-to-v0.12.md
and for the changelog at https://gitea.com/gitea/go-sdk/releases