### PR TITLE
feat: Expose semver for snapshots

### DIFF
--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -3,6 +3,7 @@ package tmpl
 
 import (
 	"bytes"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -25,6 +26,7 @@ const (
 	// general keys
 	projectName = "ProjectName"
 	version     = "Version"
+	rawVersion  = "RawVersion"
 	tag         = "Tag"
 	commit      = "Commit"
 	shortCommit = "ShortCommit"
@@ -33,6 +35,8 @@ const (
 	major       = "Major"
 	minor       = "Minor"
 	patch       = "Patch"
+	prerelease  = "Prerelease"
+	isSnapshot  = "IsSnapshot"
 	env         = "Env"
 	date        = "Date"
 	timestamp   = "Timestamp"
@@ -58,10 +62,14 @@ const (
 
 // New Template
 func New(ctx *context.Context) *Template {
+	sv := ctx.Semver
+	rawVersionV := fmt.Sprintf("%d.%d.%d", sv.Major, sv.Minor, sv.Patch)
+
 	return &Template{
 		fields: Fields{
 			projectName: ctx.Config.ProjectName,
 			version:     ctx.Version,
+			rawVersion:  rawVersionV,
 			tag:         ctx.Git.CurrentTag,
 			commit:      ctx.Git.Commit,
 			shortCommit: ctx.Git.ShortCommit,
@@ -73,7 +81,8 @@ func New(ctx *context.Context) *Template {
 			major:       ctx.Semver.Major,
 			minor:       ctx.Semver.Minor,
 			patch:       ctx.Semver.Patch,
-			// TODO: no reason not to add prerelease here too I guess
+			prerelease:  ctx.Semver.Prerelease,
+			isSnapshot:  ctx.Snapshot,
 		},
 	}
 }

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -90,6 +90,7 @@ type Semver struct {
 	Major      uint64
 	Minor      uint64
 	Patch      uint64
+	RawVersion string
 	Prerelease string
 }
 

--- a/www/docs/customization/templates.md
+++ b/www/docs/customization/templates.md
@@ -10,21 +10,24 @@ templating is available.
 
 On fields that support templating, this fields are always available:
 
-|      Key       |                   Description                    |
-| :------------: | :----------------------------------------------: |
-| `.ProjectName` |                 the project name                 |
-|   `.Version`   | the version being released (`v` prefix stripped) |
-|     `.Tag`     |               the current git tag                |
-| `.ShortCommit` |            the git commit short hash             |
-| `.FullCommit`  |            the git commit full hash              |
-|   `.Commit`    |       the git commit hash (deprecated)           |
-|   `.GitURL`    |               the git remote url                 |
-|    `.Major`    |          the major part of the version           |
-|    `.Minor`    |          the minor part of the version           |
-|    `.Patch`    |          the patch part of the version           |
-|     `.Env`     |    a map with system's environment variables     |
-|    `.Date`     |        current UTC date in RFC3339 format        |
-|  `.Timestamp`  |         current UTC time in Unix format          |
+|       Key      |                                                          Description                                                         |
+|:--------------:|:----------------------------------------------------------------------------------------------------------------------------:|
+| `.ProjectName` |                                                       the project name                                                       |
+|   `.Version`   | the version being released (`v` prefix stripped),<br>or `{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}` in case of snapshot release |
+|     `.Tag`     |                                                      the current git tag                                                     |
+| `.ShortCommit` |                                                   the git commit short hash                                                  |
+|  `.FullCommit` |                                                   the git commit full hash                                                   |
+|    `.Commit`   |                                               the git commit hash (deprecated)                                               |
+|    `.GitURL`   |                                                      the git remote url                                                      |
+|    `.Major`    |                          the major part of the version (assuming `Tag` is a valid semver, else `0`)                          |
+|    `.Minor`    |                          the minor part of the version (assuming `Tag` is a valid semver, else `0`)                          |
+|    `.Patch`    |                          the patch part of the version (assuming `Tag` is a valid semver, else `0`)                          |
+|  `.Prerelease` |                      the prerelease part of the version, e.g. `beta` (assuming `Tag` is a valid semver)                      |
+|  `.RawVersion` |                              Major.Minor.Patch (assuming `Tag` is a valid semver, else `0.0.0`)                              |
+|  `.IsSnapshot` |                                   `true` if a snapshot is being released, `false` otherwise                                  |
+|     `.Env`     |                                           a map with system's environment variables                                          |
+|     `.Date`    |                                              current UTC date in RFC3339 format                                              |
+|  `.Timestamp`  |                                                current UTC time in Unix format                                               |
 
 On fields that are related to a single artifact (e.g., the binary name), you
 may have some extra fields:


### PR DESCRIPTION
Closes #1549 

--- 

I formatted the table via https://www.tablesgenerator.com/markdown_tables but I wish it was a bit easier to modify these tables manually without having to use any external tools/services.

We could make it easier by using the default left-side text-aligning, which I think would be also easier to read when rendered. That's something to discuss in a separate PR, where we could sweep all the tables at once and discuss whether it's a good idea.