### PR TITLE
fix: Brew versioned formulae now supported

### DIFF
--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -309,5 +309,6 @@ func split(s string) []string {
 func formulaNameFor(name string) string {
 	name = strings.Replace(name, "-", " ", -1)
 	name = strings.Replace(name, "_", " ", -1)
+	name = strings.Replace(name, "@", "AT", -1)
 	return strings.Replace(strings.Title(name), " ", "", -1)
 }

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -29,6 +29,10 @@ func TestNameWithUnderline(t *testing.T) {
 	assert.Equal(t, formulaNameFor("some_binary"), "SomeBinary")
 }
 
+func TestNameWithAT(t *testing.T) {
+	assert.Equal(t, formulaNameFor("some_binary@1"), "SomeBinaryAT1")
+}
+
 func TestSimpleName(t *testing.T) {
 	assert.Equal(t, formulaNameFor("binary"), "Binary")
 }


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->
Will replace `@` for `AT` in brew formulae name.

<!-- Why is this change being made? -->
Allow for Brew versioned releases (eg: foo@1). See how [awscli](https://github.com/Homebrew/homebrew-core/blob/master/Formula/awscli.rb#L1) and [awscli@1](https://github.com/Homebrew/homebrew-core/blob/master/Formula/awscli%401.rb#L1) do it.

<!-- # Provide links to any relevant tickets, URLs or other resources -->
- Fixes https://github.com/goreleaser/goreleaser/issues/1537
- https://github.com/Homebrew/homebrew-core/blob/master/Formula/awscli.rb#L1
- https://github.com/Homebrew/homebrew-core/blob/master/Formula/awscli%401.rb#L1
