### PR TITLE
docs: Format markdown tables

### DIFF
--- a/www/docs/ci/actions.md
+++ b/www/docs/ci/actions.md
@@ -115,11 +115,11 @@ signs:
 
 Following inputs can be used as `step.with` keys
 
-| Name          | Type    | Default   | Description                               |
-|---------------|---------|-----------|-------------------------------------------|
-| `version`     | String  | `latest`  | GoReleaser version. Example: `v0.117.0`   |
-| `args`        | String  |           | Arguments to pass to GoReleaser           |
-| `workdir`     | String  | `.`       | Working directory (below repository root) |
+| Name      | Type   | Default  | Description                               |
+|-----------|--------|----------|-------------------------------------------|
+| `version` | String | `latest` | GoReleaser version. Example: `v0.117.0`   |
+| `args`    | String |          | Arguments to pass to GoReleaser           |
+| `workdir` | String | `.`      | Working directory (below repository root) |
 
 ### environment variables
 

--- a/www/docs/customization/build.md
+++ b/www/docs/customization/build.md
@@ -182,12 +182,12 @@ All properties of a hook (`cmd`, `dir` and `env`) support [templating](/customiz
 with `post` hooks having binary artifact available (as these run _after_ the build).
 Additionally the following build details are exposed to both `pre` and `post` hooks:
 
-|       Key       |              Description               |
-| :-------------: | :------------------------------------: |
-|      .Name      | Filename of the binary, e.g. `bin.exe` |
-|      .Ext       | Extension, e.g. `.exe`                 |
-|      .Path      | Absolute path to the binary            |
-|     .Target     | Build target, e.g. `darwin_amd64`      |
+| Key     | Description                            |
+|---------|----------------------------------------|
+| .Name   | Filename of the binary, e.g. `bin.exe` |
+| .Ext    | Extension, e.g. `.exe`                 |
+| .Path   | Absolute path to the binary            |
+| .Target | Build target, e.g. `darwin_amd64`      |
 
 Environment variables are inherited and overridden in the following order:
 

--- a/www/docs/customization/templates.md
+++ b/www/docs/customization/templates.md
@@ -10,56 +10,56 @@ templating is available.
 
 On fields that support templating, this fields are always available:
 
-|       Key      |                                                          Description                                                         |
-|:--------------:|:----------------------------------------------------------------------------------------------------------------------------:|
-| `.ProjectName` |                                                       the project name                                                       |
-|   `.Version`   | the version being released (`v` prefix stripped),<br>or `{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}` in case of snapshot release |
-|     `.Tag`     |                                                      the current git tag                                                     |
-| `.ShortCommit` |                                                   the git commit short hash                                                  |
-|  `.FullCommit` |                                                   the git commit full hash                                                   |
-|    `.Commit`   |                                               the git commit hash (deprecated)                                               |
-|    `.GitURL`   |                                                      the git remote url                                                      |
-|    `.Major`    |                          the major part of the version (assuming `Tag` is a valid semver, else `0`)                          |
-|    `.Minor`    |                          the minor part of the version (assuming `Tag` is a valid semver, else `0`)                          |
-|    `.Patch`    |                          the patch part of the version (assuming `Tag` is a valid semver, else `0`)                          |
-|  `.Prerelease` |                      the prerelease part of the version, e.g. `beta` (assuming `Tag` is a valid semver)                      |
-|  `.RawVersion` |                              Major.Minor.Patch (assuming `Tag` is a valid semver, else `0.0.0`)                              |
-|  `.IsSnapshot` |                                   `true` if a snapshot is being released, `false` otherwise                                  |
-|     `.Env`     |                                           a map with system's environment variables                                          |
-|     `.Date`    |                                              current UTC date in RFC3339 format                                              |
-|  `.Timestamp`  |                                                current UTC time in Unix format                                               |
+| Key            | Description                                                                                                                  |
+|----------------|------------------------------------------------------------------------------------------------------------------------------|
+| `.ProjectName` | the project name                                                                                                             |
+| `.Version`     | the version being released (`v` prefix stripped),<br>or `{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}` in case of snapshot release |
+| `.Tag`         | the current git tag                                                                                                          |
+| `.ShortCommit` | the git commit short hash                                                                                                    |
+| `.FullCommit`  | the git commit full hash                                                                                                     |
+| `.Commit`      | the git commit hash (deprecated)                                                                                             |
+| `.GitURL`      | the git remote url                                                                                                           |
+| `.Major`       | the major part of the version (assuming `Tag` is a valid semver, else `0`)                                                   |
+| `.Minor`       | the minor part of the version (assuming `Tag` is a valid semver, else `0`)                                                   |
+| `.Patch`       | the patch part of the version (assuming `Tag` is a valid semver, else `0`)                                                   |
+| `.Prerelease`  | the prerelease part of the version, e.g. `beta` (assuming `Tag` is a valid semver)                                           |
+| `.RawVersion`  | Major.Minor.Patch (assuming `Tag` is a valid semver, else `0.0.0`)                                                           |
+| `.IsSnapshot`  | `true` if a snapshot is being released, `false` otherwise                                                                    |
+| `.Env`         | a map with system's environment variables                                                                                    |
+| `.Date`        | current UTC date in RFC3339 format                                                                                           |
+| `.Timestamp`   | current UTC time in Unix format                                                                                              |
 
 On fields that are related to a single artifact (e.g., the binary name), you
 may have some extra fields:
 
-|       Key       |              Description              |
-| :-------------: | :-----------------------------------: |
-|      `.Os`      |  `GOOS` (usually allow replacements)  |
-|     `.Arch`     | `GOARCH` (usually allow replacements) |
-|     `.Arm`      | `GOARM` (usually allow replacements)  |
-|     `.Mips`     | `GOMIPS` (usually allow replacements) |
-|    `.Binary`    |              Binary name              |
-| `.ArtifactName` |             Archive name              |
-| `.ArtifactPath` |       Relative path to artifact       |
+| Key             | Description                           |
+|-----------------|---------------------------------------|
+| `.Os`           | `GOOS` (usually allow replacements)   |
+| `.Arch`         | `GOARCH` (usually allow replacements) |
+| `.Arm`          | `GOARM` (usually allow replacements)  |
+| `.Mips`         | `GOMIPS` (usually allow replacements) |
+| `.Binary`       | Binary name                           |
+| `.ArtifactName` | Archive name                          |
+| `.ArtifactPath` | Relative path to artifact             |
 
 On the NFPM name template field, you can use those extra fields as well:
 
-|       Key       |              Description              |
-| :-------------: | :-----------------------------------: |
-|   `.Release`    |     Release from the nfpm config      |
-|    `.Epoch`     |      Epoch from the nfpm config       |
+| Key        | Description                  |
+|------------|------------------------------|
+| `.Release` | Release from the nfpm config |
+| `.Epoch`   | Epoch from the nfpm config   |
 
 On all fields, you have these available functions:
 
-|        Usage            |               Description                                                                                |
-| :--------------------:  | :----------------------------------------------------------------------------------:                     |
-| `replace "v1.2" "v" ""` | replaces all matches. See [ReplaceAll](https://golang.org/pkg/strings/#ReplaceAll)                       |
-| `time "01/02/2006"`     | current UTC time in the specified format                                                                 |
-| `tolower "V1.2"`        | makes input string lowercase. See [ToLower](https://golang.org/pkg/strings/#ToLower)                     |
-| `toupper "v1.2"`        | makes input string uppercase. See [ToUpper](https://golang.org/pkg/strings/#ToUpper)                     |
-| `trim " v1.2  "`        | removes all leading and trailing white space. See [TrimSpace](https://golang.org/pkg/strings/#TrimSpace) |
+| Usage                   | Description                                                                                                                    |
+|-------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `replace "v1.2" "v" ""` | replaces all matches. See [ReplaceAll](https://golang.org/pkg/strings/#ReplaceAll)                                             |
+| `time "01/02/2006"`     | current UTC time in the specified format                                                                                       |
+| `tolower "V1.2"`        | makes input string lowercase. See [ToLower](https://golang.org/pkg/strings/#ToLower)                                           |
+| `toupper "v1.2"`        | makes input string uppercase. See [ToUpper](https://golang.org/pkg/strings/#ToUpper)                                           |
+| `trim " v1.2  "`        | removes all leading and trailing white space. See [TrimSpace](https://golang.org/pkg/strings/#TrimSpace)                       |
 | `dir .Path`             | returns all but the last element of path, typically the path's directory. See [Dir](https://golang.org/pkg/path/filepath/#Dir) |
-| `abs .ArtifactPath`     | returns an absolute representation of path. See [Abs](https://golang.org/pkg/path/filepath/#Abs) |
+| `abs .ArtifactPath`     | returns an absolute representation of path. See [Abs](https://golang.org/pkg/path/filepath/#Abs)                               |
 
 With all those fields, you may be able to compose the name of your artifacts
 pretty much the way you want:


### PR DESCRIPTION
This patch formats all existing markdown tables in docs in a way that aligns cell content to left, as opposed to the centre (in most cases). This in turn makes it easier for anyone without any markdown generators to edit the source and getting the spacing right.
