### PR TITLE
fix: docker images: bzr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM golang:1.14-alpine
 
 RUN apk add --no-cache bash \
-                       bzr \
                        curl \
                        docker-cli \
                        git \

--- a/Dockerfile.cgo
+++ b/Dockerfile.cgo
@@ -2,7 +2,6 @@ FROM golang:1.14-alpine
 
 RUN apk add --no-cache bash \
                        build-base \
-                       bzr \
                        curl \
                        docker-cli \
                        git \


### PR DESCRIPTION
seems like the newer alpine doesn't have `bzr` in their repos anymore...

```
~/Code/goreleaser/goreleaser alpine 1m 6s
λ docker run -it --rm alpine:3.12 sh
Unable to find image 'alpine:3.12' locally
3.12: Pulling from library/alpine
df20fa9351a1: Pull complete
Digest: sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321
Status: Downloaded newer image for alpine:3.12
/ # apk add -U bzr
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  bzr (missing):
    required by: world[bzr]
/ # apk search bzr
bzr-zsh-completion-5.8-r1
bzrtp-4.3.1-r0
bzrtp-dev-4.3.1-r0
/ #
~/Code/goreleaser/goreleaser alpine* 48s
λ
```

not sure if we can do anything, I vote for just remove the dep 🤔