### PR TITLE
feat: Add docker image for cross compilation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,6 +31,21 @@ changelog:
     - Merge branch
 dockers:
 - image_templates:
+  - 'goreleaser/goreleaser:{{ .Tag }}-crossgo'
+  - 'goreleaser/goreleaser:v{{ .Major }}.{{ .Minor }}-crossgo'
+  - 'goreleaser/goreleaser:latest-crossgo'
+  dockerfile: Dockerfile.crossgo
+  binaries:
+  - goreleaser
+  build_flag_templates:
+  - "--pull"
+  - "--label=org.opencontainers.image.created={{.Date}}"
+  - "--label=org.opencontainers.image.name={{.ProjectName}}"
+  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  - "--label=org.opencontainers.image.version={{.Version}}"
+  extra_files:
+  - scripts/entrypoint.sh
+- image_templates:
   - 'goreleaser/goreleaser:{{ .Tag }}-cgo'
   - 'goreleaser/goreleaser:v{{ .Major }}.{{ .Minor }}-cgo'
   - 'goreleaser/goreleaser:latest-cgo'

--- a/Dockerfile.crossgo
+++ b/Dockerfile.crossgo
@@ -1,0 +1,18 @@
+FROM dockercore/golang-cross:1.13.12
+
+RUN apt-get update && \
+    apt-get install -y bash \
+                       build-essential \
+                       curl \
+                       docker \
+                       git \
+                       mercurial \
+                       rpm
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD [ "-h" ]
+
+COPY scripts/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+COPY goreleaser /bin/goreleaser


### PR DESCRIPTION
## If applied, this commit will...
Adds a cross compilation image that allows goreleaser to build artefacts for linux, windows and darwin. This image builds on top of a base image used to cross compile golang. It includes the MinGW compiler for Windows, and an OSX SDK. It makes life easier when seeking to cross compilation.

## Why is this change being made?
Without a cross compilation image users have to find bespoke solutions e.g. run builds on separate executors or potentially run some builds locally. This is all a lot more cumbersome than leveraging an image that has cross-compilation capabilities (i.e. https://hub.docker.com/r/dockercore/golang-cross/)

## Provide links to any relevant tickets, URLs or other resources
Associated with https://github.com/goreleaser/goreleaser/issues/1585
