### PR TITLE
docs: remove incorrect quotes

### DIFF
--- a/www/docs/customization/docker.md
+++ b/www/docs/customization/docker.md
@@ -213,9 +213,9 @@ This will execute the following command:
 ```bash
 docker build -t myuser/myimage . \
   --pull \
-  --label=org.opencontainers.image.created=2020-01-19T15:58:07Z" \
-  --label=org.opencontainers.image.name=mybinary" \
-  --label=org.opencontainers.image.revision=da39a3ee5e6b4b0d3255bfef95601890afd80709" \
+  --label=org.opencontainers.image.created=2020-01-19T15:58:07Z \
+  --label=org.opencontainers.image.name=mybinary \
+  --label=org.opencontainers.image.revision=da39a3ee5e6b4b0d3255bfef95601890afd80709 \
   --label=org.opencontainers.image.version=1.6.4
 ```
 


### PR DESCRIPTION
Fix bug in [the documentation](https://goreleaser.com/customization/docker/#applying-docker-build-flags)

<img width="792" alt="image" src="https://user-images.githubusercontent.com/1165416/84587381-60d8cd00-ae27-11ea-996f-b4dc6813ea0c.png">
