### PR TITLE
docs: (GitHub Actions) Modify "Unshallow" command

### DIFF
--- a/www/docs/ci/actions.md
+++ b/www/docs/ci/actions.md
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v2
       -
         name: Unshallow
-        run: git fetch --prune --unshallow
+        run: git fetch --prune --unshallow --tags --force
       -
         name: Set up Go
         uses: actions/setup-go@v2


### PR DESCRIPTION
...to fetch tags info to generate changelog correctly from previous tag

----

Recently, I started to use GoReleaser to release a Golang project on GitHub.

With the sample setting shown on this page, I found all commit history appear on my release notes.  
It should be only commits from previous release.

I found this is because the tags info were missing even after the "Unshallow" step.  
I added options `--tags --force`, then I get right changelog including commits from previous release like this:

- https://github.com/progrhyme/shelp/releases/tag/v0.5.1-pre-release

Executed workflow job for above is this: https://github.com/progrhyme/shelp/actions/runs/135036661

Thanks,