### PR TITLE
fix: docker login using password stdin

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -2,7 +2,7 @@
 
 if [ -n "$DOCKER_USERNAME" ] && [ -n "$DOCKER_PASSWORD" ]; then
     echo "Login to the docker..."
-    docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD $DOCKER_REGISTRY
+    echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin $DOCKER_REGISTRY
 fi
 
 # Workaround for github actions when access to different repositories is needed.


### PR DESCRIPTION
Instead of passing the password using the `-p` arg which is deprecated, we now use `--password-stdin` which is recommended.

Solves the following warning:
```
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
```