### PR TITLE
feat: Install make into docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ RUN apk add --no-cache bash \
                        curl \
                        docker-cli \
                        git \
-                       mercurial
+                       mercurial \
+					   make
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD [ "-h" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache bash \
                        docker-cli \
                        git \
                        mercurial \
-					   make
+                       make
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD [ "-h" ]


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

This patch adds make to the docker image. The cgo one should already have it via `build-base`.

For projects that have a Makefile, it'd be nice to be able to use the goreleaser docker image to build the project.

Refs https://gitlab.com/gitlab-org/pubsubbeat/-/merge_requests/47.

<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->

<!-- # Provide links to any relevant tickets, URLs or other resources -->
