### PR TITLE
fix: use correct filename for GCS downloads

### DIFF
--- a/internal/pipe/blob/upload.go
+++ b/internal/pipe/blob/upload.go
@@ -229,10 +229,13 @@ func (u *productionUploader) Open(ctx *context.Context, bucket string) error {
 	return nil
 }
 
-func (u *productionUploader) Upload(ctx *context.Context, path string, data []byte) (err error) {
-	log.WithField("path", path).Info("uploading")
+func (u *productionUploader) Upload(ctx *context.Context, filepath string, data []byte) (err error) {
+	log.WithField("path", filepath).Info("uploading")
 
-	w, err := u.bucket.NewWriter(ctx, path, nil)
+	opts := &blob.WriterOptions{
+		ContentDisposition: "attachment; filename=" + path.Base(filepath),
+	}
+	w, err := u.bucket.NewWriter(ctx, filepath, opts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently if uploading a file to Google Cloud Storage the filename contains the path when downloading e.g. `bucket/path/to/file.ext` will download as `path_to_file.ext`.

Setting the `Content-Disposition` metadata on upload ensures the filename we have locally is what it's called when downloading from GCS.