### PR TITLE
fix: Don't try and get release information if releases are disabled

### DIFF
--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -30,9 +30,14 @@ func (Pipe) Run(ctx *context.Context) error {
 		return err
 	}
 	ctx.Git = info
-	log.Infof("releasing %s, commit %s", info.CurrentTag, info.Commit)
-	ctx.Version = strings.TrimPrefix(ctx.Git.CurrentTag, "v")
-	return validate(ctx)
+	if !ctx.Config.Release.Disable {
+		log.Infof("releasing %s, commit %s", info.CurrentTag, info.Commit)
+		ctx.Version = strings.TrimPrefix(ctx.Git.CurrentTag, "v")
+		return validate(ctx)
+	}
+	ctx.Version = info.ShortCommit
+	log.Infof("commit %s", info.Commit)
+	return nil
 }
 
 // nolint: gochecknoglobals

--- a/internal/pipe/semver/semver.go
+++ b/internal/pipe/semver/semver.go
@@ -18,6 +18,9 @@ func (Pipe) String() string {
 
 // Run executes the hooks.
 func (Pipe) Run(ctx *context.Context) error {
+	if ctx.Config.Release.Disable {
+		return pipe.Skip("release disabled")
+	}
 	sv, err := semver.NewVersion(ctx.Git.CurrentTag)
 	if err != nil {
 		if ctx.Snapshot {

--- a/internal/pipe/snapshot/snapshot.go
+++ b/internal/pipe/snapshot/snapshot.go
@@ -20,7 +20,11 @@ func (Pipe) String() string {
 // Default sets the pipe defaults.
 func (Pipe) Default(ctx *context.Context) error {
 	if ctx.Config.Snapshot.NameTemplate == "" {
-		ctx.Config.Snapshot.NameTemplate = "{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}"
+		if ctx.Config.Release.Disable {
+			ctx.Config.Snapshot.NameTemplate = "SNAPSHOT-{{ .ShortCommit }}"
+		} else {
+			ctx.Config.Snapshot.NameTemplate = "{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}"
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->
If applied, this commit will not try and get the version from Git/handle Git dirty states if releases are set to false.

<!-- Why is this change being made? -->
Releases being disabled signifies that the user does not want to handle getting a GitHub version, so that should be handled accordingly. This is useful for local development.

<!-- # Provide links to any relevant tickets, URLs or other resources -->
