### PR TITLE
feat: support custom tokens in Homebrew & Scoop

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -18,11 +18,23 @@ type Info struct {
 	URL         string
 }
 
+type Repo struct {
+	Owner string
+	Name  string
+}
+
+func (r Repo) String() string {
+	if r.Owner == "" && r.Name == "" {
+		return ""
+	}
+	return r.Owner + "/" + r.Name
+}
+
 // Client interface.
 type Client interface {
 	CreateRelease(ctx *context.Context, body string) (releaseID string, err error)
 	ReleaseURLTemplate(ctx *context.Context) (string, error)
-	CreateFile(ctx *context.Context, commitAuthor config.CommitAuthor, repo config.Repo, content []byte, path, message string) (err error)
+	CreateFile(ctx *context.Context, commitAuthor config.CommitAuthor, repo Repo, content []byte, path, message string) (err error)
 	Upload(ctx *context.Context, releaseID string, artifact *artifact.Artifact, file *os.File) (err error)
 }
 
@@ -30,13 +42,26 @@ type Client interface {
 func New(ctx *context.Context) (Client, error) {
 	log.WithField("type", ctx.TokenType).Info("token type")
 	if ctx.TokenType == context.TokenTypeGitHub {
-		return NewGitHub(ctx)
+		return NewGitHub(ctx, ctx.Token)
 	}
 	if ctx.TokenType == context.TokenTypeGitLab {
-		return NewGitLab(ctx)
+		return NewGitLab(ctx, ctx.Token)
 	}
 	if ctx.TokenType == context.TokenTypeGitea {
-		return NewGitea(ctx)
+		return NewGitea(ctx, ctx.Token)
+	}
+	return nil, nil
+}
+
+func NewWithToken(ctx *context.Context, token string) (Client, error) {
+	if ctx.TokenType == context.TokenTypeGitHub {
+		return NewGitHub(ctx, token)
+	}
+	if ctx.TokenType == context.TokenTypeGitLab {
+		return NewGitLab(ctx, token)
+	}
+	if ctx.TokenType == context.TokenTypeGitea {
+		return NewGitea(ctx, token)
 	}
 	return nil, nil
 }

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -1,0 +1,12 @@
+package client
+
+import (
+	"github.com/goreleaser/goreleaser/pkg/config"
+)
+
+func RepoFromRef(ref config.RepoRef) Repo {
+	return Repo{
+		Owner: ref.Owner,
+		Name:  ref.Name,
+	}
+}

--- a/internal/client/gitea.go
+++ b/internal/client/gitea.go
@@ -34,12 +34,12 @@ func getInstanceURL(apiURL string) (string, error) {
 }
 
 // NewGitea returns a gitea client implementation.
-func NewGitea(ctx *context.Context) (Client, error) {
+func NewGitea(ctx *context.Context, token string) (Client, error) {
 	instanceURL, err := getInstanceURL(ctx.Config.GiteaURLs.API)
 	if err != nil {
 		return nil, err
 	}
-	client := gitea.NewClient(instanceURL, ctx.Token)
+	client := gitea.NewClient(instanceURL, token)
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			// nolint: gosec
@@ -56,7 +56,7 @@ func NewGitea(ctx *context.Context) (Client, error) {
 func (c *giteaClient) CreateFile(
 	ctx *context.Context,
 	commitAuthor config.CommitAuthor,
-	repo config.Repo,
+	repo Repo,
 	content []byte,
 	path,
 	message string,

--- a/internal/client/gitea_test.go
+++ b/internal/client/gitea_test.go
@@ -245,7 +245,7 @@ func TestGiteaCreateFile(t *testing.T) {
 	client := giteaClient{}
 	ctx := context.Context{}
 	author := config.CommitAuthor{}
-	repo := config.Repo{}
+	repo := Repo{}
 	content := []byte{}
 	path := ""
 	message := ""

--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -25,9 +25,9 @@ type githubClient struct {
 }
 
 // NewGitHub returns a github client implementation.
-func NewGitHub(ctx *context.Context) (Client, error) {
+func NewGitHub(ctx *context.Context, token string) (Client, error) {
 	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: ctx.Token},
+		&oauth2.Token{AccessToken: token},
 	)
 	httpClient := oauth2.NewClient(ctx, ts)
 	base := httpClient.Transport.(*oauth2.Transport).Base
@@ -59,7 +59,7 @@ func NewGitHub(ctx *context.Context) (Client, error) {
 func (c *githubClient) CreateFile(
 	ctx *context.Context,
 	commitAuthor config.CommitAuthor,
-	repo config.Repo,
+	repo Repo,
 	content []byte,
 	path,
 	message string,

--- a/internal/client/github_test.go
+++ b/internal/client/github_test.go
@@ -11,34 +11,37 @@ import (
 
 func TestNewGitHubClient(t *testing.T) {
 	t.Run("good urls", func(t *testing.T) {
-		_, err := NewGitHub(context.New(config.Project{
+		ctx := context.New(config.Project{
 			GitHubURLs: config.GitHubURLs{
 				API:    "https://github.mycompany.com/api",
 				Upload: "https://github.mycompany.com/upload",
 			},
-		}))
+		})
+		_, err := NewGitHub(ctx, ctx.Token)
 
 		require.NoError(t, err)
 	})
 
 	t.Run("bad api url", func(t *testing.T) {
-		_, err := NewGitHub(context.New(config.Project{
+		ctx := context.New(config.Project{
 			GitHubURLs: config.GitHubURLs{
 				API:    "://github.mycompany.com/api",
 				Upload: "https://github.mycompany.com/upload",
 			},
-		}))
+		})
+		_, err := NewGitHub(ctx, ctx.Token)
 
 		require.EqualError(t, err, `parse "://github.mycompany.com/api": missing protocol scheme`)
 	})
 
 	t.Run("bad upload url", func(t *testing.T) {
-		_, err := NewGitHub(context.New(config.Project{
+		ctx := context.New(config.Project{
 			GitHubURLs: config.GitHubURLs{
 				API:    "https://github.mycompany.com/api",
 				Upload: "not a url:4994",
 			},
-		}))
+		})
+		_, err := NewGitHub(ctx, ctx.Token)
 
 		require.EqualError(t, err, `parse "not a url:4994": first path segment in URL cannot contain colon`)
 	})
@@ -46,7 +49,7 @@ func TestNewGitHubClient(t *testing.T) {
 
 func TestGitHubUploadReleaseIDNotInt(t *testing.T) {
 	var ctx = context.New(config.Project{})
-	client, err := NewGitHub(ctx)
+	client, err := NewGitHub(ctx, ctx.Token)
 	require.NoError(t, err)
 
 	require.EqualError(
@@ -69,7 +72,7 @@ func TestGitHubReleaseURLTemplate(t *testing.T) {
 			},
 		},
 	})
-	client, err := NewGitHub(ctx)
+	client, err := NewGitHub(ctx, ctx.Token)
 	require.NoError(t, err)
 
 	urlTpl, err := client.ReleaseURLTemplate(ctx)
@@ -85,7 +88,7 @@ func TestGitHubCreateReleaseWrongNameTemplate(t *testing.T) {
 			NameTemplate: "{{.dddddddddd",
 		},
 	})
-	client, err := NewGitHub(ctx)
+	client, err := NewGitHub(ctx, ctx.Token)
 	require.NoError(t, err)
 
 	str, err := client.CreateRelease(ctx, "")

--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -26,8 +26,7 @@ type gitlabClient struct {
 }
 
 // NewGitLab returns a gitlab client implementation.
-func NewGitLab(ctx *context.Context) (Client, error) {
-	token := ctx.Token
+func NewGitLab(ctx *context.Context, token string) (Client, error) {
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			// nolint: gosec
@@ -54,7 +53,7 @@ func NewGitLab(ctx *context.Context) (Client, error) {
 func (c *gitlabClient) CreateFile(
 	ctx *context.Context,
 	commitAuthor config.CommitAuthor,
-	repo config.Repo,
+	repo Repo,
 	content []byte, // the content of the formula.rb
 	path, // the path to the formula.rb
 	message string, // the commit msg

--- a/internal/client/gitlab_test.go
+++ b/internal/client/gitlab_test.go
@@ -47,7 +47,7 @@ func TestGitLabReleaseURLTemplate(t *testing.T) {
 			},
 		},
 	})
-	client, err := NewGitLab(ctx)
+	client, err := NewGitLab(ctx, ctx.Token)
 	assert.NoError(t, err)
 
 	urlTpl, err := client.ReleaseURLTemplate(ctx)

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -269,7 +269,7 @@ func TestRunPipeForMultipleArmVersions(t *testing.T) {
 						Dependencies: []config.HomebrewDependency{{Name: "zsh"}, {Name: "bash", Type: "recommended"}},
 						Conflicts:    []string{"gtk+", "qt"},
 						Install:      `bin.install "{{ .ProjectName }}"`,
-						Tap: config.Repo{
+						Tap: config.RepoRef{
 							Owner: "test",
 							Name:  "test",
 						},
@@ -365,7 +365,7 @@ func TestRunPipeNoDarwin64Build(t *testing.T) {
 		Config: config.Project{
 			Brews: []config.Homebrew{
 				{
-					Tap: config.Repo{
+					Tap: config.RepoRef{
 						Owner: "test",
 						Name:  "test",
 					},
@@ -383,7 +383,7 @@ func TestRunPipeMultipleArchivesSameOsBuild(t *testing.T) {
 		config.Project{
 			Brews: []config.Homebrew{
 				{
-					Tap: config.Repo{
+					Tap: config.RepoRef{
 						Owner: "test",
 						Name:  "test",
 					},
@@ -537,7 +537,7 @@ func TestRunPipeBinaryRelease(t *testing.T) {
 		config.Project{
 			Brews: []config.Homebrew{
 				{
-					Tap: config.Repo{
+					Tap: config.RepoRef{
 						Owner: "test",
 						Name:  "test",
 					},
@@ -566,7 +566,7 @@ func TestRunPipeNoUpload(t *testing.T) {
 		Release:     config.Release{},
 		Brews: []config.Homebrew{
 			{
-				Tap: config.Repo{
+				Tap: config.RepoRef{
 					Owner: "test",
 					Name:  "test",
 				},
@@ -618,7 +618,7 @@ func TestRunEmptyTokenType(t *testing.T) {
 		Release:     config.Release{},
 		Brews: []config.Homebrew{
 			{
-				Tap: config.Repo{
+				Tap: config.RepoRef{
 					Owner: "test",
 					Name:  "test",
 				},
@@ -653,7 +653,7 @@ func TestRunTokenTypeNotImplementedForBrew(t *testing.T) {
 		Release:     config.Release{},
 		Brews: []config.Homebrew{
 			{
-				Tap: config.Repo{
+				Tap: config.RepoRef{
 					Owner: "test",
 					Name:  "test",
 				},
@@ -743,7 +743,7 @@ func (dc *DummyClient) ReleaseURLTemplate(ctx *context.Context) (string, error) 
 	return "https://dummyhost/download/{{ .Tag }}/{{ .ArtifactName }}", nil
 }
 
-func (dc *DummyClient) CreateFile(ctx *context.Context, commitAuthor config.CommitAuthor, repo config.Repo, content []byte, path, msg string) (err error) {
+func (dc *DummyClient) CreateFile(ctx *context.Context, commitAuthor config.CommitAuthor, repo client.Repo, content []byte, path, msg string) (err error) {
 	dc.CreatedFile = true
 	dc.Content = string(content)
 	return

--- a/internal/pipe/release/release_test.go
+++ b/internal/pipe/release/release_test.go
@@ -550,7 +550,7 @@ func (c *DummyClient) ReleaseURLTemplate(ctx *context.Context) (string, error) {
 	return "", nil
 }
 
-func (c *DummyClient) CreateFile(ctx *context.Context, commitAuthor config.CommitAuthor, repo config.Repo, content []byte, path, msg string) (err error) {
+func (c *DummyClient) CreateFile(ctx *context.Context, commitAuthor config.CommitAuthor, repo client.Repo, content []byte, path, msg string) (err error) {
 	return
 }
 
@@ -570,7 +570,7 @@ func (c *DummyClient) Upload(ctx *context.Context, releaseID string, artifact *a
 	}
 	if c.FailFirstUpload {
 		c.FailFirstUpload = false
-		return client.RetriableError{errors.New("upload failed, should retry")}
+		return client.RetriableError{Err: errors.New("upload failed, should retry")}
 	}
 	c.UploadedFile = true
 	c.UploadedFileNames = append(c.UploadedFileNames, artifact.Name)

--- a/internal/pipe/scoop/scoop_test.go
+++ b/internal/pipe/scoop/scoop_test.go
@@ -113,7 +113,7 @@ func Test_doRun(t *testing.T) {
 							},
 						},
 						Scoop: config.Scoop{
-							Bucket: config.Repo{
+							Bucket: config.RepoRef{
 								Owner: "test",
 								Name:  "test",
 							},
@@ -156,7 +156,7 @@ func Test_doRun(t *testing.T) {
 							},
 						},
 						Scoop: config.Scoop{
-							Bucket: config.Repo{
+							Bucket: config.RepoRef{
 								Owner: "test",
 								Name:  "test",
 							},
@@ -216,7 +216,7 @@ func Test_doRun(t *testing.T) {
 							},
 						},
 						Scoop: config.Scoop{
-							Bucket: config.Repo{
+							Bucket: config.RepoRef{
 								Owner: "test",
 								Name:  "test",
 							},
@@ -259,7 +259,7 @@ func Test_doRun(t *testing.T) {
 							},
 						},
 						Scoop: config.Scoop{
-							Bucket: config.Repo{
+							Bucket: config.RepoRef{
 								Owner: "test",
 								Name:  "test",
 							},
@@ -319,7 +319,7 @@ func Test_doRun(t *testing.T) {
 							},
 						},
 						Scoop: config.Scoop{
-							Bucket: config.Repo{
+							Bucket: config.RepoRef{
 								Owner: "test",
 								Name:  "test",
 							},
@@ -377,7 +377,7 @@ func Test_doRun(t *testing.T) {
 							},
 						},
 						Scoop: config.Scoop{
-							Bucket: config.Repo{
+							Bucket: config.RepoRef{
 								Owner: "test",
 								Name:  "test",
 							},
@@ -420,7 +420,7 @@ func Test_doRun(t *testing.T) {
 							},
 						},
 						Scoop: config.Scoop{
-							Bucket: config.Repo{
+							Bucket: config.RepoRef{
 								Owner: "test",
 								Name:  "test",
 							},
@@ -498,7 +498,7 @@ func Test_doRun(t *testing.T) {
 							},
 						},
 						Scoop: config.Scoop{
-							Bucket: config.Repo{
+							Bucket: config.RepoRef{
 								Owner: "test",
 								Name:  "test",
 							},
@@ -539,7 +539,7 @@ func Test_doRun(t *testing.T) {
 							Draft: true,
 						},
 						Scoop: config.Scoop{
-							Bucket: config.Repo{
+							Bucket: config.RepoRef{
 								Owner: "test",
 								Name:  "test",
 							},
@@ -589,7 +589,7 @@ func Test_doRun(t *testing.T) {
 						},
 						Scoop: config.Scoop{
 							SkipUpload: "auto",
-							Bucket: config.Repo{
+							Bucket: config.RepoRef{
 								Owner: "test",
 								Name:  "test",
 							},
@@ -633,7 +633,7 @@ func Test_doRun(t *testing.T) {
 						},
 						Scoop: config.Scoop{
 							SkipUpload: "true",
-							Bucket: config.Repo{
+							Bucket: config.RepoRef{
 								Owner: "test",
 								Name:  "test",
 							},
@@ -673,7 +673,7 @@ func Test_doRun(t *testing.T) {
 							Disable: true,
 						},
 						Scoop: config.Scoop{
-							Bucket: config.Repo{
+							Bucket: config.RepoRef{
 								Owner: "test",
 								Name:  "test",
 							},
@@ -713,7 +713,7 @@ func Test_doRun(t *testing.T) {
 							Draft: true,
 						},
 						Scoop: config.Scoop{
-							Bucket: config.Repo{
+							Bucket: config.RepoRef{
 								Owner: "test",
 								Name:  "test",
 							},
@@ -780,7 +780,7 @@ func Test_buildManifest(t *testing.T) {
 						},
 					},
 					Scoop: config.Scoop{
-						Bucket: config.Repo{
+						Bucket: config.RepoRef{
 							Owner: "test",
 							Name:  "test",
 						},
@@ -820,7 +820,7 @@ func Test_buildManifest(t *testing.T) {
 						},
 					},
 					Scoop: config.Scoop{
-						Bucket: config.Repo{
+						Bucket: config.RepoRef{
 							Owner: "test",
 							Name:  "test",
 						},
@@ -862,7 +862,7 @@ func Test_buildManifest(t *testing.T) {
 						},
 					},
 					Scoop: config.Scoop{
-						Bucket: config.Repo{
+						Bucket: config.RepoRef{
 							Owner: "test",
 							Name:  "test",
 						},
@@ -968,7 +968,7 @@ func TestWrapInDirectory(t *testing.T) {
 				},
 			},
 			Scoop: config.Scoop{
-				Bucket: config.Repo{
+				Bucket: config.RepoRef{
 					Owner: "test",
 					Name:  "test",
 				},
@@ -1034,7 +1034,7 @@ func (dc *DummyClient) ReleaseURLTemplate(ctx *context.Context) (string, error) 
 	return "", nil
 }
 
-func (dc *DummyClient) CreateFile(ctx *context.Context, commitAuthor config.CommitAuthor, repo config.Repo, content []byte, path, msg string) (err error) {
+func (dc *DummyClient) CreateFile(ctx *context.Context, commitAuthor config.CommitAuthor, repo client.Repo, content []byte, path, msg string) (err error) {
 	dc.CreatedFile = true
 	dc.Content = string(content)
 	return

--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"text/template"
 	"time"
@@ -163,6 +164,41 @@ func (t *Template) Apply(s string) (string, error) {
 			"dir":     filepath.Dir,
 			"abs":     filepath.Abs,
 		}).
+		Parse(s)
+	if err != nil {
+		return "", err
+	}
+
+	err = tmpl.Execute(&out, t.fields)
+	return out.String(), err
+}
+
+type ExpectedSingleEnvErr struct{}
+
+func (e ExpectedSingleEnvErr) Error() string {
+	return "expected {{ .Env.VAR_NAME }} only (no plain-text or other interpolation)"
+}
+
+// ApplySingleEnvOnly enforces template to only contain a single environment variable
+// and nothing else.
+func (t *Template) ApplySingleEnvOnly(s string) (string, error) {
+	s = strings.TrimSpace(s)
+	if len(s) == 0 {
+		return "", nil
+	}
+
+	// text/template/parse (lexer) could be used here too,
+	// but regexp reduces the complexity and should be sufficient,
+	// given the context is mostly discouraging users from bad practice
+	// of hard-coded credentials, rather than catch all possible cases
+	envOnlyRe := regexp.MustCompile(`^{{\s*\.Env\.[^.\s}]+\s*}}$`)
+	if !envOnlyRe.Match([]byte(s)) {
+		return "", ExpectedSingleEnvErr{}
+	}
+
+	var out bytes.Buffer
+	tmpl, err := template.New("tmpl").
+		Option("missingkey=error").
 		Parse(s)
 	if err != nil {
 		return "", err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,9 +34,20 @@ type GiteaURLs struct {
 }
 
 // Repo represents any kind of repo (github, gitlab, etc).
+// to upload releases into.
 type Repo struct {
 	Owner string `yaml:",omitempty"`
 	Name  string `yaml:",omitempty"`
+}
+
+// RepoRef represents any kind of repo which may differ
+// from the one we are building from and may therefore
+// also require separate authentication
+// e.g. Homebrew Tap, Scoop bucket.
+type RepoRef struct {
+	Owner string `yaml:",omitempty"`
+	Name  string `yaml:",omitempty"`
+	Token string `yaml:",omitempty"`
 }
 
 // HomebrewDependency represents Homebrew dependency.
@@ -78,7 +89,7 @@ func (r Repo) String() string {
 // Homebrew contains the brew section.
 type Homebrew struct {
 	Name             string               `yaml:",omitempty"`
-	Tap              Repo                 `yaml:",omitempty"`
+	Tap              RepoRef              `yaml:",omitempty"`
 	CommitAuthor     CommitAuthor         `yaml:"commit_author,omitempty"`
 	Folder           string               `yaml:",omitempty"`
 	Caveats          string               `yaml:",omitempty"`
@@ -105,7 +116,7 @@ type Homebrew struct {
 // Scoop contains the scoop.sh section.
 type Scoop struct {
 	Name                  string       `yaml:",omitempty"`
-	Bucket                Repo         `yaml:",omitempty"`
+	Bucket                RepoRef      `yaml:",omitempty"`
 	CommitAuthor          CommitAuthor `yaml:"commit_author,omitempty"`
 	CommitMessageTemplate string       `yaml:"commit_msg_template,omitempty"`
 	Homepage              string       `yaml:",omitempty"`

--- a/www/docs/customization/homebrew.md
+++ b/www/docs/customization/homebrew.md
@@ -44,6 +44,8 @@ brews:
     tap:
       owner: repo-owner
       name: homebrew-tap
+      # Optionally a token can be provided, if it differs from the token provided to GoReleaser
+      token: {{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}
 
     # Template for the url which is determined by the given Token (github or gitlab)
     # Default for github is "https://github.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"

--- a/www/docs/customization/scoop.md
+++ b/www/docs/customization/scoop.md
@@ -21,6 +21,8 @@ scoop:
   bucket:
     owner: user
     name: scoop-bucket
+    # Optionally a token can be provided, if it differs from the token provided to GoReleaser
+    token: {{ .Env.SCOOP_BUCKET_GITHUB_TOKEN }}
 
   # Git author used to commit to the repository.
   # Defaults are shown.


### PR DESCRIPTION
Closes #1643

--- 

This introduces a new config options for Homebrew and Scoop as mentioned in #1643 - allowing the use of dedicated tokens when publishing to a Homebrew tap or Scoop bucket.

Most of the implementation is hopefully self-explanatory, or the comments in code explain it.

It's worth pointing out that this introduces a new precedent of a limited/enforced templating, scoped to just environment variables, mostly to prevent people from hard-coding tokens in the config, which this new option would otherwise allow. I'm open to alternative ideas on how to solve this problem though.

```yaml
brews:
  -
    tap:
      owner: repo-owner
      name: homebrew-tap
      token: {{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}

scoop:
  bucket:
    owner: user
    name: scoop-bucket
    token: {{ .Env.SCOOP_BUCKET_GITHUB_TOKEN }}
```
