### PR TITLE
docs: add missing quotes around templating syntax

### DIFF
--- a/www/docs/customization/homebrew.md
+++ b/www/docs/customization/homebrew.md
@@ -45,7 +45,7 @@ brews:
       owner: repo-owner
       name: homebrew-tap
       # Optionally a token can be provided, if it differs from the token provided to GoReleaser
-      token: {{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
 
     # Template for the url which is determined by the given Token (github or gitlab)
     # Default for github is "https://github.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"

--- a/www/docs/customization/scoop.md
+++ b/www/docs/customization/scoop.md
@@ -22,7 +22,7 @@ scoop:
     owner: user
     name: scoop-bucket
     # Optionally a token can be provided, if it differs from the token provided to GoReleaser
-    token: {{ .Env.SCOOP_BUCKET_GITHUB_TOKEN }}
+    token: "{{ .Env.SCOOP_BUCKET_GITHUB_TOKEN }}"
 
   # Git author used to commit to the repository.
   # Defaults are shown.


### PR DESCRIPTION
Quotes are apparently necessary, otherwise the example leads to the following error:

```
   • releasing...
   • loading config file       file=.goreleaser.yml
   ⨯ release failed after 0.00s error=yaml: unmarshal errors:
  line 59: cannot unmarshal !!map into string
```