### PR TITLE
feat: support closing milestones

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -32,6 +32,7 @@ func (r Repo) String() string {
 
 // Client interface.
 type Client interface {
+	CloseMilestone(ctx *context.Context, repo Repo, title string) (err error)
 	CreateRelease(ctx *context.Context, body string) (releaseID string, err error)
 	ReleaseURLTemplate(ctx *context.Context) (string, error)
 	CreateFile(ctx *context.Context, commitAuthor config.CommitAuthor, repo Repo, content []byte, path, message string) (err error)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -67,6 +67,15 @@ func NewWithToken(ctx *context.Context, token string) (Client, error) {
 	return nil, nil
 }
 
+// ErrNoMilestoneFound is an error when no milestone is found.
+type ErrNoMilestoneFound struct {
+	Title string
+}
+
+func (e ErrNoMilestoneFound) Error() string {
+	return fmt.Sprintf("no milestone found: %s", e.Title)
+}
+
 // RetriableError is an error that will cause the action to be retried.
 type RetriableError struct {
 	Err error

--- a/internal/client/gitea.go
+++ b/internal/client/gitea.go
@@ -60,7 +60,7 @@ func (c *giteaClient) CloseMilestone(ctx *context.Context, repo Repo, title stri
 	}
 
 	if milestone == nil {
-		return fmt.Errorf("no open milestone matching: %s", title)
+		return ErrNoMilestoneFound{Title: title}
 	}
 
 	closedState := string(gitea.StateClosed)
@@ -74,11 +74,7 @@ func (c *giteaClient) CloseMilestone(ctx *context.Context, repo Repo, title stri
 
 	_, err = c.client.EditMilestone(repo.Owner, repo.Name, milestone.ID, opts)
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // CreateFile creates a file in the repository at a given path

--- a/internal/client/gitea.go
+++ b/internal/client/gitea.go
@@ -51,6 +51,36 @@ func NewGitea(ctx *context.Context, token string) (Client, error) {
 	return &giteaClient{client: client}, nil
 }
 
+// CloseMilestone closes a given milestone.
+func (c *giteaClient) CloseMilestone(ctx *context.Context, repo Repo, title string) error {
+	milestone, err := c.getMilestoneByTitle(repo, title)
+
+	if err != nil {
+		return err
+	}
+
+	if milestone == nil {
+		return fmt.Errorf("no open milestone matching: %s", title)
+	}
+
+	closedState := string(gitea.StateClosed)
+
+	opts := gitea.EditMilestoneOption{
+		Deadline:    milestone.Deadline,
+		Description: &milestone.Description,
+		State:       &closedState,
+		Title:       milestone.Title,
+	}
+
+	_, err = c.client.EditMilestone(repo.Owner, repo.Name, milestone.ID, opts)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // CreateFile creates a file in the repository at a given path
 // or updates the file if it exists.
 func (c *giteaClient) CreateFile(
@@ -192,4 +222,22 @@ func (c *giteaClient) Upload(
 		return RetriableError{err}
 	}
 	return nil
+}
+
+// getMilestoneByTitle returns a milestone by title.
+func (c *giteaClient) getMilestoneByTitle(repo Repo, title string) (*gitea.Milestone, error) {
+	// The Gitea API/SDK does not provide lookup by title functionality currently.
+	milestones, err := c.client.ListRepoMilestones(repo.Owner, repo.Name, gitea.ListMilestoneOption{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, milestone := range milestones {
+		if milestone.Title == title {
+			return milestone, nil
+		}
+	}
+
+	return nil, nil
 }

--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -65,7 +65,7 @@ func (c *githubClient) CloseMilestone(ctx *context.Context, repo Repo, title str
 	}
 
 	if milestone == nil {
-		return fmt.Errorf("no open milestone matching: %s", title)
+		return ErrNoMilestoneFound{Title: title}
 	}
 
 	closedState := "closed"
@@ -79,11 +79,7 @@ func (c *githubClient) CloseMilestone(ctx *context.Context, repo Repo, title str
 		milestone,
 	)
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (c *githubClient) CreateFile(

--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -56,6 +56,36 @@ func NewGitHub(ctx *context.Context, token string) (Client, error) {
 	return &githubClient{client: client}, nil
 }
 
+// CloseMilestone closes a given milestone.
+func (c *githubClient) CloseMilestone(ctx *context.Context, repo Repo, title string) error {
+	milestone, err := c.getMilestoneByTitle(ctx, repo, title)
+
+	if err != nil {
+		return err
+	}
+
+	if milestone == nil {
+		return fmt.Errorf("no open milestone matching: %s", title)
+	}
+
+	closedState := "closed"
+	milestone.State = &closedState
+
+	_, _, err = c.client.Issues.EditMilestone(
+		ctx,
+		repo.Owner,
+		repo.Name,
+		*milestone.Number,
+		milestone,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (c *githubClient) CreateFile(
 	ctx *context.Context,
 	commitAuthor config.CommitAuthor,
@@ -186,4 +216,39 @@ func (c *githubClient) Upload(
 		return err
 	}
 	return RetriableError{err}
+}
+
+// getMilestoneByTitle returns a milestone by title.
+func (c *githubClient) getMilestoneByTitle(ctx *context.Context, repo Repo, title string) (*github.Milestone, error) {
+	// The GitHub API/SDK does not provide lookup by title functionality currently.
+	opts := &github.MilestoneListOptions{
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+
+	for {
+		milestones, resp, err := c.client.Issues.ListMilestones(
+			ctx,
+			repo.Owner,
+			repo.Name,
+			opts,
+		)
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, m := range milestones {
+			if m != nil && m.Title != nil && *m.Title == title {
+				return m, nil
+			}
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+
+		opts.Page = resp.NextPage
+	}
+
+	return nil, nil
 }

--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -48,6 +48,41 @@ func NewGitLab(ctx *context.Context, token string) (Client, error) {
 	return &gitlabClient{client: client}, nil
 }
 
+// CloseMilestone closes a given milestone.
+func (c *gitlabClient) CloseMilestone(ctx *context.Context, repo Repo, title string) error {
+	milestone, err := c.getMilestoneByTitle(repo, title)
+
+	if err != nil {
+		return err
+	}
+
+	if milestone == nil {
+		return fmt.Errorf("no open milestone matching: %s", title)
+	}
+
+	closeStateEvent := "close"
+
+	opts := &gitlab.UpdateMilestoneOptions{
+		Description: &milestone.Description,
+		DueDate:     milestone.DueDate,
+		StartDate:   milestone.StartDate,
+		StateEvent:  &closeStateEvent,
+		Title:       &milestone.Title,
+	}
+
+	_, _, err = c.client.Milestones.UpdateMilestone(
+		repo.String(),
+		milestone.ID,
+		opts,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // CreateFile gets a file in the repository at a given path
 // and updates if it exists or creates it for later pipes in the pipeline.
 func (c *gitlabClient) CreateFile(
@@ -318,4 +353,33 @@ func extractProjectFileHashFrom(projectFileURL string) (string, error) {
 		"fileHash":       fileHash,
 	}).Debug("extracted file hash")
 	return fileHash, nil
+}
+
+// getMilestoneByTitle returns a milestone by title.
+func (c *gitlabClient) getMilestoneByTitle(repo Repo, title string) (*gitlab.Milestone, error) {
+	opts := &gitlab.ListMilestonesOptions{
+		Title: &title,
+	}
+
+	for {
+		milestones, resp, err := c.client.Milestones.ListMilestones(repo.String(), opts)
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, milestone := range milestones {
+			if milestone != nil && milestone.Title == title {
+				return milestone, nil
+			}
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+
+		opts.Page = resp.NextPage
+	}
+
+	return nil, nil
 }

--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -57,7 +57,7 @@ func (c *gitlabClient) CloseMilestone(ctx *context.Context, repo Repo, title str
 	}
 
 	if milestone == nil {
-		return fmt.Errorf("no open milestone matching: %s", title)
+		return ErrNoMilestoneFound{Title: title}
 	}
 
 	closeStateEvent := "close"
@@ -76,11 +76,7 @@ func (c *gitlabClient) CloseMilestone(ctx *context.Context, repo Repo, title str
 		opts,
 	)
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // CreateFile gets a file in the repository at a given path

--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -1,27 +1,26 @@
-package release
+package git
 
 import (
 	"fmt"
 	"strings"
 
-	"github.com/goreleaser/goreleaser/internal/git"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/pkg/errors"
 )
 
-// remoteRepo gets the repo name from the Git config.
-func remoteRepo() (result config.Repo, err error) {
-	if !git.IsRepo() {
+// ExtractRepoFromConfig gets the repo name from the Git config.
+func ExtractRepoFromConfig() (result config.Repo, err error) {
+	if !IsRepo() {
 		return result, errors.New("current folder is not a git repository")
 	}
-	out, err := git.Run("config", "--get", "remote.origin.url")
+	out, err := Run("config", "--get", "remote.origin.url")
 	if err != nil {
 		return result, fmt.Errorf("repository doesn't have an `origin` remote")
 	}
-	return extractRepoFromURL(out), nil
+	return ExtractRepoFromURL(out), nil
 }
 
-func extractRepoFromURL(s string) config.Repo {
+func ExtractRepoFromURL(s string) config.Repo {
 	// removes the .git suffix and any new lines
 	s = strings.NewReplacer(
 		".git", "",

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -1,8 +1,9 @@
-package release
+package git_test
 
 import (
 	"testing"
 
+	"github.com/goreleaser/goreleaser/internal/git"
 	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/stretchr/testify/assert"
 )
@@ -12,7 +13,7 @@ func TestRepoName(t *testing.T) {
 	defer back()
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:goreleaser/goreleaser.git")
-	repo, err := remoteRepo()
+	repo, err := git.ExtractRepoFromConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, "goreleaser/goreleaser", repo.String())
 }
@@ -27,7 +28,7 @@ func TestExtractRepoFromURL(t *testing.T) {
 		"https://github.enterprise.com/crazy/url/goreleaser/goreleaser.git",
 	} {
 		t.Run(url, func(t *testing.T) {
-			repo := extractRepoFromURL(url)
+			repo := git.ExtractRepoFromURL(url)
 			assert.Equal(t, "goreleaser/goreleaser", repo.String())
 		})
 	}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,18 +1,19 @@
-package git
+package git_test
 
 import (
 	"os"
 	"testing"
 
+	"github.com/goreleaser/goreleaser/internal/git"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGit(t *testing.T) {
-	out, err := Run("status")
+	out, err := git.Run("status")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, out)
 
-	out, err = Run("command-that-dont-exist")
+	out, err = git.Run("command-that-dont-exist")
 	assert.Error(t, err)
 	assert.Empty(t, out)
 	assert.Equal(
@@ -23,18 +24,18 @@ func TestGit(t *testing.T) {
 }
 
 func TestRepo(t *testing.T) {
-	assert.True(t, IsRepo(), "goreleaser folder should be a git repo")
+	assert.True(t, git.IsRepo(), "goreleaser folder should be a git repo")
 
 	assert.NoError(t, os.Chdir(os.TempDir()))
-	assert.False(t, IsRepo(), os.TempDir()+" folder should be a git repo")
+	assert.False(t, git.IsRepo(), os.TempDir()+" folder should be a git repo")
 }
 
 func TestClean(t *testing.T) {
-	out, err := Clean("asdasd 'ssadas'\nadasd", nil)
+	out, err := git.Clean("asdasd 'ssadas'\nadasd", nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "asdasd ssadas", out)
 
-	out, err = Clean(Run("command-that-dont-exist"))
+	out, err = git.Clean(git.Run("command-that-dont-exist"))
 	assert.Error(t, err)
 	assert.Empty(t, out)
 	assert.Equal(

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -731,6 +731,10 @@ type DummyClient struct {
 	NotImplemented bool
 }
 
+func (dc *DummyClient) CloseMilestone(ctx *context.Context, repo client.Repo, title string) error {
+	return nil
+}
+
 func (dc *DummyClient) CreateRelease(ctx *context.Context, body string) (releaseID string, err error) {
 	return
 }

--- a/internal/pipe/milestone/doc.go
+++ b/internal/pipe/milestone/doc.go
@@ -1,0 +1,2 @@
+// Package milestone implements Pipe and manages VCS milestones.
+package milestone

--- a/internal/pipe/milestone/milestone.go
+++ b/internal/pipe/milestone/milestone.go
@@ -1,0 +1,132 @@
+package milestone
+
+import (
+	"github.com/apex/log"
+	"github.com/goreleaser/goreleaser/internal/client"
+	"github.com/goreleaser/goreleaser/internal/git"
+	"github.com/goreleaser/goreleaser/internal/pipe"
+	"github.com/goreleaser/goreleaser/internal/tmpl"
+	"github.com/goreleaser/goreleaser/pkg/config"
+	"github.com/goreleaser/goreleaser/pkg/context"
+)
+
+const defaultNameTemplate = "{{ .Tag }}"
+
+// Pipe for milestone.
+type Pipe struct{}
+
+func (Pipe) String() string {
+	return "milestones"
+}
+
+// Default sets the pipe defaults.
+func (Pipe) Default(ctx *context.Context) error {
+	if len(ctx.Config.Milestones) == 0 {
+		ctx.Config.Milestones = append(ctx.Config.Milestones, config.Milestone{})
+	}
+
+	for i := range ctx.Config.Milestones {
+		milestone := &ctx.Config.Milestones[i]
+
+		if milestone.NameTemplate == "" {
+			milestone.NameTemplate = defaultNameTemplate
+		}
+
+		// nolint: exhaustive
+		switch ctx.TokenType {
+		case context.TokenTypeGitLab:
+			{
+				if milestone.GitLab.Name == "" {
+					repo, err := git.ExtractRepoFromConfig()
+					if err != nil {
+						return err
+					}
+					milestone.GitLab = repo
+				}
+
+				return nil
+			}
+		case context.TokenTypeGitea:
+			{
+				if milestone.Gitea.Name == "" {
+					repo, err := git.ExtractRepoFromConfig()
+					if err != nil {
+						return err
+					}
+					milestone.Gitea = repo
+				}
+
+				return nil
+			}
+		}
+
+		if milestone.GitHub.Name == "" {
+			repo, err := git.ExtractRepoFromConfig()
+			if err != nil && !ctx.Snapshot {
+				return err
+			}
+			milestone.GitHub = repo
+		}
+	}
+
+	return nil
+}
+
+// Publish the release.
+func (Pipe) Publish(ctx *context.Context) error {
+	if ctx.SkipPublish {
+		return pipe.ErrSkipPublishEnabled
+	}
+	c, err := client.New(ctx)
+	if err != nil {
+		return err
+	}
+	return doPublish(ctx, c)
+}
+
+func doPublish(ctx *context.Context, vcsClient client.Client) error {
+	for i := range ctx.Config.Milestones {
+		milestone := &ctx.Config.Milestones[i]
+
+		if !milestone.Close {
+			return pipe.Skip("milestone pipe is disabled")
+		}
+
+		name, err := tmpl.New(ctx).Apply(milestone.NameTemplate)
+
+		if err != nil {
+			return err
+		}
+
+		var repo client.Repo
+		// nolint: gocritic
+		if milestone.GitHub.String() != "" {
+			repo = client.Repo{
+				Name:  milestone.GitHub.Name,
+				Owner: milestone.GitHub.Owner,
+			}
+		} else if milestone.GitLab.String() != "" {
+			repo = client.Repo{
+				Name:  milestone.GitLab.Name,
+				Owner: milestone.GitLab.Owner,
+			}
+		} else if milestone.Gitea.String() != "" {
+			repo = client.Repo{
+				Name:  milestone.Gitea.Name,
+				Owner: milestone.Gitea.Owner,
+			}
+		}
+
+		log.WithField("milestone", name).
+			WithField("repo", repo.String()).
+			Info("closing milestone")
+
+		err = vcsClient.CloseMilestone(ctx, repo, name)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/pipe/milestone/milestone.go
+++ b/internal/pipe/milestone/milestone.go
@@ -32,40 +32,14 @@ func (Pipe) Default(ctx *context.Context) error {
 			milestone.NameTemplate = defaultNameTemplate
 		}
 
-		// nolint: exhaustive
-		switch ctx.TokenType {
-		case context.TokenTypeGitLab:
-			{
-				if milestone.GitLab.Name == "" {
-					repo, err := git.ExtractRepoFromConfig()
-					if err != nil {
-						return err
-					}
-					milestone.GitLab = repo
-				}
-
-				return nil
-			}
-		case context.TokenTypeGitea:
-			{
-				if milestone.Gitea.Name == "" {
-					repo, err := git.ExtractRepoFromConfig()
-					if err != nil {
-						return err
-					}
-					milestone.Gitea = repo
-				}
-
-				return nil
-			}
-		}
-
-		if milestone.GitHub.Name == "" {
+		if milestone.Repo.Name == "" {
 			repo, err := git.ExtractRepoFromConfig()
+
 			if err != nil && !ctx.Snapshot {
 				return err
 			}
-			milestone.GitHub = repo
+
+			milestone.Repo = repo
 		}
 	}
 
@@ -98,23 +72,9 @@ func doPublish(ctx *context.Context, vcsClient client.Client) error {
 			return err
 		}
 
-		var repo client.Repo
-		// nolint: gocritic
-		if milestone.GitHub.String() != "" {
-			repo = client.Repo{
-				Name:  milestone.GitHub.Name,
-				Owner: milestone.GitHub.Owner,
-			}
-		} else if milestone.GitLab.String() != "" {
-			repo = client.Repo{
-				Name:  milestone.GitLab.Name,
-				Owner: milestone.GitLab.Owner,
-			}
-		} else if milestone.Gitea.String() != "" {
-			repo = client.Repo{
-				Name:  milestone.Gitea.Name,
-				Owner: milestone.Gitea.Owner,
-			}
+		repo := client.Repo{
+			Name:  milestone.Repo.Name,
+			Owner: milestone.Repo.Owner,
 		}
 
 		log.WithField("milestone", name).

--- a/internal/pipe/milestone/milestone.go
+++ b/internal/pipe/milestone/milestone.go
@@ -84,7 +84,13 @@ func doPublish(ctx *context.Context, vcsClient client.Client) error {
 		err = vcsClient.CloseMilestone(ctx, repo, name)
 
 		if err != nil {
-			return err
+			if milestone.FailOnError {
+				return err
+			}
+
+			log.WithField("milestone", name).
+				WithField("repo", repo.String()).
+				Warnf("error closing milestone: %s", err)
 		}
 	}
 

--- a/internal/pipe/milestone/milestone_test.go
+++ b/internal/pipe/milestone/milestone_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDefaultWithGithubConfig(t *testing.T) {
+func TestDefaultWithRepoConfig(t *testing.T) {
 	_, back := testlib.Mktmp(t)
 	defer back()
 	testlib.GitInit(t)
@@ -23,7 +23,7 @@ func TestDefaultWithGithubConfig(t *testing.T) {
 		Config: config.Project{
 			Milestones: []config.Milestone{
 				{
-					GitHub: config.Repo{
+					Repo: config.Repo{
 						Name:  "configrepo",
 						Owner: "configowner",
 					},
@@ -33,11 +33,11 @@ func TestDefaultWithGithubConfig(t *testing.T) {
 	}
 	ctx.TokenType = context.TokenTypeGitHub
 	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Equal(t, "configrepo", ctx.Config.Milestones[0].GitHub.Name)
-	assert.Equal(t, "configowner", ctx.Config.Milestones[0].GitHub.Owner)
+	assert.Equal(t, "configrepo", ctx.Config.Milestones[0].Repo.Name)
+	assert.Equal(t, "configowner", ctx.Config.Milestones[0].Repo.Owner)
 }
 
-func TestDefaultWithGithubRemote(t *testing.T) {
+func TestDefaultWithRepoRemote(t *testing.T) {
 	_, back := testlib.Mktmp(t)
 	defer back()
 	testlib.GitInit(t)
@@ -46,82 +46,8 @@ func TestDefaultWithGithubRemote(t *testing.T) {
 	var ctx = context.New(config.Project{})
 	ctx.TokenType = context.TokenTypeGitHub
 	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Equal(t, "githubrepo", ctx.Config.Milestones[0].GitHub.Name)
-	assert.Equal(t, "githubowner", ctx.Config.Milestones[0].GitHub.Owner)
-}
-
-func TestDefaultWithGitlabConfig(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
-	testlib.GitInit(t)
-	testlib.GitRemoteAdd(t, "git@gitlab.com:gitlabowner/gitlabrepo.git")
-
-	var ctx = &context.Context{
-		Config: config.Project{
-			Milestones: []config.Milestone{
-				{
-					GitLab: config.Repo{
-						Name:  "configrepo",
-						Owner: "configowner",
-					},
-				},
-			},
-		},
-	}
-	ctx.TokenType = context.TokenTypeGitLab
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Equal(t, "configrepo", ctx.Config.Milestones[0].GitLab.Name)
-	assert.Equal(t, "configowner", ctx.Config.Milestones[0].GitLab.Owner)
-}
-
-func TestDefaultWithGitlabRemote(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
-	testlib.GitInit(t)
-	testlib.GitRemoteAdd(t, "git@gitlab.com:gitlabowner/gitlabrepo.git")
-
-	var ctx = context.New(config.Project{})
-	ctx.TokenType = context.TokenTypeGitLab
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Equal(t, "gitlabrepo", ctx.Config.Milestones[0].GitLab.Name)
-	assert.Equal(t, "gitlabowner", ctx.Config.Milestones[0].GitLab.Owner)
-}
-
-func TestDefaultWithGiteaConfig(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
-	testlib.GitInit(t)
-	testlib.GitRemoteAdd(t, "git@gitea.example.com:giteaowner/gitearepo.git")
-
-	var ctx = &context.Context{
-		Config: config.Project{
-			Milestones: []config.Milestone{
-				{
-					Gitea: config.Repo{
-						Name:  "configrepo",
-						Owner: "configowner",
-					},
-				},
-			},
-		},
-	}
-	ctx.TokenType = context.TokenTypeGitea
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Equal(t, "configrepo", ctx.Config.Milestones[0].Gitea.Name)
-	assert.Equal(t, "configowner", ctx.Config.Milestones[0].Gitea.Owner)
-}
-
-func TestDefaultWithGiteaRemote(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
-	testlib.GitInit(t)
-	testlib.GitRemoteAdd(t, "git@gitea.example.com:giteaowner/gitearepo.git")
-
-	var ctx = context.New(config.Project{})
-	ctx.TokenType = context.TokenTypeGitea
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Equal(t, "gitearepo", ctx.Config.Milestones[0].Gitea.Name)
-	assert.Equal(t, "giteaowner", ctx.Config.Milestones[0].Gitea.Owner)
+	assert.Equal(t, "githubrepo", ctx.Config.Milestones[0].Repo.Name)
+	assert.Equal(t, "githubowner", ctx.Config.Milestones[0].Repo.Owner)
 }
 
 func TestDefaultWithNameTemplate(t *testing.T) {
@@ -146,7 +72,7 @@ func TestDefaultWithoutGitRepo(t *testing.T) {
 	}
 	ctx.TokenType = context.TokenTypeGitHub
 	assert.EqualError(t, Pipe{}.Default(ctx), "current folder is not a git repository")
-	assert.Empty(t, ctx.Config.Milestones[0].GitHub.String())
+	assert.Empty(t, ctx.Config.Milestones[0].Repo.String())
 }
 
 func TestDefaultWithoutGitRepoOrigin(t *testing.T) {
@@ -158,7 +84,7 @@ func TestDefaultWithoutGitRepoOrigin(t *testing.T) {
 	ctx.TokenType = context.TokenTypeGitHub
 	testlib.GitInit(t)
 	assert.EqualError(t, Pipe{}.Default(ctx), "repository doesn't have an `origin` remote")
-	assert.Empty(t, ctx.Config.Milestones[0].GitHub.String())
+	assert.Empty(t, ctx.Config.Milestones[0].Repo.String())
 }
 
 func TestDefaultWithoutGitRepoSnapshot(t *testing.T) {
@@ -170,7 +96,7 @@ func TestDefaultWithoutGitRepoSnapshot(t *testing.T) {
 	ctx.TokenType = context.TokenTypeGitHub
 	ctx.Snapshot = true
 	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Empty(t, ctx.Config.Milestones[0].GitHub.String())
+	assert.Empty(t, ctx.Config.Milestones[0].Repo.String())
 }
 
 func TestDefaultWithoutNameTemplate(t *testing.T) {
@@ -204,12 +130,12 @@ func TestPublishCloseEnabled(t *testing.T) {
 	var ctx = context.New(config.Project{
 		Milestones: []config.Milestone{
 			{
-				Close: true,
-				GitHub: config.Repo{
+				Close:        true,
+				NameTemplate: defaultNameTemplate,
+				Repo: config.Repo{
 					Name:  "configrepo",
 					Owner: "configowner",
 				},
-				NameTemplate: defaultNameTemplate,
 			},
 		},
 	})
@@ -223,12 +149,12 @@ func TestPublishCloseError(t *testing.T) {
 	var config = config.Project{
 		Milestones: []config.Milestone{
 			{
-				Close: true,
-				GitHub: config.Repo{
+				Close:        true,
+				NameTemplate: defaultNameTemplate,
+				Repo: config.Repo{
 					Name:  "configrepo",
 					Owner: "configowner",
 				},
-				NameTemplate: defaultNameTemplate,
 			},
 		},
 	}

--- a/internal/pipe/milestone/milestone_test.go
+++ b/internal/pipe/milestone/milestone_test.go
@@ -163,6 +163,29 @@ func TestPublishCloseError(t *testing.T) {
 	client := &DummyClient{
 		FailToCloseMilestone: true,
 	}
+	assert.NoError(t, doPublish(ctx, client))
+	assert.Equal(t, "", client.ClosedMilestone)
+}
+
+func TestPublishCloseFailOnError(t *testing.T) {
+	var config = config.Project{
+		Milestones: []config.Milestone{
+			{
+				Close:        true,
+				FailOnError:  true,
+				NameTemplate: defaultNameTemplate,
+				Repo: config.Repo{
+					Name:  "configrepo",
+					Owner: "configowner",
+				},
+			},
+		},
+	}
+	var ctx = context.New(config)
+	ctx.Git.CurrentTag = "v1.0.0"
+	client := &DummyClient{
+		FailToCloseMilestone: true,
+	}
 	assert.Error(t, doPublish(ctx, client))
 	assert.Equal(t, "", client.ClosedMilestone)
 }

--- a/internal/pipe/milestone/milestone_test.go
+++ b/internal/pipe/milestone/milestone_test.go
@@ -1,0 +1,273 @@
+package milestone
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/goreleaser/goreleaser/internal/artifact"
+	"github.com/goreleaser/goreleaser/internal/client"
+	"github.com/goreleaser/goreleaser/internal/testlib"
+	"github.com/goreleaser/goreleaser/pkg/config"
+	"github.com/goreleaser/goreleaser/pkg/context"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultWithGithubConfig(t *testing.T) {
+	_, back := testlib.Mktmp(t)
+	defer back()
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:githubowner/githubrepo.git")
+
+	var ctx = &context.Context{
+		Config: config.Project{
+			Milestones: []config.Milestone{
+				{
+					GitHub: config.Repo{
+						Name:  "configrepo",
+						Owner: "configowner",
+					},
+				},
+			},
+		},
+	}
+	ctx.TokenType = context.TokenTypeGitHub
+	assert.NoError(t, Pipe{}.Default(ctx))
+	assert.Equal(t, "configrepo", ctx.Config.Milestones[0].GitHub.Name)
+	assert.Equal(t, "configowner", ctx.Config.Milestones[0].GitHub.Owner)
+}
+
+func TestDefaultWithGithubRemote(t *testing.T) {
+	_, back := testlib.Mktmp(t)
+	defer back()
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:githubowner/githubrepo.git")
+
+	var ctx = context.New(config.Project{})
+	ctx.TokenType = context.TokenTypeGitHub
+	assert.NoError(t, Pipe{}.Default(ctx))
+	assert.Equal(t, "githubrepo", ctx.Config.Milestones[0].GitHub.Name)
+	assert.Equal(t, "githubowner", ctx.Config.Milestones[0].GitHub.Owner)
+}
+
+func TestDefaultWithGitlabConfig(t *testing.T) {
+	_, back := testlib.Mktmp(t)
+	defer back()
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@gitlab.com:gitlabowner/gitlabrepo.git")
+
+	var ctx = &context.Context{
+		Config: config.Project{
+			Milestones: []config.Milestone{
+				{
+					GitLab: config.Repo{
+						Name:  "configrepo",
+						Owner: "configowner",
+					},
+				},
+			},
+		},
+	}
+	ctx.TokenType = context.TokenTypeGitLab
+	assert.NoError(t, Pipe{}.Default(ctx))
+	assert.Equal(t, "configrepo", ctx.Config.Milestones[0].GitLab.Name)
+	assert.Equal(t, "configowner", ctx.Config.Milestones[0].GitLab.Owner)
+}
+
+func TestDefaultWithGitlabRemote(t *testing.T) {
+	_, back := testlib.Mktmp(t)
+	defer back()
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@gitlab.com:gitlabowner/gitlabrepo.git")
+
+	var ctx = context.New(config.Project{})
+	ctx.TokenType = context.TokenTypeGitLab
+	assert.NoError(t, Pipe{}.Default(ctx))
+	assert.Equal(t, "gitlabrepo", ctx.Config.Milestones[0].GitLab.Name)
+	assert.Equal(t, "gitlabowner", ctx.Config.Milestones[0].GitLab.Owner)
+}
+
+func TestDefaultWithGiteaConfig(t *testing.T) {
+	_, back := testlib.Mktmp(t)
+	defer back()
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@gitea.example.com:giteaowner/gitearepo.git")
+
+	var ctx = &context.Context{
+		Config: config.Project{
+			Milestones: []config.Milestone{
+				{
+					Gitea: config.Repo{
+						Name:  "configrepo",
+						Owner: "configowner",
+					},
+				},
+			},
+		},
+	}
+	ctx.TokenType = context.TokenTypeGitea
+	assert.NoError(t, Pipe{}.Default(ctx))
+	assert.Equal(t, "configrepo", ctx.Config.Milestones[0].Gitea.Name)
+	assert.Equal(t, "configowner", ctx.Config.Milestones[0].Gitea.Owner)
+}
+
+func TestDefaultWithGiteaRemote(t *testing.T) {
+	_, back := testlib.Mktmp(t)
+	defer back()
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@gitea.example.com:giteaowner/gitearepo.git")
+
+	var ctx = context.New(config.Project{})
+	ctx.TokenType = context.TokenTypeGitea
+	assert.NoError(t, Pipe{}.Default(ctx))
+	assert.Equal(t, "gitearepo", ctx.Config.Milestones[0].Gitea.Name)
+	assert.Equal(t, "giteaowner", ctx.Config.Milestones[0].Gitea.Owner)
+}
+
+func TestDefaultWithNameTemplate(t *testing.T) {
+	var ctx = &context.Context{
+		Config: config.Project{
+			Milestones: []config.Milestone{
+				{
+					NameTemplate: "confignametemplate",
+				},
+			},
+		},
+	}
+	assert.NoError(t, Pipe{}.Default(ctx))
+	assert.Equal(t, "confignametemplate", ctx.Config.Milestones[0].NameTemplate)
+}
+
+func TestDefaultWithoutGitRepo(t *testing.T) {
+	_, back := testlib.Mktmp(t)
+	defer back()
+	var ctx = &context.Context{
+		Config: config.Project{},
+	}
+	ctx.TokenType = context.TokenTypeGitHub
+	assert.EqualError(t, Pipe{}.Default(ctx), "current folder is not a git repository")
+	assert.Empty(t, ctx.Config.Milestones[0].GitHub.String())
+}
+
+func TestDefaultWithoutGitRepoOrigin(t *testing.T) {
+	_, back := testlib.Mktmp(t)
+	defer back()
+	var ctx = &context.Context{
+		Config: config.Project{},
+	}
+	ctx.TokenType = context.TokenTypeGitHub
+	testlib.GitInit(t)
+	assert.EqualError(t, Pipe{}.Default(ctx), "repository doesn't have an `origin` remote")
+	assert.Empty(t, ctx.Config.Milestones[0].GitHub.String())
+}
+
+func TestDefaultWithoutGitRepoSnapshot(t *testing.T) {
+	_, back := testlib.Mktmp(t)
+	defer back()
+	var ctx = &context.Context{
+		Config: config.Project{},
+	}
+	ctx.TokenType = context.TokenTypeGitHub
+	ctx.Snapshot = true
+	assert.NoError(t, Pipe{}.Default(ctx))
+	assert.Empty(t, ctx.Config.Milestones[0].GitHub.String())
+}
+
+func TestDefaultWithoutNameTemplate(t *testing.T) {
+	var ctx = &context.Context{
+		Config: config.Project{
+			Milestones: []config.Milestone{},
+		},
+	}
+	assert.NoError(t, Pipe{}.Default(ctx))
+	assert.Equal(t, "{{ .Tag }}", ctx.Config.Milestones[0].NameTemplate)
+}
+
+func TestString(t *testing.T) {
+	assert.NotEmpty(t, Pipe{}.String())
+}
+
+func TestPublishCloseDisabled(t *testing.T) {
+	var ctx = context.New(config.Project{
+		Milestones: []config.Milestone{
+			{
+				Close: false,
+			},
+		},
+	})
+	client := &DummyClient{}
+	testlib.AssertSkipped(t, doPublish(ctx, client))
+	assert.Equal(t, "", client.ClosedMilestone)
+}
+
+func TestPublishCloseEnabled(t *testing.T) {
+	var ctx = context.New(config.Project{
+		Milestones: []config.Milestone{
+			{
+				Close: true,
+				GitHub: config.Repo{
+					Name:  "configrepo",
+					Owner: "configowner",
+				},
+				NameTemplate: defaultNameTemplate,
+			},
+		},
+	})
+	ctx.Git.CurrentTag = "v1.0.0"
+	client := &DummyClient{}
+	assert.NoError(t, doPublish(ctx, client))
+	assert.Equal(t, "v1.0.0", client.ClosedMilestone)
+}
+
+func TestPublishCloseError(t *testing.T) {
+	var config = config.Project{
+		Milestones: []config.Milestone{
+			{
+				Close: true,
+				GitHub: config.Repo{
+					Name:  "configrepo",
+					Owner: "configowner",
+				},
+				NameTemplate: defaultNameTemplate,
+			},
+		},
+	}
+	var ctx = context.New(config)
+	ctx.Git.CurrentTag = "v1.0.0"
+	client := &DummyClient{
+		FailToCloseMilestone: true,
+	}
+	assert.Error(t, doPublish(ctx, client))
+	assert.Equal(t, "", client.ClosedMilestone)
+}
+
+type DummyClient struct {
+	ClosedMilestone      string
+	FailToCloseMilestone bool
+}
+
+func (c *DummyClient) CloseMilestone(ctx *context.Context, repo client.Repo, title string) error {
+	if c.FailToCloseMilestone {
+		return errors.New("milestone failed")
+	}
+
+	c.ClosedMilestone = title
+
+	return nil
+}
+
+func (c *DummyClient) CreateRelease(ctx *context.Context, body string) (string, error) {
+	return "", nil
+}
+
+func (c *DummyClient) ReleaseURLTemplate(ctx *context.Context) (string, error) {
+	return "", nil
+}
+
+func (c *DummyClient) CreateFile(ctx *context.Context, commitAuthor config.CommitAuthor, repo client.Repo, content []byte, path, msg string) error {
+	return nil
+}
+
+func (c *DummyClient) Upload(ctx *context.Context, releaseID string, artifact *artifact.Artifact, file *os.File) error {
+	return nil
+}

--- a/internal/pipe/publish/publish.go
+++ b/internal/pipe/publish/publish.go
@@ -10,6 +10,7 @@ import (
 	"github.com/goreleaser/goreleaser/internal/pipe/brew"
 	"github.com/goreleaser/goreleaser/internal/pipe/custompublishers"
 	"github.com/goreleaser/goreleaser/internal/pipe/docker"
+	"github.com/goreleaser/goreleaser/internal/pipe/milestone"
 	"github.com/goreleaser/goreleaser/internal/pipe/release"
 	"github.com/goreleaser/goreleaser/internal/pipe/scoop"
 	"github.com/goreleaser/goreleaser/internal/pipe/snapcraft"
@@ -46,6 +47,7 @@ var publishers = []Publisher{
 	// brew and scoop use the release URL, so, they should be last
 	brew.Pipe{},
 	scoop.Pipe{},
+	milestone.Pipe{},
 }
 
 // Run the pipe.

--- a/internal/pipe/release/release.go
+++ b/internal/pipe/release/release.go
@@ -8,6 +8,7 @@ import (
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/internal/client"
 	"github.com/goreleaser/goreleaser/internal/extrafiles"
+	"github.com/goreleaser/goreleaser/internal/git"
 	"github.com/goreleaser/goreleaser/internal/pipe"
 	"github.com/goreleaser/goreleaser/internal/semerrgroup"
 	"github.com/goreleaser/goreleaser/pkg/context"
@@ -50,7 +51,7 @@ func (Pipe) Default(ctx *context.Context) error {
 	case context.TokenTypeGitLab:
 		{
 			if ctx.Config.Release.GitLab.Name == "" {
-				repo, err := remoteRepo()
+				repo, err := git.ExtractRepoFromConfig()
 				if err != nil {
 					return err
 				}
@@ -62,7 +63,7 @@ func (Pipe) Default(ctx *context.Context) error {
 	case context.TokenTypeGitea:
 		{
 			if ctx.Config.Release.Gitea.Name == "" {
-				repo, err := remoteRepo()
+				repo, err := git.ExtractRepoFromConfig()
 				if err != nil {
 					return err
 				}
@@ -75,7 +76,7 @@ func (Pipe) Default(ctx *context.Context) error {
 
 	// We keep github as default for now
 	if ctx.Config.Release.GitHub.Name == "" {
-		repo, err := remoteRepo()
+		repo, err := git.ExtractRepoFromConfig()
 		if err != nil && !ctx.Snapshot {
 			return err
 		}

--- a/internal/pipe/release/release_test.go
+++ b/internal/pipe/release/release_test.go
@@ -538,6 +538,10 @@ type DummyClient struct {
 	Lock                sync.Mutex
 }
 
+func (c *DummyClient) CloseMilestone(ctx *context.Context, repo client.Repo, title string) error {
+	return nil
+}
+
 func (c *DummyClient) CreateRelease(ctx *context.Context, body string) (releaseID string, err error) {
 	if c.FailToCreateRelease {
 		return "", errors.New("release failed")

--- a/internal/pipe/scoop/scoop_test.go
+++ b/internal/pipe/scoop/scoop_test.go
@@ -1023,6 +1023,10 @@ type DummyClient struct {
 	NotImplemented bool
 }
 
+func (dc *DummyClient) CloseMilestone(ctx *context.Context, repo client.Repo, title string) error {
+	return nil
+}
+
 func (dc *DummyClient) CreateRelease(ctx *context.Context, body string) (releaseID string, err error) {
 	return
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -282,6 +282,15 @@ type Release struct {
 	ExtraFiles   []ExtraFile `yaml:"extra_files,omitempty"`
 }
 
+// Milestone config used for VCS milestone.
+type Milestone struct {
+	GitHub       Repo   `yaml:",omitempty"`
+	GitLab       Repo   `yaml:",omitempty"`
+	Gitea        Repo   `yaml:",omitempty"`
+	Close        bool   `yaml:",omitempty"`
+	NameTemplate string `yaml:"name_template,omitempty"`
+}
+
 // ExtraFile on a release.
 type ExtraFile struct {
 	Glob string `yaml:"glob,omitempty"`
@@ -477,6 +486,7 @@ type Project struct {
 	ProjectName   string      `yaml:"project_name,omitempty"`
 	Env           []string    `yaml:",omitempty"`
 	Release       Release     `yaml:",omitempty"`
+	Milestones    []Milestone `yaml:",omitempty"`
 	Brews         []Homebrew  `yaml:",omitempty"`
 	Scoop         Scoop       `yaml:",omitempty"`
 	Builds        []Build     `yaml:",omitempty"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -286,6 +286,7 @@ type Release struct {
 type Milestone struct {
 	Repo         Repo   `yaml:",omitempty"`
 	Close        bool   `yaml:",omitempty"`
+	FailOnError  bool   `yaml:"fail_on_error,omitempty"`
 	NameTemplate string `yaml:"name_template,omitempty"`
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -284,9 +284,7 @@ type Release struct {
 
 // Milestone config used for VCS milestone.
 type Milestone struct {
-	GitHub       Repo   `yaml:",omitempty"`
-	GitLab       Repo   `yaml:",omitempty"`
-	Gitea        Repo   `yaml:",omitempty"`
+	Repo         Repo   `yaml:",omitempty"`
 	Close        bool   `yaml:",omitempty"`
 	NameTemplate string `yaml:"name_template,omitempty"`
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -12,6 +12,7 @@ import (
 	"github.com/goreleaser/goreleaser/internal/pipe/build"
 	"github.com/goreleaser/goreleaser/internal/pipe/checksums"
 	"github.com/goreleaser/goreleaser/internal/pipe/docker"
+	"github.com/goreleaser/goreleaser/internal/pipe/milestone"
 	"github.com/goreleaser/goreleaser/internal/pipe/nfpm"
 	"github.com/goreleaser/goreleaser/internal/pipe/project"
 	"github.com/goreleaser/goreleaser/internal/pipe/release"
@@ -50,4 +51,5 @@ var Defaulters = []Defaulter{
 	blob.Pipe{},
 	brew.Pipe{},
 	scoop.Pipe{},
+	milestone.Pipe{},
 }

--- a/www/docs/customization/milestone.md
+++ b/www/docs/customization/milestone.md
@@ -1,0 +1,43 @@
+---
+title: Milestone
+---
+
+GoReleaser can close GitHub/GitLab/Gitea milestones after successfully
+publishing all artifacts.
+
+Let's see what can be customized in the `milestones` section:
+
+```yaml
+# .goreleaser.yml
+milestones:
+  # You can have multiple milestone configs
+  -
+    # GitHub repository for the milestone
+    # Default is extracted from the origin remote URL
+    github:
+      owner: user
+      name: repo
+
+    # GitLab project for the milestone
+    # Default is extracted from the origin remote URL
+    gitlab:
+      owner: user
+      name: repo
+
+    # Gitea repository for the milestone
+    # Default is extracted from the origin remote URL
+    gitea:
+      owner: user
+      name: repo
+
+    # Whether to close the milestone
+    # Default is true
+    close: true
+
+    # Name of the milestone
+    # Default is `{{ .Tag }}`
+    name_template: "Current Release"
+```
+
+!!! tip
+    Learn more about the [name template engine](/customization/templates).

--- a/www/docs/customization/milestone.md
+++ b/www/docs/customization/milestone.md
@@ -2,7 +2,7 @@
 title: Milestone
 ---
 
-GoReleaser can close GitHub/GitLab/Gitea milestones after successfully
+GoReleaser can close repository milestones after successfully
 publishing all artifacts.
 
 Let's see what can be customized in the `milestones` section:
@@ -12,21 +12,9 @@ Let's see what can be customized in the `milestones` section:
 milestones:
   # You can have multiple milestone configs
   -
-    # GitHub repository for the milestone
+    # Repository for the milestone
     # Default is extracted from the origin remote URL
-    github:
-      owner: user
-      name: repo
-
-    # GitLab project for the milestone
-    # Default is extracted from the origin remote URL
-    gitlab:
-      owner: user
-      name: repo
-
-    # Gitea repository for the milestone
-    # Default is extracted from the origin remote URL
-    gitea:
+    repo:
       owner: user
       name: repo
 

--- a/www/docs/customization/milestone.md
+++ b/www/docs/customization/milestone.md
@@ -22,6 +22,10 @@ milestones:
     # Default is false
     close: true
 
+    # Fail release on errors, such as missing milestone on close
+    # Default is false
+    fail_on_error: true
+
     # Name of the milestone
     # Default is `{{ .Tag }}`
     name_template: "Current Release"

--- a/www/docs/customization/milestone.md
+++ b/www/docs/customization/milestone.md
@@ -31,7 +31,7 @@ milestones:
       name: repo
 
     # Whether to close the milestone
-    # Default is true
+    # Default is false
     close: true
 
     # Name of the milestone

--- a/www/mkdocs.yml
+++ b/www/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
   - customization/homebrew.md
   - customization/upload.md
   - customization/templates.md
+  - customization/milestone.md
   - customization/nfpm.md
   - customization/project.md
   - customization/release.md


### PR DESCRIPTION
Closes #1415

---

Enables configuration to automatically close milestones matching the tag name (or any configurable name template) at the end of the publishing pipeline with GitHub, GitLab, and Gitea. In its simplest form:

```yaml
milestones:
  - close: true
```

Will close the milestone title matching the release tag after all publishing has occurred.