### PR TITLE
docs: fix OCI annotation example

### DIFF
--- a/www/docs/customization/docker.md
+++ b/www/docs/customization/docker.md
@@ -84,7 +84,7 @@ dockers:
     build_flag_templates:
     - "--pull"
     - "--label=org.opencontainers.image.created={{.Date}}"
-    - "--label=org.opencontainers.image.name={{.ProjectName}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
     - "--label=org.opencontainers.image.version={{.Version}}"
     - "--build-arg=FOO={{.Env.Bar}}"
@@ -203,7 +203,7 @@ dockers:
     build_flag_templates:
     - "--pull"
     - "--label=org.opencontainers.image.created={{.Date}}"
-    - "--label=org.opencontainers.image.name={{.ProjectName}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
     - "--label=org.opencontainers.image.version={{.Version}}"
 ```
@@ -214,7 +214,7 @@ This will execute the following command:
 docker build -t myuser/myimage . \
   --pull \
   --label=org.opencontainers.image.created=2020-01-19T15:58:07Z \
-  --label=org.opencontainers.image.name=mybinary \
+  --label=org.opencontainers.image.title=mybinary \
   --label=org.opencontainers.image.revision=da39a3ee5e6b4b0d3255bfef95601890afd80709 \
   --label=org.opencontainers.image.version=1.6.4
 ```


### PR DESCRIPTION
Signed-off-by: Jeremy Gustie <jeremy@gustie.com>

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->

<!-- # Provide links to any relevant tickets, URLs or other resources -->

If applied, this commit will change the example labels in the Docker documentation to match the OCI recommendations.

The `org.label-schema.name` label became `org.opencontainers.image.title` ([Annotations](https://github.com/opencontainers/image-spec/blob/master/annotations.md)).