### PR TITLE
fix: Completer script link errors for snapcraft

### DIFF
--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -270,7 +270,7 @@ func create(ctx *context.Context, snap config.Snapcraft, arch string, binaries [
 				log.WithField("src", config.Completer).
 					WithField("dst", destCompleterPath).
 					Debug("linking")
-				if err := os.Link(config.Completer, destCompleterPath); err != nil {
+				if err := os.Link(config.Completer, destCompleterPath); err != nil && !os.IsExist(err) {
 					return errors.Wrap(err, "failed to link completer")
 				}
 				if err := os.Chmod(destCompleterPath, 0644); err != nil {

--- a/internal/pipe/snapcraft/snapcraft_test.go
+++ b/internal/pipe/snapcraft/snapcraft_test.go
@@ -311,13 +311,14 @@ func TestCompleter(t *testing.T) {
 						Completer: "testdata/mybin-completer.bash",
 					},
 				},
-				Builds: []string{"foo"},
+				Builds: []string{"foo", "bar"},
 			},
 		},
 	})
 	ctx.Git.CurrentTag = "v1.2.3"
 	ctx.Version = "v1.2.3"
 	addBinaries(t, ctx, "foo", dist, "mybin")
+	addBinaries(t, ctx, "bar", dist, "mybin")
 	require.NoError(t, Pipe{}.Run(ctx))
 	yamlFile, err := ioutil.ReadFile(filepath.Join(dist, "foo_amd64", "prime", "meta", "snap.yaml"))
 	require.NoError(t, err)


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

## Changes

Closes #1678

<!-- Why is this change being made? -->

## Description

Do not fail on `os.Link` errors if `os.IsExist(err)`

## Considered alternatives

- Loop through the completer scripts separately and only once.
- Keep track of files that have been linked already and do not try to link again.

<!-- # Provide links to any relevant tickets, URLs or other resources -->
