### PR TITLE
fix: Fix indent of yaml generated by `init`

### DIFF
--- a/internal/static/config.go
+++ b/internal/static/config.go
@@ -14,19 +14,19 @@ before:
     # you may remove this if you don't need go generate
     - go generate ./...
 builds:
-- env:
-  - CGO_ENABLED=0
+  - env:
+      - CGO_ENABLED=0
     goos:
-    - linux
-    - windows
-    - darwin
+      - linux
+      - windows
+      - darwin
 archives:
-- replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
 snapshot:
@@ -35,6 +35,6 @@ changelog:
   sort: asc
   filters:
     exclude:
-    - '^docs:'
-    - '^test:'
+      - '^docs:'
+      - '^test:'
 `

--- a/internal/static/config_test.go
+++ b/internal/static/config_test.go
@@ -1,0 +1,14 @@
+package static
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/goreleaser/goreleaser/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExampleConfig(t *testing.T) {
+	_, err := config.LoadReader(strings.NewReader(ExampleConfig))
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Fixes #1705.