### PR TITLE
remove --pull option from docker run

### DIFF
--- a/www/docs/ci/gitlab.md
+++ b/www/docs/ci/gitlab.md
@@ -38,7 +38,7 @@ release:
 
     # GITLAB_TOKEN is needed to create GitLab releases.
     # DOCKER_* are needed to push Docker images.
-    docker run --pull --rm --privileged \
+    docker run --rm --privileged \
       -v $PWD:/go/src/gitlab.com/YourGitLabUser/YourGitLabRepo \
       -w /go/src/gitlab.com/YourGitLabUser/YourGitLabRepo \
       -v /var/run/docker.sock:/var/run/docker.sock \


### PR DESCRIPTION
docker run command has not the option `--pull`
here's the `docker run` [documentation](https://docs.docker.com/engine/reference/run/)