### PR TITLE
fix(ci): htmltest failing with 416 on some sites

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,4 +25,4 @@ jobs:
         run: |
           cd www
           curl https://htmltest.wjdp.uk | bash
-          ./bin/htmltest -c htmltest.yml .
+          ./bin/htmltest -c htmltest.yml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,4 +25,4 @@ jobs:
         run: |
           cd www
           curl https://htmltest.wjdp.uk | bash
-          ./bin/htmltest -c htmltest.yml site
+          ./bin/htmltest -c htmltest.yml .

--- a/www/htmltest.yml
+++ b/www/htmltest.yml
@@ -1,4 +1,4 @@
-DirectoryPath: "site"
+DirectoryPath: ./site
 IgnoreURLs:
 - www.google-analytics.com
 - fonts.gstatic.com

--- a/www/htmltest.yml
+++ b/www/htmltest.yml
@@ -8,3 +8,6 @@ IgnoreDirs:
 - overrides
 IgnoreDirectoryMissingTrailingSlash: true
 IgnoreAltMissing: true
+HTTPHeaders:
+  Range: bytes=0-10
+  Accept: "*/*"

--- a/www/htmltest.yml
+++ b/www/htmltest.yml
@@ -8,6 +8,4 @@ IgnoreDirs:
 - overrides
 IgnoreDirectoryMissingTrailingSlash: true
 IgnoreAltMissing: true
-HTTPHeaders:
-  Range: bytes=0-10
-  Accept: "*/*"
+HTTPHeaders: '{"Range": "bytes=0-10", "Accept": "*/*"}'


### PR DESCRIPTION
it defaults headers to `Range: bytes=0-0`, which some providers may not support.

changing to `0-10` seems to yield a 206 on the providers I tested.