### PR TITLE
fix: ignore git warnings

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -4,7 +4,6 @@ package git
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"os/exec"
 	"strings"
 
@@ -40,14 +39,17 @@ func RunEnv(env map[string]string, args ...string) (string, error) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf(stderr.String())
-	}
-
 	log.WithField("args", args).Debug("running git")
+	err := cmd.Run()
+
 	log.WithField("stdout", stdout.String()).
 		WithField("stderr", stderr.String()).
 		Debug("git result")
+
+	if err != nil {
+		return "", errors.New(stderr.String())
+	}
+
 	return string(stdout.String()), nil
 }
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -50,7 +50,7 @@ func RunEnv(env map[string]string, args ...string) (string, error) {
 		return "", errors.New(stderr.String())
 	}
 
-	return string(stdout.String()), nil
+	return stdout.String(), nil
 }
 
 // Run runs a git command and returns its output or errors.

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/goreleaser/goreleaser/internal/git"
+	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,6 +22,22 @@ func TestGit(t *testing.T) {
 		"git: 'command-that-dont-exist' is not a git command. See 'git --help'.\n",
 		err.Error(),
 	)
+}
+
+func TestGitWarning(t *testing.T) {
+	_, back := testlib.Mktmp(t)
+	defer back()
+	testlib.GitInit(t)
+	testlib.GitCommit(t, "foo")
+	testlib.GitBranch(t, "tags/1.2.2")
+	testlib.GitTag(t, "1.2.2")
+	testlib.GitCommit(t, "foobar")
+	testlib.GitBranch(t, "tags/1.2.3")
+	testlib.GitTag(t, "1.2.3")
+
+	out, err := git.Run("describe", "--tags", "--abbrev=0", "tags/1.2.3^")
+	assert.NoError(t, err)
+	assert.Equal(t, "1.2.2\n", out)
 }
 
 func TestRepo(t *testing.T) {

--- a/internal/testlib/git.go
+++ b/internal/testlib/git.go
@@ -48,6 +48,13 @@ func GitTag(t *testing.T, tag string) {
 	assert.Empty(t, out)
 }
 
+// GitBranch creates a git branch.
+func GitBranch(t *testing.T, branch string) {
+	out, err := fakeGit("branch", branch)
+	assert.NoError(t, err)
+	assert.Empty(t, out)
+}
+
 // GitAdd adds all files to stage.
 func GitAdd(t *testing.T) {
 	out, err := fakeGit("add", "-A")

--- a/internal/testlib/git.go
+++ b/internal/testlib/git.go
@@ -78,8 +78,8 @@ func fakeGit(args ...string) (string, error) {
 }
 
 // GitCheckoutBranch allows us to change the active branch that we're using.
-func GitCheckoutBranch(t *testing.T, tag string) {
-	out, err := fakeGit("checkout", "-b", tag)
+func GitCheckoutBranch(t *testing.T, name string) {
+	out, err := fakeGit("checkout", "-b", name)
 	assert.NoError(t, err)
-	assert.Contains(t, out, tag)
+	assert.Empty(t, out)
 }


### PR DESCRIPTION
should avoid issues like https://github.com/goreleaser/goreleaser/issues/1734, although I'm not sure how to reproduce it (and therefore write a test for it).