### PR TITLE
docs: make commands copy-paste friendly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,19 +18,19 @@ Prerequisites:
 Clone `goreleaser` anywhere:
 
 ```sh
-$ git clone git@github.com:goreleaser/goreleaser.git
+git clone git@github.com:goreleaser/goreleaser.git
 ```
 
 Install the build and lint dependencies:
 
 ```sh
-$ make setup
+make setup
 ```
 
 A good way of making sure everything is all right is running the test suite:
 
 ```sh
-$ make test
+make test
 ```
 
 ## Test your change
@@ -38,13 +38,13 @@ $ make test
 You can create a branch for your changes and try to build from the source as you go:
 
 ```sh
-$ make build
+make build
 ```
 
 When you are satisfied with the changes, we suggest you run:
 
 ```sh
-$ make ci
+make ci
 ```
 
 Which runs all the linters and tests.

--- a/www/docs/customization/release.md
+++ b/www/docs/customization/release.md
@@ -129,6 +129,7 @@ release:
 ```
 
 To enable uploading `tar.gz` and `checksums.txt` files you need to add the following to your Gitea config in `app.ini`:
+
 ```ini
 [attachment]
 ALLOWED_TYPES = application/gzip|application/x-gzip|application/x-gtar|application/x-tgz|application/x-compressed-tar|text/plain
@@ -188,7 +189,7 @@ To list all commits since the last tag, but skip ones starting with `Merge` or
 `docs`, you could run this command:
 
 ```sh
-$ goreleaser --release-notes <(some_changelog_generator)
+goreleaser --release-notes <(some_changelog_generator)
 ```
 
 Some changelog generators you can use:

--- a/www/docs/customization/scoop.md
+++ b/www/docs/customization/scoop.md
@@ -79,9 +79,9 @@ the root of the repository specified in the `bucket` section.
 
 Your users can then install your app by doing:
 
-```console
-$ scoop bucket add org https://github.com/org/repo.git
-$ scoop install org/drumroll
+```sh
+scoop bucket add org https://github.com/org/repo.git
+scoop install org/drumroll
 ```
 
 You can check the

--- a/www/docs/deprecations.md
+++ b/www/docs/deprecations.md
@@ -9,8 +9,8 @@ deprecated.
 
 You can check your use of deprecated configurations by running:
 
-```console
-$ goreleaser check
+```sh
+goreleaser check
 ```
 
 ## Active deprecation notices

--- a/www/docs/install.md
+++ b/www/docs/install.md
@@ -9,27 +9,27 @@ Here are the steps for each of them:
 
 **homebrew tap** (only on macOS for now):
 
-```console
-$ brew install goreleaser/tap/goreleaser
+```sh
+brew install goreleaser/tap/goreleaser
 ```
 
 **homebrew** (may not be the latest version):
 
-```console
-$ brew install goreleaser
+```sh
+brew install goreleaser
 ```
 
 **snapcraft**:
 
-```console
-$ sudo snap install --classic goreleaser
+```sh
+sudo snap install --classic goreleaser
 ```
 
 **scoop**:
 
-```console
-$ scoop bucket add goreleaser https://github.com/goreleaser/scoop-bucket.git
-$ scoop install goreleaser
+```sh
+scoop bucket add goreleaser https://github.com/goreleaser/scoop-bucket.git
+scoop install goreleaser
 ```
 
 **deb/rpm**:
@@ -39,8 +39,8 @@ install with `dpkg -i` and `rpm -i` respectively.
 
 **Shell script**:
 
-```console
-$ curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
+```sh
+curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
 ```
 
 **manually**:
@@ -53,8 +53,8 @@ copy to the desired location.
 You can also use it within a Docker container. To do that, you'll need to
 execute something more-or-less like the following:
 
-```console
-$ docker run --rm --privileged \
+```sh
+docker run --rm --privileged \
   -v $PWD:/go/src/github.com/user/repo \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -w /go/src/github.com/user/repo \
@@ -92,25 +92,25 @@ If you just want to build from source for whatever reason, follow these steps:
 
 **Clone:**
 
-```console
-$ git clone https://github.com/goreleaser/goreleaser
-$ cd goreleaser
+```sh
+git clone https://github.com/goreleaser/goreleaser
+cd goreleaser
 ```
 
 **Get the dependencies:**
 
-```console
-$ go get ./...
+```sh
+go get ./...
 ```
 
 **Build:**
 
-```console
-$ go build -o goreleaser .
+```sh
+go build -o goreleaser .
 ```
 
 **Verify it works:**
 
-```console
-$ ./goreleaser --version
+```sh
+./goreleaser --version
 ```

--- a/www/docs/quick-start.md
+++ b/www/docs/quick-start.md
@@ -15,11 +15,8 @@ func main() {
 
 Run `goreleaser init` to create an example `.goreleaser.yaml` file:
 
-```console
-$ goreleaser init
-
-   • Generating .goreleaser.yml file
-   • config created; please edit accordingly to your needs file=.goreleaser.yml
+```sh
+goreleaser init
 ```
 
 You can [customize](/customization/) the generated `.goreleaser.yml` or leave
@@ -29,8 +26,8 @@ You can test the configuration at any time by running GoReleaser with a few
 extra parameters to not require a version tag, skip publishing to GitHub,
 and remove any already-built files:
 
-```console
-$ goreleaser --snapshot --skip-publish --rm-dist
+```sh
+goreleaser --snapshot --skip-publish --rm-dist
 ```
 
 If you are not using vgo or Go modules, then you will need to comment out the
@@ -51,19 +48,23 @@ contain a valid GitHub token with the `repo` scope or GitLab token with `api` sc
 It will be used to deploy releases to your GitHub/GitLab repository.
 You can create a token [here](https://github.com/settings/tokens/new) for GitHub or [here](https://gitlab.com/profile/personal_access_tokens) for GitLab.
 
-```console
-$ export GITHUB_TOKEN="YOUR_GH_TOKEN"
-# or
-$ export GITLAB_TOKEN="YOUR_GL_TOKEN"
+```sh
+export GITHUB_TOKEN="YOUR_GH_TOKEN"
+```
+
+or
+
+```sh
+export GITLAB_TOKEN="YOUR_GL_TOKEN"
 ```
 
 GoReleaser will use the latest
 [Git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) of your repository.
 Create a tag and push it to GitHub:
 
-```console
-$ git tag -a v0.1.0 -m "First release"
-$ git push origin v0.1.0
+```sh
+git tag -a v0.1.0 -m "First release"
+git push origin v0.1.0
 ```
 
 !!! info
@@ -72,14 +73,14 @@ $ git push origin v0.1.0
 If you don't want to create a tag yet, you can also run GoReleaser without publishing
 based on the latest commit by using the `--snapshot` flag:
 
-```console
-$ goreleaser --snapshot
+```sh
+goreleaser --snapshot
 ```
 
 Now you can run GoReleaser at the root of your repository:
 
-```console
-$ goreleaser
+```sh
+goreleaser
 ```
 
 That's all! Check your GitHub project's release page.
@@ -111,8 +112,8 @@ use the following techniques.
 
 Build command will build the project
 
-```console
-$ goreleaser build
+```sh
+goreleaser build
 ```
 
 This can be useful as part of CI pipelines to verify the project builds
@@ -120,26 +121,26 @@ without errors for all build targets.
 
 You can check the other options by running:
 
-```console
-$ goreleaser build --help
+```sh
+goreleaser build --help
 ```
 
 ### Release Flags
 
 Use the `--skip-publish` flag to skip publishing:
 
-```console
-$ goreleaser release --skip-publish
+```sh
+goreleaser release --skip-publish
 ```
 
 You can check the other options by running:
 
-```console
-$ goreleaser --help
+```sh
+goreleaser --help
 ```
 
 and
 
-```console
-$ goreleaser release --help
+```sh
+goreleaser release --help
 ```


### PR DESCRIPTION
so users can copy without worrying about the `$` prefix.