### PR TITLE
fix: Go 1.15 cannot build for darwin/386

### DIFF
--- a/internal/static/config.go
+++ b/internal/static/config.go
@@ -20,6 +20,9 @@ builds:
       - linux
       - windows
       - darwin
+    ignore:
+      - goos: darwin
+        goarch: 386
 archives:
   - replacements:
       darwin: Darwin


### PR DESCRIPTION
<!-- If applied, this commit will... -->

Provide a better default `.goreleaser.yml` when running `init`

<!-- Why is this change being made? -->

Darwin/386 is not supported by Go 1.15 anymore. Until `386` is removed for the `goreleaser` default `goarch`, this looks reasonable.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

https://golang.org/doc/go1.15#darwin