### PR TITLE
feat: Add `gobinary` option to build configs.

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -56,6 +56,9 @@ func (*Builder) WithDefaults(build config.Build) config.Build {
 	if len(build.Targets) == 0 {
 		build.Targets = matrix(build)
 	}
+	if build.GoBinary == "" {
+		build.GoBinary = "go"
+	}
 	return build
 }
 
@@ -69,7 +72,7 @@ func (*Builder) Build(ctx *context.Context, build config.Build, options api.Opti
 		return err
 	}
 
-	var cmd = []string{"go", "build"}
+	var cmd = []string{build.GoBinary, "build"}
 
 	var env = append(ctx.Env.Strings(), build.Env...)
 	env = append(env, target.Env()...)

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -24,8 +24,9 @@ var runtimeTarget = runtime.GOOS + "_" + runtime.GOARCH
 
 func TestWithDefaults(t *testing.T) {
 	for name, testcase := range map[string]struct {
-		build   config.Build
-		targets []string
+		build    config.Build
+		targets  []string
+		goBinary string
 	}{
 		"full": {
 			build: config.Build{
@@ -47,6 +48,7 @@ func TestWithDefaults(t *testing.T) {
 				Gomips: []string{
 					"softfloat",
 				},
+				GoBinary: "go1.2.3",
 			},
 			targets: []string{
 				"linux_amd64",
@@ -55,6 +57,7 @@ func TestWithDefaults(t *testing.T) {
 				"windows_amd64",
 				"linux_arm_6",
 			},
+			goBinary: "go1.2.3",
 		},
 		"empty": {
 			build: config.Build{
@@ -66,6 +69,7 @@ func TestWithDefaults(t *testing.T) {
 				"linux_386",
 				"darwin_amd64",
 			},
+			goBinary: "go",
 		},
 	} {
 		t.Run(name, func(tt *testing.T) {
@@ -78,6 +82,7 @@ func TestWithDefaults(t *testing.T) {
 			ctx.Git.CurrentTag = "5.6.7"
 			var build = Default.WithDefaults(ctx.Config.Builds[0])
 			assert.ElementsMatch(t, build.Targets, testcase.targets)
+			assert.EqualValues(t, testcase.goBinary, build.GoBinary)
 		})
 	}
 }
@@ -104,6 +109,7 @@ func TestBuild(t *testing.T) {
 				Asmflags: []string{".=", "all="},
 				Gcflags:  []string{"all="},
 				Flags:    []string{"{{.Env.GO_FLAGS}}"},
+				GoBinary: "go",
 			},
 		},
 	}
@@ -259,6 +265,7 @@ func TestBuildCodeInSubdir(t *testing.T) {
 				Targets: []string{
 					runtimeTarget,
 				},
+				GoBinary: "go",
 			},
 		},
 	}
@@ -286,6 +293,7 @@ func TestBuildFailed(t *testing.T) {
 				Targets: []string{
 					runtimeTarget,
 				},
+				GoBinary: "go",
 			},
 		},
 	}
@@ -476,6 +484,7 @@ func TestRunPipeWithMainFuncNotInMainGoFile(t *testing.T) {
 				Targets: []string{
 					runtimeTarget,
 				},
+				GoBinary: "go",
 			},
 		},
 	}
@@ -643,6 +652,7 @@ func TestBuildModTimestamp(t *testing.T) {
 				Gcflags:      []string{"all="},
 				Flags:        []string{"{{.Env.GO_FLAGS}}"},
 				ModTimestamp: fmt.Sprintf("%d", modTime.Unix()),
+				GoBinary:     "go",
 			},
 		},
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -201,6 +201,7 @@ type Build struct {
 	Gcflags      StringArray    `yaml:",omitempty"`
 	ModTimestamp string         `yaml:"mod_timestamp,omitempty"`
 	Skip         bool           `yaml:",omitempty"`
+	GoBinary     string         `yaml:",omitempty"`
 }
 
 type HookConfig struct {

--- a/www/docs/customization/build.md
+++ b/www/docs/customization/build.md
@@ -104,7 +104,7 @@ builds:
     # Set a specific go binary to use when building. It is safe to ignore
     # this option in most cases.
     # Default is "go"
-    go_binary: "go1.13.4"
+    gobinary: "go1.13.4"
 
     # Set the modified timestamp on the output binary, typically
     # you would do this to ensure a build was reproducible. Pass

--- a/www/docs/customization/build.md
+++ b/www/docs/customization/build.md
@@ -101,6 +101,11 @@ builds:
       - goarm: mips64
         gomips: hardfloat
 
+    # Set a specific go binary to use when building. It is safe to ignore
+    # this option in most cases.
+    # Default is "go"
+    go_binary: "go1.13.4"
+
     # Set the modified timestamp on the output binary, typically
     # you would do this to ensure a build was reproducible. Pass
     # empty string to skip modifying the output.


### PR DESCRIPTION
If applied, this commit will add a `gobinary` option to the build config allowing specification of specific go binaries to use during a build.

The change is being made because it was listed in #1235 as requested.

See: #1235 for further details.
