### PR TITLE
fix:make minio based tests run locally again.

### DIFF
--- a/internal/pipe/blob/blob_minio_test.go
+++ b/internal/pipe/blob/blob_minio_test.go
@@ -272,7 +272,8 @@ func start(t *testing.T, name, listen string) {
 		"-e", "MINIO_ACCESS_KEY=minio",
 		"-e", "MINIO_SECRET_KEY=miniostorage",
 		"--health-interval", "1s",
-		"minio/minio:RELEASE.2019-05-14T23-57-45Z",
+		"--health-cmd=curl --silent --fail http://localhost:9000/minio/health/ready || exit 1",
+		"minio/minio",
 		"server", "/data",
 	).CombinedOutput(); err != nil {
 		t.Fatalf("failed to start minio: %s", string(out))


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

If applied, this commit will update the version of the minio container used during the pipe/blob tests.

While working on #1775 I discovered that I could not get the pipe/blob tests to pass locally even on master. The apparent cause was a failure of the test_upload container to start at all. (Note: I'm on macOs 10.15.6) I was able to determine that minio failed on start up with this output:
```

 You are running an older version of MinIO released 1 year ago
 Update: docker pull minio/minio:RELEASE.2020-08-27T05-16-20Z


ERROR Unable to initialize config system: Unexpected error, please report this issue at https://github.com/minio/minio/issues.
```

I could not determine the specific cause other than it had something to do with the `testdata/data` directory (minio would work just fine unless the volume for that directory was added to the docker run line).

In testing, I was able to determine that updating to the most recent minio and adding a `--health-cmd` that used curl to check the [ready url](https://github.com/minio/minio/blob/master/docs/metrics/healthcheck/README.md) corrected the problem. 

