### PR TITLE
fix: artifact string method switch statement

### DIFF
--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -55,16 +55,13 @@ func (t Type) String() string {
 		return "Archive"
 	case UploadableFile:
 		return "File"
-	case UploadableBinary:
-	case Binary:
+	case UploadableBinary, Binary:
 		return "Binary"
 	case LinuxPackage:
 		return "Linux Package"
-	case DockerImage:
-	case PublishableDockerImage:
+	case PublishableDockerImage, DockerImage:
 		return "Docker Image"
-	case PublishableSnapcraft:
-	case Snapcraft:
+	case PublishableSnapcraft, Snapcraft:
 		return "Snap"
 	case Checksum:
 		return "Checksum"
@@ -72,8 +69,9 @@ func (t Type) String() string {
 		return "Signature"
 	case UploadableSourceArchive:
 		return "Source"
+	default:
+		return "unknown"
 	}
-	return "unknown"
 }
 
 // Artifact represents an artifact and its relevant info.


### PR DESCRIPTION
Existing implementation seemed to rely on implicit case fallthrough, which doesn't exist in Go. Moving default return to default case helps catch this error in the future, as it will cause a "missing return" compile error.