### PR TITLE
fix: allow help command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,6 +88,11 @@ func shouldPrependRelease(cmd *cobra.Command, args []string) bool {
 		return false
 	}
 
+	// allow help command.
+	if len(args) > 0 && args[0] == "help" {
+		return false
+	}
+
 	// if we have != 1 args, assume its a release
 	if len(args) != 1 {
 		return true

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -84,4 +84,8 @@ func TestShouldPrependRelease(t *testing.T) {
 	t.Run("check", func(t *testing.T) {
 		require.False(t, result([]string{"check", "-f", "testdata/good.yml"}))
 	})
+
+	t.Run("help", func(t *testing.T) {
+		require.False(t, result([]string{"help"}))
+	})
 }


### PR DESCRIPTION
## If applied, this commit will... 
Allow help commands like:
```bash
goreleaser help
goreleaser help check
```

## Why is this change being made?
When you run: `goreleaser help` it should output help and not run `releaser`.

Thanks.
