### PR TITLE
fix: typo on warning log

### DIFF
--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -96,7 +96,7 @@ func (Pipe) Default(ctx *context.Context) error {
 				)
 			}
 			brew.Install = strings.Join(installs, "\n")
-			log.Warnf("optimistically guessing `brew[%d].installs`, double check", i)
+			log.Warnf("optimistically guessing `brew[%d].install`, double check", i)
 		}
 		if brew.GitHub.String() != "" {
 			deprecate.Notice(ctx, "brews.github")


### PR DESCRIPTION
<!-- If applied, this commit will... -->

Disambiguate a confusing warning message

<!-- Why is this change being made? -->

The warning `optimistically guessing `brew[%d].installs`, double check` made me thinks of a hidden `installs` option (note the final "s"). Thanks god, it's just a typo, the existing and documented option is `install` (without the "s")
