### PR TITLE
fix #1821: use name template for bare binary files

### DIFF
--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -196,10 +196,17 @@ func skip(ctx *context.Context, archive config.Archive, binaries []*artifact.Art
 		if err != nil {
 			return err
 		}
+		name += binary.ExtraOr("Ext", "").(string)
+		renamePath := filepath.Join(ctx.Config.Dist, name)
+		if err := os.Rename(binary.Path, renamePath); err != nil {
+			return err
+		}
+		_ = os.Remove(filepath.Dir(binary.Path))
 		ctx.Artifacts.Add(&artifact.Artifact{
-			Type:   artifact.UploadableBinary,
-			Name:   name + binary.ExtraOr("Ext", "").(string),
-			Path:   binary.Path,
+			Type: artifact.UploadableBinary,
+			// this is the name it shows
+			Name:   name,
+			Path:   renamePath,
 			Goos:   binary.Goos,
 			Goarch: binary.Goarch,
 			Goarm:  binary.Goarm,

--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -203,8 +203,7 @@ func skip(ctx *context.Context, archive config.Archive, binaries []*artifact.Art
 		}
 		_ = os.Remove(filepath.Dir(binary.Path))
 		ctx.Artifacts.Add(&artifact.Artifact{
-			Type: artifact.UploadableBinary,
-			// this is the name it shows
+			Type:   artifact.UploadableBinary,
 			Name:   name,
 			Path:   renamePath,
 			Goos:   binary.Goos,


### PR DESCRIPTION
<!-- If applied, this commit will... -->

Update `skip` to rename binary files according to `archives.name_template` in the same way that `tar`, `zip`, and others are updated.

<!-- Why is this change being made? -->

This is to fix https://github.com/goreleaser/goreleaser/issues/1821

<!-- # Provide links to any relevant tickets, URLs or other resources -->

## Remaining Problem

The directory name and the binary name are the same by default, so I added a `bins` directory.

I realize this is probably not a desirable solution, so I'd like some direction on how to better solve for that.