### PR TITLE
feat: allows to specify custom files for a specific GOOS

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -259,6 +259,12 @@ type FormatOverride struct {
 	Format string `yaml:",omitempty"`
 }
 
+// FileCustom is used to specify custom files for a specific GOOS.
+type FileCustom struct {
+	Goos  string   `yaml:",omitempty"`
+	Files []string `yaml:",omitempty"`
+}
+
 // Archive config used for the archive.
 type Archive struct {
 	ID              string            `yaml:",omitempty"`
@@ -269,6 +275,7 @@ type Archive struct {
 	FormatOverrides []FormatOverride  `yaml:"format_overrides,omitempty"`
 	WrapInDirectory string            `yaml:"wrap_in_directory,omitempty"`
 	Files           []string          `yaml:",omitempty"`
+	FileCustom      []FileCustom      `yaml:"file_custom,omitempty"`
 }
 
 // Release config used for the GitHub/GitLab release.


### PR DESCRIPTION
## Allows to specify custom files for a specific GOOS

Hi,

I haven't found parameters for able to push custom files in archive for a specific GOOS, so I have make this one for my personal use and I think that can be useful for other people.

### How it's work ?

It is similar format than "format_overrides", that look like : 

```yml
archives:
  - file_custom:
      - goos: linux
        files:
          - linux.sh
      - goos: darwin
        files:
          - mac.sh
```
We specify goos output and we add files in an array.