### PR TITLE
refactor: use require on all tests

### DIFF
--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
@@ -41,8 +40,8 @@ func TestAdd(t *testing.T) {
 			return nil
 		})
 	}
-	assert.NoError(t, g.Wait())
-	assert.Len(t, artifacts.List(), 4)
+	require.NoError(t, g.Wait())
+	require.Len(t, artifacts.List(), 4)
 }
 
 func TestFilter(t *testing.T) {
@@ -74,21 +73,21 @@ func TestFilter(t *testing.T) {
 		artifacts.Add(a)
 	}
 
-	assert.Len(t, artifacts.Filter(ByGoos("linux")).items, 1)
-	assert.Len(t, artifacts.Filter(ByGoos("darwin")).items, 0)
+	require.Len(t, artifacts.Filter(ByGoos("linux")).items, 1)
+	require.Len(t, artifacts.Filter(ByGoos("darwin")).items, 0)
 
-	assert.Len(t, artifacts.Filter(ByGoarch("amd64")).items, 1)
-	assert.Len(t, artifacts.Filter(ByGoarch("386")).items, 0)
+	require.Len(t, artifacts.Filter(ByGoarch("amd64")).items, 1)
+	require.Len(t, artifacts.Filter(ByGoarch("386")).items, 0)
 
-	assert.Len(t, artifacts.Filter(ByGoarm("6")).items, 1)
-	assert.Len(t, artifacts.Filter(ByGoarm("7")).items, 0)
+	require.Len(t, artifacts.Filter(ByGoarm("6")).items, 1)
+	require.Len(t, artifacts.Filter(ByGoarm("7")).items, 0)
 
-	assert.Len(t, artifacts.Filter(ByType(Checksum)).items, 2)
-	assert.Len(t, artifacts.Filter(ByType(Binary)).items, 0)
+	require.Len(t, artifacts.Filter(ByType(Checksum)).items, 2)
+	require.Len(t, artifacts.Filter(ByType(Binary)).items, 0)
 
-	assert.Len(t, artifacts.Filter(nil).items, 5)
+	require.Len(t, artifacts.Filter(nil).items, 5)
 
-	assert.Len(t, artifacts.Filter(
+	require.Len(t, artifacts.Filter(
 		And(
 			ByType(Checksum),
 			func(a *Artifact) bool {
@@ -97,7 +96,7 @@ func TestFilter(t *testing.T) {
 		),
 	).List(), 1)
 
-	assert.Len(t, artifacts.Filter(
+	require.Len(t, artifacts.Filter(
 		Or(
 			ByType(Checksum),
 			And(
@@ -149,10 +148,10 @@ func TestGroupByPlatform(t *testing.T) {
 	}
 
 	var groups = artifacts.GroupByPlatform()
-	assert.Len(t, groups["linuxamd64"], 2)
-	assert.Len(t, groups["linuxarm6"], 1)
-	assert.Len(t, groups["linuxmipssoftfloat"], 1)
-	assert.Len(t, groups["linuxmipshardfloat"], 1)
+	require.Len(t, groups["linuxamd64"], 2)
+	require.Len(t, groups["linuxarm6"], 1)
+	require.Len(t, groups["linuxmipssoftfloat"], 1)
+	require.Len(t, groups["linuxmipshardfloat"], 1)
 }
 
 func TestChecksum(t *testing.T) {

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -16,7 +16,6 @@ import (
 	api "github.com/goreleaser/goreleaser/pkg/build"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -96,8 +95,8 @@ func TestWithDefaults(t *testing.T) {
 			var ctx = context.New(config)
 			ctx.Git.CurrentTag = "5.6.7"
 			var build = Default.WithDefaults(ctx.Config.Builds[0])
-			assert.ElementsMatch(t, build.Targets, testcase.targets)
-			assert.EqualValues(t, testcase.goBinary, build.GoBinary)
+			require.ElementsMatch(t, build.Targets, testcase.targets)
+			require.EqualValues(t, testcase.goBinary, build.GoBinary)
 		})
 	}
 }
@@ -152,9 +151,9 @@ func TestBuild(t *testing.T) {
 			Path:   filepath.Join(folder, "dist", target, bin+ext),
 			Ext:    ext,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
-	assert.ElementsMatch(t, ctx.Artifacts.List(), []*artifact.Artifact{
+	require.ElementsMatch(t, ctx.Artifacts.List(), []*artifact.Artifact{
 		{
 			Name:   "bin/foo-v5.6.7",
 			Path:   filepath.Join(folder, "dist", "linux_amd64", "bin", "foo-v5.6.7"),
@@ -251,7 +250,7 @@ func TestBuild(t *testing.T) {
 		}
 
 		fi, err := os.Stat(bin.Path)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// make this a suitable map key, per docs: https://golang.org/pkg/time/#Time
 		modTime := fi.ModTime().UTC().Round(0)
@@ -268,7 +267,7 @@ func TestBuildCodeInSubdir(t *testing.T) {
 	defer back()
 	subdir := filepath.Join(folder, "bar")
 	err := os.Mkdir(subdir, 0755)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	writeGoodMain(t, subdir)
 	var config = config.Project{
 		Builds: []config.Build{
@@ -293,7 +292,7 @@ func TestBuildCodeInSubdir(t *testing.T) {
 		Path:   filepath.Join(folder, "dist", runtimeTarget, build.Binary),
 		Ext:    "",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestBuildFailed(t *testing.T) {
@@ -318,7 +317,7 @@ func TestBuildFailed(t *testing.T) {
 		Target: "darwin_amd64",
 	})
 	assertContainsError(t, err, `flag provided but not defined: -flag-that-dont-exists-to-force-failure`)
-	assert.Empty(t, ctx.Artifacts.List())
+	require.Empty(t, ctx.Artifacts.List())
 }
 
 func TestBuildInvalidTarget(t *testing.T) {
@@ -343,8 +342,8 @@ func TestBuildInvalidTarget(t *testing.T) {
 		Name:   build.Binary,
 		Path:   filepath.Join(folder, "dist", target, build.Binary),
 	})
-	assert.EqualError(t, err, "linux is not a valid build target")
-	assert.Len(t, ctx.Artifacts.List(), 0)
+	require.EqualError(t, err, "linux is not a valid build target")
+	require.Len(t, ctx.Artifacts.List(), 0)
 }
 
 func TestRunInvalidAsmflags(t *testing.T) {
@@ -367,7 +366,7 @@ func TestRunInvalidAsmflags(t *testing.T) {
 	var err = Default.Build(ctx, ctx.Config.Builds[0], api.Options{
 		Target: runtimeTarget,
 	})
-	assert.EqualError(t, err, `template: tmpl:1: unexpected "}" in operand`)
+	require.EqualError(t, err, `template: tmpl:1: unexpected "}" in operand`)
 }
 
 func TestRunInvalidGcflags(t *testing.T) {
@@ -390,7 +389,7 @@ func TestRunInvalidGcflags(t *testing.T) {
 	var err = Default.Build(ctx, ctx.Config.Builds[0], api.Options{
 		Target: runtimeTarget,
 	})
-	assert.EqualError(t, err, `template: tmpl:1: unexpected "}" in operand`)
+	require.EqualError(t, err, `template: tmpl:1: unexpected "}" in operand`)
 }
 
 func TestRunInvalidLdflags(t *testing.T) {
@@ -414,7 +413,7 @@ func TestRunInvalidLdflags(t *testing.T) {
 	var err = Default.Build(ctx, ctx.Config.Builds[0], api.Options{
 		Target: runtimeTarget,
 	})
-	assert.EqualError(t, err, `template: tmpl:1: unexpected "}" in operand`)
+	require.EqualError(t, err, `template: tmpl:1: unexpected "}" in operand`)
 }
 
 func TestRunInvalidFlags(t *testing.T) {
@@ -436,7 +435,7 @@ func TestRunInvalidFlags(t *testing.T) {
 	var err = Default.Build(ctx, ctx.Config.Builds[0], api.Options{
 		Target: runtimeTarget,
 	})
-	assert.EqualError(t, err, `template: tmpl:1: unexpected "}" in operand`)
+	require.EqualError(t, err, `template: tmpl:1: unexpected "}" in operand`)
 }
 
 func TestRunPipeWithoutMainFunc(t *testing.T) {
@@ -458,25 +457,25 @@ func TestRunPipeWithoutMainFunc(t *testing.T) {
 	ctx.Git.CurrentTag = "5.6.7"
 	t.Run("empty", func(t *testing.T) {
 		ctx.Config.Builds[0].Main = ""
-		assert.EqualError(t, Default.Build(ctx, ctx.Config.Builds[0], api.Options{
+		require.EqualError(t, Default.Build(ctx, ctx.Config.Builds[0], api.Options{
 			Target: runtimeTarget,
 		}), `build for no-main does not contain a main function`)
 	})
 	t.Run("not main.go", func(t *testing.T) {
 		ctx.Config.Builds[0].Main = "foo.go"
-		assert.EqualError(t, Default.Build(ctx, ctx.Config.Builds[0], api.Options{
+		require.EqualError(t, Default.Build(ctx, ctx.Config.Builds[0], api.Options{
 			Target: runtimeTarget,
 		}), `stat foo.go: no such file or directory`)
 	})
 	t.Run("glob", func(t *testing.T) {
 		ctx.Config.Builds[0].Main = "."
-		assert.EqualError(t, Default.Build(ctx, ctx.Config.Builds[0], api.Options{
+		require.EqualError(t, Default.Build(ctx, ctx.Config.Builds[0], api.Options{
 			Target: runtimeTarget,
 		}), `build for no-main does not contain a main function`)
 	})
 	t.Run("fixed main.go", func(t *testing.T) {
 		ctx.Config.Builds[0].Main = "main.go"
-		assert.EqualError(t, Default.Build(ctx, ctx.Config.Builds[0], api.Options{
+		require.EqualError(t, Default.Build(ctx, ctx.Config.Builds[0], api.Options{
 			Target: runtimeTarget,
 		}), `build for no-main does not contain a main function`)
 	})
@@ -485,7 +484,7 @@ func TestRunPipeWithoutMainFunc(t *testing.T) {
 func TestRunPipeWithMainFuncNotInMainGoFile(t *testing.T) {
 	folder, back := testlib.Mktmp(t)
 	defer back()
-	assert.NoError(t, ioutil.WriteFile(
+	require.NoError(t, ioutil.WriteFile(
 		filepath.Join(folder, "foo.go"),
 		[]byte("package main\nfunc main() {println(0)}"),
 		0644,
@@ -507,19 +506,19 @@ func TestRunPipeWithMainFuncNotInMainGoFile(t *testing.T) {
 	ctx.Git.CurrentTag = "5.6.7"
 	t.Run("empty", func(t *testing.T) {
 		ctx.Config.Builds[0].Main = ""
-		assert.NoError(t, Default.Build(ctx, ctx.Config.Builds[0], api.Options{
+		require.NoError(t, Default.Build(ctx, ctx.Config.Builds[0], api.Options{
 			Target: runtimeTarget,
 		}))
 	})
 	t.Run("foo.go", func(t *testing.T) {
 		ctx.Config.Builds[0].Main = "foo.go"
-		assert.NoError(t, Default.Build(ctx, ctx.Config.Builds[0], api.Options{
+		require.NoError(t, Default.Build(ctx, ctx.Config.Builds[0], api.Options{
 			Target: runtimeTarget,
 		}))
 	})
 	t.Run("glob", func(t *testing.T) {
 		ctx.Config.Builds[0].Main = "."
-		assert.NoError(t, Default.Build(ctx, ctx.Config.Builds[0], api.Options{
+		require.NoError(t, Default.Build(ctx, ctx.Config.Builds[0], api.Options{
 			Target: runtimeTarget,
 		}))
 	})
@@ -542,16 +541,16 @@ func TestLdFlagsFullTemplate(t *testing.T) {
 	var artifact = &artifact.Artifact{Goarch: "amd64"}
 	flags, err := tmpl.New(ctx).WithArtifact(artifact, map[string]string{}).
 		Apply(`-s -w -X main.version={{.Version}} -X main.tag={{.Tag}} -X main.date={{.Date}} -X main.commit={{.Commit}} -X "main.foo={{.Env.FOO}}" -X main.time={{ time "20060102" }} -X main.arch={{.Arch}} -X main.commitDate={{.CommitDate}}`)
-	assert.NoError(t, err)
-	assert.Contains(t, flags, "-s -w")
-	assert.Contains(t, flags, "-X main.version=1.2.3")
-	assert.Contains(t, flags, "-X main.tag=v1.2.3")
-	assert.Contains(t, flags, "-X main.commit=123")
-	assert.Contains(t, flags, fmt.Sprintf("-X main.date=%d", run.Year()))
-	assert.Contains(t, flags, fmt.Sprintf("-X main.time=%d", run.Year()))
-	assert.Contains(t, flags, `-X "main.foo=123"`)
-	assert.Contains(t, flags, `-X main.arch=amd64`)
-	assert.Contains(t, flags, fmt.Sprintf("-X main.commitDate=%d", commit.Year()))
+	require.NoError(t, err)
+	require.Contains(t, flags, "-s -w")
+	require.Contains(t, flags, "-X main.version=1.2.3")
+	require.Contains(t, flags, "-X main.tag=v1.2.3")
+	require.Contains(t, flags, "-X main.commit=123")
+	require.Contains(t, flags, fmt.Sprintf("-X main.date=%d", run.Year()))
+	require.Contains(t, flags, fmt.Sprintf("-X main.time=%d", run.Year()))
+	require.Contains(t, flags, `-X "main.foo=123"`)
+	require.Contains(t, flags, `-X main.arch=amd64`)
+	require.Contains(t, flags, fmt.Sprintf("-X main.commitDate=%d", commit.Year()))
 }
 
 func TestInvalidTemplate(t *testing.T) {
@@ -563,8 +562,8 @@ func TestInvalidTemplate(t *testing.T) {
 			var ctx = context.New(config.Project{})
 			ctx.Git.CurrentTag = "3.4.1"
 			flags, err := tmpl.New(ctx).Apply(template)
-			assert.EqualError(tt, err, eerr)
-			assert.Empty(tt, flags)
+			require.EqualError(tt, err, eerr)
+			require.Empty(tt, flags)
 		})
 	}
 }
@@ -606,9 +605,9 @@ func TestProcessFlags(t *testing.T) {
 	}
 
 	flags, err := processFlags(ctx, artifact, []string{}, source, "-testflag=")
-	assert.NoError(t, err)
-	assert.Len(t, flags, 7)
-	assert.Equal(t, expected, flags)
+	require.NoError(t, err)
+	require.Len(t, flags, 7)
+	require.Equal(t, expected, flags)
 }
 
 func TestProcessFlagsInvalid(t *testing.T) {
@@ -621,8 +620,8 @@ func TestProcessFlagsInvalid(t *testing.T) {
 	var expected = `template: tmpl:1: unexpected "}" in operand`
 
 	flags, err := processFlags(ctx, &artifact.Artifact{}, []string{}, source, "-testflag=")
-	assert.EqualError(t, err, expected)
-	assert.Nil(t, flags)
+	require.EqualError(t, err, expected)
+	require.Nil(t, flags)
 }
 
 func TestJoinLdFlags(t *testing.T) {
@@ -636,7 +635,7 @@ func TestJoinLdFlags(t *testing.T) {
 
 	for _, test := range tests {
 		joinedLdFlags := joinLdFlags(test.input)
-		assert.Equal(t, joinedLdFlags, test.output)
+		require.Equal(t, joinedLdFlags, test.output)
 	}
 }
 
@@ -695,7 +694,7 @@ func TestBuildModTimestamp(t *testing.T) {
 			Path:   filepath.Join(folder, "dist", target, bin+ext),
 			Ext:    ext,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	for _, bin := range ctx.Artifacts.List() {
@@ -704,8 +703,8 @@ func TestBuildModTimestamp(t *testing.T) {
 		}
 
 		fi, err := os.Stat(bin.Path)
-		assert.NoError(t, err)
-		assert.True(t, modTime.Equal(fi.ModTime()), "inconsistent mod times found when specifying ModTimestamp")
+		require.NoError(t, err)
+		require.True(t, modTime.Equal(fi.ModTime()), "inconsistent mod times found when specifying ModTimestamp")
 	}
 }
 
@@ -714,7 +713,7 @@ func TestBuildModTimestamp(t *testing.T) {
 //
 
 func writeMainWithoutMainFunc(t *testing.T, folder string) {
-	assert.NoError(t, ioutil.WriteFile(
+	require.NoError(t, ioutil.WriteFile(
 		filepath.Join(folder, "main.go"),
 		[]byte("package main\nconst a = 2\nfunc notMain() {println(0)}"),
 		0644,
@@ -722,7 +721,7 @@ func writeMainWithoutMainFunc(t *testing.T, folder string) {
 }
 
 func writeGoodMain(t *testing.T, folder string) {
-	assert.NoError(t, ioutil.WriteFile(
+	require.NoError(t, ioutil.WriteFile(
 		filepath.Join(folder, "main.go"),
 		[]byte("package main\nvar a = 1\nfunc main() {println(0)}"),
 		0644,
@@ -730,6 +729,6 @@ func writeGoodMain(t *testing.T, folder string) {
 }
 
 func assertContainsError(t *testing.T, err error, s string) {
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), s)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), s)
 }

--- a/internal/builders/golang/targets_test.go
+++ b/internal/builders/golang/targets_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/goreleaser/goreleaser/pkg/config"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAllBuildTargets(t *testing.T) {
@@ -53,7 +53,7 @@ func TestAllBuildTargets(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, []string{
+	require.Equal(t, []string{
 		"linux_386",
 		"linux_amd64",
 		"linux_arm_6",
@@ -128,7 +128,7 @@ func TestGoosGoarchCombos(t *testing.T) {
 	}
 	for _, p := range platforms {
 		t.Run(fmt.Sprintf("%v %v valid=%v", p.os, p.arch, p.valid), func(t *testing.T) {
-			assert.Equal(t, p.valid, valid(target{p.os, p.arch, "", ""}))
+			require.Equal(t, p.valid, valid(target{p.os, p.arch, "", ""}))
 		})
 	}
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -5,14 +5,14 @@ import (
 
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClientEmpty(t *testing.T) {
 	ctx := &context.Context{}
 	client, err := New(ctx)
-	assert.Nil(t, client)
-	assert.NoError(t, err)
+	require.Nil(t, client)
+	require.NoError(t, err)
 }
 
 func TestClientNewGitea(t *testing.T) {
@@ -26,9 +26,9 @@ func TestClientNewGitea(t *testing.T) {
 		Token:     "giteatoken",
 	}
 	client, err := New(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, ok := client.(*giteaClient)
-	assert.True(t, ok)
+	require.True(t, ok)
 }
 
 func TestClientNewGiteaInvalidURL(t *testing.T) {
@@ -42,8 +42,8 @@ func TestClientNewGiteaInvalidURL(t *testing.T) {
 		Token:     "giteatoken",
 	}
 	client, err := New(ctx)
-	assert.Error(t, err)
-	assert.Nil(t, client)
+	require.Error(t, err)
+	require.Nil(t, client)
 }
 
 func TestClientNewGitLab(t *testing.T) {
@@ -52,7 +52,7 @@ func TestClientNewGitLab(t *testing.T) {
 		Token:     "gitlabtoken",
 	}
 	client, err := New(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, ok := client.(*gitlabClient)
-	assert.True(t, ok)
+	require.True(t, ok)
 }

--- a/internal/client/gitea_test.go
+++ b/internal/client/gitea_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
 	"github.com/jarcoal/httpmock"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -25,31 +24,31 @@ func (s *GetInstanceURLSuite) TestWithScheme() {
 	t := s.T()
 	rootURL := "https://git.dtluna.net"
 	result, err := getInstanceURL(rootURL + "/api/v1")
-	assert.NoError(t, err)
-	assert.Equal(t, rootURL, result)
+	require.NoError(t, err)
+	require.Equal(t, rootURL, result)
 }
 
 func (s *GetInstanceURLSuite) TestParseError() {
 	t := s.T()
 	host := "://.dtluna.net"
 	result, err := getInstanceURL(host)
-	assert.Error(t, err)
-	assert.Empty(t, result)
+	require.Error(t, err)
+	require.Empty(t, result)
 }
 
 func (s *GetInstanceURLSuite) TestNoScheme() {
 	t := s.T()
 	host := "git.dtluna.net"
 	result, err := getInstanceURL(host)
-	assert.Error(t, err)
-	assert.Empty(t, result)
+	require.Error(t, err)
+	require.Empty(t, result)
 }
 
 func (s *GetInstanceURLSuite) TestEmpty() {
 	t := s.T()
 	result, err := getInstanceURL("")
-	assert.Error(t, err)
-	assert.Empty(t, result)
+	require.Error(t, err)
+	require.Empty(t, result)
 }
 
 func TestGetInstanceURLSuite(t *testing.T) {
@@ -122,7 +121,7 @@ func (s *GiteaReleasesTestSuite) SetupTest() {
 	s.releaseURL = fmt.Sprintf("%v/%v", s.releasesURL, s.releaseID)
 	httpmock.RegisterResponder("GET", fmt.Sprintf("%s/api/v1/version", s.url), httpmock.NewStringResponder(200, "{\"version\":\"1.12.0\"}"))
 	newClient, err := gitea.NewClient(s.url)
-	assert.NoError(s.T(), err)
+	require.NoError(s.T(), err)
 	s.client = &giteaClient{client: newClient}
 }
 
@@ -139,8 +138,8 @@ func (s *GetExistingReleaseSuite) TestNoReleases() {
 	httpmock.RegisterResponder("GET", s.releasesURL, httpmock.NewStringResponder(200, "[]"))
 
 	release, err := s.client.getExistingRelease(s.owner, s.repoName, s.tag)
-	assert.Nil(t, release)
-	assert.NoError(t, err)
+	require.Nil(t, release)
+	require.NoError(t, err)
 }
 
 func (s *GetExistingReleaseSuite) TestNoRepo() {
@@ -148,8 +147,8 @@ func (s *GetExistingReleaseSuite) TestNoRepo() {
 	httpmock.RegisterResponder("GET", s.releasesURL, httpmock.NewStringResponder(404, ""))
 
 	release, err := s.client.getExistingRelease(s.owner, s.repoName, s.tag)
-	assert.Nil(t, release)
-	assert.Error(t, err)
+	require.Nil(t, release)
+	require.Error(t, err)
 }
 
 func (s *GetExistingReleaseSuite) TestReleaseExists() {
@@ -160,9 +159,9 @@ func (s *GetExistingReleaseSuite) TestReleaseExists() {
 	httpmock.RegisterResponder("GET", s.releasesURL, resp)
 
 	result, err := s.client.getExistingRelease(s.owner, s.repoName, s.tag)
-	assert.NotNil(t, result)
-	assert.Equal(t, *result, release)
-	assert.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, *result, release)
+	require.NoError(t, err)
 
 }
 
@@ -188,9 +187,9 @@ func (s *GiteacreateReleaseSuite) TestSuccess() {
 	httpmock.RegisterResponder("POST", s.releasesURL, resp)
 
 	release, err := s.client.createRelease(s.ctx, s.title, s.description)
-	assert.NoError(t, err)
-	assert.NotNil(t, release)
-	assert.Equal(t, expectedRelease, *release)
+	require.NoError(t, err)
+	require.NotNil(t, release)
+	require.Equal(t, expectedRelease, *release)
 }
 
 func (s *GiteacreateReleaseSuite) TestError() {
@@ -198,8 +197,8 @@ func (s *GiteacreateReleaseSuite) TestError() {
 	httpmock.RegisterResponder("POST", s.releasesURL, httpmock.NewStringResponder(400, ""))
 
 	release, err := s.client.createRelease(s.ctx, s.title, s.description)
-	assert.Error(t, err)
-	assert.Nil(t, release)
+	require.Error(t, err)
+	require.Nil(t, release)
 }
 
 func TestGiteacreateReleaseSuite(t *testing.T) {
@@ -228,8 +227,8 @@ func (s *GiteaupdateReleaseSuite) TestSuccess() {
 	httpmock.RegisterResponder("PATCH", s.releaseURL, resp)
 
 	release, err := s.client.updateRelease(s.ctx, s.title, s.description, s.releaseID)
-	assert.NoError(t, err)
-	assert.NotNil(t, release)
+	require.NoError(t, err)
+	require.NotNil(t, release)
 }
 
 func (s *GiteaupdateReleaseSuite) TestError() {
@@ -237,8 +236,8 @@ func (s *GiteaupdateReleaseSuite) TestError() {
 	httpmock.RegisterResponder("PATCH", s.releaseURL, httpmock.NewStringResponder(400, ""))
 
 	release, err := s.client.updateRelease(s.ctx, s.title, s.description, s.releaseID)
-	assert.Error(t, err)
-	assert.Nil(t, release)
+	require.Error(t, err)
+	require.Nil(t, release)
 }
 
 func TestGiteaupdateReleaseSuite(t *testing.T) {
@@ -254,7 +253,7 @@ func TestGiteaCreateFile(t *testing.T) {
 	path := ""
 	message := ""
 	file := client.CreateFile(&ctx, author, repo, content, path, message)
-	assert.Nil(t, file)
+	require.Nil(t, file)
 }
 
 type GiteaCreateReleaseSuite struct {
@@ -266,8 +265,8 @@ func (s *GiteaCreateReleaseSuite) TestTemplateError() {
 	s.ctx.Config.Release.NameTemplate = "{{ .NoKeyLikeThat }}"
 
 	releaseID, err := s.client.CreateRelease(s.ctx, s.description)
-	assert.Empty(t, releaseID)
-	assert.Error(t, err)
+	require.Empty(t, releaseID)
+	require.Error(t, err)
 }
 
 func (s *GiteaCreateReleaseSuite) TestErrorGettingExisitngRelease() {
@@ -275,8 +274,8 @@ func (s *GiteaCreateReleaseSuite) TestErrorGettingExisitngRelease() {
 	httpmock.RegisterResponder("GET", s.releasesURL, httpmock.NewStringResponder(404, ""))
 
 	releaseID, err := s.client.CreateRelease(s.ctx, s.description)
-	assert.Empty(t, releaseID)
-	assert.Error(t, err)
+	require.Empty(t, releaseID)
+	require.Error(t, err)
 }
 
 func (s *GiteaCreateReleaseSuite) TestErrorUpdatingRelease() {
@@ -288,8 +287,8 @@ func (s *GiteaCreateReleaseSuite) TestErrorUpdatingRelease() {
 	httpmock.RegisterResponder("PATCH", s.releaseURL, httpmock.NewStringResponder(400, ""))
 
 	releaseID, err := s.client.CreateRelease(s.ctx, s.description)
-	assert.Empty(t, releaseID)
-	assert.Error(t, err)
+	require.Empty(t, releaseID)
+	require.Error(t, err)
 }
 
 func (s *GiteaCreateReleaseSuite) TestSuccessUpdatingRelease() {
@@ -311,8 +310,8 @@ func (s *GiteaCreateReleaseSuite) TestSuccessUpdatingRelease() {
 
 	newDescription := "NewDescription"
 	releaseID, err := s.client.CreateRelease(s.ctx, newDescription)
-	assert.Equal(t, fmt.Sprint(expectedRelease.ID), releaseID)
-	assert.NoError(t, err)
+	require.Equal(t, fmt.Sprint(expectedRelease.ID), releaseID)
+	require.NoError(t, err)
 }
 
 func (s *GiteaCreateReleaseSuite) TestErrorCreatingRelease() {
@@ -321,8 +320,8 @@ func (s *GiteaCreateReleaseSuite) TestErrorCreatingRelease() {
 	httpmock.RegisterResponder("POST", s.releasesURL, httpmock.NewStringResponder(400, ""))
 
 	releaseID, err := s.client.CreateRelease(s.ctx, s.description)
-	assert.Empty(t, releaseID)
-	assert.Error(t, err)
+	require.Empty(t, releaseID)
+	require.Error(t, err)
 }
 
 func (s *GiteaCreateReleaseSuite) TestSuccessCreatingRelease() {
@@ -341,8 +340,8 @@ func (s *GiteaCreateReleaseSuite) TestSuccessCreatingRelease() {
 	httpmock.RegisterResponder("POST", s.releasesURL, resp)
 
 	releaseID, err := s.client.CreateRelease(s.ctx, s.description)
-	assert.Equal(t, fmt.Sprint(expectedRelease.ID), releaseID)
-	assert.NoError(t, err)
+	require.Equal(t, fmt.Sprint(expectedRelease.ID), releaseID)
+	require.NoError(t, err)
 }
 
 func TestGiteaCreateReleaseSuite(t *testing.T) {
@@ -377,7 +376,7 @@ func (s *GiteaUploadSuite) TearDownTest() {
 func (s *GiteaUploadSuite) TestErrorParsingReleaseID() {
 	t := s.T()
 	err := s.client.Upload(s.ctx, "notint", s.artifact, s.file)
-	assert.EqualError(t, err, "strconv.ParseInt: parsing \"notint\": invalid syntax")
+	require.EqualError(t, err, "strconv.ParseInt: parsing \"notint\": invalid syntax")
 }
 
 func (s *GiteaUploadSuite) TestErrorCreatingReleaseAttachment() {
@@ -385,7 +384,7 @@ func (s *GiteaUploadSuite) TestErrorCreatingReleaseAttachment() {
 	httpmock.RegisterResponder("POST", s.releaseAttachmentsURL, httpmock.NewStringResponder(400, ""))
 
 	err := s.client.Upload(s.ctx, fmt.Sprint(s.releaseID), s.artifact, s.file)
-	assert.True(t, strings.HasPrefix(err.Error(), "Unknown API Error: 400"))
+	require.True(t, strings.HasPrefix(err.Error(), "Unknown API Error: 400"))
 }
 
 func (s *GiteaUploadSuite) TestSuccess() {
@@ -396,7 +395,7 @@ func (s *GiteaUploadSuite) TestSuccess() {
 	httpmock.RegisterResponder("POST", s.releaseAttachmentsURL, resp)
 
 	err = s.client.Upload(s.ctx, fmt.Sprint(s.releaseID), s.artifact, s.file)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestGiteaUploadSuite(t *testing.T) {

--- a/internal/client/gitlab_test.go
+++ b/internal/client/gitlab_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExtractHashFromProjectFileURL(t *testing.T) {
@@ -16,7 +16,7 @@ func TestExtractHashFromProjectFileURL(t *testing.T) {
 	if err != nil {
 		t.Errorf("expexted no error but got: %v", err)
 	}
-	assert.Equal(t, givenHash, extractedHash)
+	require.Equal(t, givenHash, extractedHash)
 }
 
 func TestFailToExtractHashFromProjectFileURL(t *testing.T) {
@@ -48,11 +48,11 @@ func TestGitLabReleaseURLTemplate(t *testing.T) {
 		},
 	})
 	client, err := NewGitLab(ctx, ctx.Token)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	urlTpl, err := client.ReleaseURLTemplate(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expectedUrl := "https://gitlab.com/owner/name/uploads/{{ .ArtifactUploadHash }}/{{ .ArtifactName }}"
-	assert.Equal(t, expectedUrl, urlTpl)
+	require.Equal(t, expectedUrl, urlTpl)
 }

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -225,8 +224,8 @@ func TestExecute(t *testing.T) {
 				require.NoError(t, err)
 				return
 			}
-			if assert.Error(t, err) {
-				assert.Equal(t, tc.expectErr.Error(), err.Error())
+			if require.Error(t, err) {
+				require.Equal(t, tc.expectErr.Error(), err.Error())
 			}
 		})
 	}

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -224,9 +224,8 @@ func TestExecute(t *testing.T) {
 				require.NoError(t, err)
 				return
 			}
-			if require.Error(t, err) {
-				require.Equal(t, tc.expectErr.Error(), err.Error())
-			}
+			require.Error(t, err)
+			require.Equal(t, tc.expectErr.Error(), err.Error())
 		})
 	}
 }

--- a/internal/extrafiles/extra_files_test.go
+++ b/internal/extrafiles/extra_files_test.go
@@ -8,61 +8,55 @@ import (
 )
 
 func TestShouldGetAllFiles(t *testing.T) {
-	assert := require.New(t)
-
 	globs := []config.ExtraFile{
 		{Glob: "./testdata/file1.golden"},
 	}
 
 	files, err := Find(globs)
-	require.NoError(err)
-	require.Equal(1, len(files))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(files))
 
 	path, ok := files["file1.golden"]
-	require.True(ok)
-	require.Equal(path, "./testdata/file1.golden")
+	require.True(t, ok)
+	require.Equal(t, path, "./testdata/file1.golden")
 }
 
 func TestShouldGetAllFilesWithGoldenExtension(t *testing.T) {
-	assert := require.New(t)
-
 	globs := []config.ExtraFile{
 		{Glob: "./testdata/*.golden"},
 	}
 
 	files, err := Find(globs)
-	require.NoError(err)
-	require.Equal(2, len(files))
+	require.NoError(t, err)
+	require.Equal(t, 2, len(files))
 
 	path, ok := files["file1.golden"]
-	require.True(ok)
-	require.Equal(path, "testdata/file1.golden")
+	require.True(t, ok)
+	require.Equal(t, path, "testdata/file1.golden")
 
 	path, ok = files["file2.golden"]
-	require.True(ok)
-	require.Equal(path, "testdata/file2.golden")
+	require.True(t, ok)
+	require.Equal(t, path, "testdata/file2.golden")
 }
 
 func TestShouldGetAllFilesInsideTestdata(t *testing.T) {
-	assert := require.New(t)
-
 	globs := []config.ExtraFile{
 		{Glob: "./testdata/*"},
 	}
 
 	files, err := Find(globs)
-	require.NoError(err)
-	require.Equal(3, len(files))
+	require.NoError(t, err)
+	require.Equal(t, 3, len(files))
 
 	path, ok := files["file1.golden"]
-	require.True(ok)
-	require.Equal(path, "testdata/file1.golden")
+	require.True(t, ok)
+	require.Equal(t, path, "testdata/file1.golden")
 
 	path, ok = files["file2.golden"]
-	require.True(ok)
-	require.Equal(path, "testdata/file2.golden")
+	require.True(t, ok)
+	require.Equal(t, path, "testdata/file2.golden")
 
 	path, ok = files["file3.gold"]
-	require.True(ok)
-	require.Equal(path, "testdata/file3.gold")
+	require.True(t, ok)
+	require.Equal(t, path, "testdata/file3.gold")
 }

--- a/internal/extrafiles/extra_files_test.go
+++ b/internal/extrafiles/extra_files_test.go
@@ -4,65 +4,65 @@ import (
 	"testing"
 
 	"github.com/goreleaser/goreleaser/pkg/config"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestShouldGetAllFiles(t *testing.T) {
-	assert := assert.New(t)
+	assert := require.New(t)
 
 	globs := []config.ExtraFile{
 		{Glob: "./testdata/file1.golden"},
 	}
 
 	files, err := Find(globs)
-	assert.NoError(err)
-	assert.Equal(1, len(files))
+	require.NoError(err)
+	require.Equal(1, len(files))
 
 	path, ok := files["file1.golden"]
-	assert.True(ok)
-	assert.Equal(path, "./testdata/file1.golden")
+	require.True(ok)
+	require.Equal(path, "./testdata/file1.golden")
 }
 
 func TestShouldGetAllFilesWithGoldenExtension(t *testing.T) {
-	assert := assert.New(t)
+	assert := require.New(t)
 
 	globs := []config.ExtraFile{
 		{Glob: "./testdata/*.golden"},
 	}
 
 	files, err := Find(globs)
-	assert.NoError(err)
-	assert.Equal(2, len(files))
+	require.NoError(err)
+	require.Equal(2, len(files))
 
 	path, ok := files["file1.golden"]
-	assert.True(ok)
-	assert.Equal(path, "testdata/file1.golden")
+	require.True(ok)
+	require.Equal(path, "testdata/file1.golden")
 
 	path, ok = files["file2.golden"]
-	assert.True(ok)
-	assert.Equal(path, "testdata/file2.golden")
+	require.True(ok)
+	require.Equal(path, "testdata/file2.golden")
 }
 
 func TestShouldGetAllFilesInsideTestdata(t *testing.T) {
-	assert := assert.New(t)
+	assert := require.New(t)
 
 	globs := []config.ExtraFile{
 		{Glob: "./testdata/*"},
 	}
 
 	files, err := Find(globs)
-	assert.NoError(err)
-	assert.Equal(3, len(files))
+	require.NoError(err)
+	require.Equal(3, len(files))
 
 	path, ok := files["file1.golden"]
-	assert.True(ok)
-	assert.Equal(path, "testdata/file1.golden")
+	require.True(ok)
+	require.Equal(path, "testdata/file1.golden")
 
 	path, ok = files["file2.golden"]
-	assert.True(ok)
-	assert.Equal(path, "testdata/file2.golden")
+	require.True(ok)
+	require.Equal(path, "testdata/file2.golden")
 
 	path, ok = files["file3.gold"]
-	assert.True(ok)
-	assert.Equal(path, "testdata/file3.gold")
+	require.True(ok)
+	require.Equal(path, "testdata/file3.gold")
 }

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/goreleaser/goreleaser/internal/git"
 	"github.com/goreleaser/goreleaser/internal/testlib"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRepoName(t *testing.T) {
@@ -14,8 +14,8 @@ func TestRepoName(t *testing.T) {
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:goreleaser/goreleaser.git")
 	repo, err := git.ExtractRepoFromConfig()
-	assert.NoError(t, err)
-	assert.Equal(t, "goreleaser/goreleaser", repo.String())
+	require.NoError(t, err)
+	require.Equal(t, "goreleaser/goreleaser", repo.String())
 }
 
 func TestExtractRepoFromURL(t *testing.T) {
@@ -29,7 +29,7 @@ func TestExtractRepoFromURL(t *testing.T) {
 	} {
 		t.Run(url, func(t *testing.T) {
 			repo := git.ExtractRepoFromURL(url)
-			assert.Equal(t, "goreleaser/goreleaser", repo.String())
+			require.Equal(t, "goreleaser/goreleaser", repo.String())
 		})
 	}
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -6,18 +6,18 @@ import (
 
 	"github.com/goreleaser/goreleaser/internal/git"
 	"github.com/goreleaser/goreleaser/internal/testlib"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGit(t *testing.T) {
 	out, err := git.Run("status")
-	assert.NoError(t, err)
-	assert.NotEmpty(t, out)
+	require.NoError(t, err)
+	require.NotEmpty(t, out)
 
 	out, err = git.Run("command-that-dont-exist")
-	assert.Error(t, err)
-	assert.Empty(t, out)
-	assert.Equal(
+	require.Error(t, err)
+	require.Empty(t, out)
+	require.Equal(
 		t,
 		"git: 'command-that-dont-exist' is not a git command. See 'git --help'.\n",
 		err.Error(),
@@ -36,26 +36,26 @@ func TestGitWarning(t *testing.T) {
 	testlib.GitTag(t, "1.2.3")
 
 	out, err := git.Run("describe", "--tags", "--abbrev=0", "tags/1.2.3^")
-	assert.NoError(t, err)
-	assert.Equal(t, "1.2.2\n", out)
+	require.NoError(t, err)
+	require.Equal(t, "1.2.2\n", out)
 }
 
 func TestRepo(t *testing.T) {
-	assert.True(t, git.IsRepo(), "goreleaser folder should be a git repo")
+	require.True(t, git.IsRepo(), "goreleaser folder should be a git repo")
 
-	assert.NoError(t, os.Chdir(os.TempDir()))
-	assert.False(t, git.IsRepo(), os.TempDir()+" folder should be a git repo")
+	require.NoError(t, os.Chdir(os.TempDir()))
+	require.False(t, git.IsRepo(), os.TempDir()+" folder should be a git repo")
 }
 
 func TestClean(t *testing.T) {
 	out, err := git.Clean("asdasd 'ssadas'\nadasd", nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "asdasd ssadas", out)
+	require.NoError(t, err)
+	require.Equal(t, "asdasd ssadas", out)
 
 	out, err = git.Clean(git.Run("command-that-dont-exist"))
-	assert.Error(t, err)
-	assert.Empty(t, out)
-	assert.Equal(
+	require.Error(t, err)
+	require.Empty(t, out)
+	require.Equal(
 		t,
 		"git: 'command-that-dont-exist' is not a git command. See 'git --help'.",
 		err.Error(),

--- a/internal/linux/arch_test.go
+++ b/internal/linux/arch_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestArch(t *testing.T) {
@@ -20,7 +20,7 @@ func TestArch(t *testing.T) {
 		"linuxwhat":    "what",
 	} {
 		t.Run(fmt.Sprintf("%s to %s", from, to), func(t *testing.T) {
-			assert.Equal(t, to, Arch(from))
+			require.Equal(t, to, Arch(from))
 		})
 	}
 }

--- a/internal/pipe/artifactory/artifactory_test.go
+++ b/internal/pipe/artifactory/artifactory_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/goreleaser/goreleaser/internal/pipe"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -56,14 +56,14 @@ func TestRunPipe_ModeBinary(t *testing.T) {
 	defer teardown()
 
 	folder, err := ioutil.TempDir("", "archivetest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var dist = filepath.Join(folder, "dist")
-	assert.NoError(t, os.Mkdir(dist, 0755))
-	assert.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
+	require.NoError(t, os.Mkdir(dist, 0755))
+	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
 	err = ioutil.WriteFile(binPath, d1, 0666)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Dummy artifactories
 	mux.HandleFunc("/example-repo-local/mybin/darwin/amd64/mybin", func(w http.ResponseWriter, r *http.Request) {
@@ -206,8 +206,8 @@ func TestRunPipe_ModeBinary(t *testing.T) {
 		})
 	}
 
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.NoError(t, Pipe{}.Publish(ctx))
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Publish(ctx))
 }
 
 func TestRunPipe_ModeArchive(t *testing.T) {
@@ -215,11 +215,11 @@ func TestRunPipe_ModeArchive(t *testing.T) {
 	defer teardown()
 
 	folder, err := ioutil.TempDir("", "goreleasertest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tarfile, err := os.Create(filepath.Join(folder, "bin.tar.gz"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	debfile, err := os.Create(filepath.Join(folder, "bin.deb"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var ctx = context.New(config.Project{
 		ProjectName: "goreleaser",
@@ -307,19 +307,19 @@ func TestRunPipe_ModeArchive(t *testing.T) {
 		uploads.Store("deb", true)
 	})
 
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.NoError(t, Pipe{}.Publish(ctx))
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Publish(ctx))
 	_, ok := uploads.Load("targz")
-	assert.True(t, ok, "tar.gz file was not uploaded")
+	require.True(t, ok, "tar.gz file was not uploaded")
 	_, ok = uploads.Load("deb")
-	assert.True(t, ok, "deb file was not uploaded")
+	require.True(t, ok, "deb file was not uploaded")
 }
 
 func TestRunPipe_ArtifactoryDown(t *testing.T) {
 	folder, err := ioutil.TempDir("", "goreleasertest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tarfile, err := os.Create(filepath.Join(folder, "bin.tar.gz"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var ctx = context.New(config.Project{
 		ProjectName: "goreleaser",
@@ -343,15 +343,15 @@ func TestRunPipe_ArtifactoryDown(t *testing.T) {
 		Path: tarfile.Name(),
 	})
 
-	assert.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Default(ctx))
 	err = Pipe{}.Publish(ctx)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "connection refused")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "connection refused")
 }
 
 func TestRunPipe_TargetTemplateError(t *testing.T) {
 	folder, err := ioutil.TempDir("", "archivetest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var dist = filepath.Join(folder, "dist")
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 
@@ -382,8 +382,8 @@ func TestRunPipe_TargetTemplateError(t *testing.T) {
 		Type:   artifact.UploadableBinary,
 	})
 
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.EqualError(t, Pipe{}.Publish(ctx), `artifactory: error while building the target url: template: tmpl:1: unexpected "/" in operand`)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.EqualError(t, Pipe{}.Publish(ctx), `artifactory: error while building the target url: template: tmpl:1: unexpected "/" in operand`)
 }
 
 func TestRunPipe_BadCredentials(t *testing.T) {
@@ -391,14 +391,14 @@ func TestRunPipe_BadCredentials(t *testing.T) {
 	defer teardown()
 
 	folder, err := ioutil.TempDir("", "archivetest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var dist = filepath.Join(folder, "dist")
-	assert.NoError(t, os.Mkdir(dist, 0755))
-	assert.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
+	require.NoError(t, os.Mkdir(dist, 0755))
+	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
 	err = ioutil.WriteFile(binPath, d1, 0666)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Dummy artifactories
 	mux.HandleFunc("/example-repo-local/mybin/darwin/amd64/mybin", func(w http.ResponseWriter, r *http.Request) {
@@ -442,10 +442,10 @@ func TestRunPipe_BadCredentials(t *testing.T) {
 		Type:   artifact.UploadableBinary,
 	})
 
-	assert.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Default(ctx))
 	err = Pipe{}.Publish(ctx)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "Bad credentials")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Bad credentials")
 }
 
 func TestRunPipe_UnparsableErrorResponse(t *testing.T) {
@@ -453,14 +453,14 @@ func TestRunPipe_UnparsableErrorResponse(t *testing.T) {
 	defer teardown()
 
 	folder, err := ioutil.TempDir("", "archivetest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var dist = filepath.Join(folder, "dist")
-	assert.NoError(t, os.Mkdir(dist, 0755))
-	assert.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
+	require.NoError(t, os.Mkdir(dist, 0755))
+	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
 	err = ioutil.WriteFile(binPath, d1, 0666)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Dummy artifactories
 	mux.HandleFunc("/example-repo-local/mybin/darwin/amd64/mybin", func(w http.ResponseWriter, r *http.Request) {
@@ -503,8 +503,8 @@ func TestRunPipe_UnparsableErrorResponse(t *testing.T) {
 		Type:   artifact.UploadableBinary,
 	})
 
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.EqualError(t, Pipe{}.Publish(ctx), `artifactory: upload failed: invalid character '.' looking for beginning of value`)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.EqualError(t, Pipe{}.Publish(ctx), `artifactory: upload failed: invalid character '.' looking for beginning of value`)
 }
 
 func TestRunPipe_FileNotFound(t *testing.T) {
@@ -534,20 +534,20 @@ func TestRunPipe_FileNotFound(t *testing.T) {
 		Type:   artifact.UploadableBinary,
 	})
 
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.EqualError(t, Pipe{}.Publish(ctx), `open archivetest/dist/mybin/mybin: no such file or directory`)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.EqualError(t, Pipe{}.Publish(ctx), `open archivetest/dist/mybin/mybin: no such file or directory`)
 }
 
 func TestRunPipe_UnparsableTarget(t *testing.T) {
 	folder, err := ioutil.TempDir("", "archivetest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var dist = filepath.Join(folder, "dist")
-	assert.NoError(t, os.Mkdir(dist, 0755))
-	assert.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
+	require.NoError(t, os.Mkdir(dist, 0755))
+	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
 	err = ioutil.WriteFile(binPath, d1, 0666)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var ctx = context.New(config.Project{
 		ProjectName: "mybin",
@@ -575,8 +575,8 @@ func TestRunPipe_UnparsableTarget(t *testing.T) {
 		Type:   artifact.UploadableBinary,
 	})
 
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.EqualError(t, Pipe{}.Publish(ctx), `artifactory: upload failed: parse "://artifacts.company.com/example-repo-local/mybin/darwin/amd64/mybin": missing protocol scheme`)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.EqualError(t, Pipe{}.Publish(ctx), `artifactory: upload failed: parse "://artifacts.company.com/example-repo-local/mybin/darwin/amd64/mybin": missing protocol scheme`)
 }
 
 func TestRunPipe_SkipWhenPublishFalse(t *testing.T) {
@@ -598,18 +598,18 @@ func TestRunPipe_SkipWhenPublishFalse(t *testing.T) {
 	}
 	ctx.SkipPublish = true
 
-	assert.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Default(ctx))
 	err := Pipe{}.Publish(ctx)
-	assert.True(t, pipe.IsSkip(err))
-	assert.EqualError(t, err, pipe.ErrSkipPublishEnabled.Error())
+	require.True(t, pipe.IsSkip(err))
+	require.EqualError(t, err, pipe.ErrSkipPublishEnabled.Error())
 }
 
 func TestRunPipe_DirUpload(t *testing.T) {
 	folder, err := ioutil.TempDir("", "archivetest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var dist = filepath.Join(folder, "dist")
-	assert.NoError(t, os.Mkdir(dist, 0755))
-	assert.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
+	require.NoError(t, os.Mkdir(dist, 0755))
+	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin")
 
 	var ctx = context.New(config.Project{
@@ -638,18 +638,18 @@ func TestRunPipe_DirUpload(t *testing.T) {
 		Type:   artifact.UploadableBinary,
 	})
 
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.EqualError(t, Pipe{}.Publish(ctx), `artifactory: upload failed: the asset to upload can't be a directory`)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.EqualError(t, Pipe{}.Publish(ctx), `artifactory: upload failed: the asset to upload can't be a directory`)
 }
 
 func TestDescription(t *testing.T) {
-	assert.NotEmpty(t, Pipe{}.String())
+	require.NotEmpty(t, Pipe{}.String())
 }
 
 func TestNoArtifactories(t *testing.T) {
 	var ctx = context.New(config.Project{})
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.True(t, pipe.IsSkip(Pipe{}.Publish(ctx)))
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.True(t, pipe.IsSkip(Pipe{}.Publish(ctx)))
 }
 
 func TestArtifactoriesWithoutTarget(t *testing.T) {
@@ -667,8 +667,8 @@ func TestArtifactoriesWithoutTarget(t *testing.T) {
 		},
 	}
 
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.True(t, pipe.IsSkip(Pipe{}.Publish(ctx)))
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.True(t, pipe.IsSkip(Pipe{}.Publish(ctx)))
 }
 
 func TestArtifactoriesWithoutUsername(t *testing.T) {
@@ -686,8 +686,8 @@ func TestArtifactoriesWithoutUsername(t *testing.T) {
 		},
 	}
 
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.True(t, pipe.IsSkip(Pipe{}.Publish(ctx)))
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.True(t, pipe.IsSkip(Pipe{}.Publish(ctx)))
 }
 
 func TestArtifactoriesWithoutName(t *testing.T) {
@@ -699,8 +699,8 @@ func TestArtifactoriesWithoutName(t *testing.T) {
 			},
 		},
 	})
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.True(t, pipe.IsSkip(Pipe{}.Publish(ctx)))
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.True(t, pipe.IsSkip(Pipe{}.Publish(ctx)))
 }
 
 func TestArtifactoriesWithoutSecret(t *testing.T) {
@@ -713,8 +713,8 @@ func TestArtifactoriesWithoutSecret(t *testing.T) {
 			},
 		},
 	})
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.True(t, pipe.IsSkip(Pipe{}.Publish(ctx)))
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.True(t, pipe.IsSkip(Pipe{}.Publish(ctx)))
 }
 
 func TestArtifactoriesWithInvalidMode(t *testing.T) {
@@ -734,8 +734,8 @@ func TestArtifactoriesWithInvalidMode(t *testing.T) {
 		},
 	}
 
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Error(t, Pipe{}.Publish(ctx))
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Error(t, Pipe{}.Publish(ctx))
 }
 
 func TestDefault(t *testing.T) {
@@ -751,10 +751,10 @@ func TestDefault(t *testing.T) {
 		},
 	}
 
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Len(t, ctx.Config.Artifactories, 1)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Len(t, ctx.Config.Artifactories, 1)
 	var artifactory = ctx.Config.Artifactories[0]
-	assert.Equal(t, "archive", artifactory.Mode)
+	require.Equal(t, "archive", artifactory.Mode)
 }
 
 func TestDefaultNoArtifactories(t *testing.T) {
@@ -763,8 +763,8 @@ func TestDefaultNoArtifactories(t *testing.T) {
 			Artifactories: []config.Upload{},
 		},
 	}
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Empty(t, ctx.Config.Artifactories)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Empty(t, ctx.Config.Artifactories)
 }
 
 func TestDefaultSet(t *testing.T) {
@@ -777,9 +777,9 @@ func TestDefaultSet(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Len(t, ctx.Config.Artifactories, 1)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Len(t, ctx.Config.Artifactories, 1)
 	var artifactory = ctx.Config.Artifactories[0]
-	assert.Equal(t, "custom", artifactory.Mode)
-	assert.Equal(t, "X-Checksum-SHA256", artifactory.ChecksumHeader)
+	require.Equal(t, "custom", artifactory.Mode)
+	require.Equal(t, "X-Checksum-SHA256", artifactory.ChecksumHeader)
 }

--- a/internal/pipe/blob/blob_minio_test.go
+++ b/internal/pipe/blob/blob_minio_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gocloud.dev/blob"
 )
@@ -26,15 +25,15 @@ import (
 func TestMinioUpload(t *testing.T) {
 	var listen = randomListen(t)
 	folder, err := ioutil.TempDir("", "goreleasertest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	srcpath := filepath.Join(folder, "source.tar.gz")
 	tgzpath := filepath.Join(folder, "bin.tar.gz")
 	debpath := filepath.Join(folder, "bin.deb")
 	checkpath := filepath.Join(folder, "check.txt")
-	assert.NoError(t, ioutil.WriteFile(checkpath, []byte("fake checksums"), 0744))
-	assert.NoError(t, ioutil.WriteFile(srcpath, []byte("fake\nsrc"), 0744))
-	assert.NoError(t, ioutil.WriteFile(tgzpath, []byte("fake\ntargz"), 0744))
-	assert.NoError(t, ioutil.WriteFile(debpath, []byte("fake\ndeb"), 0744))
+	require.NoError(t, ioutil.WriteFile(checkpath, []byte("fake checksums"), 0744))
+	require.NoError(t, ioutil.WriteFile(srcpath, []byte("fake\nsrc"), 0744))
+	require.NoError(t, ioutil.WriteFile(tgzpath, []byte("fake\ntargz"), 0744))
+	require.NoError(t, ioutil.WriteFile(debpath, []byte("fake\ndeb"), 0744))
 	var ctx = context.New(config.Project{
 		Dist:        folder,
 		ProjectName: "testupload",
@@ -82,8 +81,8 @@ func TestMinioUpload(t *testing.T) {
 	defer stop(t, name)
 	start(t, name, listen)
 	prepareEnv(t, listen)
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.NoError(t, Pipe{}.Publish(ctx))
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Publish(ctx))
 
 	require.Subset(t, getFiles(t, ctx, ctx.Config.Blobs[0]), []string{
 		"testupload/v1.0.0/bin.deb",
@@ -96,14 +95,14 @@ func TestMinioUpload(t *testing.T) {
 func TestMinioUploadCustomBucketID(t *testing.T) {
 	var listen = randomListen(t)
 	folder, err := ioutil.TempDir("", "goreleasertest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tgzpath := filepath.Join(folder, "bin.tar.gz")
 	debpath := filepath.Join(folder, "bin.deb")
-	assert.NoError(t, ioutil.WriteFile(tgzpath, []byte("fake\ntargz"), 0744))
-	assert.NoError(t, ioutil.WriteFile(debpath, []byte("fake\ndeb"), 0744))
+	require.NoError(t, ioutil.WriteFile(tgzpath, []byte("fake\ntargz"), 0744))
+	require.NoError(t, ioutil.WriteFile(debpath, []byte("fake\ndeb"), 0744))
 	// Set custom BUCKET_ID env variable.
 	err = os.Setenv("BUCKET_ID", "test")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var ctx = context.New(config.Project{
 		Dist:        folder,
 		ProjectName: "testupload",
@@ -130,20 +129,20 @@ func TestMinioUploadCustomBucketID(t *testing.T) {
 	defer stop(t, name)
 	start(t, name, listen)
 	prepareEnv(t, listen)
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.NoError(t, Pipe{}.Publish(ctx))
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Publish(ctx))
 }
 
 func TestMinioUploadInvalidCustomBucketID(t *testing.T) {
 	var listen = randomListen(t)
 	folder, err := ioutil.TempDir("", "goreleasertest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tgzpath := filepath.Join(folder, "bin.tar.gz")
 	debpath := filepath.Join(folder, "bin.deb")
-	assert.NoError(t, ioutil.WriteFile(tgzpath, []byte("fake\ntargz"), 0744))
-	assert.NoError(t, ioutil.WriteFile(debpath, []byte("fake\ndeb"), 0744))
+	require.NoError(t, ioutil.WriteFile(tgzpath, []byte("fake\ntargz"), 0744))
+	require.NoError(t, ioutil.WriteFile(debpath, []byte("fake\ndeb"), 0744))
 	// Set custom BUCKET_ID env variable.
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var ctx = context.New(config.Project{
 		Dist:        folder,
 		ProjectName: "testupload",
@@ -170,22 +169,22 @@ func TestMinioUploadInvalidCustomBucketID(t *testing.T) {
 	defer stop(t, name)
 	start(t, name, listen)
 	prepareEnv(t, listen)
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Error(t, Pipe{}.Publish(ctx))
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Error(t, Pipe{}.Publish(ctx))
 }
 
 func TestMinioUploadSkipPublish(t *testing.T) {
 	var listen = randomListen(t)
 	folder, err := ioutil.TempDir("", "goreleasertest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	srcpath := filepath.Join(folder, "source.tar.gz")
 	tgzpath := filepath.Join(folder, "bin.tar.gz")
 	debpath := filepath.Join(folder, "bin.deb")
 	checkpath := filepath.Join(folder, "check.txt")
-	assert.NoError(t, ioutil.WriteFile(checkpath, []byte("fake checksums"), 0744))
-	assert.NoError(t, ioutil.WriteFile(srcpath, []byte("fake\nsrc"), 0744))
-	assert.NoError(t, ioutil.WriteFile(tgzpath, []byte("fake\ntargz"), 0744))
-	assert.NoError(t, ioutil.WriteFile(debpath, []byte("fake\ndeb"), 0744))
+	require.NoError(t, ioutil.WriteFile(checkpath, []byte("fake checksums"), 0744))
+	require.NoError(t, ioutil.WriteFile(srcpath, []byte("fake\nsrc"), 0744))
+	require.NoError(t, ioutil.WriteFile(tgzpath, []byte("fake\ntargz"), 0744))
+	require.NoError(t, ioutil.WriteFile(debpath, []byte("fake\ndeb"), 0744))
 	var ctx = context.New(config.Project{
 		Dist:        folder,
 		ProjectName: "testupload",
@@ -234,8 +233,8 @@ func TestMinioUploadSkipPublish(t *testing.T) {
 	defer stop(t, name)
 	start(t, name, listen)
 	prepareEnv(t, listen)
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.NoError(t, Pipe{}.Publish(ctx))
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Publish(ctx))
 
 	require.NotContains(t, getFiles(t, ctx, ctx.Config.Blobs[0]), []string{
 		"testupload/v1.2.0/bin.deb",

--- a/internal/pipe/blob/blob_test.go
+++ b/internal/pipe/blob/blob_test.go
@@ -24,18 +24,16 @@ func TestNoBlob(t *testing.T) {
 
 func TestDefaultsNoConfig(t *testing.T) {
 	errorString := "bucket or provider cannot be empty"
-	var assert = require.New(t)
 	var ctx = context.New(config.Project{
 		Blobs: []config.Blob{
 			{},
 		},
 	})
-	require.EqualError(Pipe{}.Default(ctx), errorString)
+	require.EqualError(t, Pipe{}.Default(ctx), errorString)
 }
 
 func TestDefaultsNoBucket(t *testing.T) {
 	errorString := "bucket or provider cannot be empty"
-	var assert = require.New(t)
 	var ctx = context.New(config.Project{
 		Blobs: []config.Blob{
 			{
@@ -43,12 +41,11 @@ func TestDefaultsNoBucket(t *testing.T) {
 			},
 		},
 	})
-	require.EqualError(Pipe{}.Default(ctx), errorString)
+	require.EqualError(t, Pipe{}.Default(ctx), errorString)
 }
 
 func TestDefaultsNoProvider(t *testing.T) {
 	errorString := "bucket or provider cannot be empty"
-	var assert = require.New(t)
 	var ctx = context.New(config.Project{
 		Blobs: []config.Blob{
 			{
@@ -56,7 +53,7 @@ func TestDefaultsNoProvider(t *testing.T) {
 			},
 		},
 	})
-	require.EqualError(Pipe{}.Default(ctx), errorString)
+	require.EqualError(t, Pipe{}.Default(ctx), errorString)
 }
 
 func TestDefaults(t *testing.T) {
@@ -90,7 +87,6 @@ func TestDefaults(t *testing.T) {
 }
 
 func TestDefaultsWithProvider(t *testing.T) {
-	var assert = require.New(t)
 	var ctx = context.New(config.Project{
 		Blobs: []config.Blob{
 			{
@@ -107,7 +103,7 @@ func TestDefaultsWithProvider(t *testing.T) {
 			},
 		},
 	})
-	require.Nil(Pipe{}.Default(ctx))
+	require.Nil(t, Pipe{}.Default(ctx))
 }
 
 func TestPipe_Publish(t *testing.T) {

--- a/internal/pipe/blob/blob_test.go
+++ b/internal/pipe/blob/blob_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,18 +24,18 @@ func TestNoBlob(t *testing.T) {
 
 func TestDefaultsNoConfig(t *testing.T) {
 	errorString := "bucket or provider cannot be empty"
-	var assert = assert.New(t)
+	var assert = require.New(t)
 	var ctx = context.New(config.Project{
 		Blobs: []config.Blob{
 			{},
 		},
 	})
-	assert.EqualError(Pipe{}.Default(ctx), errorString)
+	require.EqualError(Pipe{}.Default(ctx), errorString)
 }
 
 func TestDefaultsNoBucket(t *testing.T) {
 	errorString := "bucket or provider cannot be empty"
-	var assert = assert.New(t)
+	var assert = require.New(t)
 	var ctx = context.New(config.Project{
 		Blobs: []config.Blob{
 			{
@@ -44,12 +43,12 @@ func TestDefaultsNoBucket(t *testing.T) {
 			},
 		},
 	})
-	assert.EqualError(Pipe{}.Default(ctx), errorString)
+	require.EqualError(Pipe{}.Default(ctx), errorString)
 }
 
 func TestDefaultsNoProvider(t *testing.T) {
 	errorString := "bucket or provider cannot be empty"
-	var assert = assert.New(t)
+	var assert = require.New(t)
 	var ctx = context.New(config.Project{
 		Blobs: []config.Blob{
 			{
@@ -57,7 +56,7 @@ func TestDefaultsNoProvider(t *testing.T) {
 			},
 		},
 	})
-	assert.EqualError(Pipe{}.Default(ctx), errorString)
+	require.EqualError(Pipe{}.Default(ctx), errorString)
 }
 
 func TestDefaults(t *testing.T) {
@@ -91,7 +90,7 @@ func TestDefaults(t *testing.T) {
 }
 
 func TestDefaultsWithProvider(t *testing.T) {
-	var assert = assert.New(t)
+	var assert = require.New(t)
 	var ctx = context.New(config.Project{
 		Blobs: []config.Blob{
 			{
@@ -108,7 +107,7 @@ func TestDefaultsWithProvider(t *testing.T) {
 			},
 		},
 	})
-	assert.Nil(Pipe{}.Default(ctx))
+	require.Nil(Pipe{}.Default(ctx))
 }
 
 func TestPipe_Publish(t *testing.T) {
@@ -128,11 +127,11 @@ func pipePublish(t *testing.T, extra []config.ExtraFile) {
 	gcloudCredentials, _ := filepath.Abs("./testdata/credentials.json")
 
 	folder, err := ioutil.TempDir("", "goreleasertest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tgzpath := filepath.Join(folder, "bin.tar.gz")
 	debpath := filepath.Join(folder, "bin.deb")
-	assert.NoError(t, ioutil.WriteFile(tgzpath, []byte("fake\ntargz"), 0744))
-	assert.NoError(t, ioutil.WriteFile(debpath, []byte("fake\ndeb"), 0744))
+	require.NoError(t, ioutil.WriteFile(tgzpath, []byte("fake\ntargz"), 0744))
+	require.NoError(t, ioutil.WriteFile(debpath, []byte("fake\ndeb"), 0744))
 
 	// Azure Blob Context
 	var azblobctx = context.New(config.Project{

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -13,30 +13,29 @@ import (
 	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 var update = flag.Bool("update", false, "update .golden files")
 
 func TestDescription(t *testing.T) {
-	assert.NotEmpty(t, Pipe{}.String())
+	require.NotEmpty(t, Pipe{}.String())
 }
 
 func TestNameWithDash(t *testing.T) {
-	assert.Equal(t, formulaNameFor("some-binary"), "SomeBinary")
+	require.Equal(t, formulaNameFor("some-binary"), "SomeBinary")
 }
 
 func TestNameWithUnderline(t *testing.T) {
-	assert.Equal(t, formulaNameFor("some_binary"), "SomeBinary")
+	require.Equal(t, formulaNameFor("some_binary"), "SomeBinary")
 }
 
 func TestNameWithAT(t *testing.T) {
-	assert.Equal(t, formulaNameFor("some_binary@1"), "SomeBinaryAT1")
+	require.Equal(t, formulaNameFor("some_binary@1"), "SomeBinaryAT1")
 }
 
 func TestSimpleName(t *testing.T) {
-	assert.Equal(t, formulaNameFor("binary"), "Binary")
+	require.Equal(t, formulaNameFor("binary"), "Binary")
 }
 
 var defaultTemplateData = templateData{
@@ -64,11 +63,11 @@ var defaultTemplateData = templateData{
 }
 
 func assertDefaultTemplateData(t *testing.T, formulae string) {
-	assert.Contains(t, formulae, "class Test < Formula")
-	assert.Contains(t, formulae, `homepage "https://google.com"`)
-	assert.Contains(t, formulae, `url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_x86_64.tar.gz"`)
-	assert.Contains(t, formulae, `sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c68"`)
-	assert.Contains(t, formulae, `version "0.1.3"`)
+	require.Contains(t, formulae, "class Test < Formula")
+	require.Contains(t, formulae, `homepage "https://google.com"`)
+	require.Contains(t, formulae, `url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_x86_64.tar.gz"`)
+	require.Contains(t, formulae, `sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c68"`)
+	require.Contains(t, formulae, `version "0.1.3"`)
 }
 
 func TestFullFormulae(t *testing.T) {
@@ -84,34 +83,34 @@ func TestFullFormulae(t *testing.T) {
 	formulae, err := doBuildFormula(context.New(config.Project{
 		ProjectName: "foo",
 	}), data)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var golden = "testdata/test.rb.golden"
 	if *update {
 		err := ioutil.WriteFile(golden, []byte(formulae), 0655)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 	bts, err := ioutil.ReadFile(golden)
-	assert.NoError(t, err)
-	assert.Equal(t, string(bts), formulae)
+	require.NoError(t, err)
+	require.Equal(t, string(bts), formulae)
 }
 
 func TestFormulaeSimple(t *testing.T) {
 	formulae, err := doBuildFormula(context.New(config.Project{}), defaultTemplateData)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assertDefaultTemplateData(t, formulae)
-	assert.NotContains(t, formulae, "def caveats")
-	assert.NotContains(t, formulae, "depends_on")
-	assert.NotContains(t, formulae, "def plist;")
+	require.NotContains(t, formulae, "def caveats")
+	require.NotContains(t, formulae, "depends_on")
+	require.NotContains(t, formulae, "def plist;")
 }
 
 func TestSplit(t *testing.T) {
 	var parts = split("system \"true\"\nsystem \"#{bin}/foo -h\"")
-	assert.Equal(t, []string{"system \"true\"", "system \"#{bin}/foo -h\""}, parts)
+	require.Equal(t, []string{"system \"true\"", "system \"#{bin}/foo -h\""}, parts)
 	parts = split("")
-	assert.Equal(t, []string{}, parts)
+	require.Equal(t, []string{}, parts)
 	parts = split("\n  ")
-	assert.Equal(t, []string{}, parts)
+	require.Equal(t, []string{}, parts)
 }
 
 func TestRunPipe(t *testing.T) {
@@ -156,7 +155,7 @@ func TestRunPipe(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			folder, err := ioutil.TempDir("", "goreleasertest")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			var ctx = &context.Context{
 				Git: context.GitInfo{
 					CurrentTag: "v1.0.1",
@@ -214,30 +213,30 @@ func TestRunPipe(t *testing.T) {
 			})
 
 			_, err = os.Create(path)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			client := &DummyClient{}
 			var distFile = filepath.Join(folder, name+".rb")
 
-			assert.NoError(t, doRun(ctx, ctx.Config.Brews[0], client))
-			assert.True(t, client.CreatedFile)
+			require.NoError(t, doRun(ctx, ctx.Config.Brews[0], client))
+			require.True(t, client.CreatedFile)
 			var golden = fmt.Sprintf("testdata/%s.rb.golden", name)
 			if *update {
-				assert.NoError(t, ioutil.WriteFile(golden, []byte(client.Content), 0655))
+				require.NoError(t, ioutil.WriteFile(golden, []byte(client.Content), 0655))
 			}
 			bts, err := ioutil.ReadFile(golden)
-			assert.NoError(t, err)
-			assert.Equal(t, string(bts), client.Content)
+			require.NoError(t, err)
+			require.Equal(t, string(bts), client.Content)
 
 			distBts, err := ioutil.ReadFile(distFile)
-			assert.NoError(t, err)
-			assert.Equal(t, string(bts), string(distBts))
+			require.NoError(t, err)
+			require.Equal(t, string(bts), string(distBts))
 		})
 	}
 }
 
 func TestRunPipeNameTemplate(t *testing.T) {
 	folder, err := ioutil.TempDir("", "goreleasertest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var ctx = &context.Context{
 		Git: context.GitInfo{
 			CurrentTag: "v1.0.1",
@@ -279,28 +278,28 @@ func TestRunPipeNameTemplate(t *testing.T) {
 	})
 
 	_, err = os.Create(path)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	client := &DummyClient{}
 	var distFile = filepath.Join(folder, "foo_is_bar.rb")
 
-	assert.NoError(t, doRun(ctx, ctx.Config.Brews[0], client))
-	assert.True(t, client.CreatedFile)
+	require.NoError(t, doRun(ctx, ctx.Config.Brews[0], client))
+	require.True(t, client.CreatedFile)
 	var golden = "testdata/foo_is_bar.rb.golden"
 	if *update {
-		assert.NoError(t, ioutil.WriteFile(golden, []byte(client.Content), 0655))
+		require.NoError(t, ioutil.WriteFile(golden, []byte(client.Content), 0655))
 	}
 	bts, err := ioutil.ReadFile(golden)
-	assert.NoError(t, err)
-	assert.Equal(t, string(bts), client.Content)
+	require.NoError(t, err)
+	require.Equal(t, string(bts), client.Content)
 
 	distBts, err := ioutil.ReadFile(distFile)
-	assert.NoError(t, err)
-	assert.Equal(t, string(bts), string(distBts))
+	require.NoError(t, err)
+	require.Equal(t, string(bts), string(distBts))
 }
 
 func TestRunPipeMultipleBrewsWithSkip(t *testing.T) {
 	folder, err := ioutil.TempDir("", "goreleasertest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var ctx = &context.Context{
 		Git: context.GitInfo{
 			CurrentTag: "v1.0.1",
@@ -364,11 +363,11 @@ func TestRunPipeMultipleBrewsWithSkip(t *testing.T) {
 	})
 
 	_, err = os.Create(path)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var cli = &DummyClient{}
-	assert.EqualError(t, publishAll(ctx, cli), `brew.skip_upload is set`)
-	assert.True(t, cli.CreatedFile)
+	require.EqualError(t, publishAll(ctx, cli), `brew.skip_upload is set`)
+	require.True(t, cli.CreatedFile)
 
 	for _, brew := range ctx.Config.Brews {
 		var distFile = filepath.Join(folder, brew.Name+".rb")
@@ -391,7 +390,7 @@ func TestRunPipeForMultipleArmVersions(t *testing.T) {
 		},
 	} {
 		folder, err := ioutil.TempDir("", "goreleasertest")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		var ctx = &context.Context{
 			TokenType: context.TokenTypeGitHub,
 			Git: context.GitInfo{
@@ -483,25 +482,25 @@ func TestRunPipeForMultipleArmVersions(t *testing.T) {
 				},
 			})
 			_, err := os.Create(path)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
 
 		client := &DummyClient{}
 		var distFile = filepath.Join(folder, name+".rb")
 
-		assert.NoError(t, doRun(ctx, ctx.Config.Brews[0], client))
-		assert.True(t, client.CreatedFile)
+		require.NoError(t, doRun(ctx, ctx.Config.Brews[0], client))
+		require.True(t, client.CreatedFile)
 		var golden = fmt.Sprintf("testdata/%s.rb.golden", name)
 		if *update {
-			assert.NoError(t, ioutil.WriteFile(golden, []byte(client.Content), 0655))
+			require.NoError(t, ioutil.WriteFile(golden, []byte(client.Content), 0655))
 		}
 		bts, err := ioutil.ReadFile(golden)
-		assert.NoError(t, err)
-		assert.Equal(t, string(bts), client.Content)
+		require.NoError(t, err)
+		require.Equal(t, string(bts), client.Content)
 
 		distBts, err := ioutil.ReadFile(distFile)
-		assert.NoError(t, err)
-		assert.Equal(t, string(bts), string(distBts))
+		require.NoError(t, err)
+		require.Equal(t, string(bts), string(distBts))
 	}
 }
 
@@ -520,8 +519,8 @@ func TestRunPipeNoDarwin64Build(t *testing.T) {
 		},
 	}
 	client := &DummyClient{}
-	assert.Equal(t, ErrNoArchivesFound, doRun(ctx, ctx.Config.Brews[0], client))
-	assert.False(t, client.CreatedFile)
+	require.Equal(t, ErrNoArchivesFound, doRun(ctx, ctx.Config.Brews[0], client))
+	require.False(t, client.CreatedFile)
 }
 
 func TestRunPipeMultipleArchivesSameOsBuild(t *testing.T) {
@@ -540,7 +539,7 @@ func TestRunPipeMultipleArchivesSameOsBuild(t *testing.T) {
 
 	ctx.TokenType = context.TokenTypeGitHub
 	f, err := ioutil.TempFile("", "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer f.Close()
 
 	tests := []struct {
@@ -662,8 +661,8 @@ func TestRunPipeMultipleArchivesSameOsBuild(t *testing.T) {
 			})
 		}
 		client := &DummyClient{}
-		assert.Equal(t, test.expectedError, doRun(ctx, ctx.Config.Brews[0], client))
-		assert.False(t, client.CreatedFile)
+		require.Equal(t, test.expectedError, doRun(ctx, ctx.Config.Brews[0], client))
+		require.False(t, client.CreatedFile)
 		// clean the artifacts for the next run
 		ctx.Artifacts = artifact.New()
 	}
@@ -675,7 +674,7 @@ func TestRunPipeBrewNotSetup(t *testing.T) {
 	}
 	client := &DummyClient{}
 	testlib.AssertSkipped(t, doRun(ctx, config.Homebrew{}, client))
-	assert.False(t, client.CreatedFile)
+	require.False(t, client.CreatedFile)
 }
 
 func TestRunPipeBinaryRelease(t *testing.T) {
@@ -699,13 +698,13 @@ func TestRunPipeBinaryRelease(t *testing.T) {
 		Type:   artifact.Binary,
 	})
 	client := &DummyClient{}
-	assert.Equal(t, ErrNoArchivesFound, doRun(ctx, ctx.Config.Brews[0], client))
-	assert.False(t, client.CreatedFile)
+	require.Equal(t, ErrNoArchivesFound, doRun(ctx, ctx.Config.Brews[0], client))
+	require.False(t, client.CreatedFile)
 }
 
 func TestRunPipeNoUpload(t *testing.T) {
 	folder, err := ioutil.TempDir("", "goreleasertest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var ctx = context.New(config.Project{
 		Dist:        folder,
 		ProjectName: "foo",
@@ -723,7 +722,7 @@ func TestRunPipeNoUpload(t *testing.T) {
 	ctx.Git = context.GitInfo{CurrentTag: "v1.0.1"}
 	var path = filepath.Join(folder, "whatever.tar.gz")
 	_, err = os.Create(path)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "bin",
 		Path:   path,
@@ -739,7 +738,7 @@ func TestRunPipeNoUpload(t *testing.T) {
 
 	var assertNoPublish = func(t *testing.T) {
 		testlib.AssertSkipped(t, doRun(ctx, ctx.Config.Brews[0], client))
-		assert.False(t, client.CreatedFile)
+		require.False(t, client.CreatedFile)
 	}
 	t.Run("skip upload", func(tt *testing.T) {
 		ctx.Config.Release.Draft = false
@@ -757,7 +756,7 @@ func TestRunPipeNoUpload(t *testing.T) {
 
 func TestRunEmptyTokenType(t *testing.T) {
 	folder, err := ioutil.TempDir("", "goreleasertest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var ctx = context.New(config.Project{
 		Dist:        folder,
 		ProjectName: "foo",
@@ -774,7 +773,7 @@ func TestRunEmptyTokenType(t *testing.T) {
 	ctx.Git = context.GitInfo{CurrentTag: "v1.0.1"}
 	var path = filepath.Join(folder, "whatever.tar.gz")
 	_, err = os.Create(path)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "bin",
 		Path:   path,
@@ -787,12 +786,12 @@ func TestRunEmptyTokenType(t *testing.T) {
 		},
 	})
 	client := &DummyClient{}
-	assert.NoError(t, doRun(ctx, ctx.Config.Brews[0], client))
+	require.NoError(t, doRun(ctx, ctx.Config.Brews[0], client))
 }
 
 func TestRunTokenTypeNotImplementedForBrew(t *testing.T) {
 	folder, err := ioutil.TempDir("", "goreleasertest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var ctx = context.New(config.Project{
 		Dist:        folder,
 		ProjectName: "foo",
@@ -810,7 +809,7 @@ func TestRunTokenTypeNotImplementedForBrew(t *testing.T) {
 	ctx.Git = context.GitInfo{CurrentTag: "v1.0.1"}
 	var path = filepath.Join(folder, "whatever.tar.gz")
 	_, err = os.Create(path)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "bin",
 		Path:   path,
@@ -823,7 +822,7 @@ func TestRunTokenTypeNotImplementedForBrew(t *testing.T) {
 		},
 	})
 	client := &DummyClient{NotImplemented: true}
-	assert.Equal(t, ErrTokenTypeNotImplementedForBrew{TokenType: "gitea"}, doRun(ctx, ctx.Config.Brews[0], client))
+	require.Equal(t, ErrTokenTypeNotImplementedForBrew{TokenType: "gitea"}, doRun(ctx, ctx.Config.Brews[0], client))
 }
 
 func TestDefault(t *testing.T) {
@@ -859,16 +858,16 @@ func TestDefault(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Equal(t, ctx.Config.ProjectName, ctx.Config.Brews[0].Name)
-	assert.NotEmpty(t, ctx.Config.Brews[0].CommitAuthor.Name)
-	assert.NotEmpty(t, ctx.Config.Brews[0].CommitAuthor.Email)
-	assert.Equal(t, `bin.install "foo"`, ctx.Config.Brews[0].Install)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, ctx.Config.ProjectName, ctx.Config.Brews[0].Name)
+	require.NotEmpty(t, ctx.Config.Brews[0].CommitAuthor.Name)
+	require.NotEmpty(t, ctx.Config.Brews[0].CommitAuthor.Email)
+	require.Equal(t, `bin.install "foo"`, ctx.Config.Brews[0].Install)
 }
 
 func TestGHFolder(t *testing.T) {
-	assert.Equal(t, "bar.rb", buildFormulaPath("", "bar.rb"))
-	assert.Equal(t, "fooo/bar.rb", buildFormulaPath("fooo", "bar.rb"))
+	require.Equal(t, "bar.rb", buildFormulaPath("", "bar.rb"))
+	require.Equal(t, "fooo/bar.rb", buildFormulaPath("fooo", "bar.rb"))
 }
 
 type DummyClient struct {

--- a/internal/pipe/defaults/defaults_test.go
+++ b/internal/pipe/defaults/defaults_test.go
@@ -6,12 +6,11 @@ import (
 	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
-
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDescription(t *testing.T) {
-	assert.NotEmpty(t, Pipe{}.String())
+	require.NotEmpty(t, Pipe{}.String())
 }
 
 func TestFillBasicData(t *testing.T) {
@@ -25,23 +24,23 @@ func TestFillBasicData(t *testing.T) {
 		Config:    config.Project{},
 	}
 
-	assert.NoError(t, Pipe{}.Run(ctx))
-	assert.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Owner)
-	assert.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Name)
-	assert.NotEmpty(t, ctx.Config.Builds)
-	assert.Equal(t, "goreleaser", ctx.Config.Builds[0].Binary)
-	assert.Equal(t, ".", ctx.Config.Builds[0].Main)
-	assert.Contains(t, ctx.Config.Builds[0].Goos, "darwin")
-	assert.Contains(t, ctx.Config.Builds[0].Goos, "linux")
-	assert.Contains(t, ctx.Config.Builds[0].Goarch, "386")
-	assert.Contains(t, ctx.Config.Builds[0].Goarch, "amd64")
-	assert.Equal(t, "tar.gz", ctx.Config.Archives[0].Format)
-	assert.Empty(t, ctx.Config.Dockers)
-	assert.Equal(t, "https://github.com", ctx.Config.GitHubURLs.Download)
-	assert.NotEmpty(t, ctx.Config.Archives[0].NameTemplate)
-	assert.NotEmpty(t, ctx.Config.Builds[0].Ldflags)
-	assert.NotEmpty(t, ctx.Config.Archives[0].Files)
-	assert.NotEmpty(t, ctx.Config.Dist)
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Owner)
+	require.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Name)
+	require.NotEmpty(t, ctx.Config.Builds)
+	require.Equal(t, "goreleaser", ctx.Config.Builds[0].Binary)
+	require.Equal(t, ".", ctx.Config.Builds[0].Main)
+	require.Contains(t, ctx.Config.Builds[0].Goos, "darwin")
+	require.Contains(t, ctx.Config.Builds[0].Goos, "linux")
+	require.Contains(t, ctx.Config.Builds[0].Goarch, "386")
+	require.Contains(t, ctx.Config.Builds[0].Goarch, "amd64")
+	require.Equal(t, "tar.gz", ctx.Config.Archives[0].Format)
+	require.Empty(t, ctx.Config.Dockers)
+	require.Equal(t, "https://github.com", ctx.Config.GitHubURLs.Download)
+	require.NotEmpty(t, ctx.Config.Archives[0].NameTemplate)
+	require.NotEmpty(t, ctx.Config.Builds[0].Ldflags)
+	require.NotEmpty(t, ctx.Config.Archives[0].Files)
+	require.NotEmpty(t, ctx.Config.Dist)
 }
 
 func TestFillPartial(t *testing.T) {
@@ -95,14 +94,14 @@ func TestFillPartial(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, Pipe{}.Run(ctx))
-	assert.Len(t, ctx.Config.Archives[0].Files, 1)
-	assert.Equal(t, `bin.install "testreleaser"`, ctx.Config.Brews[0].Install)
-	assert.NotEmpty(t, ctx.Config.Dockers[0].Binaries)
-	assert.NotEmpty(t, ctx.Config.Dockers[0].Goos)
-	assert.NotEmpty(t, ctx.Config.Dockers[0].Goarch)
-	assert.NotEmpty(t, ctx.Config.Dockers[0].Dockerfile)
-	assert.Empty(t, ctx.Config.Dockers[0].Goarm)
-	assert.Equal(t, "disttt", ctx.Config.Dist)
-	assert.NotEqual(t, "https://github.com", ctx.Config.GitHubURLs.Download)
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Len(t, ctx.Config.Archives[0].Files, 1)
+	require.Equal(t, `bin.install "testreleaser"`, ctx.Config.Brews[0].Install)
+	require.NotEmpty(t, ctx.Config.Dockers[0].Binaries)
+	require.NotEmpty(t, ctx.Config.Dockers[0].Goos)
+	require.NotEmpty(t, ctx.Config.Dockers[0].Goarch)
+	require.NotEmpty(t, ctx.Config.Dockers[0].Dockerfile)
+	require.Empty(t, ctx.Config.Dockers[0].Goarm)
+	require.Equal(t, "disttt", ctx.Config.Dist)
+	require.NotEqual(t, "https://github.com", ctx.Config.GitHubURLs.Download)
 }

--- a/internal/pipe/dist/dist_test.go
+++ b/internal/pipe/dist/dist_test.go
@@ -8,14 +8,14 @@ import (
 
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDistDoesNotExist(t *testing.T) {
 	folder, err := ioutil.TempDir("", "disttest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var dist = filepath.Join(folder, "dist")
-	assert.NoError(
+	require.NoError(
 		t,
 		Pipe{}.Run(
 			&context.Context{
@@ -29,38 +29,38 @@ func TestDistDoesNotExist(t *testing.T) {
 
 func TestPopulatedDistExists(t *testing.T) {
 	folder, err := ioutil.TempDir("", "disttest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var dist = filepath.Join(folder, "dist")
-	assert.NoError(t, os.Mkdir(dist, 0755))
+	require.NoError(t, os.Mkdir(dist, 0755))
 	_, err = os.Create(filepath.Join(dist, "mybin"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var ctx = &context.Context{
 		Config: config.Project{
 			Dist: dist,
 		},
 	}
-	assert.Error(t, Pipe{}.Run(ctx))
+	require.Error(t, Pipe{}.Run(ctx))
 	ctx.RmDist = true
-	assert.NoError(t, Pipe{}.Run(ctx))
+	require.NoError(t, Pipe{}.Run(ctx))
 	_, err = os.Stat(dist)
-	assert.False(t, os.IsExist(err))
+	require.False(t, os.IsExist(err))
 }
 
 func TestEmptyDistExists(t *testing.T) {
 	folder, err := ioutil.TempDir("", "disttest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var dist = filepath.Join(folder, "dist")
-	assert.NoError(t, os.Mkdir(dist, 0755))
+	require.NoError(t, os.Mkdir(dist, 0755))
 	var ctx = &context.Context{
 		Config: config.Project{
 			Dist: dist,
 		},
 	}
-	assert.NoError(t, Pipe{}.Run(ctx))
+	require.NoError(t, Pipe{}.Run(ctx))
 	_, err = os.Stat(dist)
-	assert.False(t, os.IsNotExist(err))
+	require.False(t, os.IsNotExist(err))
 }
 
 func TestDescription(t *testing.T) {
-	assert.NotEmpty(t, Pipe{}.String())
+	require.NotEmpty(t, Pipe{}.String())
 }

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -662,21 +661,21 @@ func TestBuildCommand(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			command := buildCommand(images, tt.flags)
-			assert.Equal(t, tt.expect, command)
+			require.Equal(t, tt.expect, command)
 		})
 	}
 }
 
 func TestDescription(t *testing.T) {
-	assert.NotEmpty(t, Pipe{}.String())
+	require.NotEmpty(t, Pipe{}.String())
 }
 
 func TestNoDockers(t *testing.T) {
-	assert.True(t, pipe.IsSkip(Pipe{}.Run(context.New(config.Project{}))))
+	require.True(t, pipe.IsSkip(Pipe{}.Run(context.New(config.Project{}))))
 }
 
 func TestNoDockerWithoutImageName(t *testing.T) {
-	assert.True(t, pipe.IsSkip(Pipe{}.Run(context.New(config.Project{
+	require.True(t, pipe.IsSkip(Pipe{}.Run(context.New(config.Project{
 		Dockers: []config.Docker{
 			{
 				Goos: "linux",
@@ -688,9 +687,9 @@ func TestNoDockerWithoutImageName(t *testing.T) {
 func TestDockerNotInPath(t *testing.T) {
 	var path = os.Getenv("PATH")
 	defer func() {
-		assert.NoError(t, os.Setenv("PATH", path))
+		require.NoError(t, os.Setenv("PATH", path))
 	}()
-	assert.NoError(t, os.Setenv("PATH", ""))
+	require.NoError(t, os.Setenv("PATH", ""))
 	var ctx = &context.Context{
 		Version: "1.0.0",
 		Config: config.Project{
@@ -701,7 +700,7 @@ func TestDockerNotInPath(t *testing.T) {
 			},
 		},
 	}
-	assert.EqualError(t, Pipe{}.Run(ctx), ErrNoDocker.Error())
+	require.EqualError(t, Pipe{}.Run(ctx), ErrNoDocker.Error())
 }
 
 func TestDefault(t *testing.T) {
@@ -717,13 +716,13 @@ func TestDefault(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Len(t, ctx.Config.Dockers, 1)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Len(t, ctx.Config.Dockers, 1)
 	var docker = ctx.Config.Dockers[0]
-	assert.Equal(t, "linux", docker.Goos)
-	assert.Equal(t, "amd64", docker.Goarch)
-	assert.Equal(t, []string{ctx.Config.Builds[0].Binary}, docker.Binaries)
-	assert.Empty(t, docker.Builds)
+	require.Equal(t, "linux", docker.Goos)
+	require.Equal(t, "amd64", docker.Goarch)
+	require.Equal(t, []string{ctx.Config.Builds[0].Binary}, docker.Binaries)
+	require.Empty(t, docker.Builds)
 }
 
 func TestDefaultBinaries(t *testing.T) {
@@ -741,12 +740,12 @@ func TestDefaultBinaries(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.Len(t, ctx.Config.Dockers, 1)
 	var docker = ctx.Config.Dockers[0]
-	assert.Equal(t, "linux", docker.Goos)
-	assert.Equal(t, "amd64", docker.Goarch)
-	assert.Equal(t, []string{"foo"}, docker.Binaries)
+	require.Equal(t, "linux", docker.Goos)
+	require.Equal(t, "amd64", docker.Goarch)
+	require.Equal(t, []string{"foo"}, docker.Binaries)
 }
 
 func TestDefaultNoDockers(t *testing.T) {
@@ -755,8 +754,8 @@ func TestDefaultNoDockers(t *testing.T) {
 			Dockers: []config.Docker{},
 		},
 	}
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Empty(t, ctx.Config.Dockers)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Empty(t, ctx.Config.Dockers)
 }
 
 func TestDefaultFilesDot(t *testing.T) {
@@ -770,7 +769,7 @@ func TestDefaultFilesDot(t *testing.T) {
 			},
 		},
 	}
-	assert.EqualError(t, Pipe{}.Default(ctx), `invalid docker.files: can't be . or inside dist folder: .`)
+	require.EqualError(t, Pipe{}.Default(ctx), `invalid docker.files: can't be . or inside dist folder: .`)
 }
 
 func TestDefaultFilesDis(t *testing.T) {
@@ -784,7 +783,7 @@ func TestDefaultFilesDis(t *testing.T) {
 			},
 		},
 	}
-	assert.EqualError(t, Pipe{}.Default(ctx), `invalid docker.files: can't be . or inside dist folder: /tmp/dist/asdasd/asd`)
+	require.EqualError(t, Pipe{}.Default(ctx), `invalid docker.files: can't be . or inside dist folder: /tmp/dist/asdasd/asd`)
 }
 
 func TestDefaultSet(t *testing.T) {
@@ -801,14 +800,14 @@ func TestDefaultSet(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Len(t, ctx.Config.Dockers, 1)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Len(t, ctx.Config.Dockers, 1)
 	var docker = ctx.Config.Dockers[0]
-	assert.Equal(t, "windows", docker.Goos)
-	assert.Equal(t, "i386", docker.Goarch)
-	assert.Equal(t, "bar", docker.Binaries[0])
-	assert.Equal(t, "foo", docker.Builds[0])
-	assert.Equal(t, "Dockerfile.foo", docker.Dockerfile)
+	require.Equal(t, "windows", docker.Goos)
+	require.Equal(t, "i386", docker.Goarch)
+	require.Equal(t, "bar", docker.Binaries[0])
+	require.Equal(t, "foo", docker.Builds[0])
+	require.Equal(t, "Dockerfile.foo", docker.Dockerfile)
 }
 
 func Test_processImageTemplates(t *testing.T) {
@@ -848,15 +847,15 @@ func Test_processImageTemplates(t *testing.T) {
 		Patch: 0,
 	}
 
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Len(t, ctx.Config.Dockers, 1)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Len(t, ctx.Config.Dockers, 1)
 
 	docker := ctx.Config.Dockers[0]
-	assert.Equal(t, "Dockerfile.foo", docker.Dockerfile)
+	require.Equal(t, "Dockerfile.foo", docker.Dockerfile)
 
 	images, err := processImageTemplates(ctx, docker)
-	assert.NoError(t, err)
-	assert.Equal(t, []string{
+	require.NoError(t, err)
+	require.Equal(t, []string{
 		"user/image:v1.0.0",
 		"gcr.io/image:v1.0.0-123",
 		"gcr.io/image:v1.0",

--- a/internal/pipe/effectiveconfig/config_test.go
+++ b/internal/pipe/effectiveconfig/config_test.go
@@ -9,25 +9,25 @@ import (
 	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPipeDescription(t *testing.T) {
-	assert.NotEmpty(t, Pipe{}.String())
+	require.NotEmpty(t, Pipe{}.String())
 }
 
 func Test(t *testing.T) {
 	folder, back := testlib.Mktmp(t)
 	defer back()
 	dist := filepath.Join(folder, "dist")
-	assert.NoError(t, os.Mkdir(dist, 0755))
+	require.NoError(t, os.Mkdir(dist, 0755))
 	var ctx = context.New(
 		config.Project{
 			Dist: dist,
 		},
 	)
-	assert.NoError(t, Pipe{}.Run(ctx))
+	require.NoError(t, Pipe{}.Run(ctx))
 	bts, err := ioutil.ReadFile(filepath.Join(dist, "config.yaml"))
-	assert.NoError(t, err)
-	assert.NotEmpty(t, string(bts))
+	require.NoError(t, err)
+	require.NotEmpty(t, string(bts))
 }

--- a/internal/pipe/env/env_test.go
+++ b/internal/pipe/env/env_test.go
@@ -8,20 +8,20 @@ import (
 
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDescription(t *testing.T) {
-	assert.NotEmpty(t, Pipe{}.String())
+	require.NotEmpty(t, Pipe{}.String())
 }
 
 func TestSetDefaultTokenFiles(t *testing.T) {
 	t.Run("empty config", func(tt *testing.T) {
 		ctx := context.New(config.Project{})
 		setDefaultTokenFiles(ctx)
-		assert.Equal(t, "~/.config/goreleaser/github_token", ctx.Config.EnvFiles.GitHubToken)
-		assert.Equal(t, "~/.config/goreleaser/gitlab_token", ctx.Config.EnvFiles.GitLabToken)
-		assert.Equal(t, "~/.config/goreleaser/gitea_token", ctx.Config.EnvFiles.GiteaToken)
+		require.Equal(t, "~/.config/goreleaser/github_token", ctx.Config.EnvFiles.GitHubToken)
+		require.Equal(t, "~/.config/goreleaser/gitlab_token", ctx.Config.EnvFiles.GitLabToken)
+		require.Equal(t, "~/.config/goreleaser/gitea_token", ctx.Config.EnvFiles.GiteaToken)
 	})
 	t.Run("custom config config", func(tt *testing.T) {
 		cfg := "what"
@@ -31,100 +31,100 @@ func TestSetDefaultTokenFiles(t *testing.T) {
 			},
 		})
 		setDefaultTokenFiles(ctx)
-		assert.Equal(t, cfg, ctx.Config.EnvFiles.GitHubToken)
+		require.Equal(t, cfg, ctx.Config.EnvFiles.GitHubToken)
 	})
 }
 
 func TestValidGithubEnv(t *testing.T) {
-	assert.NoError(t, os.Setenv("GITHUB_TOKEN", "asdf"))
+	require.NoError(t, os.Setenv("GITHUB_TOKEN", "asdf"))
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}
-	assert.NoError(t, Pipe{}.Run(ctx))
-	assert.Equal(t, "asdf", ctx.Token)
-	assert.Equal(t, context.TokenTypeGitHub, ctx.TokenType)
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, "asdf", ctx.Token)
+	require.Equal(t, context.TokenTypeGitHub, ctx.TokenType)
 	// so the tests do not depend on each other
-	assert.NoError(t, os.Unsetenv("GITHUB_TOKEN"))
+	require.NoError(t, os.Unsetenv("GITHUB_TOKEN"))
 }
 
 func TestValidGitlabEnv(t *testing.T) {
-	assert.NoError(t, os.Setenv("GITLAB_TOKEN", "qwertz"))
+	require.NoError(t, os.Setenv("GITLAB_TOKEN", "qwertz"))
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}
-	assert.NoError(t, Pipe{}.Run(ctx))
-	assert.Equal(t, "qwertz", ctx.Token)
-	assert.Equal(t, context.TokenTypeGitLab, ctx.TokenType)
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, "qwertz", ctx.Token)
+	require.Equal(t, context.TokenTypeGitLab, ctx.TokenType)
 	// so the tests do not depend on each other
-	assert.NoError(t, os.Unsetenv("GITLAB_TOKEN"))
+	require.NoError(t, os.Unsetenv("GITLAB_TOKEN"))
 }
 
 func TestValidGiteaEnv(t *testing.T) {
-	assert.NoError(t, os.Setenv("GITEA_TOKEN", "token"))
+	require.NoError(t, os.Setenv("GITEA_TOKEN", "token"))
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}
-	assert.NoError(t, Pipe{}.Run(ctx))
-	assert.Equal(t, "token", ctx.Token)
-	assert.Equal(t, context.TokenTypeGitea, ctx.TokenType)
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, "token", ctx.Token)
+	require.Equal(t, context.TokenTypeGitea, ctx.TokenType)
 	// so the tests do not depend on each other
-	assert.NoError(t, os.Unsetenv("GITEA_TOKEN"))
+	require.NoError(t, os.Unsetenv("GITEA_TOKEN"))
 }
 
 func TestInvalidEnv(t *testing.T) {
-	assert.NoError(t, os.Unsetenv("GITHUB_TOKEN"))
-	assert.NoError(t, os.Unsetenv("GITLAB_TOKEN"))
+	require.NoError(t, os.Unsetenv("GITHUB_TOKEN"))
+	require.NoError(t, os.Unsetenv("GITLAB_TOKEN"))
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}
-	assert.Error(t, Pipe{}.Run(ctx))
-	assert.EqualError(t, Pipe{}.Run(ctx), ErrMissingToken.Error())
+	require.Error(t, Pipe{}.Run(ctx))
+	require.EqualError(t, Pipe{}.Run(ctx), ErrMissingToken.Error())
 }
 
 func TestMultipleEnvTokens(t *testing.T) {
-	assert.NoError(t, os.Setenv("GITHUB_TOKEN", "asdf"))
-	assert.NoError(t, os.Setenv("GITLAB_TOKEN", "qwertz"))
-	assert.NoError(t, os.Setenv("GITEA_TOKEN", "token"))
+	require.NoError(t, os.Setenv("GITHUB_TOKEN", "asdf"))
+	require.NoError(t, os.Setenv("GITLAB_TOKEN", "qwertz"))
+	require.NoError(t, os.Setenv("GITEA_TOKEN", "token"))
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}
-	assert.Error(t, Pipe{}.Run(ctx))
-	assert.EqualError(t, Pipe{}.Run(ctx), ErrMultipleTokens.Error())
+	require.Error(t, Pipe{}.Run(ctx))
+	require.EqualError(t, Pipe{}.Run(ctx), ErrMultipleTokens.Error())
 	// so the tests do not depend on each other
-	assert.NoError(t, os.Unsetenv("GITHUB_TOKEN"))
-	assert.NoError(t, os.Unsetenv("GITLAB_TOKEN"))
-	assert.NoError(t, os.Unsetenv("GITEA_TOKEN"))
+	require.NoError(t, os.Unsetenv("GITHUB_TOKEN"))
+	require.NoError(t, os.Unsetenv("GITLAB_TOKEN"))
+	require.NoError(t, os.Unsetenv("GITEA_TOKEN"))
 }
 
 func TestEmptyGithubFileEnv(t *testing.T) {
-	assert.NoError(t, os.Unsetenv("GITHUB_TOKEN"))
+	require.NoError(t, os.Unsetenv("GITHUB_TOKEN"))
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}
-	assert.Error(t, Pipe{}.Run(ctx))
+	require.Error(t, Pipe{}.Run(ctx))
 }
 
 func TestEmptyGitlabFileEnv(t *testing.T) {
-	assert.NoError(t, os.Unsetenv("GITLAB_TOKEN"))
+	require.NoError(t, os.Unsetenv("GITLAB_TOKEN"))
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}
-	assert.Error(t, Pipe{}.Run(ctx))
+	require.Error(t, Pipe{}.Run(ctx))
 }
 
 func TestEmptyGiteaFileEnv(t *testing.T) {
-	assert.NoError(t, os.Unsetenv("GITEA_TOKEN"))
+	require.NoError(t, os.Unsetenv("GITEA_TOKEN"))
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}
-	assert.Error(t, Pipe{}.Run(ctx))
+	require.Error(t, Pipe{}.Run(ctx))
 }
 
 func TestEmptyGithubEnvFile(t *testing.T) {
-	assert.NoError(t, os.Unsetenv("GITHUB_TOKEN"))
+	require.NoError(t, os.Unsetenv("GITHUB_TOKEN"))
 	f, err := ioutil.TempFile("", "token")
-	assert.NoError(t, err)
-	assert.NoError(t, os.Chmod(f.Name(), 0377))
+	require.NoError(t, err)
+	require.NoError(t, os.Chmod(f.Name(), 0377))
 	var ctx = &context.Context{
 		Config: config.Project{
 			EnvFiles: config.EnvFiles{
@@ -132,14 +132,14 @@ func TestEmptyGithubEnvFile(t *testing.T) {
 			},
 		},
 	}
-	assert.EqualError(t, Pipe{}.Run(ctx), fmt.Sprintf("failed to load github token: open %s: permission denied", f.Name()))
+	require.EqualError(t, Pipe{}.Run(ctx), fmt.Sprintf("failed to load github token: open %s: permission denied", f.Name()))
 }
 
 func TestEmptyGitlabEnvFile(t *testing.T) {
-	assert.NoError(t, os.Unsetenv("GITLAB_TOKEN"))
+	require.NoError(t, os.Unsetenv("GITLAB_TOKEN"))
 	f, err := ioutil.TempFile("", "token")
-	assert.NoError(t, err)
-	assert.NoError(t, os.Chmod(f.Name(), 0377))
+	require.NoError(t, err)
+	require.NoError(t, os.Chmod(f.Name(), 0377))
 	var ctx = &context.Context{
 		Config: config.Project{
 			EnvFiles: config.EnvFiles{
@@ -147,14 +147,14 @@ func TestEmptyGitlabEnvFile(t *testing.T) {
 			},
 		},
 	}
-	assert.EqualError(t, Pipe{}.Run(ctx), fmt.Sprintf("failed to load gitlab token: open %s: permission denied", f.Name()))
+	require.EqualError(t, Pipe{}.Run(ctx), fmt.Sprintf("failed to load gitlab token: open %s: permission denied", f.Name()))
 }
 
 func TestEmptyGiteaEnvFile(t *testing.T) {
-	assert.NoError(t, os.Unsetenv("GITEA_TOKEN"))
+	require.NoError(t, os.Unsetenv("GITEA_TOKEN"))
 	f, err := ioutil.TempFile("", "token")
-	assert.NoError(t, err)
-	assert.NoError(t, os.Chmod(f.Name(), 0377))
+	require.NoError(t, err)
+	require.NoError(t, os.Chmod(f.Name(), 0377))
 	var ctx = &context.Context{
 		Config: config.Project{
 			EnvFiles: config.EnvFiles{
@@ -162,20 +162,20 @@ func TestEmptyGiteaEnvFile(t *testing.T) {
 			},
 		},
 	}
-	assert.EqualError(t, Pipe{}.Run(ctx), fmt.Sprintf("failed to load gitea token: open %s: permission denied", f.Name()))
+	require.EqualError(t, Pipe{}.Run(ctx), fmt.Sprintf("failed to load gitea token: open %s: permission denied", f.Name()))
 }
 
 func TestInvalidEnvChecksSkipped(t *testing.T) {
-	assert.NoError(t, os.Unsetenv("GITHUB_TOKEN"))
+	require.NoError(t, os.Unsetenv("GITHUB_TOKEN"))
 	var ctx = &context.Context{
 		Config:      config.Project{},
 		SkipPublish: true,
 	}
-	assert.NoError(t, Pipe{}.Run(ctx))
+	require.NoError(t, Pipe{}.Run(ctx))
 }
 
 func TestInvalidEnvReleaseDisabled(t *testing.T) {
-	assert.NoError(t, os.Unsetenv("GITHUB_TOKEN"))
+	require.NoError(t, os.Unsetenv("GITHUB_TOKEN"))
 	var ctx = &context.Context{
 		Config: config.Project{
 			Release: config.Release{
@@ -183,47 +183,47 @@ func TestInvalidEnvReleaseDisabled(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, Pipe{}.Run(ctx))
+	require.NoError(t, Pipe{}.Run(ctx))
 }
 
 func TestLoadEnv(t *testing.T) {
 	t.Run("env exists", func(tt *testing.T) {
 		var env = "SUPER_SECRET_ENV"
-		assert.NoError(tt, os.Setenv(env, "1"))
+		require.NoError(tt, os.Setenv(env, "1"))
 		v, err := loadEnv(env, "nope")
-		assert.NoError(tt, err)
-		assert.Equal(tt, "1", v)
+		require.NoError(tt, err)
+		require.Equal(tt, "1", v)
 	})
 	t.Run("env file exists", func(tt *testing.T) {
 		var env = "SUPER_SECRET_ENV_NOPE"
-		assert.NoError(tt, os.Unsetenv(env))
+		require.NoError(tt, os.Unsetenv(env))
 		f, err := ioutil.TempFile("", "token")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		fmt.Fprintf(f, "123")
 		v, err := loadEnv(env, f.Name())
-		assert.NoError(tt, err)
-		assert.Equal(tt, "123", v)
+		require.NoError(tt, err)
+		require.Equal(tt, "123", v)
 	})
 	t.Run("env file with an empty line at the end", func(tt *testing.T) {
 		var env = "SUPER_SECRET_ENV_NOPE"
-		assert.NoError(tt, os.Unsetenv(env))
+		require.NoError(tt, os.Unsetenv(env))
 		f, err := ioutil.TempFile("", "token")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		fmt.Fprintf(f, "123\n")
 		v, err := loadEnv(env, f.Name())
-		assert.NoError(tt, err)
-		assert.Equal(tt, "123", v)
+		require.NoError(tt, err)
+		require.Equal(tt, "123", v)
 	})
 	t.Run("env file is not readable", func(tt *testing.T) {
 		var env = "SUPER_SECRET_ENV_NOPE"
-		assert.NoError(tt, os.Unsetenv(env))
+		require.NoError(tt, os.Unsetenv(env))
 		f, err := ioutil.TempFile("", "token")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		fmt.Fprintf(f, "123")
 		err = os.Chmod(f.Name(), 0377)
-		assert.NoError(tt, err)
+		require.NoError(tt, err)
 		v, err := loadEnv(env, f.Name())
-		assert.EqualError(tt, err, fmt.Sprintf("open %s: permission denied", f.Name()))
-		assert.Equal(tt, "", v)
+		require.EqualError(tt, err, fmt.Sprintf("open %s: permission denied", f.Name()))
+		require.Equal(tt, "", v)
 	})
 }

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/goreleaser/goreleaser/internal/testlib"
@@ -16,7 +15,7 @@ import (
 )
 
 func TestDescription(t *testing.T) {
-	assert.NotEmpty(t, Pipe{}.String())
+	require.NotEmpty(t, Pipe{}.String())
 }
 
 func TestNotAGitFolder(t *testing.T) {
@@ -25,7 +24,7 @@ func TestNotAGitFolder(t *testing.T) {
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}
-	assert.EqualError(t, Pipe{}.Run(ctx), ErrNotRepository.Error())
+	require.EqualError(t, Pipe{}.Run(ctx), ErrNotRepository.Error())
 }
 
 func TestSingleCommit(t *testing.T) {
@@ -38,8 +37,8 @@ func TestSingleCommit(t *testing.T) {
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}
-	assert.NoError(t, Pipe{}.Run(ctx))
-	assert.Equal(t, "v0.0.1", ctx.Git.CurrentTag)
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, "v0.0.1", ctx.Git.CurrentTag)
 }
 
 func TestNoRemote(t *testing.T) {
@@ -51,7 +50,7 @@ func TestNoRemote(t *testing.T) {
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}
-	assert.EqualError(t, Pipe{}.Run(ctx), "couldn't get remote URL: fatal: No remote configured to list refs from.")
+	require.EqualError(t, Pipe{}.Run(ctx), "couldn't get remote URL: fatal: No remote configured to list refs from.")
 }
 
 func TestNewRepository(t *testing.T) {
@@ -62,7 +61,7 @@ func TestNewRepository(t *testing.T) {
 		Config: config.Project{},
 	}
 	// TODO: improve this error handling
-	assert.Contains(t, Pipe{}.Run(ctx).Error(), `fatal: ambiguous argument 'HEAD'`)
+	require.Contains(t, Pipe{}.Run(ctx).Error(), `fatal: ambiguous argument 'HEAD'`)
 }
 
 // TestNoTagsNoSnapshot covers the situation where a repository
@@ -76,7 +75,7 @@ func TestNoTagsNoSnapshot(t *testing.T) {
 	testlib.GitCommit(t, "first")
 	var ctx = context.New(config.Project{})
 	ctx.Snapshot = false
-	assert.EqualError(t, Pipe{}.Run(ctx), `git doesn't contain any tags. Either add a tag or use --snapshot`)
+	require.EqualError(t, Pipe{}.Run(ctx), `git doesn't contain any tags. Either add a tag or use --snapshot`)
 }
 
 func TestDirty(t *testing.T) {
@@ -85,15 +84,15 @@ func TestDirty(t *testing.T) {
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	dummy, err := os.Create(filepath.Join(folder, "dummy"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	testlib.GitAdd(t)
 	testlib.GitCommit(t, "commit2")
 	testlib.GitTag(t, "v0.0.1")
-	assert.NoError(t, ioutil.WriteFile(dummy.Name(), []byte("lorem ipsum"), 0644))
+	require.NoError(t, ioutil.WriteFile(dummy.Name(), []byte("lorem ipsum"), 0644))
 	t.Run("all checks up", func(t *testing.T) {
 		err = Pipe{}.Run(context.New(config.Project{}))
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "git is currently in a dirty state")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "git is currently in a dirty state")
 	})
 	t.Run("skip validate is set", func(t *testing.T) {
 		ctx := context.New(config.Project{})
@@ -118,8 +117,8 @@ func TestTagIsNotLastCommit(t *testing.T) {
 	testlib.GitTag(t, "v0.0.1")
 	testlib.GitCommit(t, "commit4")
 	err := Pipe{}.Run(context.New(config.Project{}))
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "git tag v0.0.1 was not made against commit")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "git tag v0.0.1 was not made against commit")
 }
 
 func TestValidState(t *testing.T) {
@@ -132,9 +131,9 @@ func TestValidState(t *testing.T) {
 	testlib.GitCommit(t, "commit4")
 	testlib.GitTag(t, "v0.0.2")
 	var ctx = context.New(config.Project{})
-	assert.NoError(t, Pipe{}.Run(ctx))
-	assert.Equal(t, "v0.0.2", ctx.Git.CurrentTag)
-	assert.Equal(t, "git@github.com:foo/bar.git", ctx.Git.URL)
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, "v0.0.2", ctx.Git.CurrentTag)
+	require.Equal(t, "git@github.com:foo/bar.git", ctx.Git.URL)
 }
 
 func TestSnapshotNoTags(t *testing.T) {
@@ -147,7 +146,7 @@ func TestSnapshotNoTags(t *testing.T) {
 	var ctx = context.New(config.Project{})
 	ctx.Snapshot = true
 	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
-	assert.Equal(t, fakeInfo.CurrentTag, ctx.Git.CurrentTag)
+	require.Equal(t, fakeInfo.CurrentTag, ctx.Git.CurrentTag)
 }
 
 func TestSnapshotNoCommits(t *testing.T) {
@@ -158,7 +157,7 @@ func TestSnapshotNoCommits(t *testing.T) {
 	var ctx = context.New(config.Project{})
 	ctx.Snapshot = true
 	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
-	assert.Equal(t, fakeInfo, ctx.Git)
+	require.Equal(t, fakeInfo, ctx.Git)
 }
 
 func TestSnapshotWithoutRepo(t *testing.T) {
@@ -167,7 +166,7 @@ func TestSnapshotWithoutRepo(t *testing.T) {
 	var ctx = context.New(config.Project{})
 	ctx.Snapshot = true
 	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
-	assert.Equal(t, fakeInfo, ctx.Git)
+	require.Equal(t, fakeInfo, ctx.Git)
 }
 
 func TestSnapshotDirty(t *testing.T) {
@@ -178,7 +177,7 @@ func TestSnapshotDirty(t *testing.T) {
 	testlib.GitAdd(t)
 	testlib.GitCommit(t, "whatever")
 	testlib.GitTag(t, "v0.0.1")
-	assert.NoError(t, ioutil.WriteFile(filepath.Join(folder, "foo"), []byte("foobar"), 0644))
+	require.NoError(t, ioutil.WriteFile(filepath.Join(folder, "foo"), []byte("foobar"), 0644))
 	var ctx = context.New(config.Project{})
 	ctx.Snapshot = true
 	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
@@ -187,10 +186,10 @@ func TestSnapshotDirty(t *testing.T) {
 func TestGitNotInPath(t *testing.T) {
 	var path = os.Getenv("PATH")
 	defer func() {
-		assert.NoError(t, os.Setenv("PATH", path))
+		require.NoError(t, os.Setenv("PATH", path))
 	}()
-	assert.NoError(t, os.Setenv("PATH", ""))
-	assert.EqualError(t, Pipe{}.Run(context.New(config.Project{})), ErrNoGit.Error())
+	require.NoError(t, os.Setenv("PATH", ""))
+	require.EqualError(t, Pipe{}.Run(context.New(config.Project{})), ErrNoGit.Error())
 }
 
 func TestTagFromCI(t *testing.T) {
@@ -222,8 +221,8 @@ func TestTagFromCI(t *testing.T) {
 		var ctx = &context.Context{
 			Config: config.Project{},
 		}
-		assert.NoError(t, Pipe{}.Run(ctx))
-		assert.Equal(t, tc.expected, ctx.Git.CurrentTag)
+		require.NoError(t, Pipe{}.Run(ctx))
+		require.Equal(t, tc.expected, ctx.Git.CurrentTag)
 
 		for name := range tc.envs {
 			require.NoError(t, os.Setenv(name, ""))
@@ -244,7 +243,7 @@ func TestCommitDate(t *testing.T) {
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}
-	assert.NoError(t, Pipe{}.Run(ctx))
-	assert.Equal(t, "v0.0.1", ctx.Git.CurrentTag)
-	assert.True(t, commitDate.Equal(ctx.Git.CommitDate), "commit date does not match expected")
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, "v0.0.1", ctx.Git.CurrentTag)
+	require.True(t, commitDate.Equal(ctx.Git.CommitDate), "commit date does not match expected")
 }

--- a/internal/pipe/milestone/milestone_test.go
+++ b/internal/pipe/milestone/milestone_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDefaultWithRepoConfig(t *testing.T) {
@@ -32,9 +32,9 @@ func TestDefaultWithRepoConfig(t *testing.T) {
 		},
 	}
 	ctx.TokenType = context.TokenTypeGitHub
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Equal(t, "configrepo", ctx.Config.Milestones[0].Repo.Name)
-	assert.Equal(t, "configowner", ctx.Config.Milestones[0].Repo.Owner)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, "configrepo", ctx.Config.Milestones[0].Repo.Name)
+	require.Equal(t, "configowner", ctx.Config.Milestones[0].Repo.Owner)
 }
 
 func TestDefaultWithRepoRemote(t *testing.T) {
@@ -45,9 +45,9 @@ func TestDefaultWithRepoRemote(t *testing.T) {
 
 	var ctx = context.New(config.Project{})
 	ctx.TokenType = context.TokenTypeGitHub
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Equal(t, "githubrepo", ctx.Config.Milestones[0].Repo.Name)
-	assert.Equal(t, "githubowner", ctx.Config.Milestones[0].Repo.Owner)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, "githubrepo", ctx.Config.Milestones[0].Repo.Name)
+	require.Equal(t, "githubowner", ctx.Config.Milestones[0].Repo.Owner)
 }
 
 func TestDefaultWithNameTemplate(t *testing.T) {
@@ -60,8 +60,8 @@ func TestDefaultWithNameTemplate(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Equal(t, "confignametemplate", ctx.Config.Milestones[0].NameTemplate)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, "confignametemplate", ctx.Config.Milestones[0].NameTemplate)
 }
 
 func TestDefaultWithoutGitRepo(t *testing.T) {
@@ -71,8 +71,8 @@ func TestDefaultWithoutGitRepo(t *testing.T) {
 		Config: config.Project{},
 	}
 	ctx.TokenType = context.TokenTypeGitHub
-	assert.EqualError(t, Pipe{}.Default(ctx), "current folder is not a git repository")
-	assert.Empty(t, ctx.Config.Milestones[0].Repo.String())
+	require.EqualError(t, Pipe{}.Default(ctx), "current folder is not a git repository")
+	require.Empty(t, ctx.Config.Milestones[0].Repo.String())
 }
 
 func TestDefaultWithoutGitRepoOrigin(t *testing.T) {
@@ -83,8 +83,8 @@ func TestDefaultWithoutGitRepoOrigin(t *testing.T) {
 	}
 	ctx.TokenType = context.TokenTypeGitHub
 	testlib.GitInit(t)
-	assert.EqualError(t, Pipe{}.Default(ctx), "repository doesn't have an `origin` remote")
-	assert.Empty(t, ctx.Config.Milestones[0].Repo.String())
+	require.EqualError(t, Pipe{}.Default(ctx), "repository doesn't have an `origin` remote")
+	require.Empty(t, ctx.Config.Milestones[0].Repo.String())
 }
 
 func TestDefaultWithoutGitRepoSnapshot(t *testing.T) {
@@ -95,8 +95,8 @@ func TestDefaultWithoutGitRepoSnapshot(t *testing.T) {
 	}
 	ctx.TokenType = context.TokenTypeGitHub
 	ctx.Snapshot = true
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Empty(t, ctx.Config.Milestones[0].Repo.String())
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Empty(t, ctx.Config.Milestones[0].Repo.String())
 }
 
 func TestDefaultWithoutNameTemplate(t *testing.T) {
@@ -105,12 +105,12 @@ func TestDefaultWithoutNameTemplate(t *testing.T) {
 			Milestones: []config.Milestone{},
 		},
 	}
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Equal(t, "{{ .Tag }}", ctx.Config.Milestones[0].NameTemplate)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, "{{ .Tag }}", ctx.Config.Milestones[0].NameTemplate)
 }
 
 func TestString(t *testing.T) {
-	assert.NotEmpty(t, Pipe{}.String())
+	require.NotEmpty(t, Pipe{}.String())
 }
 
 func TestPublishCloseDisabled(t *testing.T) {
@@ -123,7 +123,7 @@ func TestPublishCloseDisabled(t *testing.T) {
 	})
 	client := &DummyClient{}
 	testlib.AssertSkipped(t, doPublish(ctx, client))
-	assert.Equal(t, "", client.ClosedMilestone)
+	require.Equal(t, "", client.ClosedMilestone)
 }
 
 func TestPublishCloseEnabled(t *testing.T) {
@@ -141,8 +141,8 @@ func TestPublishCloseEnabled(t *testing.T) {
 	})
 	ctx.Git.CurrentTag = "v1.0.0"
 	client := &DummyClient{}
-	assert.NoError(t, doPublish(ctx, client))
-	assert.Equal(t, "v1.0.0", client.ClosedMilestone)
+	require.NoError(t, doPublish(ctx, client))
+	require.Equal(t, "v1.0.0", client.ClosedMilestone)
 }
 
 func TestPublishCloseError(t *testing.T) {
@@ -163,8 +163,8 @@ func TestPublishCloseError(t *testing.T) {
 	client := &DummyClient{
 		FailToCloseMilestone: true,
 	}
-	assert.NoError(t, doPublish(ctx, client))
-	assert.Equal(t, "", client.ClosedMilestone)
+	require.NoError(t, doPublish(ctx, client))
+	require.Equal(t, "", client.ClosedMilestone)
 }
 
 func TestPublishCloseFailOnError(t *testing.T) {
@@ -186,8 +186,8 @@ func TestPublishCloseFailOnError(t *testing.T) {
 	client := &DummyClient{
 		FailToCloseMilestone: true,
 	}
-	assert.Error(t, doPublish(ctx, client))
-	assert.Equal(t, "", client.ClosedMilestone)
+	require.Error(t, doPublish(ctx, client))
+	require.Equal(t, "", client.ClosedMilestone)
 }
 
 type DummyClient struct {

--- a/internal/pipe/pipe_test.go
+++ b/internal/pipe/pipe_test.go
@@ -4,19 +4,19 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSkipPipe(t *testing.T) {
 	var reason = "this is a test"
 	var err = Skip(reason)
-	assert.Error(t, err)
-	assert.Equal(t, reason, err.Error())
+	require.Error(t, err)
+	require.Equal(t, reason, err.Error())
 }
 
 func TestIsSkip(t *testing.T) {
-	assert.True(t, IsSkip(Skip("whatever")))
-	assert.False(t, IsSkip(errors.New("nope")))
+	require.True(t, IsSkip(Skip("whatever")))
+	require.False(t, IsSkip(errors.New("nope")))
 }
 
 func TestSkipMemento(t *testing.T) {
@@ -26,10 +26,10 @@ func TestSkipMemento(t *testing.T) {
 	// test duplicated errors
 	m.Remember(Skip("dupe"))
 	m.Remember(Skip("dupe"))
-	assert.EqualError(t, m.Evaluate(), `foo, bar, dupe`)
-	assert.True(t, IsSkip(m.Evaluate()))
+	require.EqualError(t, m.Evaluate(), `foo, bar, dupe`)
+	require.True(t, IsSkip(m.Evaluate()))
 }
 
 func TestSkipMementoNoErrors(t *testing.T) {
-	assert.NoError(t, (&SkipMemento{}).Evaluate())
+	require.NoError(t, (&SkipMemento{}).Evaluate())
 }

--- a/internal/pipe/release/body_test.go
+++ b/internal/pipe/release/body_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var update = flag.Bool("update", false, "update .golden files")
@@ -28,15 +28,15 @@ func TestDescribeBody(t *testing.T) {
 		})
 	}
 	out, err := describeBody(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var golden = "testdata/release1.golden"
 	if *update {
 		_ = ioutil.WriteFile(golden, out.Bytes(), 0755)
 	}
 	bts, err := ioutil.ReadFile(golden)
-	assert.NoError(t, err)
-	assert.Equal(t, string(bts), out.String())
+	require.NoError(t, err)
+	require.Equal(t, string(bts), out.String())
 }
 
 func TestDescribeBodyNoDockerImagesNoBrews(t *testing.T) {
@@ -45,16 +45,16 @@ func TestDescribeBodyNoDockerImagesNoBrews(t *testing.T) {
 		ReleaseNotes: changelog,
 	}
 	out, err := describeBody(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var golden = "testdata/release2.golden"
 	if *update {
 		_ = ioutil.WriteFile(golden, out.Bytes(), 0655)
 	}
 	bts, err := ioutil.ReadFile(golden)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, string(bts), out.String())
+	require.Equal(t, string(bts), out.String())
 }
 
 func TestDontEscapeHTML(t *testing.T) {
@@ -63,6 +63,6 @@ func TestDontEscapeHTML(t *testing.T) {
 	ctx.ReleaseNotes = changelog
 
 	out, err := describeBody(ctx)
-	assert.NoError(t, err)
-	assert.Contains(t, out.String(), changelog)
+	require.NoError(t, err)
+	require.Contains(t, out.String(), changelog)
 }

--- a/internal/pipe/release/release_test.go
+++ b/internal/pipe/release/release_test.go
@@ -15,26 +15,26 @@ import (
 	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPipeDescription(t *testing.T) {
-	assert.NotEmpty(t, Pipe{}.String())
+	require.NotEmpty(t, Pipe{}.String())
 }
 
 func TestRunPipeWithoutIDsThenDoesNotFilter(t *testing.T) {
 	folder, err := ioutil.TempDir("", "goreleasertest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tarfile, err := os.Create(filepath.Join(folder, "bin.tar.gz"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	srcfile, err := os.Create(filepath.Join(folder, "source.tar.gz"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	debfile, err := os.Create(filepath.Join(folder, "bin.deb"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	filteredtarfile, err := os.Create(filepath.Join(folder, "filtered.tar.gz"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	filtereddebfile, err := os.Create(filepath.Join(folder, "filtered.deb"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var config = config.Project{
 		Dist: folder,
@@ -88,27 +88,27 @@ func TestRunPipeWithoutIDsThenDoesNotFilter(t *testing.T) {
 		},
 	})
 	client := &DummyClient{}
-	assert.NoError(t, doPublish(ctx, client))
-	assert.True(t, client.CreatedRelease)
-	assert.True(t, client.UploadedFile)
-	assert.Contains(t, client.UploadedFileNames, "source.tar.gz")
-	assert.Contains(t, client.UploadedFileNames, "bin.deb")
-	assert.Contains(t, client.UploadedFileNames, "bin.tar.gz")
-	assert.Contains(t, client.UploadedFileNames, "filtered.deb")
-	assert.Contains(t, client.UploadedFileNames, "filtered.tar.gz")
+	require.NoError(t, doPublish(ctx, client))
+	require.True(t, client.CreatedRelease)
+	require.True(t, client.UploadedFile)
+	require.Contains(t, client.UploadedFileNames, "source.tar.gz")
+	require.Contains(t, client.UploadedFileNames, "bin.deb")
+	require.Contains(t, client.UploadedFileNames, "bin.tar.gz")
+	require.Contains(t, client.UploadedFileNames, "filtered.deb")
+	require.Contains(t, client.UploadedFileNames, "filtered.tar.gz")
 }
 
 func TestRunPipeWithIDsThenFilters(t *testing.T) {
 	folder, err := ioutil.TempDir("", "goreleasertest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tarfile, err := os.Create(filepath.Join(folder, "bin.tar.gz"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	debfile, err := os.Create(filepath.Join(folder, "bin.deb"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	filteredtarfile, err := os.Create(filepath.Join(folder, "filtered.tar.gz"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	filtereddebfile, err := os.Create(filepath.Join(folder, "filtered.deb"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var config = config.Project{
 		Dist: folder,
@@ -158,16 +158,16 @@ func TestRunPipeWithIDsThenFilters(t *testing.T) {
 		},
 	})
 	client := &DummyClient{}
-	assert.NoError(t, doPublish(ctx, client))
-	assert.True(t, client.CreatedRelease)
-	assert.True(t, client.UploadedFile)
-	assert.Contains(t, client.UploadedFileNames, "bin.deb")
-	assert.Contains(t, client.UploadedFileNames, "bin.tar.gz")
-	assert.Contains(t, client.UploadedFileNames, "release1.golden")
-	assert.Contains(t, client.UploadedFileNames, "release2.golden")
-	assert.Contains(t, client.UploadedFileNames, "f1")
-	assert.NotContains(t, client.UploadedFileNames, "filtered.deb")
-	assert.NotContains(t, client.UploadedFileNames, "filtered.tar.gz")
+	require.NoError(t, doPublish(ctx, client))
+	require.True(t, client.CreatedRelease)
+	require.True(t, client.UploadedFile)
+	require.Contains(t, client.UploadedFileNames, "bin.deb")
+	require.Contains(t, client.UploadedFileNames, "bin.tar.gz")
+	require.Contains(t, client.UploadedFileNames, "release1.golden")
+	require.Contains(t, client.UploadedFileNames, "release2.golden")
+	require.Contains(t, client.UploadedFileNames, "f1")
+	require.NotContains(t, client.UploadedFileNames, "filtered.deb")
+	require.NotContains(t, client.UploadedFileNames, "filtered.tar.gz")
 }
 
 func TestRunPipeReleaseCreationFailed(t *testing.T) {
@@ -184,9 +184,9 @@ func TestRunPipeReleaseCreationFailed(t *testing.T) {
 	client := &DummyClient{
 		FailToCreateRelease: true,
 	}
-	assert.Error(t, doPublish(ctx, client))
-	assert.False(t, client.CreatedRelease)
-	assert.False(t, client.UploadedFile)
+	require.Error(t, doPublish(ctx, client))
+	require.False(t, client.CreatedRelease)
+	require.False(t, client.UploadedFile)
 }
 
 func TestRunPipeWithFileThatDontExist(t *testing.T) {
@@ -206,16 +206,16 @@ func TestRunPipeWithFileThatDontExist(t *testing.T) {
 		Path: "/nope/nope/nope",
 	})
 	client := &DummyClient{}
-	assert.Error(t, doPublish(ctx, client))
-	assert.True(t, client.CreatedRelease)
-	assert.False(t, client.UploadedFile)
+	require.Error(t, doPublish(ctx, client))
+	require.True(t, client.CreatedRelease)
+	require.False(t, client.UploadedFile)
 }
 
 func TestRunPipeUploadFailure(t *testing.T) {
 	folder, err := ioutil.TempDir("", "goreleasertest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tarfile, err := os.Create(filepath.Join(folder, "bin.tar.gz"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var config = config.Project{
 		Release: config.Release{
 			GitHub: config.Repo{
@@ -234,9 +234,9 @@ func TestRunPipeUploadFailure(t *testing.T) {
 	client := &DummyClient{
 		FailToUpload: true,
 	}
-	assert.EqualError(t, doPublish(ctx, client), "failed to upload bin.tar.gz after 1 tries: upload failed")
-	assert.True(t, client.CreatedRelease)
-	assert.False(t, client.UploadedFile)
+	require.EqualError(t, doPublish(ctx, client), "failed to upload bin.tar.gz after 1 tries: upload failed")
+	require.True(t, client.CreatedRelease)
+	require.False(t, client.UploadedFile)
 }
 
 func TestRunPipeExtraFileNotFound(t *testing.T) {
@@ -255,9 +255,9 @@ func TestRunPipeExtraFileNotFound(t *testing.T) {
 	var ctx = context.New(config)
 	ctx.Git = context.GitInfo{CurrentTag: "v1.0.0"}
 	client := &DummyClient{}
-	assert.EqualError(t, doPublish(ctx, client), "globbing failed for pattern ./nope: file does not exist")
-	assert.True(t, client.CreatedRelease)
-	assert.False(t, client.UploadedFile)
+	require.EqualError(t, doPublish(ctx, client), "globbing failed for pattern ./nope: file does not exist")
+	require.True(t, client.CreatedRelease)
+	require.False(t, client.UploadedFile)
 }
 
 func TestRunPipeExtraOverride(t *testing.T) {
@@ -276,18 +276,18 @@ func TestRunPipeExtraOverride(t *testing.T) {
 	var ctx = context.New(config)
 	ctx.Git = context.GitInfo{CurrentTag: "v1.0.0"}
 	client := &DummyClient{}
-	assert.NoError(t, doPublish(ctx, client))
-	assert.True(t, client.CreatedRelease)
-	assert.True(t, client.UploadedFile)
-	assert.Contains(t, client.UploadedFileNames, "f1")
-	assert.True(t, strings.HasSuffix(client.UploadedFilePaths["f1"], "testdata/upload_same_name/f1"))
+	require.NoError(t, doPublish(ctx, client))
+	require.True(t, client.CreatedRelease)
+	require.True(t, client.UploadedFile)
+	require.Contains(t, client.UploadedFileNames, "f1")
+	require.True(t, strings.HasSuffix(client.UploadedFilePaths["f1"], "testdata/upload_same_name/f1"))
 }
 
 func TestRunPipeUploadRetry(t *testing.T) {
 	folder, err := ioutil.TempDir("", "goreleasertest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tarfile, err := os.Create(filepath.Join(folder, "bin.tar.gz"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var config = config.Project{
 		Release: config.Release{
 			GitHub: config.Repo{
@@ -306,9 +306,9 @@ func TestRunPipeUploadRetry(t *testing.T) {
 	client := &DummyClient{
 		FailFirstUpload: true,
 	}
-	assert.NoError(t, doPublish(ctx, client))
-	assert.True(t, client.CreatedRelease)
-	assert.True(t, client.UploadedFile)
+	require.NoError(t, doPublish(ctx, client))
+	require.True(t, client.CreatedRelease)
+	require.True(t, client.UploadedFile)
 }
 
 func TestPipeDisabled(t *testing.T) {
@@ -319,8 +319,8 @@ func TestPipeDisabled(t *testing.T) {
 	})
 	client := &DummyClient{}
 	testlib.AssertSkipped(t, doPublish(ctx, client))
-	assert.False(t, client.CreatedRelease)
-	assert.False(t, client.UploadedFile)
+	require.False(t, client.CreatedRelease)
+	require.False(t, client.UploadedFile)
 }
 
 func TestDefault(t *testing.T) {
@@ -331,9 +331,9 @@ func TestDefault(t *testing.T) {
 
 	var ctx = context.New(config.Project{})
 	ctx.TokenType = context.TokenTypeGitHub
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Name)
-	assert.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Owner)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Name)
+	require.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Owner)
 }
 
 func TestDefaultWithGitlab(t *testing.T) {
@@ -344,9 +344,9 @@ func TestDefaultWithGitlab(t *testing.T) {
 
 	var ctx = context.New(config.Project{})
 	ctx.TokenType = context.TokenTypeGitLab
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Equal(t, "gitlabrepo", ctx.Config.Release.GitLab.Name)
-	assert.Equal(t, "gitlabowner", ctx.Config.Release.GitLab.Owner)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, "gitlabrepo", ctx.Config.Release.GitLab.Name)
+	require.Equal(t, "gitlabowner", ctx.Config.Release.GitLab.Owner)
 }
 
 func TestDefaultWithGitea(t *testing.T) {
@@ -357,9 +357,9 @@ func TestDefaultWithGitea(t *testing.T) {
 
 	var ctx = context.New(config.Project{})
 	ctx.TokenType = context.TokenTypeGitea
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Equal(t, "gitearepo", ctx.Config.Release.Gitea.Name)
-	assert.Equal(t, "giteaowner", ctx.Config.Release.Gitea.Owner)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, "gitearepo", ctx.Config.Release.Gitea.Name)
+	require.Equal(t, "giteaowner", ctx.Config.Release.Gitea.Owner)
 }
 
 func TestDefaultPreReleaseAuto(t *testing.T) {
@@ -380,8 +380,8 @@ func TestDefaultPreReleaseAuto(t *testing.T) {
 			Minor: 0,
 			Patch: 0,
 		}
-		assert.NoError(t, Pipe{}.Default(ctx))
-		assert.Equal(t, false, ctx.PreRelease)
+		require.NoError(t, Pipe{}.Default(ctx))
+		require.Equal(t, false, ctx.PreRelease)
 	})
 
 	t.Run("auto-rc", func(t *testing.T) {
@@ -397,8 +397,8 @@ func TestDefaultPreReleaseAuto(t *testing.T) {
 			Patch:      0,
 			Prerelease: "rc1",
 		}
-		assert.NoError(t, Pipe{}.Default(ctx))
-		assert.Equal(t, true, ctx.PreRelease)
+		require.NoError(t, Pipe{}.Default(ctx))
+		require.Equal(t, true, ctx.PreRelease)
 	})
 
 	t.Run("auto-rc-github-setup", func(t *testing.T) {
@@ -418,8 +418,8 @@ func TestDefaultPreReleaseAuto(t *testing.T) {
 			Patch:      0,
 			Prerelease: "rc1",
 		}
-		assert.NoError(t, Pipe{}.Default(ctx))
-		assert.Equal(t, true, ctx.PreRelease)
+		require.NoError(t, Pipe{}.Default(ctx))
+		require.Equal(t, true, ctx.PreRelease)
 	})
 }
 
@@ -435,9 +435,9 @@ func TestDefaultPipeDisabled(t *testing.T) {
 		},
 	})
 	ctx.TokenType = context.TokenTypeGitHub
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Name)
-	assert.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Owner)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Name)
+	require.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Owner)
 }
 
 func TestDefaultFilled(t *testing.T) {
@@ -457,9 +457,9 @@ func TestDefaultFilled(t *testing.T) {
 		},
 	}
 	ctx.TokenType = context.TokenTypeGitHub
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Equal(t, "foo", ctx.Config.Release.GitHub.Name)
-	assert.Equal(t, "bar", ctx.Config.Release.GitHub.Owner)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, "foo", ctx.Config.Release.GitHub.Name)
+	require.Equal(t, "bar", ctx.Config.Release.GitHub.Owner)
 }
 
 func TestDefaultNotAGitRepo(t *testing.T) {
@@ -469,8 +469,8 @@ func TestDefaultNotAGitRepo(t *testing.T) {
 		Config: config.Project{},
 	}
 	ctx.TokenType = context.TokenTypeGitHub
-	assert.EqualError(t, Pipe{}.Default(ctx), "current folder is not a git repository")
-	assert.Empty(t, ctx.Config.Release.GitHub.String())
+	require.EqualError(t, Pipe{}.Default(ctx), "current folder is not a git repository")
+	require.Empty(t, ctx.Config.Release.GitHub.String())
 }
 
 func TestDefaultGitRepoWithoutOrigin(t *testing.T) {
@@ -481,8 +481,8 @@ func TestDefaultGitRepoWithoutOrigin(t *testing.T) {
 	}
 	ctx.TokenType = context.TokenTypeGitHub
 	testlib.GitInit(t)
-	assert.EqualError(t, Pipe{}.Default(ctx), "repository doesn't have an `origin` remote")
-	assert.Empty(t, ctx.Config.Release.GitHub.String())
+	require.EqualError(t, Pipe{}.Default(ctx), "repository doesn't have an `origin` remote")
+	require.Empty(t, ctx.Config.Release.GitHub.String())
 }
 
 func TestDefaultNotAGitRepoSnapshot(t *testing.T) {
@@ -493,8 +493,8 @@ func TestDefaultNotAGitRepoSnapshot(t *testing.T) {
 	}
 	ctx.TokenType = context.TokenTypeGitHub
 	ctx.Snapshot = true
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Empty(t, ctx.Config.Release.GitHub.String())
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Empty(t, ctx.Config.Release.GitHub.String())
 }
 
 func TestDefaultGitRepoWithoutRemote(t *testing.T) {
@@ -504,8 +504,8 @@ func TestDefaultGitRepoWithoutRemote(t *testing.T) {
 		Config: config.Project{},
 	}
 	ctx.TokenType = context.TokenTypeGitHub
-	assert.Error(t, Pipe{}.Default(ctx))
-	assert.Empty(t, ctx.Config.Release.GitHub.String())
+	require.Error(t, Pipe{}.Default(ctx))
+	require.Empty(t, ctx.Config.Release.GitHub.String())
 }
 
 func TestDefaultMultipleReleasesDefined(t *testing.T) {
@@ -525,7 +525,7 @@ func TestDefaultMultipleReleasesDefined(t *testing.T) {
 			},
 		},
 	})
-	assert.EqualError(t, Pipe{}.Default(ctx), ErrMultipleReleases.Error())
+	require.EqualError(t, Pipe{}.Default(ctx), ErrMultipleReleases.Error())
 }
 
 type DummyClient struct {

--- a/internal/pipe/scoop/scoop_test.go
+++ b/internal/pipe/scoop/scoop_test.go
@@ -14,14 +14,13 @@ import (
 	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 var update = flag.Bool("update", false, "update .golden files")
 
 func TestDescription(t *testing.T) {
-	assert.NotEmpty(t, Pipe{}.String())
+	require.NotEmpty(t, Pipe{}.String())
 }
 
 func TestDefault(t *testing.T) {
@@ -54,11 +53,11 @@ func TestDefault(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Equal(t, ctx.Config.ProjectName, ctx.Config.Scoop.Name)
-	assert.NotEmpty(t, ctx.Config.Scoop.CommitAuthor.Name)
-	assert.NotEmpty(t, ctx.Config.Scoop.CommitAuthor.Email)
-	assert.NotEmpty(t, ctx.Config.Scoop.CommitMessageTemplate)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, ctx.Config.ProjectName, ctx.Config.Scoop.Name)
+	require.NotEmpty(t, ctx.Config.Scoop.CommitAuthor.Name)
+	require.NotEmpty(t, ctx.Config.Scoop.CommitAuthor.Email)
+	require.NotEmpty(t, ctx.Config.Scoop.CommitMessageTemplate)
 }
 
 func Test_doRun(t *testing.T) {
@@ -70,12 +69,12 @@ func Test_doRun(t *testing.T) {
 	type errChecker func(*testing.T, error)
 	var shouldErr = func(msg string) errChecker {
 		return func(t *testing.T, err error) {
-			assert.Error(t, err)
-			assert.EqualError(t, err, msg)
+			require.Error(t, err)
+			require.EqualError(t, err, msg)
 		}
 	}
 	var shouldNotErr = func(t *testing.T, err error) {
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 	type args struct {
 		ctx    *context.Context

--- a/internal/pipe/semver/semver_test.go
+++ b/internal/pipe/semver/semver_test.go
@@ -7,12 +7,11 @@ import (
 
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDescription(t *testing.T) {
-	assert.NotEmpty(t, Pipe{}.String())
+	require.NotEmpty(t, Pipe{}.String())
 }
 
 func TestValidSemver(t *testing.T) {

--- a/internal/pipe/snapshot/snapshot_test.go
+++ b/internal/pipe/snapshot/snapshot_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStringer(t *testing.T) {
-	assert.NotEmpty(t, Pipe{}.String())
+	require.NotEmpty(t, Pipe{}.String())
 }
 func TestDefault(t *testing.T) {
 	var ctx = &context.Context{
@@ -18,8 +18,8 @@ func TestDefault(t *testing.T) {
 			Snapshot: config.Snapshot{},
 		},
 	}
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Equal(t, "{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}", ctx.Config.Snapshot.NameTemplate)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, "{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}", ctx.Config.Snapshot.NameTemplate)
 }
 
 func TestDefaultSet(t *testing.T) {
@@ -30,8 +30,8 @@ func TestDefaultSet(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Equal(t, "snap", ctx.Config.Snapshot.NameTemplate)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, "snap", ctx.Config.Snapshot.NameTemplate)
 }
 
 func TestSnapshotInvalidNametemplate(t *testing.T) {
@@ -41,7 +41,7 @@ func TestSnapshotInvalidNametemplate(t *testing.T) {
 		},
 	})
 	ctx.Snapshot = true
-	assert.EqualError(t, Pipe{}.Run(ctx), `failed to generate snapshot name: template: tmpl:1: unexpected "}" in operand`)
+	require.EqualError(t, Pipe{}.Run(ctx), `failed to generate snapshot name: template: tmpl:1: unexpected "}" in operand`)
 }
 
 func TestSnapshotEmptyFinalName(t *testing.T) {
@@ -52,7 +52,7 @@ func TestSnapshotEmptyFinalName(t *testing.T) {
 	})
 	ctx.Snapshot = true
 	ctx.Git.CurrentTag = "v1.2.3"
-	assert.EqualError(t, Pipe{}.Run(ctx), "empty snapshot name")
+	require.EqualError(t, Pipe{}.Run(ctx), "empty snapshot name")
 }
 
 func TestNotASnapshot(t *testing.T) {

--- a/internal/pipe/upload/upload_test.go
+++ b/internal/pipe/upload/upload_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/goreleaser/goreleaser/internal/pipe"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -57,14 +57,14 @@ func TestRunPipe_ModeBinary(t *testing.T) {
 	defer teardown()
 
 	folder, err := ioutil.TempDir("", "archivetest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var dist = filepath.Join(folder, "dist")
-	assert.NoError(t, os.Mkdir(dist, 0755))
-	assert.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
+	require.NoError(t, os.Mkdir(dist, 0755))
+	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
 	err = ioutil.WriteFile(binPath, d1, 0666)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Dummy http server
 	mux.HandleFunc("/example-repo-local/mybin/darwin/amd64/mybin", func(w http.ResponseWriter, r *http.Request) {
@@ -141,7 +141,7 @@ func TestRunPipe_ModeBinary(t *testing.T) {
 		})
 	}
 
-	assert.NoError(t, Pipe{}.Publish(ctx))
+	require.NoError(t, Pipe{}.Publish(ctx))
 }
 
 func TestRunPipe_ModeArchive(t *testing.T) {
@@ -149,11 +149,11 @@ func TestRunPipe_ModeArchive(t *testing.T) {
 	defer teardown()
 
 	folder, err := ioutil.TempDir("", "goreleasertest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tarfile, err := os.Create(filepath.Join(folder, "bin.tar.gz"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	debfile, err := os.Create(filepath.Join(folder, "bin.deb"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var ctx = context.New(config.Project{
 		ProjectName: "goreleaser",
@@ -208,11 +208,11 @@ func TestRunPipe_ModeArchive(t *testing.T) {
 		uploads.Store("deb", true)
 	})
 
-	assert.NoError(t, Pipe{}.Publish(ctx))
+	require.NoError(t, Pipe{}.Publish(ctx))
 	_, ok := uploads.Load("targz")
-	assert.True(t, ok, "tar.gz file was not uploaded")
+	require.True(t, ok, "tar.gz file was not uploaded")
 	_, ok = uploads.Load("deb")
-	assert.True(t, ok, "deb file was not uploaded")
+	require.True(t, ok, "deb file was not uploaded")
 }
 
 func TestRunPipe_ModeBinary_CustomArtifactName(t *testing.T) {
@@ -220,14 +220,14 @@ func TestRunPipe_ModeBinary_CustomArtifactName(t *testing.T) {
 	defer teardown()
 
 	folder, err := ioutil.TempDir("", "archivetest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var dist = filepath.Join(folder, "dist")
-	assert.NoError(t, os.Mkdir(dist, 0755))
-	assert.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
+	require.NoError(t, os.Mkdir(dist, 0755))
+	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
 	err = ioutil.WriteFile(binPath, d1, 0666)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Dummy http server
 	mux.HandleFunc("/example-repo-local/mybin/darwin/amd64/mybin;deb.distribution=xenial", func(w http.ResponseWriter, r *http.Request) {
@@ -279,7 +279,7 @@ func TestRunPipe_ModeBinary_CustomArtifactName(t *testing.T) {
 		})
 	}
 
-	assert.NoError(t, Pipe{}.Publish(ctx))
+	require.NoError(t, Pipe{}.Publish(ctx))
 }
 
 func TestRunPipe_ModeArchive_CustomArtifactName(t *testing.T) {
@@ -287,11 +287,11 @@ func TestRunPipe_ModeArchive_CustomArtifactName(t *testing.T) {
 	defer teardown()
 
 	folder, err := ioutil.TempDir("", "goreleasertest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tarfile, err := os.Create(filepath.Join(folder, "bin.tar.gz"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	debfile, err := os.Create(filepath.Join(folder, "bin.deb"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var ctx = context.New(config.Project{
 		ProjectName: "goreleaser",
@@ -347,18 +347,18 @@ func TestRunPipe_ModeArchive_CustomArtifactName(t *testing.T) {
 		uploads.Store("deb", true)
 	})
 
-	assert.NoError(t, Pipe{}.Publish(ctx))
+	require.NoError(t, Pipe{}.Publish(ctx))
 	_, ok := uploads.Load("targz")
-	assert.True(t, ok, "tar.gz file was not uploaded")
+	require.True(t, ok, "tar.gz file was not uploaded")
 	_, ok = uploads.Load("deb")
-	assert.True(t, ok, "deb file was not uploaded")
+	require.True(t, ok, "deb file was not uploaded")
 }
 
 func TestRunPipe_ArtifactoryDown(t *testing.T) {
 	folder, err := ioutil.TempDir("", "goreleasertest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tarfile, err := os.Create(filepath.Join(folder, "bin.tar.gz"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var ctx = context.New(config.Project{
 		ProjectName: "goreleaser",
@@ -383,13 +383,13 @@ func TestRunPipe_ArtifactoryDown(t *testing.T) {
 		Path: tarfile.Name(),
 	})
 	err = Pipe{}.Publish(ctx)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "connection refused")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "connection refused")
 }
 
 func TestRunPipe_TargetTemplateError(t *testing.T) {
 	folder, err := ioutil.TempDir("", "archivetest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var dist = filepath.Join(folder, "dist")
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 
@@ -421,8 +421,8 @@ func TestRunPipe_TargetTemplateError(t *testing.T) {
 		Type:   artifact.UploadableBinary,
 	})
 	err = Pipe{}.Publish(ctx)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), `upload: error while building the target url: template: tmpl:1: unexpected "/" in operand`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `upload: error while building the target url: template: tmpl:1: unexpected "/" in operand`)
 }
 
 func TestRunPipe_BadCredentials(t *testing.T) {
@@ -430,14 +430,14 @@ func TestRunPipe_BadCredentials(t *testing.T) {
 	defer teardown()
 
 	folder, err := ioutil.TempDir("", "archivetest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var dist = filepath.Join(folder, "dist")
-	assert.NoError(t, os.Mkdir(dist, 0755))
-	assert.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
+	require.NoError(t, os.Mkdir(dist, 0755))
+	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
 	err = ioutil.WriteFile(binPath, d1, 0666)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Dummy http server
 	mux.HandleFunc("/example-repo-local/mybin/darwin/amd64/mybin", func(w http.ResponseWriter, r *http.Request) {
@@ -477,8 +477,8 @@ func TestRunPipe_BadCredentials(t *testing.T) {
 	})
 
 	err = Pipe{}.Publish(ctx)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "Unauthorized")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Unauthorized")
 }
 
 func TestRunPipe_FileNotFound(t *testing.T) {
@@ -509,19 +509,19 @@ func TestRunPipe_FileNotFound(t *testing.T) {
 		Type:   artifact.UploadableBinary,
 	})
 
-	assert.EqualError(t, Pipe{}.Publish(ctx), `open archivetest/dist/mybin/mybin: no such file or directory`)
+	require.EqualError(t, Pipe{}.Publish(ctx), `open archivetest/dist/mybin/mybin: no such file or directory`)
 }
 
 func TestRunPipe_UnparsableTarget(t *testing.T) {
 	folder, err := ioutil.TempDir("", "archivetest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var dist = filepath.Join(folder, "dist")
-	assert.NoError(t, os.Mkdir(dist, 0755))
-	assert.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
+	require.NoError(t, os.Mkdir(dist, 0755))
+	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
 	err = ioutil.WriteFile(binPath, d1, 0666)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var ctx = context.New(config.Project{
 		ProjectName: "mybin",
@@ -550,7 +550,7 @@ func TestRunPipe_UnparsableTarget(t *testing.T) {
 		Type:   artifact.UploadableBinary,
 	})
 
-	assert.EqualError(t, Pipe{}.Publish(ctx), `upload: upload failed: parse "://artifacts.company.com/example-repo-local/mybin/darwin/amd64/mybin": missing protocol scheme`)
+	require.EqualError(t, Pipe{}.Publish(ctx), `upload: upload failed: parse "://artifacts.company.com/example-repo-local/mybin/darwin/amd64/mybin": missing protocol scheme`)
 }
 
 func TestRunPipe_SkipWhenPublishFalse(t *testing.T) {
@@ -573,16 +573,16 @@ func TestRunPipe_SkipWhenPublishFalse(t *testing.T) {
 	ctx.SkipPublish = true
 
 	err := Pipe{}.Publish(ctx)
-	assert.True(t, pipe.IsSkip(err))
-	assert.EqualError(t, err, pipe.ErrSkipPublishEnabled.Error())
+	require.True(t, pipe.IsSkip(err))
+	require.EqualError(t, err, pipe.ErrSkipPublishEnabled.Error())
 }
 
 func TestRunPipe_DirUpload(t *testing.T) {
 	folder, err := ioutil.TempDir("", "archivetest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var dist = filepath.Join(folder, "dist")
-	assert.NoError(t, os.Mkdir(dist, 0755))
-	assert.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
+	require.NoError(t, os.Mkdir(dist, 0755))
+	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin")
 
 	var ctx = context.New(config.Project{
@@ -612,15 +612,15 @@ func TestRunPipe_DirUpload(t *testing.T) {
 		Type:   artifact.UploadableBinary,
 	})
 
-	assert.EqualError(t, Pipe{}.Publish(ctx), `upload: upload failed: the asset to upload can't be a directory`)
+	require.EqualError(t, Pipe{}.Publish(ctx), `upload: upload failed: the asset to upload can't be a directory`)
 }
 
 func TestDescription(t *testing.T) {
-	assert.NotEmpty(t, Pipe{}.String())
+	require.NotEmpty(t, Pipe{}.String())
 }
 
 func TestNoPuts(t *testing.T) {
-	assert.True(t, pipe.IsSkip(Pipe{}.Publish(context.New(config.Project{}))))
+	require.True(t, pipe.IsSkip(Pipe{}.Publish(context.New(config.Project{}))))
 }
 
 func TestPutsWithoutTarget(t *testing.T) {
@@ -639,7 +639,7 @@ func TestPutsWithoutTarget(t *testing.T) {
 		},
 	}
 
-	assert.True(t, pipe.IsSkip(Pipe{}.Publish(ctx)))
+	require.True(t, pipe.IsSkip(Pipe{}.Publish(ctx)))
 }
 
 func TestPutsWithoutUsername(t *testing.T) {
@@ -658,11 +658,11 @@ func TestPutsWithoutUsername(t *testing.T) {
 		},
 	}
 
-	assert.True(t, pipe.IsSkip(Pipe{}.Publish(ctx)))
+	require.True(t, pipe.IsSkip(Pipe{}.Publish(ctx)))
 }
 
 func TestPutsWithoutName(t *testing.T) {
-	assert.True(t, pipe.IsSkip(Pipe{}.Publish(context.New(config.Project{
+	require.True(t, pipe.IsSkip(Pipe{}.Publish(context.New(config.Project{
 		Uploads: []config.Upload{
 			{
 				Method:   h.MethodPut,
@@ -674,7 +674,7 @@ func TestPutsWithoutName(t *testing.T) {
 }
 
 func TestPutsWithoutSecret(t *testing.T) {
-	assert.True(t, pipe.IsSkip(Pipe{}.Publish(context.New(config.Project{
+	require.True(t, pipe.IsSkip(Pipe{}.Publish(context.New(config.Project{
 		Uploads: []config.Upload{
 			{
 				Method:   h.MethodPut,
@@ -703,7 +703,7 @@ func TestPutsWithInvalidMode(t *testing.T) {
 			},
 		},
 	}
-	assert.Error(t, Pipe{}.Publish(ctx))
+	require.Error(t, Pipe{}.Publish(ctx))
 }
 
 func TestDefault(t *testing.T) {
@@ -718,11 +718,11 @@ func TestDefault(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Len(t, ctx.Config.Uploads, 1)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Len(t, ctx.Config.Uploads, 1)
 	var upload = ctx.Config.Uploads[0]
-	assert.Equal(t, "archive", upload.Mode)
-	assert.Equal(t, h.MethodPut, upload.Method)
+	require.Equal(t, "archive", upload.Mode)
+	require.Equal(t, h.MethodPut, upload.Method)
 }
 
 func TestDefaultNoPuts(t *testing.T) {
@@ -731,8 +731,8 @@ func TestDefaultNoPuts(t *testing.T) {
 			Uploads: []config.Upload{},
 		},
 	}
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Empty(t, ctx.Config.Uploads)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Empty(t, ctx.Config.Uploads)
 }
 
 func TestDefaultSet(t *testing.T) {
@@ -746,9 +746,9 @@ func TestDefaultSet(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, Pipe{}.Default(ctx))
-	assert.Len(t, ctx.Config.Uploads, 1)
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Len(t, ctx.Config.Uploads, 1)
 	var upload = ctx.Config.Uploads[0]
-	assert.Equal(t, "custom", upload.Mode)
-	assert.Equal(t, h.MethodPost, upload.Method)
+	require.Equal(t, "custom", upload.Mode)
+	require.Equal(t, h.MethodPost, upload.Method)
 }

--- a/internal/static/config_test.go
+++ b/internal/static/config_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 
 	"github.com/goreleaser/goreleaser/pkg/config"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExampleConfig(t *testing.T) {
 	_, err := config.LoadReader(strings.NewReader(ExampleConfig))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/internal/testlib/git.go
+++ b/internal/testlib/git.go
@@ -5,22 +5,22 @@ import (
 	"time"
 
 	"github.com/goreleaser/goreleaser/internal/git"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // GitInit inits a new git project.
 func GitInit(t *testing.T) {
 	out, err := fakeGit("init")
-	assert.NoError(t, err)
-	assert.Contains(t, out, "Initialized empty Git repository")
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	require.Contains(t, out, "Initialized empty Git repository")
+	require.NoError(t, err)
 }
 
 // GitRemoteAdd adds the given url as remote.
 func GitRemoteAdd(t *testing.T, url string) {
 	out, err := fakeGit("remote", "add", "origin", url)
-	assert.NoError(t, err)
-	assert.Empty(t, out)
+	require.NoError(t, err)
+	require.Empty(t, out)
 }
 
 // GitCommit creates a git commits.
@@ -37,29 +37,29 @@ func GitCommitWithDate(t *testing.T, msg string, commitDate time.Time) {
 		}
 	}
 	out, err := fakeGitEnv(env, "commit", "--allow-empty", "-m", msg)
-	assert.NoError(t, err)
-	assert.Contains(t, out, "master", msg)
+	require.NoError(t, err)
+	require.Contains(t, out, "master", msg)
 }
 
 // GitTag creates a git tag.
 func GitTag(t *testing.T, tag string) {
 	out, err := fakeGit("tag", tag)
-	assert.NoError(t, err)
-	assert.Empty(t, out)
+	require.NoError(t, err)
+	require.Empty(t, out)
 }
 
 // GitBranch creates a git branch.
 func GitBranch(t *testing.T, branch string) {
 	out, err := fakeGit("branch", branch)
-	assert.NoError(t, err)
-	assert.Empty(t, out)
+	require.NoError(t, err)
+	require.Empty(t, out)
 }
 
 // GitAdd adds all files to stage.
 func GitAdd(t *testing.T) {
 	out, err := fakeGit("add", "-A")
-	assert.NoError(t, err)
-	assert.Empty(t, out)
+	require.NoError(t, err)
+	require.Empty(t, out)
 }
 
 func fakeGitEnv(env map[string]string, args ...string) (string, error) {
@@ -80,6 +80,6 @@ func fakeGit(args ...string) (string, error) {
 // GitCheckoutBranch allows us to change the active branch that we're using.
 func GitCheckoutBranch(t *testing.T, name string) {
 	out, err := fakeGit("checkout", "-b", name)
-	assert.NoError(t, err)
-	assert.Empty(t, out)
+	require.NoError(t, err)
+	require.Empty(t, out)
 }

--- a/internal/testlib/mktemp.go
+++ b/internal/testlib/mktemp.go
@@ -6,18 +6,18 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Mktmp creates a new tempdir, cd into it and provides a back function that
 // cd into the previous directory.
 func Mktmp(t *testing.T) (folder string, back func()) {
 	folder, err := ioutil.TempDir("", "goreleasertest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	current, err := os.Getwd()
-	assert.NoError(t, err)
-	assert.NoError(t, os.Chdir(folder))
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(folder))
 	return folder, func() {
-		assert.NoError(t, os.Chdir(current))
+		require.NoError(t, os.Chdir(current))
 	}
 }

--- a/internal/testlib/mktemp_test.go
+++ b/internal/testlib/mktemp_test.go
@@ -4,16 +4,16 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMkTemp(t *testing.T) {
 	current, err := os.Getwd()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	folder, back := Mktmp(t)
-	assert.NotEmpty(t, folder)
+	require.NotEmpty(t, folder)
 	back()
 	newCurrent, err := os.Getwd()
-	assert.NoError(t, err)
-	assert.Equal(t, current, newCurrent)
+	require.NoError(t, err)
+	require.Equal(t, current, newCurrent)
 }

--- a/internal/testlib/skip.go
+++ b/internal/testlib/skip.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/goreleaser/goreleaser/internal/pipe"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // AssertSkipped asserts that a pipe was skipped.
 func AssertSkipped(t *testing.T, err error) {
 	_, ok := err.(pipe.ErrSkip)
-	assert.True(t, ok, "expected a pipe.ErrSkip but got %v", err)
+	require.True(t, ok, "expected a pipe.ErrSkip but got %v", err)
 }

--- a/internal/tmpl/tmpl_test.go
+++ b/internal/tmpl/tmpl_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,8 +62,8 @@ func TestWithArtifact(t *testing.T) {
 				},
 				map[string]string{"linux": "Linux"},
 			).Apply(tmpl)
-			assert.NoError(tt, err)
-			assert.Equal(tt, expect, result)
+			require.NoError(tt, err)
+			require.Equal(tt, expect, result)
 		})
 	}
 
@@ -82,8 +81,8 @@ func TestWithArtifact(t *testing.T) {
 				},
 			}, map[string]string{},
 		).Apply("{{ .ArtifactUploadHash }}")
-		assert.NoError(tt, err)
-		assert.Equal(tt, uploadHash, result)
+		require.NoError(tt, err)
+		require.Equal(tt, uploadHash, result)
 	})
 
 	t.Run("artifact without binary name", func(tt *testing.T) {
@@ -96,15 +95,15 @@ func TestWithArtifact(t *testing.T) {
 				Goarm:  "6",
 			}, map[string]string{},
 		).Apply("{{ .Binary }}")
-		assert.NoError(tt, err)
-		assert.Equal(tt, ctx.Config.ProjectName, result)
+		require.NoError(tt, err)
+		require.Equal(tt, ctx.Config.ProjectName, result)
 	})
 
 	t.Run("template using artifact Fields with no artifact", func(tt *testing.T) {
 		tt.Parallel()
 		result, err := New(ctx).Apply("{{ .Os }}")
-		assert.EqualError(tt, err, `template: tmpl:1:3: executing "tmpl" at <.Os>: map has no entry for key "Os"`)
-		assert.Empty(tt, result)
+		require.EqualError(tt, err, `template: tmpl:1:3: executing "tmpl" at <.Os>: map has no entry for key "Os"`)
+		require.Empty(tt, result)
 	})
 }
 
@@ -133,7 +132,7 @@ func TestEnv(t *testing.T) {
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
 			out, _ := New(ctx).Apply(tC.in)
-			assert.Equal(t, tC.out, out)
+			require.Equal(t, tC.out, out)
 		})
 	}
 }
@@ -148,8 +147,8 @@ func TestWithEnv(t *testing.T) {
 		"FOO=foo",
 		"BAR=bar",
 	}).Apply("{{ .Env.FOO }}-{{ .Env.BAR }}")
-	assert.NoError(t, err)
-	assert.Equal(t, "foo-bar", out)
+	require.NoError(t, err)
+	require.Equal(t, "foo-bar", out)
 }
 
 func TestFuncMap(t *testing.T) {
@@ -204,11 +203,11 @@ func TestFuncMap(t *testing.T) {
 		},
 	} {
 		out, err := New(ctx).Apply(tc.Template)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		if tc.Expected != "" {
-			assert.Equal(t, tc.Expected, out)
+			require.Equal(t, tc.Expected, out)
 		} else {
-			assert.NotEmpty(t, out)
+			require.NotEmpty(t, out)
 		}
 	}
 }
@@ -271,9 +270,9 @@ func TestApplySingleEnvOnly(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := New(ctx).ApplySingleEnvOnly(tc.tpl)
 			if tc.expectedErr != nil {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -283,15 +282,15 @@ func TestInvalidTemplate(t *testing.T) {
 	ctx := context.New(config.Project{})
 	ctx.Git.CurrentTag = "v1.1.1"
 	_, err := New(ctx).Apply("{{{.Foo}")
-	assert.EqualError(t, err, "template: tmpl:1: unexpected \"{\" in command")
+	require.EqualError(t, err, "template: tmpl:1: unexpected \"{\" in command")
 }
 
 func TestEnvNotFound(t *testing.T) {
 	var ctx = context.New(config.Project{})
 	ctx.Git.CurrentTag = "v1.2.4"
 	result, err := New(ctx).Apply("{{.Env.FOO}}")
-	assert.Empty(t, result)
-	assert.EqualError(t, err, `template: tmpl:1:6: executing "tmpl" at <.Env.FOO>: map has no entry for key "FOO"`)
+	require.Empty(t, result)
+	require.EqualError(t, err, `template: tmpl:1:6: executing "tmpl" at <.Env.FOO>: map has no entry for key "FOO"`)
 }
 
 func TestWithExtraFields(t *testing.T) {
@@ -299,6 +298,6 @@ func TestWithExtraFields(t *testing.T) {
 	out, _ := New(ctx).WithExtraFields(Fields{
 		"MyCustomField": "foo",
 	}).Apply("{{ .MyCustomField }}")
-	assert.Equal(t, "foo", out)
+	require.Equal(t, "foo", out)
 
 }

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -5,30 +5,30 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestArchive(t *testing.T) {
-	var assert = assert.New(t)
+	var assert = require.New(t)
 	folder, err := ioutil.TempDir("", "archivetest")
-	assert.NoError(err)
+	require.NoError(err)
 	empty, err := os.Create(folder + "/empty.txt")
-	assert.NoError(err)
-	assert.NoError(os.Mkdir(folder+"/folder-inside", 0755))
+	require.NoError(err)
+	require.NoError(os.Mkdir(folder+"/folder-inside", 0755))
 
 	for _, format := range []string{"tar.gz", "zip", "gz", "tar.xz", "willbeatargzanyway"} {
 		format := format
 		t.Run(format, func(t *testing.T) {
 			var archive = newArchive(folder, format, t)
-			assert.NoError(archive.Add("empty.txt", empty.Name()))
-			assert.Error(archive.Add("dont.txt", empty.Name()+"_nope"))
-			assert.NoError(archive.Close())
+			require.NoError(archive.Add("empty.txt", empty.Name()))
+			require.Error(archive.Add("dont.txt", empty.Name()+"_nope"))
+			require.NoError(archive.Close())
 		})
 	}
 }
 
 func newArchive(folder, format string, t *testing.T) Archive {
 	file, err := os.Create(folder + "/folder." + format)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	return New(file)
 }

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -9,20 +9,19 @@ import (
 )
 
 func TestArchive(t *testing.T) {
-	var assert = require.New(t)
 	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(err)
+	require.NoError(t, err)
 	empty, err := os.Create(folder + "/empty.txt")
-	require.NoError(err)
-	require.NoError(os.Mkdir(folder+"/folder-inside", 0755))
+	require.NoError(t, err)
+	require.NoError(t, os.Mkdir(folder+"/folder-inside", 0755))
 
 	for _, format := range []string{"tar.gz", "zip", "gz", "tar.xz", "willbeatargzanyway"} {
 		format := format
 		t.Run(format, func(t *testing.T) {
 			var archive = newArchive(folder, format, t)
-			require.NoError(archive.Add("empty.txt", empty.Name()))
-			require.Error(archive.Add("dont.txt", empty.Name()+"_nope"))
-			require.NoError(archive.Close())
+			require.NoError(t, archive.Add("empty.txt", empty.Name()))
+			require.Error(t, archive.Add("dont.txt", empty.Name()+"_nope"))
+			require.NoError(t, archive.Close())
 		})
 	}
 }

--- a/pkg/archive/gzip/gzip_test.go
+++ b/pkg/archive/gzip/gzip_test.go
@@ -11,36 +11,35 @@ import (
 )
 
 func TestGzFile(t *testing.T) {
-	var assert = require.New(t)
 	tmp, err := ioutil.TempDir("", "")
-	require.NoError(err)
+	require.NoError(t, err)
 	f, err := os.Create(filepath.Join(tmp, "test.gz"))
-	require.NoError(err)
+	require.NoError(t, err)
 	defer f.Close() // nolint: errcheck
 	archive := New(f)
 
-	require.NoError(archive.Add("sub1/sub2/subfoo.txt", "../testdata/sub1/sub2/subfoo.txt"))
-	require.EqualError(archive.Add("foo.txt", "../testdata/foo.txt"), "gzip: failed to add foo.txt, only one file can be archived in gz format")
-	require.NoError(archive.Close())
+	require.NoError(t, archive.Add("sub1/sub2/subfoo.txt", "../testdata/sub1/sub2/subfoo.txt"))
+	require.EqualError(t, archive.Add("foo.txt", "../testdata/foo.txt"), "gzip: failed to add foo.txt, only one file can be archived in gz format")
+	require.NoError(t, archive.Close())
 
-	require.NoError(f.Close())
+	require.NoError(t, f.Close())
 
 	t.Log(f.Name())
 	f, err = os.Open(f.Name())
-	require.NoError(err)
+	require.NoError(t, err)
 	defer f.Close() // nolint: errcheck
 
 	info, err := f.Stat()
-	require.NoError(err)
-	require.Truef(info.Size() < 500, "archived file should be smaller than %d", info.Size())
+	require.NoError(t, err)
+	require.Truef(t, info.Size() < 500, "archived file should be smaller than %d", info.Size())
 
 	gzf, err := gzip.NewReader(f)
-	require.NoError(err)
+	require.NoError(t, err)
 	defer gzf.Close() // nolint: errcheck
 
-	require.Equal("sub1/sub2/subfoo.txt", gzf.Name)
+	require.Equal(t, "sub1/sub2/subfoo.txt", gzf.Name)
 
 	bts, err := ioutil.ReadAll(gzf)
-	require.NoError(err)
-	require.Equal("sub\n", string(bts))
+	require.NoError(t, err)
+	require.Equal(t, "sub\n", string(bts))
 }

--- a/pkg/archive/gzip/gzip_test.go
+++ b/pkg/archive/gzip/gzip_test.go
@@ -7,40 +7,40 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGzFile(t *testing.T) {
-	var assert = assert.New(t)
+	var assert = require.New(t)
 	tmp, err := ioutil.TempDir("", "")
-	assert.NoError(err)
+	require.NoError(err)
 	f, err := os.Create(filepath.Join(tmp, "test.gz"))
-	assert.NoError(err)
+	require.NoError(err)
 	defer f.Close() // nolint: errcheck
 	archive := New(f)
 
-	assert.NoError(archive.Add("sub1/sub2/subfoo.txt", "../testdata/sub1/sub2/subfoo.txt"))
-	assert.EqualError(archive.Add("foo.txt", "../testdata/foo.txt"), "gzip: failed to add foo.txt, only one file can be archived in gz format")
-	assert.NoError(archive.Close())
+	require.NoError(archive.Add("sub1/sub2/subfoo.txt", "../testdata/sub1/sub2/subfoo.txt"))
+	require.EqualError(archive.Add("foo.txt", "../testdata/foo.txt"), "gzip: failed to add foo.txt, only one file can be archived in gz format")
+	require.NoError(archive.Close())
 
-	assert.NoError(f.Close())
+	require.NoError(f.Close())
 
 	t.Log(f.Name())
 	f, err = os.Open(f.Name())
-	assert.NoError(err)
+	require.NoError(err)
 	defer f.Close() // nolint: errcheck
 
 	info, err := f.Stat()
-	assert.NoError(err)
-	assert.Truef(info.Size() < 500, "archived file should be smaller than %d", info.Size())
+	require.NoError(err)
+	require.Truef(info.Size() < 500, "archived file should be smaller than %d", info.Size())
 
 	gzf, err := gzip.NewReader(f)
-	assert.NoError(err)
+	require.NoError(err)
 	defer gzf.Close() // nolint: errcheck
 
-	assert.Equal("sub1/sub2/subfoo.txt", gzf.Name)
+	require.Equal("sub1/sub2/subfoo.txt", gzf.Name)
 
 	bts, err := ioutil.ReadAll(gzf)
-	assert.NoError(err)
-	assert.Equal("sub\n", string(bts))
+	require.NoError(err)
+	require.Equal("sub\n", string(bts))
 }

--- a/pkg/archive/targz/targz_test.go
+++ b/pkg/archive/targz/targz_test.go
@@ -13,37 +13,36 @@ import (
 )
 
 func TestTarGzFile(t *testing.T) {
-	var assert = require.New(t)
 	tmp, err := ioutil.TempDir("", "")
-	require.NoError(err)
+	require.NoError(t, err)
 	f, err := os.Create(filepath.Join(tmp, "test.tar.gz"))
-	require.NoError(err)
+	require.NoError(t, err)
 	defer f.Close() // nolint: errcheck
 	archive := New(f)
 
-	require.Error(archive.Add("nope.txt", "../testdata/nope.txt"))
-	require.NoError(archive.Add("foo.txt", "../testdata/foo.txt"))
-	require.NoError(archive.Add("sub1", "../testdata/sub1"))
-	require.NoError(archive.Add("sub1/bar.txt", "../testdata/sub1/bar.txt"))
-	require.NoError(archive.Add("sub1/executable", "../testdata/sub1/executable"))
-	require.NoError(archive.Add("sub1/sub2", "../testdata/sub1/sub2"))
-	require.NoError(archive.Add("sub1/sub2/subfoo.txt", "../testdata/sub1/sub2/subfoo.txt"))
+	require.Error(t, archive.Add("nope.txt", "../testdata/nope.txt"))
+	require.NoError(t, archive.Add("foo.txt", "../testdata/foo.txt"))
+	require.NoError(t, archive.Add("sub1", "../testdata/sub1"))
+	require.NoError(t, archive.Add("sub1/bar.txt", "../testdata/sub1/bar.txt"))
+	require.NoError(t, archive.Add("sub1/executable", "../testdata/sub1/executable"))
+	require.NoError(t, archive.Add("sub1/sub2", "../testdata/sub1/sub2"))
+	require.NoError(t, archive.Add("sub1/sub2/subfoo.txt", "../testdata/sub1/sub2/subfoo.txt"))
 
-	require.NoError(archive.Close())
-	require.Error(archive.Add("tar.go", "tar.go"))
-	require.NoError(f.Close())
+	require.NoError(t, archive.Close())
+	require.Error(t, archive.Add("tar.go", "tar.go"))
+	require.NoError(t, f.Close())
 
 	t.Log(f.Name())
 	f, err = os.Open(f.Name())
-	require.NoError(err)
+	require.NoError(t, err)
 	defer f.Close() // nolint: errcheck
 
 	info, err := f.Stat()
-	require.NoError(err)
-	require.Truef(info.Size() < 500, "archived file should be smaller than %d", info.Size())
+	require.NoError(t, err)
+	require.Truef(t, info.Size() < 500, "archived file should be smaller than %d", info.Size())
 
 	gzf, err := gzip.NewReader(f)
-	require.NoError(err)
+	require.NoError(t, err)
 	defer gzf.Close() // nolint: errcheck
 
 	var paths []string
@@ -53,15 +52,15 @@ func TestTarGzFile(t *testing.T) {
 		if err == io.EOF {
 			break
 		}
-		require.NoError(err)
+		require.NoError(t, err)
 		paths = append(paths, next.Name)
 		t.Logf("%s: %v", next.Name, next.FileInfo().Mode())
 		if next.Name == "sub1/executable" {
 			var ex = next.FileInfo().Mode() | 0111
-			require.Equal(next.FileInfo().Mode().String(), ex.String())
+			require.Equal(t, next.FileInfo().Mode().String(), ex.String())
 		}
 	}
-	require.Equal([]string{
+	require.Equal(t, []string{
 		"foo.txt",
 		"sub1",
 		"sub1/bar.txt",

--- a/pkg/archive/targz/targz_test.go
+++ b/pkg/archive/targz/targz_test.go
@@ -9,41 +9,41 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTarGzFile(t *testing.T) {
-	var assert = assert.New(t)
+	var assert = require.New(t)
 	tmp, err := ioutil.TempDir("", "")
-	assert.NoError(err)
+	require.NoError(err)
 	f, err := os.Create(filepath.Join(tmp, "test.tar.gz"))
-	assert.NoError(err)
+	require.NoError(err)
 	defer f.Close() // nolint: errcheck
 	archive := New(f)
 
-	assert.Error(archive.Add("nope.txt", "../testdata/nope.txt"))
-	assert.NoError(archive.Add("foo.txt", "../testdata/foo.txt"))
-	assert.NoError(archive.Add("sub1", "../testdata/sub1"))
-	assert.NoError(archive.Add("sub1/bar.txt", "../testdata/sub1/bar.txt"))
-	assert.NoError(archive.Add("sub1/executable", "../testdata/sub1/executable"))
-	assert.NoError(archive.Add("sub1/sub2", "../testdata/sub1/sub2"))
-	assert.NoError(archive.Add("sub1/sub2/subfoo.txt", "../testdata/sub1/sub2/subfoo.txt"))
+	require.Error(archive.Add("nope.txt", "../testdata/nope.txt"))
+	require.NoError(archive.Add("foo.txt", "../testdata/foo.txt"))
+	require.NoError(archive.Add("sub1", "../testdata/sub1"))
+	require.NoError(archive.Add("sub1/bar.txt", "../testdata/sub1/bar.txt"))
+	require.NoError(archive.Add("sub1/executable", "../testdata/sub1/executable"))
+	require.NoError(archive.Add("sub1/sub2", "../testdata/sub1/sub2"))
+	require.NoError(archive.Add("sub1/sub2/subfoo.txt", "../testdata/sub1/sub2/subfoo.txt"))
 
-	assert.NoError(archive.Close())
-	assert.Error(archive.Add("tar.go", "tar.go"))
-	assert.NoError(f.Close())
+	require.NoError(archive.Close())
+	require.Error(archive.Add("tar.go", "tar.go"))
+	require.NoError(f.Close())
 
 	t.Log(f.Name())
 	f, err = os.Open(f.Name())
-	assert.NoError(err)
+	require.NoError(err)
 	defer f.Close() // nolint: errcheck
 
 	info, err := f.Stat()
-	assert.NoError(err)
-	assert.Truef(info.Size() < 500, "archived file should be smaller than %d", info.Size())
+	require.NoError(err)
+	require.Truef(info.Size() < 500, "archived file should be smaller than %d", info.Size())
 
 	gzf, err := gzip.NewReader(f)
-	assert.NoError(err)
+	require.NoError(err)
 	defer gzf.Close() // nolint: errcheck
 
 	var paths []string
@@ -53,15 +53,15 @@ func TestTarGzFile(t *testing.T) {
 		if err == io.EOF {
 			break
 		}
-		assert.NoError(err)
+		require.NoError(err)
 		paths = append(paths, next.Name)
 		t.Logf("%s: %v", next.Name, next.FileInfo().Mode())
 		if next.Name == "sub1/executable" {
 			var ex = next.FileInfo().Mode() | 0111
-			assert.Equal(next.FileInfo().Mode().String(), ex.String())
+			require.Equal(next.FileInfo().Mode().String(), ex.String())
 		}
 	}
-	assert.Equal([]string{
+	require.Equal([]string{
 		"foo.txt",
 		"sub1",
 		"sub1/bar.txt",

--- a/pkg/archive/tarxz/tarxz_test.go
+++ b/pkg/archive/tarxz/tarxz_test.go
@@ -8,42 +8,42 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/ulikunitz/xz"
 )
 
 func TestTarXzFile(t *testing.T) {
-	var assert = assert.New(t)
+	var assert = require.New(t)
 	tmp, err := ioutil.TempDir("", "")
-	assert.NoError(err)
+	require.NoError(err)
 	f, err := os.Create(filepath.Join(tmp, "test.tar.xz"))
-	assert.NoError(err)
+	require.NoError(err)
 	defer f.Close() // nolint: errcheck
 	archive := New(f)
 
-	assert.Error(archive.Add("nope.txt", "../testdata/nope.txt"))
-	assert.NoError(archive.Add("foo.txt", "../testdata/foo.txt"))
-	assert.NoError(archive.Add("sub1", "../testdata/sub1"))
-	assert.NoError(archive.Add("sub1/bar.txt", "../testdata/sub1/bar.txt"))
-	assert.NoError(archive.Add("sub1/executable", "../testdata/sub1/executable"))
-	assert.NoError(archive.Add("sub1/sub2", "../testdata/sub1/sub2"))
-	assert.NoError(archive.Add("sub1/sub2/subfoo.txt", "../testdata/sub1/sub2/subfoo.txt"))
+	require.Error(archive.Add("nope.txt", "../testdata/nope.txt"))
+	require.NoError(archive.Add("foo.txt", "../testdata/foo.txt"))
+	require.NoError(archive.Add("sub1", "../testdata/sub1"))
+	require.NoError(archive.Add("sub1/bar.txt", "../testdata/sub1/bar.txt"))
+	require.NoError(archive.Add("sub1/executable", "../testdata/sub1/executable"))
+	require.NoError(archive.Add("sub1/sub2", "../testdata/sub1/sub2"))
+	require.NoError(archive.Add("sub1/sub2/subfoo.txt", "../testdata/sub1/sub2/subfoo.txt"))
 
-	assert.NoError(archive.Close())
-	assert.Error(archive.Add("tar.go", "tar.go"))
-	assert.NoError(f.Close())
+	require.NoError(archive.Close())
+	require.Error(archive.Add("tar.go", "tar.go"))
+	require.NoError(f.Close())
 
 	t.Log(f.Name())
 	f, err = os.Open(f.Name())
-	assert.NoError(err)
+	require.NoError(err)
 	defer f.Close() // nolint: errcheck
 
 	info, err := f.Stat()
-	assert.NoError(err)
-	assert.Truef(info.Size() < 500, "archived file should be smaller than %d", info.Size())
+	require.NoError(err)
+	require.Truef(info.Size() < 500, "archived file should be smaller than %d", info.Size())
 
 	xzf, err := xz.NewReader(f)
-	assert.NoError(err)
+	require.NoError(err)
 	//defer xzf.Close() // nolint: errcheck
 
 	var paths []string
@@ -53,15 +53,15 @@ func TestTarXzFile(t *testing.T) {
 		if err == io.EOF {
 			break
 		}
-		assert.NoError(err)
+		require.NoError(err)
 		paths = append(paths, next.Name)
 		t.Logf("%s: %v", next.Name, next.FileInfo().Mode())
 		if next.Name == "sub1/executable" {
 			var ex = next.FileInfo().Mode() | 0111
-			assert.Equal(next.FileInfo().Mode().String(), ex.String())
+			require.Equal(next.FileInfo().Mode().String(), ex.String())
 		}
 	}
-	assert.Equal([]string{
+	require.Equal([]string{
 		"foo.txt",
 		"sub1",
 		"sub1/bar.txt",

--- a/pkg/archive/tarxz/tarxz_test.go
+++ b/pkg/archive/tarxz/tarxz_test.go
@@ -13,37 +13,36 @@ import (
 )
 
 func TestTarXzFile(t *testing.T) {
-	var assert = require.New(t)
 	tmp, err := ioutil.TempDir("", "")
-	require.NoError(err)
+	require.NoError(t, err)
 	f, err := os.Create(filepath.Join(tmp, "test.tar.xz"))
-	require.NoError(err)
+	require.NoError(t, err)
 	defer f.Close() // nolint: errcheck
 	archive := New(f)
 
-	require.Error(archive.Add("nope.txt", "../testdata/nope.txt"))
-	require.NoError(archive.Add("foo.txt", "../testdata/foo.txt"))
-	require.NoError(archive.Add("sub1", "../testdata/sub1"))
-	require.NoError(archive.Add("sub1/bar.txt", "../testdata/sub1/bar.txt"))
-	require.NoError(archive.Add("sub1/executable", "../testdata/sub1/executable"))
-	require.NoError(archive.Add("sub1/sub2", "../testdata/sub1/sub2"))
-	require.NoError(archive.Add("sub1/sub2/subfoo.txt", "../testdata/sub1/sub2/subfoo.txt"))
+	require.Error(t, archive.Add("nope.txt", "../testdata/nope.txt"))
+	require.NoError(t, archive.Add("foo.txt", "../testdata/foo.txt"))
+	require.NoError(t, archive.Add("sub1", "../testdata/sub1"))
+	require.NoError(t, archive.Add("sub1/bar.txt", "../testdata/sub1/bar.txt"))
+	require.NoError(t, archive.Add("sub1/executable", "../testdata/sub1/executable"))
+	require.NoError(t, archive.Add("sub1/sub2", "../testdata/sub1/sub2"))
+	require.NoError(t, archive.Add("sub1/sub2/subfoo.txt", "../testdata/sub1/sub2/subfoo.txt"))
 
-	require.NoError(archive.Close())
-	require.Error(archive.Add("tar.go", "tar.go"))
-	require.NoError(f.Close())
+	require.NoError(t, archive.Close())
+	require.Error(t, archive.Add("tar.go", "tar.go"))
+	require.NoError(t, f.Close())
 
 	t.Log(f.Name())
 	f, err = os.Open(f.Name())
-	require.NoError(err)
+	require.NoError(t, err)
 	defer f.Close() // nolint: errcheck
 
 	info, err := f.Stat()
-	require.NoError(err)
-	require.Truef(info.Size() < 500, "archived file should be smaller than %d", info.Size())
+	require.NoError(t, err)
+	require.Truef(t, info.Size() < 500, "archived file should be smaller than %d", info.Size())
 
 	xzf, err := xz.NewReader(f)
-	require.NoError(err)
+	require.NoError(t, err)
 	//defer xzf.Close() // nolint: errcheck
 
 	var paths []string
@@ -53,15 +52,15 @@ func TestTarXzFile(t *testing.T) {
 		if err == io.EOF {
 			break
 		}
-		require.NoError(err)
+		require.NoError(t, err)
 		paths = append(paths, next.Name)
 		t.Logf("%s: %v", next.Name, next.FileInfo().Mode())
 		if next.Name == "sub1/executable" {
 			var ex = next.FileInfo().Mode() | 0111
-			require.Equal(next.FileInfo().Mode().String(), ex.String())
+			require.Equal(t, next.FileInfo().Mode().String(), ex.String())
 		}
 	}
-	require.Equal([]string{
+	require.Equal(t, []string{
 		"foo.txt",
 		"sub1",
 		"sub1/bar.txt",

--- a/pkg/archive/zip/zip_test.go
+++ b/pkg/archive/zip/zip_test.go
@@ -8,42 +8,42 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestZipFile(t *testing.T) {
-	var assert = assert.New(t)
+	var assert = require.New(t)
 	tmp, err := ioutil.TempDir("", "")
-	assert.NoError(err)
+	require.NoError(err)
 	f, err := os.Create(filepath.Join(tmp, "test.zip"))
-	assert.NoError(err)
+	require.NoError(err)
 	fmt.Println(f.Name())
 	defer f.Close() // nolint: errcheck
 	archive := New(f)
 
-	assert.Error(archive.Add("nope.txt", "../testdata/nope.txt"))
-	assert.NoError(archive.Add("foo.txt", "../testdata/foo.txt"))
-	assert.NoError(archive.Add("sub1", "../testdata/sub1"))
-	assert.NoError(archive.Add("sub1/bar.txt", "../testdata/sub1/bar.txt"))
-	assert.NoError(archive.Add("sub1/executable", "../testdata/sub1/executable"))
-	assert.NoError(archive.Add("sub1/sub2", "../testdata/sub1/sub2"))
-	assert.NoError(archive.Add("sub1/sub2/subfoo.txt", "../testdata/sub1/sub2/subfoo.txt"))
+	require.Error(archive.Add("nope.txt", "../testdata/nope.txt"))
+	require.NoError(archive.Add("foo.txt", "../testdata/foo.txt"))
+	require.NoError(archive.Add("sub1", "../testdata/sub1"))
+	require.NoError(archive.Add("sub1/bar.txt", "../testdata/sub1/bar.txt"))
+	require.NoError(archive.Add("sub1/executable", "../testdata/sub1/executable"))
+	require.NoError(archive.Add("sub1/sub2", "../testdata/sub1/sub2"))
+	require.NoError(archive.Add("sub1/sub2/subfoo.txt", "../testdata/sub1/sub2/subfoo.txt"))
 
-	assert.NoError(archive.Close())
-	assert.Error(archive.Add("tar.go", "tar.go"))
-	assert.NoError(f.Close())
+	require.NoError(archive.Close())
+	require.Error(archive.Add("tar.go", "tar.go"))
+	require.NoError(f.Close())
 
 	t.Log(f.Name())
 	f, err = os.Open(f.Name())
-	assert.NoError(err)
+	require.NoError(err)
 	defer f.Close() // nolint: errcheck
 
 	info, err := f.Stat()
-	assert.NoError(err)
-	assert.Truef(info.Size() < 900, "archived file should be smaller than %d", info.Size())
+	require.NoError(err)
+	require.Truef(info.Size() < 900, "archived file should be smaller than %d", info.Size())
 
 	r, err := zip.NewReader(f, info.Size())
-	assert.NoError(err)
+	require.NoError(err)
 
 	var paths = make([]string, len(r.File))
 	for i, zf := range r.File {
@@ -51,10 +51,10 @@ func TestZipFile(t *testing.T) {
 		t.Logf("%s: %v", zf.Name, zf.Mode())
 		if zf.Name == "sub1/executable" {
 			var ex = zf.Mode() | 0111
-			assert.Equal(zf.Mode().String(), ex.String())
+			require.Equal(zf.Mode().String(), ex.String())
 		}
 	}
-	assert.Equal([]string{
+	require.Equal([]string{
 		"foo.txt",
 		"sub1/bar.txt",
 		"sub1/executable",

--- a/pkg/archive/zip/zip_test.go
+++ b/pkg/archive/zip/zip_test.go
@@ -12,38 +12,37 @@ import (
 )
 
 func TestZipFile(t *testing.T) {
-	var assert = require.New(t)
 	tmp, err := ioutil.TempDir("", "")
-	require.NoError(err)
+	require.NoError(t, err)
 	f, err := os.Create(filepath.Join(tmp, "test.zip"))
-	require.NoError(err)
+	require.NoError(t, err)
 	fmt.Println(f.Name())
 	defer f.Close() // nolint: errcheck
 	archive := New(f)
 
-	require.Error(archive.Add("nope.txt", "../testdata/nope.txt"))
-	require.NoError(archive.Add("foo.txt", "../testdata/foo.txt"))
-	require.NoError(archive.Add("sub1", "../testdata/sub1"))
-	require.NoError(archive.Add("sub1/bar.txt", "../testdata/sub1/bar.txt"))
-	require.NoError(archive.Add("sub1/executable", "../testdata/sub1/executable"))
-	require.NoError(archive.Add("sub1/sub2", "../testdata/sub1/sub2"))
-	require.NoError(archive.Add("sub1/sub2/subfoo.txt", "../testdata/sub1/sub2/subfoo.txt"))
+	require.Error(t, archive.Add("nope.txt", "../testdata/nope.txt"))
+	require.NoError(t, archive.Add("foo.txt", "../testdata/foo.txt"))
+	require.NoError(t, archive.Add("sub1", "../testdata/sub1"))
+	require.NoError(t, archive.Add("sub1/bar.txt", "../testdata/sub1/bar.txt"))
+	require.NoError(t, archive.Add("sub1/executable", "../testdata/sub1/executable"))
+	require.NoError(t, archive.Add("sub1/sub2", "../testdata/sub1/sub2"))
+	require.NoError(t, archive.Add("sub1/sub2/subfoo.txt", "../testdata/sub1/sub2/subfoo.txt"))
 
-	require.NoError(archive.Close())
-	require.Error(archive.Add("tar.go", "tar.go"))
-	require.NoError(f.Close())
+	require.NoError(t, archive.Close())
+	require.Error(t, archive.Add("tar.go", "tar.go"))
+	require.NoError(t, f.Close())
 
 	t.Log(f.Name())
 	f, err = os.Open(f.Name())
-	require.NoError(err)
+	require.NoError(t, err)
 	defer f.Close() // nolint: errcheck
 
 	info, err := f.Stat()
-	require.NoError(err)
-	require.Truef(info.Size() < 900, "archived file should be smaller than %d", info.Size())
+	require.NoError(t, err)
+	require.Truef(t, info.Size() < 900, "archived file should be smaller than %d", info.Size())
 
 	r, err := zip.NewReader(f, info.Size())
-	require.NoError(err)
+	require.NoError(t, err)
 
 	var paths = make([]string, len(r.File))
 	for i, zf := range r.File {
@@ -51,10 +50,10 @@ func TestZipFile(t *testing.T) {
 		t.Logf("%s: %v", zf.Name, zf.Mode())
 		if zf.Name == "sub1/executable" {
 			var ex = zf.Mode() | 0111
-			require.Equal(zf.Mode().String(), ex.String())
+			require.Equal(t, zf.Mode().String(), ex.String())
 		}
 	}
-	require.Equal([]string{
+	require.Equal(t, []string{
 		"foo.txt",
 		"sub1/bar.txt",
 		"sub1/executable",

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type dummy struct{}
@@ -20,5 +20,5 @@ func (*dummy) Build(ctx *context.Context, build config.Build, options Options) e
 func TestRegisterAndGet(t *testing.T) {
 	var builder = &dummy{}
 	Register("dummy", builder)
-	assert.Equal(t, builder, For("dummy"))
+	require.Equal(t, builder, For("dummy"))
 }

--- a/pkg/config/config_array_test.go
+++ b/pkg/config/config_array_test.go
@@ -3,7 +3,7 @@ package config
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -92,10 +92,10 @@ func TestStringArray(t *testing.T) {
 
 		err := yaml.UnmarshalStrict([]byte(testCase.yaml), &actual)
 		if testCase.err == "" {
-			assert.NoError(t, err)
-			assert.Equal(t, testCase.expected, actual)
+			require.NoError(t, err)
+			require.Equal(t, testCase.expected, actual)
 		} else {
-			assert.EqualError(t, err, testCase.err)
+			require.EqualError(t, err, testCase.err)
 		}
 	}
 }
@@ -106,10 +106,10 @@ func TestFlagArray(t *testing.T) {
 
 		err := yaml.UnmarshalStrict([]byte(testCase.yaml), &actual)
 		if testCase.err == "" {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		} else {
-			assert.EqualError(t, err, testCase.err)
+			require.EqualError(t, err, testCase.err)
 		}
-		assert.Equal(t, testCase.expected, actual)
+		require.Equal(t, testCase.expected, actual)
 	}
 }

--- a/pkg/config/config_build_hook_test.go
+++ b/pkg/config/config_build_hook_test.go
@@ -3,7 +3,7 @@ package config
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -11,8 +11,8 @@ func TestBuildHook_justString(t *testing.T) {
 	var actual HookConfig
 
 	err := yaml.UnmarshalStrict([]byte(`pre: ./script.sh`), &actual)
-	assert.NoError(t, err)
-	assert.Equal(t, BuildHook{
+	require.NoError(t, err)
+	require.Equal(t, BuildHook{
 		Cmd: "./script.sh",
 		Env: nil,
 	}, actual.Pre[0])
@@ -25,9 +25,9 @@ func TestBuildHook_stringCmds(t *testing.T) {
  - ./script.sh
  - second-script.sh
 `), &actual)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, BuildHooks{
+	require.Equal(t, BuildHooks{
 		{
 			Cmd: "./script.sh",
 			Env: nil,
@@ -47,8 +47,8 @@ func TestBuildHook_complex(t *testing.T) {
    env:
     - TEST=value
 `), &actual)
-	assert.NoError(t, err)
-	assert.Equal(t, BuildHook{
+	require.NoError(t, err)
+	require.Equal(t, BuildHook{
 		Cmd: "./script.sh",
 		Env: []string{"TEST=value"},
 	}, actual.Pre[0])

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRepo(t *testing.T) {
-	assert.Equal(
+	require.Equal(
 		t,
 		"goreleaser/godownloader",
 		Repo{Owner: "goreleaser", Name: "godownloader"}.String(),
@@ -20,7 +20,7 @@ func TestRepo(t *testing.T) {
 }
 
 func TestEmptyRepoNameAndOwner(t *testing.T) {
-	assert.Empty(t, Repo{}.String())
+	require.Empty(t, Repo{}.String())
 }
 
 func TestLoadReader(t *testing.T) {
@@ -31,8 +31,8 @@ nfpms:
 	buf := strings.NewReader(conf)
 	prop, err := LoadReader(buf)
 
-	assert.NoError(t, err)
-	assert.Equal(t, "http://goreleaser.github.io", prop.NFPMs[0].Homepage, "yaml did not load correctly")
+	require.NoError(t, err)
+	require.Equal(t, "http://goreleaser.github.io", prop.NFPMs[0].Homepage, "yaml did not load correctly")
 }
 
 type errorReader struct{}
@@ -42,32 +42,32 @@ func (errorReader) Read(p []byte) (n int, err error) {
 }
 func TestLoadBadReader(t *testing.T) {
 	_, err := LoadReader(errorReader{})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestFile(t *testing.T) {
 	f, err := ioutil.TempFile(os.TempDir(), "config")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = Load(filepath.Join(f.Name()))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestFileNotFound(t *testing.T) {
 	_, err := Load("/nope/no-way.yml")
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestInvalidFields(t *testing.T) {
 	_, err := Load("testdata/invalid_config.yml")
-	assert.EqualError(t, err, "yaml: unmarshal errors:\n  line 2: field invalid_yaml not found in type config.Build")
+	require.EqualError(t, err, "yaml: unmarshal errors:\n  line 2: field invalid_yaml not found in type config.Build")
 }
 
 func TestInvalidYaml(t *testing.T) {
 	_, err := Load("testdata/invalid.yml")
-	assert.EqualError(t, err, "yaml: line 1: did not find expected node content")
+	require.EqualError(t, err, "yaml: line 1: did not find expected node content")
 }
 
 func TestConfigWithAnchors(t *testing.T) {
 	_, err := Load("testdata/anchor.yaml")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/pkg/context/context_test.go
+++ b/pkg/context/context_test.go
@@ -6,27 +6,27 @@ import (
 	"time"
 
 	"github.com/goreleaser/goreleaser/pkg/config"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
-	assert.NoError(t, os.Setenv("FOO", "NOT BAR"))
-	assert.NoError(t, os.Setenv("BAR", "1"))
+	require.NoError(t, os.Setenv("FOO", "NOT BAR"))
+	require.NoError(t, os.Setenv("BAR", "1"))
 	var ctx = New(config.Project{
 		Env: []string{
 			"FOO=BAR",
 		},
 	})
-	assert.Equal(t, "BAR", ctx.Env["FOO"])
-	assert.Equal(t, "1", ctx.Env["BAR"])
-	assert.Equal(t, 4, ctx.Parallelism)
+	require.Equal(t, "BAR", ctx.Env["FOO"])
+	require.Equal(t, "1", ctx.Env["BAR"])
+	require.Equal(t, 4, ctx.Parallelism)
 }
 
 func TestNewWithTimeout(t *testing.T) {
 	ctx, cancel := NewWithTimeout(config.Project{}, time.Second)
-	assert.NotEmpty(t, ctx.Env)
-	assert.Equal(t, 4, ctx.Parallelism)
+	require.NotEmpty(t, ctx.Env)
+	require.Equal(t, 4, ctx.Parallelism)
 	cancel()
 	<-ctx.Done()
-	assert.EqualError(t, ctx.Err(), `context canceled`)
+	require.EqualError(t, ctx.Err(), `context canceled`)
 }


### PR DESCRIPTION
makes tests fail earlier and the output easier to read... if a test has more failures, I assume people will run them manually to debug/fix the issue anyway, therefore catching further assert/require failures.

does that make sense?

---

PS: automated change with editor replace all, maybe there are things wrong 🤣 