### PR TITLE
feat: add fish completion

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,8 +1,6 @@
 package cmd
 
-import (
-	"github.com/spf13/cobra"
-)
+import "github.com/spf13/cobra"
 
 type completionCmd struct {
 	cmd *cobra.Command
@@ -12,9 +10,9 @@ func newCompletionCmd() *completionCmd {
 	var root = &completionCmd{}
 	var cmd = &cobra.Command{
 		Use:          "completion",
-		Short:        "Print shell autocompletion scripts for goreleaser for bash and zsh",
+		Short:        "Print shell autocompletion scripts for goreleaser",
 		SilenceUsage: true,
-		ValidArgs:    []string{"bash", "zsh"},
+		ValidArgs:    []string{"bash", "zsh", "fish"},
 		Args:         cobra.ExactValidArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
@@ -23,6 +21,8 @@ func newCompletionCmd() *completionCmd {
 				err = cmd.Root().GenBashCompletion(cmd.OutOrStdout())
 			case "zsh":
 				err = cmd.Root().GenZshCompletion(cmd.OutOrStdout())
+			case "fish":
+				err = cmd.Root().GenFishCompletion(cmd.OutOrStdout(), true)
 			}
 
 			return err

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -8,16 +8,18 @@ import (
 )
 
 func TestCompletionGeneration(t *testing.T) {
-	for _, shell := range []string{"bash", "zsh"} {
-		completionCmd := newCompletionCmd().cmd
-		stdout := bytes.NewBufferString("")
-		stderr := bytes.NewBufferString("")
-		completionCmd.SetOut(stdout)
-		completionCmd.SetErr(stderr)
-		completionCmd.SetArgs([]string{shell})
-		err := completionCmd.Execute()
-		require.NoError(t, err, shell+" arg experienced error with goreleaser completion:\n"+stderr.String())
-		require.Equal(t, "", stderr.String(), shell+" arg experienced error with goreleaser completion:\n"+stderr.String())
-		require.NotEmpty(t, stdout.String(), shell+" arg reported nothing to stdout with goreleaser completion")
+	for _, shell := range []string{"bash", "zsh", "fish"} {
+		t.Run(shell, func(t *testing.T) {
+			completionCmd := newCompletionCmd().cmd
+			stdout := bytes.NewBufferString("")
+			stderr := bytes.NewBufferString("")
+			completionCmd.SetOut(stdout)
+			completionCmd.SetErr(stderr)
+			completionCmd.SetArgs([]string{shell})
+			err := completionCmd.Execute()
+			require.NoError(t, err, shell+" arg experienced error with goreleaser completion:\n"+stderr.String())
+			require.Equal(t, "", stderr.String(), shell+" arg experienced error with goreleaser completion:\n"+stderr.String())
+			require.NotEmpty(t, stdout.String(), shell+" arg reported nothing to stdout with goreleaser completion")
+		})
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -89,8 +89,8 @@ func shouldPrependRelease(cmd *cobra.Command, args []string) bool {
 		return false
 	}
 
-	// allow help command.
-	if len(args) > 0 && args[0] == "help" {
+	// allow help and __complete commands.
+	if len(args) > 0 && (args[0] == "help" || args[0] == "__complete") {
 		return false
 	}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -88,4 +88,8 @@ func TestShouldPrependRelease(t *testing.T) {
 	t.Run("help", func(t *testing.T) {
 		require.False(t, result([]string{"help"}))
 	})
+
+	t.Run("__complete", func(t *testing.T) {
+		require.False(t, result([]string{"help"}))
+	})
 }


### PR DESCRIPTION
refs #1858 #1859

- added fish as well
- allow `__complete` as well (used for fish completions at least)