### PR TITLE
docs: .ArtifactPath is the absolute path, not the relative one.

### DIFF
--- a/www/docs/customization/templates.md
+++ b/www/docs/customization/templates.md
@@ -42,7 +42,7 @@ may have some extra fields:
 | `.Mips`         | `GOMIPS` (usually allow replacements) |
 | `.Binary`       | Binary name                           |
 | `.ArtifactName` | Archive name                          |
-| `.ArtifactPath` | Relative path to artifact             |
+| `.ArtifactPath` | Absolute path to artifact             |
 
 On the NFPM name template field, you can use those extra fields as well:
 


### PR DESCRIPTION
<!-- If applied, this commit will... -->
Change the documentation to reflect reality. Currently the documentation says .ArtifactPath is relative, not absolute.

The issue was raised in #1867 and this should fix the documentation.