### PR TITLE
fix: ensure uniqueness of brew's bin.install

### DIFF
--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -83,17 +83,25 @@ func (Pipe) Default(ctx *context.Context) error {
 		var brew = &ctx.Config.Brews[i]
 
 		if brew.Install == "" {
-			// TODO: maybe replace this with a simplear also optimistic
+			// TODO: maybe replace this with a simpler also optimistic
 			// approach of just doing `bin.install "project_name"`?
 			var installs []string
 			for _, build := range ctx.Config.Builds {
 				if !isBrewBuild(build) {
 					continue
 				}
-				installs = append(
-					installs,
-					fmt.Sprintf(`bin.install "%s"`, build.Binary),
-				)
+				install := fmt.Sprintf(`bin.install "%s"`, build.Binary)
+				// Do not add duplicate "bin.install" statements when binary names overlap.
+				var found bool
+				for _, instruction := range installs {
+					if instruction == install {
+						found = true
+						break
+					}
+				}
+				if !found {
+					installs = append(installs, install)
+				}
 			}
 			brew.Install = strings.Join(installs, "\n")
 			log.Warnf("optimistically guessing `brew[%d].install`, double check", i)

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -825,6 +825,37 @@ func TestRunTokenTypeNotImplementedForBrew(t *testing.T) {
 	require.Equal(t, ErrTokenTypeNotImplementedForBrew{TokenType: "gitea"}, doRun(ctx, ctx.Config.Brews[0], client))
 }
 
+func TestDefaultBinInstallUniqueness(t *testing.T) {
+	_, back := testlib.Mktmp(t)
+	defer back()
+
+	var ctx = &context.Context{
+		TokenType: context.TokenTypeGitHub,
+		Config: config.Project{
+			ProjectName: "myproject",
+			Brews: []config.Homebrew{
+				{},
+			},
+			Builds: []config.Build{
+				{
+					ID:     "macos",
+					Binary: "unique",
+					Goos:   []string{"darwin"},
+					Goarch: []string{"amd64"},
+				},
+				{
+					ID:     "macos-cgo",
+					Binary: "unique",
+					Goos:   []string{"darwin"},
+					Goarch: []string{"amd64"},
+				},
+			},
+		},
+	}
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, `bin.install "unique"`, ctx.Config.Brews[0].Install)
+}
+
 func TestDefault(t *testing.T) {
 	_, back := testlib.Mktmp(t)
 	defer back()


### PR DESCRIPTION
This patch ensures that there are no duplicate `bin.install` statements added to the homebrew formula. It resolves several upstream issues including https://github.com/ory/homebrew-kratos/issues/1 and others.

Closes https://github.com/ory/homebrew-kratos/issues/1
