### PR TITLE
feat: add support for git branch in templates

### DIFF
--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -39,6 +39,7 @@ func (Pipe) Run(ctx *context.Context) error {
 
 // nolint: gochecknoglobals
 var fakeInfo = context.GitInfo{
+	Branch:      "none",
 	CurrentTag:  "v0.0.0",
 	Commit:      "none",
 	ShortCommit: "none",
@@ -65,6 +66,10 @@ func getInfo(ctx *context.Context) (context.GitInfo, error) {
 }
 
 func getGitInfo() (context.GitInfo, error) {
+	branch, err := getBranch()
+	if err != nil {
+		return context.GitInfo{}, fmt.Errorf("couldn't get current branch: %w", err)
+	}
 	short, err := getShortCommit()
 	if err != nil {
 		return context.GitInfo{}, fmt.Errorf("couldn't get current commit: %w", err)
@@ -84,6 +89,7 @@ func getGitInfo() (context.GitInfo, error) {
 	tag, err := getTag()
 	if err != nil {
 		return context.GitInfo{
+			Branch:      branch,
 			Commit:      full,
 			FullCommit:  full,
 			ShortCommit: short,
@@ -93,6 +99,7 @@ func getGitInfo() (context.GitInfo, error) {
 		}, ErrNoTag
 	}
 	return context.GitInfo{
+		Branch:      branch,
 		CurrentTag:  tag,
 		Commit:      full,
 		FullCommit:  full,
@@ -121,6 +128,10 @@ func validate(ctx *context.Context) error {
 		}
 	}
 	return nil
+}
+
+func getBranch() (string, error) {
+	return git.Clean(git.Run("rev-parse", "--abbrev-ref", "HEAD", "--quiet"))
 }
 
 func getCommitDate() (time.Time, error) {

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -41,6 +41,21 @@ func TestSingleCommit(t *testing.T) {
 	require.Equal(t, "v0.0.1", ctx.Git.CurrentTag)
 }
 
+func TestBranch(t *testing.T) {
+	_, back := testlib.Mktmp(t)
+	defer back()
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
+	testlib.GitCommit(t, "test-branch-commit")
+	testlib.GitTag(t, "test-branch-tag")
+	testlib.GitCheckoutBranch(t, "test-branch")
+	var ctx = &context.Context{
+		Config: config.Project{},
+	}
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, "test-branch", ctx.Git.Branch)
+}
+
 func TestNoRemote(t *testing.T) {
 	_, back := testlib.Mktmp(t)
 	defer back()

--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -29,6 +29,7 @@ const (
 	version         = "Version"
 	rawVersion      = "RawVersion"
 	tag             = "Tag"
+	branch          = "Branch"
 	commit          = "Commit"
 	shortCommit     = "ShortCommit"
 	fullCommit      = "FullCommit"
@@ -74,6 +75,7 @@ func New(ctx *context.Context) *Template {
 			version:         ctx.Version,
 			rawVersion:      rawVersionV,
 			tag:             ctx.Git.CurrentTag,
+			branch:          ctx.Git.Branch,
 			commit:          ctx.Git.Commit,
 			shortCommit:     ctx.Git.ShortCommit,
 			fullCommit:      ctx.Git.FullCommit,

--- a/internal/tmpl/tmpl_test.go
+++ b/internal/tmpl/tmpl_test.go
@@ -26,6 +26,7 @@ func TestWithArtifact(t *testing.T) {
 		Minor: 2,
 		Patch: 3,
 	}
+	ctx.Git.Branch = "test-branch"
 	ctx.Git.Commit = "commit"
 	ctx.Git.FullCommit = "fullcommit"
 	ctx.Git.ShortCommit = "shortcommit"
@@ -38,6 +39,7 @@ func TestWithArtifact(t *testing.T) {
 		"1.2.3":       "{{.Version}}",
 		"v1.2.3":      "{{.Tag}}",
 		"1-2-3":       "{{.Major}}-{{.Minor}}-{{.Patch}}",
+		"test-branch": "{{.Branch}}",
 		"commit":      "{{.Commit}}",
 		"fullcommit":  "{{.FullCommit}}",
 		"shortcommit": "{{.ShortCommit}}",

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -18,6 +18,7 @@ import (
 
 // GitInfo includes tags and diffs used in some point.
 type GitInfo struct {
+	Branch      string
 	CurrentTag  string
 	Commit      string
 	ShortCommit string

--- a/www/docs/customization/templates.md
+++ b/www/docs/customization/templates.md
@@ -14,6 +14,7 @@ On fields that support templating, these fields are always available:
 |--------------------|------------------------------------------------------------------------------------------------------------------------------|
 | `.ProjectName`     | the project name                                                                                                             |
 | `.Version`         | the version being released (`v` prefix stripped),<br>or `{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}` in case of snapshot release |
+| `.Branch`          | the current git branch                                                                                                       |
 | `.Tag`             | the current git tag                                                                                                          |
 | `.ShortCommit`     | the git commit short hash                                                                                                    |
 | `.FullCommit`      | the git commit full hash                                                                                                     |


### PR DESCRIPTION
Add a `.Branch` field to the text templates populated by the current git
branch.

Signed-off-by: Ben Kochie <superq@gmail.com>