### PR TITLE
add debconf-templates cookbook

### DIFF
--- a/www/docs/cookbooks/debconf-templates.md
+++ b/www/docs/cookbooks/debconf-templates.md
@@ -19,7 +19,7 @@ Description: Poor misguided one. Why are you installing this package?
  discover the error in your ways.
 ```
 
-Maintainer script file that will trigger questions, usually its `postinst` because all package files are allready installed:
+Maintainer script file that will trigger questions, usually its `postinst` because all package files are already installed:
 
 ```sh
 #!/bin/sh -e

--- a/www/docs/cookbooks/debconf-templates.md
+++ b/www/docs/cookbooks/debconf-templates.md
@@ -1,0 +1,56 @@
+# Use debconf and templates
+
+Deb installation format has a support for user input during installation using [debconf](https://manpages.debian.org/testing/debconf-doc/debconf-devel.7.en.html).
+
+To enable it inside `goreleaser` you need:
+
+`templates` file, what to ask (all templates go into single file):
+
+```none
+Template: foo/like_debian
+Type: boolean
+Description: Do you like Debian?
+ We'd like to know if you like the Debian GNU/Linux system.
+
+Template: foo/why_debian_is_great
+Type: note
+Description: Poor misguided one. Why are you installing this package?
+ Debian is great. As you continue using Debian, we hope you will
+ discover the error in your ways.
+```
+
+Maintainer script file that will trigger questions, usually its `postinst` because all package files are allready installed:
+
+```sh
+#!/bin/sh -e
+
+# Source debconf library.
+. /usr/share/debconf/confmodule
+
+# Do you like debian?
+db_input high foo/like_debian || true
+db_go || true
+
+# Check their answer.
+# with db_get you load value into $RET env variable.
+db_get foo/like_debian
+if [ "$RET" = "false" ]; then
+    # Poor misguided one...
+    db_input high foo/why_debian_is_great || true
+    db_go || true
+fi
+```
+
+Include `templates` and `postinst` in `.goreleaser.yml`:
+
+```yaml
+    overrides:
+      deb:
+        scripts:
+          postinstall: ./deb/postinst
+    deb:
+      scripts:
+        templates: ./deb/templates
+```
+
+Useful tutorial: [Debconf Programmer's Tutorial](http://www.fifi.org/doc/debconf-doc/tutorial.html)

--- a/www/docs/customization/nfpm.md
+++ b/www/docs/customization/nfpm.md
@@ -207,8 +207,9 @@ nfpms:
 
     # Custom configuration applied only to the Deb packager.
     deb:
-      # Custom deb rules script.
+      # Custom deb special files.
       scripts:
+        # Deb rules script.
         rules: foo.sh
         # Deb templates file, when using debconf.
         templates: templates

--- a/www/mkdocs.yml
+++ b/www/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
   - cookbooks/release-a-library.md
   - cookbooks/publish-to-nexus.md
   - cookbooks/cgo-and-crosscompiling.md
+  - cookbooks/debconf-templates.md
 - tutorials.md
 - links.md
 


### PR DESCRIPTION
As promised [here](https://github.com/goreleaser/goreleaser/pull/1849#issuecomment-723122060) :smiley:.
I completed deb package in [our project](https://github.com/ethersphere/bee/pull/962) so I could wrap this up.
Change inside `www/docs/customization/nfpm.md` is to match [nfpm docs](https://goreleaser.com/customization/nfpm/).
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->

<!-- # Provide links to any relevant tickets, URLs or other resources -->
