### PR TITLE
docs: fixing internal links that result in a broken navigation sidebar

### DIFF
--- a/www/docs/customization/archive.md
+++ b/www/docs/customization/archive.md
@@ -76,7 +76,7 @@ archives:
 ```
 
 !!! tip
-    Learn more about the [name template engine](/customization/templates).
+    Learn more about the [name template engine](/customization/templates/).
 
 !!! tip
     You can add entire folders, its subfolders and files by using the glob notation,

--- a/www/docs/customization/blob.md
+++ b/www/docs/customization/blob.md
@@ -64,7 +64,7 @@ blobs:
 ```
 
 !!! tip
-    Learn more about the [name template engine](/customization/templates).
+    Learn more about the [name template engine](/customization/templates/).
 
 ## Authentication
 

--- a/www/docs/customization/build.md
+++ b/www/docs/customization/build.md
@@ -127,7 +127,7 @@ builds:
 ```
 
 !!! tip
-    Learn more about the [name template engine](/customization/templates).
+    Learn more about the [name template engine](/customization/templates/).
 
 Here is an example with multiple binaries:
 
@@ -219,7 +219,7 @@ builds:
        - second-script.sh
 ```
 
-All properties of a hook (`cmd`, `dir` and `env`) support [templating](/customization/templates)
+All properties of a hook (`cmd`, `dir` and `env`) support [templating](/customization/templates/)
 with `post` hooks having binary artifact available (as these run _after_ the build).
 Additionally the following build details are exposed to both `pre` and `post` hooks:
 

--- a/www/docs/customization/checksum.md
+++ b/www/docs/customization/checksum.md
@@ -25,4 +25,4 @@ checksum:
 ```
 
 !!! tip
-    Learn more about the [name template engine](/customization/templates).
+    Learn more about the [name template engine](/customization/templates/).

--- a/www/docs/customization/docker.md
+++ b/www/docs/customization/docker.md
@@ -14,7 +14,7 @@ If you have only one `build` setup,
 the configuration is as easy as adding the
 name of your image to your `.goreleaser.yml` file:
 
-The docker image declaration supports templating. Learn more about the [name template engine](/customization/templates).
+The docker image declaration supports templating. Learn more about the [name template engine](/customization/templates/).
 
 ```yaml
 dockers:
@@ -103,7 +103,7 @@ dockers:
 ```
 
 !!! tip
-    Learn more about the [name template engine](/customization/templates).
+    Learn more about the [name template engine](/customization/templates/).
 
 These settings should allow you to generate multiple Docker images,
 for example, using multiple `FROM` statements,
@@ -130,7 +130,7 @@ This will build and public the following images:
 - `myuser/foo`
 
 !!! tip
-    Learn more about the [name template engine](/customization/templates).
+    Learn more about the [name template engine](/customization/templates/).
 
 ## Keeping docker images updated for current major
 
@@ -162,7 +162,7 @@ With these settings you can hopefully push several different docker images
 with multiple tags.
 
 !!! tip
-    Learn more about the [name template engine](/customization/templates).
+    Learn more about the [name template engine](/customization/templates/).
 
 ## Publishing to multiple docker registries
 
@@ -220,4 +220,4 @@ docker build -t myuser/myimage . \
 ```
 
 !!! tip
-    Learn more about the [name template engine](/customization/templates).
+    Learn more about the [name template engine](/customization/templates/).

--- a/www/docs/customization/homebrew.md
+++ b/www/docs/customization/homebrew.md
@@ -130,7 +130,7 @@ brews:
 ```
 
 !!! tip
-    Learn more about the [name template engine](/customization/templates).
+    Learn more about the [name template engine](/customization/templates/).
 
 By defining the `brew` section, GoReleaser will take care of publishing the
 Homebrew tap.

--- a/www/docs/customization/hooks.md
+++ b/www/docs/customization/hooks.md
@@ -27,4 +27,4 @@ to do things that are more complex than just calling a command with some
 attributes, wrap it in a shell script or into your `Makefile`.
 
 !!! tip
-    Learn more about the [name template engine](/customization/templates).
+    Learn more about the [name template engine](/customization/templates/).

--- a/www/docs/customization/milestone.md
+++ b/www/docs/customization/milestone.md
@@ -32,4 +32,4 @@ milestones:
 ```
 
 !!! tip
-    Learn more about the [name template engine](/customization/templates).
+    Learn more about the [name template engine](/customization/templates/).

--- a/www/docs/customization/nfpm.md
+++ b/www/docs/customization/nfpm.md
@@ -261,4 +261,4 @@ nfpms:
 ```
 
 !!! tip
-    Learn more about the [name template engine](/customization/templates).
+    Learn more about the [name template engine](/customization/templates/).

--- a/www/docs/customization/publishers.md
+++ b/www/docs/customization/publishers.md
@@ -107,4 +107,4 @@ These settings should allow you to push your artifacts to any number of endpoint
 which may require non-trivial authentication or has otherwise complex requirements.
 
 !!! tip
-    Learn more about the [name template engine](/customization/templates).
+    Learn more about the [name template engine](/customization/templates/).

--- a/www/docs/customization/release.md
+++ b/www/docs/customization/release.md
@@ -144,7 +144,7 @@ ALLOWED_TYPES = application/gzip|application/x-gzip|application/x-gtar|applicati
     `draft` and `prerelease` are only supported by GitHub and Gitea.
 
 !!! tip
-    Learn more about the [name template engine](/customization/templates).
+    Learn more about the [name template engine](/customization/templates/).
 
 ## Customize the changelog
 

--- a/www/docs/customization/snapcraft.md
+++ b/www/docs/customization/snapcraft.md
@@ -146,7 +146,7 @@ snapcrafts:
 ```
 
 !!! tip
-    Learn more about the [name template engine](/customization/templates).
+    Learn more about the [name template engine](/customization/templates/).
 
 !!! note
     GoReleaser will not install `snapcraft` nor any of its dependencies for you.

--- a/www/docs/customization/snapshots.md
+++ b/www/docs/customization/snapshots.md
@@ -29,7 +29,7 @@ This means that if you use `{{ .Version }}` on your name templates, you'll
 get the snapshot version.
 
 !!! tip
-    Learn more about the [name template engine](/customization/templates).
+    Learn more about the [name template engine](/customization/templates/).
 
 Note that the idea behind GoReleaser's snapshots if mostly for local builds
 or to validate your build on the CI pipeline. Artifacts shouldn't be uploaded

--- a/www/docs/customization/source.md
+++ b/www/docs/customization/source.md
@@ -23,4 +23,4 @@ source:
 ```
 
 !!! tip
-    Learn more about the [name template engine](/customization/templates).
+    Learn more about the [name template engine](/customization/templates/).

--- a/www/docs/customization/upload.md
+++ b/www/docs/customization/upload.md
@@ -179,4 +179,4 @@ uploads:
 These settings should allow you to push your artifacts into multiple HTTP servers.
 
 !!! tip
-    Learn more about the [name template engine](/customization/templates).
+    Learn more about the [name template engine](/customization/templates/).

--- a/www/docs/limitations/semver.md
+++ b/www/docs/limitations/semver.md
@@ -7,6 +7,6 @@ GoReleaser enforces semantic versioning and will error on non compliant tags.
 Your tag **should** be a valid [semantic version](http://semver.org/).
 If it is not, GoReleaser will error.
 
-The `v` prefix is not mandatory. You can check the [templating](/customization/templates)
+The `v` prefix is not mandatory. You can check the [templating](/customization/templates/)
 documentation to see how to use the tag or each part of the semantic version
 in name templates.


### PR DESCRIPTION
I suspect this is something about the mkdocs template, but I'm not familiar enough, and this is easy.

Explanation:
Following any of these links, the resulting page reads just fine, but the navigation sidebar is lacking part of the expected path, resulting in links that are invalid.

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->
If applied, this commit will fix some internal links, which appear to work, but result in a navigation sidebar with incorrect links.

<!-- Why is this change being made? -->
This change is being made because I couldn't (fairly quickly) figure out where else an appropriate change might be made -- in the mkdocs config or in an upstream project.

<!-- # Provide links to any relevant tickets, URLs or other resources -->
