### PR TITLE
WIP: docs: adds acc test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ site/
 www/docs/static/releases.json
 .vercel
 completions/
+# for acc test setup
+acc-test/gitlab-*
+acc-test/gitea*
+acc-test/homebrew-*

--- a/acc-test/docker-compose-gitea.yml
+++ b/acc-test/docker-compose-gitea.yml
@@ -1,0 +1,25 @@
+version: '3.7'
+
+services:
+  server:
+    image: gitea/gitea:latest
+    hostname: local-gitea
+    container_name: local-gitea
+    environment:
+      - USER_UID=1000
+      - USER_GID=1000
+      - INSTALL_LOCK=true
+      - PASSWORD_COMPLEXITY=off
+      - SSH_PORT=222
+    restart: always
+    networks:
+      - gitea
+    volumes:
+      - ./gitea:/data
+    ports:
+      - "3000:3000"
+      - "222:22"
+
+networks:
+  gitea:
+    name: "gitea-network"

--- a/acc-test/docker-compose-gitlab.yml
+++ b/acc-test/docker-compose-gitlab.yml
@@ -1,0 +1,30 @@
+version: '3.7'
+services:
+  gitlab-web:
+    #image: gitlab/gitlab-ce:10.5.6-ce.0
+    #image: gitlab/gitlab-ce:12.1.4-ce.0
+    #image: gitlab/gitlab-ce:11.7.0-ce.0
+    image: gitlab/gitlab-ce:12.9.4-ce.0
+    container_name: gitlab-web
+    hostname: gitlab-web
+    volumes:
+      - './gitlab-config:/etc/gitlab'
+      - './gitlab-logs:/var/log/gitlab'
+      - './gitlab-data:/var/opt/gitlab'
+    ports:
+      - '2222:22'
+      - '8080:80'
+      - '443:443'
+      - '4567:4567'
+    environment:
+      GITLAB_OMNIBUS_CONFIG: |
+        gitlab_rails['gitlab_shell_ssh_port'] = 2222
+        registry_external_url 'http://localhost:4567'
+        registry['enable'] = true
+        unicorn['socket'] = '/opt/gitlab/var/unicorn/gitlab.socket'
+    networks:
+      - gitlab-network
+
+networks:
+  gitlab-network:
+    name: gitlab-network

--- a/acc-test/goreleaser-gitea-local.yml
+++ b/acc-test/goreleaser-gitea-local.yml
@@ -1,0 +1,73 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+project_name: release-testing
+
+gitea_urls:
+  api: http://gitea-web:3000/api/v1/
+
+release:
+   gitea:
+     owner: mavogel
+     name: release-testing
+before:
+  hooks:
+    # you may remove this if you don't use vgo
+    - go mod download
+builds:
+- env:
+  - CGO_ENABLED=0
+  goos:
+    - linux
+    - darwin
+    - windows
+  goarch:
+    - 386
+    - amd64
+archives:
+- replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'
+brews:
+  -
+    #skip_upload: true
+    name: release-testing
+    tap:
+      owner: mavogel
+      name: homebrew-tap
+    # http://gitea-web:3000/mavogel/release-testing/releases/download/0.3.46/release-testing_0.3.46_Linux_i386.tar.gz  
+    url_template: "http://gitea-web:3000/mavogel/release-testing/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    commit_author:
+      name: "Manuel Vogel"
+      email: mavogel@posteo.de
+    folder: Formula
+    homepage: "http://gitea-web.com/mavogel/release-testing"
+    description: "Software to create fast and easy drum rolls."
+    test: |
+      system "#{bin}/release-testing -r"
+    install: |
+      bin.install "release-testing"
+
+# scoop:
+#   bucket:
+#     owner: mavogel
+#     name: scoop-bucket
+#   url_template: "http://gitea-web:3000/mavogel/release-testing/uploads/{{ .ArtifactUploadHash }}/{{ .ArtifactName }}"
+#   commit_author:
+#     name: "Manuel Vogel"
+#     email: manuel.vogel-extern@deutschebahn.com
+#   homepage: "http://gitea.com/mavogel/release-testing"
+#   description: "Software to create fast and easy drum rolls."
+#   license: MIT

--- a/acc-test/goreleaser-gitlab-local.yml
+++ b/acc-test/goreleaser-gitlab-local.yml
@@ -1,0 +1,73 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+project_name: release-testing
+
+gitlab_urls:
+  api: http://gitlab-web:8080/api/v4/
+  download: http://gitlab-web:8080
+
+release:
+   gitlab:
+     owner: mavogel
+     name: release-testing
+before:
+  hooks:
+    # you may remove this if you don't use vgo
+    - go mod download
+builds:
+- env:
+  - CGO_ENABLED=0
+  goos:
+    - linux
+    - darwin
+    - windows
+  goarch:
+    - 386
+    - amd64
+archives:
+- replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'
+# brews:
+#   -
+#     #skip_upload: true
+#     name: release-testing
+#     gitlab:
+#       owner: mavogel
+#       name: homebrew-tab
+#     url_template: "http://gitlab-web:8080/mavogel/release-testing/uploads/{{ .ArtifactUploadHash }}/{{ .ArtifactName }}"
+#     commit_author:
+#       name: "Manuel Vogel"
+#       email: "mavogel@posteo.de"
+#     folder: Formula
+#     homepage: "http://gitlab-web:8080/mavogel/release-testing"
+#     description: "Software to create fast and easy drum rolls."
+#     test: |
+#       system "#{bin}/release-testing -r"
+#     install: |
+#       bin.install "release-testing"
+
+# scoop:
+#   bucket:
+#     owner: mavogel
+#     name: scoop-bucket
+#   url_template: "http://gitlab-web:8080/mavogel/release-testing/uploads/{{ .ArtifactUploadHash }}/{{ .ArtifactName }}"
+#   commit_author:
+#     name: "Manuel Vogel"
+#     email: manuel.vogel-extern@deutschebahn.com
+#   homepage: "http://gitlab-web:8080/mavogel/release-testing"
+#   description: "Software to create fast and easy drum rolls."
+#   license: MIT

--- a/acc-test/local-gitea.sh
+++ b/acc-test/local-gitea.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+set -e
+
+WORK_DIR=$(pwd)
+USER="goreleaser"
+PASSWORD="testpwd123!"
+EMAIL="goreleaser@acme.com"
+SSH_KEY="$HOME/.ssh/id_rsa_goreleaser"
+HOST="localhost"
+PORT="3000"
+CONTAINER_NAME="local-gitea"
+
+# 0 check prerequisites
+# docker-compose, nc, ssh-keygen
+
+rm -rf "$WORK_DIR"/acc-test/gitea
+
+# 0 check for local ssh key - create if necessary
+if [ ! -f "$SSH_KEY" ]; then
+ echo "SSH KEY at $SSH_KEY does not exist. Creating"
+ ssh-keygen -t rsa -b 4096 -C "$EMAIL" -f "$SSH_KEY" -q -N ""
+fi
+# add it to the agent
+ssh-add "$SSH_KEY"
+ssh-add -l
+
+# 1 start gitea
+docker-compose -f "$WORK_DIR"/acc-test/docker-compose-gitea.yml up -d
+
+# 2 wait until up
+while ! $(nc -z -v -w5 $HOST $PORT); do
+    echo "Waiting for '$HOST/$PORT' to come up... sleep 2"
+    sleep 2
+done
+echo "'$HOST/$PORT' is up. Continuing."
+sleep 5
+
+# 3 create goreleaser user
+# this command creates the user and an access token as well
+ACCESS_TOKEN=$(docker exec $CONTAINER_NAME \
+    gitea admin user create \
+        --username=${USER} \
+        --password=${PASSWORD} \
+        --email=${EMAIL} \
+        --admin=true \
+        --must-change-password=false \
+        --access-token \
+        | grep -o "Access token was successfully created....*" \
+        | sed -ne 's/^.*Access token was successfully created... //p')
+
+echo "ACCESS_TOKEN: '$ACCESS_TOKEN'"
+if [ -z "$ACCESS_TOKEN" ]; then
+    echo "Empty ACCESS_TOKEN"
+    exit 1
+fi
+
+# add the pub key
+# the 'gitea admin user create' command does not have the option to do this
+PAYLOAD=$(echo ' 
+{ 
+    "title": "'${USER}'",
+    "key": "'$(cat ${SSH_KEY}.pub)'",
+    "read_only": false}
+}
+')
+curl -f -X POST "http://$HOST:$PORT/api/v1/user/keys" \
+    -H "accept: application/json" \
+    -H "Authorization: token $ACCESS_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$PAYLOAD" 
+
+# 4 create gorleaser-testing repo
+PAYLOAD=$(echo ' 
+{
+    "auto_init": false,
+    "name": "goreleaser-testing"
+}
+')
+curl -f -X POST "http://$HOST:$PORT/api/v1/user/repos" \
+    -H "accept: application/json" \
+    -H "Authorization: token $ACCESS_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$PAYLOAD"
+
+
+# 5 create homebrew-tap repo
+PAYLOAD=$(echo ' 
+{
+    "auto_init": true,
+    "name": "homebrew-tap"
+}
+')
+curl -f -X POST "http://$HOST:$PORT/api/v1/user/repos" \
+    -H "accept: application/json" \
+    -H "Authorization: token $ACCESS_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$PAYLOAD"
+
+# # create readme.file
+# README=$(echo "
+# # homebrew tap
+# ## Usage
+# \`\`\`sh
+# brew tap ${USER}/gitea-tools ssh://git@localhost:222/${USER}/homebrew-tap.git
+# brew install ${USER}/gitea-tools/goreleaser
+# \`\`\`
+# "
+# )
+
+# create the Formula path
+# PAYLOAD=$(echo ' 
+# {
+#   "content": "",
+#   "message": "chore: adds Formula folder"
+# }
+# ')
+# curl -f -X POST "http://$HOST:$PORT/api/v1/repos/${USER}/homebrew-tap/contents/Formula/.gitkeep" \
+#     -H "accept: application/json" \
+#     -H "Authorization: token $ACCESS_TOKEN" \
+#     -H "Content-Type: application/json" \
+#     -d "$PAYLOAD"
+
+# 6 push to gitea repo
+# fails atm: https://github.com/wkulhanek/docker-openshift-gitea/issues/9
+git remote add origin ssh://git@localhost:222/goreleaser/goreleaser-testing.git
+ssh -vvvT git@localhost -p 222

--- a/acc-test/readme.md
+++ b/acc-test/readme.md
@@ -1,0 +1,15 @@
+# goreleaser accteptance tests
+Currently we test `homebrew-taps` for `gitlab` and `gitea` with a local
+setup and some manual steps. To simplify this process we provide as much
+automation as possible to set up a local instance.
+
+## gitea
+```sh
+# starts and initializes a local server
+acc-test/local-gitea.sh
+# shutdown
+docker-compose -f acc-test/docker-compose-gitea.yml down
+```
+
+## gitlab
+TBD

--- a/www/docs/contributing.md
+++ b/www/docs/contributing.md
@@ -7,3 +7,7 @@ to the project.
 
 Also check the [CONTRIBUTING.md](https://github.com/goreleaser/goreleaser/blob/master/CONTRIBUTING.md)
 file on the root of our repository.
+
+## Acceptance test setup
+To test the releasing process against local VCS like `gitlab` or `gitea`, set it up locally
+and follow the instructions in the `acc-test` folder.

--- a/www/docs/customization/homebrew.md
+++ b/www/docs/customization/homebrew.md
@@ -50,6 +50,7 @@ brews:
     # Template for the url which is determined by the given Token (github or gitlab)
     # Default for github is "https://github.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     # Default for gitlab is "https://gitlab.com/<repo_owner>/<repo_name>/uploads/{{ .ArtifactUploadHash }}/{{ .ArtifactName }}"
+    # Default for gitea is "https://gitea.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     url_template: "http://github.mycompany.com/foo/bar/releases/{{ .Tag }}/{{ .ArtifactName }}"
 
     # Allows you to set a custom download strategy. Note that you'll need

--- a/www/docs/customization/scoop.md
+++ b/www/docs/customization/scoop.md
@@ -15,7 +15,6 @@ scoop:
   # Default for github is "https://github.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
   # Default for gitlab is "https://gitlab.com/<repo_owner>/<repo_name>/uploads/{{ .ArtifactUploadHash }}/{{ .ArtifactName }}"
   # Default for gitea is "https://gitea.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-  # Gitea is not supported yet, but the support coming
   url_template: "http://github.mycompany.com/foo/bar/releases/{{ .Tag }}/{{ .ArtifactName }}"
 
   # Repository to push the app manifest to.

--- a/www/docs/customization/scoop.md
+++ b/www/docs/customization/scoop.md
@@ -14,6 +14,7 @@ scoop:
   # Template for the url which is determined by the given Token (github or gitlab)
   # Default for github is "https://github.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
   # Default for gitlab is "https://gitlab.com/<repo_owner>/<repo_name>/uploads/{{ .ArtifactUploadHash }}/{{ .ArtifactName }}"
+  # Default for gitea is "https://gitea.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
   # Gitea is not supported yet, but the support coming
   url_template: "http://github.mycompany.com/foo/bar/releases/{{ .Tag }}/{{ .ArtifactName }}"
 


### PR DESCRIPTION
## If applied, this commit will...
enhance the documentation for an acceptance test setup for gitlab and gitab

## Why is this change being made?
Contributors can test releasing, brews and scoops locally and set-up quickly a local test environment.

### Provide links to any relevant tickets, URLs or other resources
- https://github.com/goreleaser/goreleaser/pull/1547#issuecomment-731347586
