### PR TITLE
feat: make generated brew formulas `brew audit` compatible (#1908)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -101,6 +101,7 @@ brews:
     folder: Formula
     homepage:  https://goreleaser.com
     description: Deliver Go binaries as fast and easily as possible
+    license: MIT
     test: |
       system "#{bin}/goreleaser -v"
     dependencies:

--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -266,6 +266,7 @@ func dataFor(ctx *context.Context, cfg config.Homebrew, cl client.Client, artifa
 		Desc:             cfg.Description,
 		Homepage:         cfg.Homepage,
 		Version:          ctx.Version,
+		License:          cfg.License,
 		Caveats:          split(cfg.Caveats),
 		Dependencies:     cfg.Dependencies,
 		Conflicts:        cfg.Conflicts,

--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -1,6 +1,7 @@
 package brew
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
@@ -257,7 +258,28 @@ func doBuildFormula(ctx *context.Context, data templateData) (string, error) {
 	if err := t.Execute(&out, data); err != nil {
 		return "", err
 	}
-	return tmpl.New(ctx).Apply(out.String())
+
+	content, err := tmpl.New(ctx).Apply(out.String())
+	if err != nil {
+		return "", err
+	}
+	out.Reset()
+
+	// Sanitize the template output and get rid of trailing whitespace.
+	var (
+		r = strings.NewReader(content)
+		s = bufio.NewScanner(r)
+	)
+	for s.Scan() {
+		l := strings.TrimRight(s.Text(), " ")
+		_, _ = out.WriteString(l)
+		_ = out.WriteByte('\n')
+	}
+	if err := s.Err(); err != nil {
+		return "", err
+	}
+
+	return out.String(), nil
 }
 
 func dataFor(ctx *context.Context, cfg config.Homebrew, cl client.Client, artifacts []*artifact.Artifact) (templateData, error) {

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -72,6 +72,7 @@ func assertDefaultTemplateData(t *testing.T, formulae string) {
 
 func TestFullFormulae(t *testing.T) {
 	data := defaultTemplateData
+	data.License = "MIT"
 	data.Caveats = []string{"Here are some caveats"}
 	data.Dependencies = []config.HomebrewDependency{{Name: "gtk+"}}
 	data.Conflicts = []string{"svn"}

--- a/internal/pipe/brew/template.go
+++ b/internal/pipe/brew/template.go
@@ -7,6 +7,7 @@ type templateData struct {
 	Desc             string
 	Homepage         string
 	Version          string
+	License          string
 	Caveats          []string
 	Plist            string
 	DownloadStrategy string
@@ -36,6 +37,9 @@ class {{ .Name }} < Formula
   desc "{{ .Desc }}"
   homepage "{{ .Homepage }}"
   version "{{ .Version }}"
+  {{ if .License -}}
+  license "{{ .License }}"
+  {{ end -}}
   bottle :unneeded
   {{- if and (not .MacOS.DownloadURL) (or .LinuxAmd64.DownloadURL .LinuxArm.DownloadURL .LinuxArm64.DownloadURL) }}
   depends_on :linux

--- a/internal/pipe/brew/testdata/custom_block.rb.golden
+++ b/internal/pipe/brew/testdata/custom_block.rb.golden
@@ -9,12 +9,12 @@ class CustomBlock < Formula
     url "https://dummyhost/download/v1.0.1/bin.tar.gz"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   end
-  
+
   head "https://github.com/caarlos0/test.git"
-  
+
   depends_on "zsh" => :optional
   depends_on "bash"
-  
+
   conflicts_with "gtk+"
   conflicts_with "qt"
 

--- a/internal/pipe/brew/testdata/custom_download_strategy.rb.golden
+++ b/internal/pipe/brew/testdata/custom_download_strategy.rb.golden
@@ -9,10 +9,10 @@ class CustomDownloadStrategy < Formula
     url "https://dummyhost/download/v1.0.1/bin.tar.gz", :using => GitHubPrivateRepositoryReleaseDownloadStrategy
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   end
-  
+
   depends_on "zsh" => :optional
   depends_on "bash"
-  
+
   conflicts_with "gtk+"
   conflicts_with "qt"
 

--- a/internal/pipe/brew/testdata/custom_require.rb.golden
+++ b/internal/pipe/brew/testdata/custom_require.rb.golden
@@ -10,10 +10,10 @@ class CustomRequire < Formula
     url "https://dummyhost/download/v1.0.1/bin.tar.gz", :using => CustomDownloadStrategy
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   end
-  
+
   depends_on "zsh" => :optional
   depends_on "bash"
-  
+
   conflicts_with "gtk+"
   conflicts_with "qt"
 

--- a/internal/pipe/brew/testdata/default.rb.golden
+++ b/internal/pipe/brew/testdata/default.rb.golden
@@ -9,10 +9,10 @@ class Default < Formula
     url "https://dummyhost/download/v1.0.1/bin.tar.gz"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   end
-  
+
   depends_on "zsh" => :optional
   depends_on "bash"
-  
+
   conflicts_with "gtk+"
   conflicts_with "qt"
 

--- a/internal/pipe/brew/testdata/default_gitlab.rb.golden
+++ b/internal/pipe/brew/testdata/default_gitlab.rb.golden
@@ -9,10 +9,10 @@ class DefaultGitlab < Formula
     url "https://dummyhost/download/v1.0.1/bin.tar.gz"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   end
-  
+
   depends_on "zsh" => :optional
   depends_on "bash"
-  
+
   conflicts_with "gtk+"
   conflicts_with "qt"
 

--- a/internal/pipe/brew/testdata/multiple_armv5.rb.golden
+++ b/internal/pipe/brew/testdata/multiple_armv5.rb.golden
@@ -17,10 +17,10 @@ class MultipleArmv5 < Formula
     url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   end
-  
+
   depends_on "zsh"
   depends_on "bash" => :recommended
-  
+
   conflicts_with "gtk+"
   conflicts_with "qt"
 

--- a/internal/pipe/brew/testdata/multiple_armv6.rb.golden
+++ b/internal/pipe/brew/testdata/multiple_armv6.rb.golden
@@ -17,10 +17,10 @@ class MultipleArmv6 < Formula
     url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   end
-  
+
   depends_on "zsh"
   depends_on "bash" => :recommended
-  
+
   conflicts_with "gtk+"
   conflicts_with "qt"
 

--- a/internal/pipe/brew/testdata/multiple_armv7.rb.golden
+++ b/internal/pipe/brew/testdata/multiple_armv7.rb.golden
@@ -17,10 +17,10 @@ class MultipleArmv7 < Formula
     url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   end
-  
+
   depends_on "zsh"
   depends_on "bash" => :recommended
-  
+
   conflicts_with "gtk+"
   conflicts_with "qt"
 

--- a/internal/pipe/brew/testdata/test.rb.golden
+++ b/internal/pipe/brew/testdata/test.rb.golden
@@ -22,14 +22,14 @@ class Test < Formula
     url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Arm64.tar.gz"
     sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67"
   end
-  
+
   devel do
     url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_x86_64.tar.gz"
     sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c68"
   end
-  
+
   depends_on "gtk+"
-  
+
   conflicts_with "svn"
 
   def install

--- a/internal/pipe/brew/testdata/test.rb.golden
+++ b/internal/pipe/brew/testdata/test.rb.golden
@@ -3,6 +3,7 @@ class Test < Formula
   desc "Some desc"
   homepage "https://google.com"
   version "0.1.3"
+  license "MIT"
   bottle :unneeded
 
   if OS.mac?

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -102,6 +102,7 @@ type Homebrew struct {
 	Conflicts        []string             `yaml:",omitempty"`
 	Description      string               `yaml:",omitempty"`
 	Homepage         string               `yaml:",omitempty"`
+	License          string               `yaml:",omitempty"`
 	SkipUpload       string               `yaml:"skip_upload,omitempty"`
 	DownloadStrategy string               `yaml:"download_strategy,omitempty"`
 	URLTemplate      string               `yaml:"url_template,omitempty"`

--- a/www/docs/customization/homebrew.md
+++ b/www/docs/customization/homebrew.md
@@ -84,6 +84,10 @@ brews:
     # Default is empty.
     description: "Software to create fast and easy drum rolls."
 
+    # SPDX identifier of your app's license.
+    # Default is empty.
+    license: "MIT"
+
     # Setting this will prevent goreleaser to actually try to commit the updated
     # formula - instead, the formula file will be stored on the dist folder only,
     # leaving the responsibility of publishing it to the user.


### PR DESCRIPTION
This PR resolves the issues described in #1908. I want to split this into two commits:

1. Add the license field (optional). If no SPDX license identifier is set, the field won't be present in the generated Formula.
2. Get rid of the whitespaces in otherwise empty lines.

Figuring the first one out was easy but I kinda struggle with the whitespaces. Really never thought that was the hard part... but gotemplates 🤦 