### PR TITLE
fix: prevent error if "dockerfile" isn't set

### DIFF
--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -40,6 +40,9 @@ func (Pipe) Default(ctx *context.Context) error {
 		if docker.Goarch == "" {
 			docker.Goarch = "amd64"
 		}
+		if docker.Dockerfile == "" {
+			docker.Dockerfile = "Dockerfile"
+		}
 		for _, f := range docker.Files {
 			if f == "." || strings.HasPrefix(f, ctx.Config.Dist) {
 				return fmt.Errorf("invalid docker.files: can't be . or inside dist folder: %s", f)
@@ -54,9 +57,6 @@ func (Pipe) Default(ctx *context.Context) error {
 		ctx.Config.Dockers[0].Binaries = []string{
 			ctx.Config.Builds[0].Binary,
 		}
-	}
-	if ctx.Config.Dockers[0].Dockerfile == "" {
-		ctx.Config.Dockers[0].Dockerfile = "Dockerfile"
 	}
 	return nil
 }

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -725,6 +725,24 @@ func TestDefault(t *testing.T) {
 	require.Empty(t, docker.Builds)
 }
 
+func TestDefaultDockerfile(t *testing.T) {
+	var ctx = &context.Context{
+		Config: config.Project{
+			Builds: []config.Build{
+				{},
+			},
+			Dockers: []config.Docker{
+				{},
+				{},
+			},
+		},
+	}
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Len(t, ctx.Config.Dockers, 2)
+	require.Equal(t, "Dockerfile", ctx.Config.Dockers[0].Dockerfile)
+	require.Equal(t, "Dockerfile", ctx.Config.Dockers[1].Dockerfile)
+}
+
 func TestDefaultBinaries(t *testing.T) {
 	var ctx = &context.Context{
 		Config: config.Project{


### PR DESCRIPTION
Closes #1916. The problem was that the default Dockerfile name isn't taken into account if there are several lines in the matrix.

Thanks for this great project.