### PR TITLE
fix: ensure Changelog ends on a newline

### DIFF
--- a/internal/pipe/changelog/changelog.go
+++ b/internal/pipe/changelog/changelog.go
@@ -104,7 +104,11 @@ func (Pipe) Run(ctx *context.Context) error {
 	if len(ctx.ReleaseFooter) > 0 {
 		changelogElements = append(changelogElements, ctx.ReleaseFooter)
 	}
+
 	ctx.ReleaseNotes = strings.Join(changelogElements, "\n\n")
+	if !strings.HasSuffix(ctx.ReleaseNotes, "\n") {
+		ctx.ReleaseNotes += "\n"
+	}
 
 	var path = filepath.Join(ctx.Config.Dist, "CHANGELOG.md")
 	log.WithField("changelog", path).Info("writing")

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -406,6 +406,7 @@ func TestChangeLogWithReleaseFooter(t *testing.T) {
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Contains(t, ctx.ReleaseNotes, "## Changelog")
 	require.Contains(t, ctx.ReleaseNotes, "test footer")
+	require.Equal(t, rune(ctx.ReleaseNotes[len(ctx.ReleaseNotes)-1]), '\n')
 }
 
 func TestChangeLogWithTemplatedReleaseFooter(t *testing.T) {
@@ -432,4 +433,30 @@ func TestChangeLogWithTemplatedReleaseFooter(t *testing.T) {
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Contains(t, ctx.ReleaseNotes, "## Changelog")
 	require.Contains(t, ctx.ReleaseNotes, "test footer with tag v0.0.1")
+	require.Equal(t, rune(ctx.ReleaseNotes[len(ctx.ReleaseNotes)-1]), '\n')
+}
+
+func TestChangeLogWithoutReleaseFooter(t *testing.T) {
+	current, err := os.Getwd()
+	require.NoError(t, err)
+	tmpdir, back := testlib.Mktmp(t)
+	defer back()
+	require.NoError(t, os.Symlink(current+"/testdata", tmpdir+"/testdata"))
+	testlib.GitInit(t)
+	var msgs = []string{
+		"initial commit",
+		"another one",
+		"one more",
+		"and finally this one",
+	}
+	for _, msg := range msgs {
+		testlib.GitCommit(t, msg)
+	}
+	testlib.GitTag(t, "v0.0.1")
+	testlib.GitCheckoutBranch(t, "v0.0.1")
+	var ctx = context.New(config.Project{})
+	ctx.Git.CurrentTag = "v0.0.1"
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Contains(t, ctx.ReleaseNotes, "## Changelog")
+	require.Equal(t, rune(ctx.ReleaseNotes[len(ctx.ReleaseNotes)-1]), '\n')
 }


### PR DESCRIPTION
This ensures the Changelog ends with a trailing newline, regardless of a footer being set.

Also added tests to verify this behavior.