### PR TITLE
Support __completeNoDesc hidden command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,8 +87,9 @@ func shouldPrependRelease(cmd *cobra.Command, args []string) bool {
 		return false
 	}
 
-	// allow help and __complete commands.
-	if len(args) > 0 && (args[0] == "help" || args[0] == "__complete") {
+	// allow help and the two __complete commands.
+	if len(args) > 0 && (args[0] == "help" ||
+		args[0] == cobra.ShellCompRequestCmd || args[0] == cobra.ShellCompNoDescRequestCmd) {
 		return false
 	}
 


### PR DESCRIPTION
While investigating https://github.com/spf13/cobra/issues/1279, I noticed that turning off descriptions does not currently work for goreleaser.  And that this could impact bash completion if `ValidArgsFunction` is to eventually be used.

The `__completeNoDesc` command is used by bash to request completion without any descriptions.  It is an alias for the `__complete` command. It must be properly supported for `cobra.Command.ValidArgsFunction` to work with bash completion.

You can test this change by turning off descriptions for Fish completion at this line by changing `true` to `false`:
https://github.com/goreleaser/goreleaser/blob/c0119436136826241bb1a926a65d526f9ae417ce/cmd/completion.go#L57

Then without this PR, fish completion will be broken.

This test is representative because `bash` does not support descriptions, so instead of using `__complete` it uses `__completeNoDesc`.

