### PR TITLE
fix: nfpm signing error with `--skip-sign` when gpg key is not found

### DIFF
--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -218,6 +218,12 @@ func create(ctx *context.Context, fpm config.NFPM, format, arch string, binaries
 		},
 	}
 
+	if ctx.SkipSign {
+		info.APK.Signature = nfpm.APKSignature{}
+		info.RPM.Signature = nfpm.RPMSignature{}
+		info.Deb.Signature = nfpm.DebSignature{}
+	}
+
 	if err = nfpm.Validate(info); err != nil {
 		return fmt.Errorf("invalid nfpm config: %w", err)
 	}

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -671,3 +671,76 @@ func TestMeta(t *testing.T) {
 		}
 	}
 }
+
+func TestSkipSign(t *testing.T) {
+	folder, err := ioutil.TempDir("", "archivetest")
+	require.NoError(t, err)
+	var dist = filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0755))
+	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
+	var binPath = filepath.Join(dist, "mybin", "mybin")
+	_, err = os.Create(binPath)
+	require.NoError(t, err)
+	var ctx = context.New(config.Project{
+		ProjectName: "mybin",
+		Dist:        dist,
+		NFPMs: []config.NFPM{
+			{
+				ID:      "someid",
+				Builds:  []string{"default"},
+				Formats: []string{"deb", "rpm", "apk"},
+				NFPMOverridables: config.NFPMOverridables{
+					PackageName:      "foo",
+					FileNameTemplate: defaultNameTemplate,
+					Files: map[string]string{
+						"./testdata/testfile.txt": "/usr/share/testfile.txt",
+					},
+					Deb: config.NFPMDeb{
+						Signature: config.NFPMDebSignature{
+							KeyFile: "/does/not/exist.gpg",
+						},
+					},
+					RPM: config.NFPMRPM{
+						Signature: config.NFPMRPMSignature{
+							KeyFile: "/does/not/exist.gpg",
+						},
+					},
+					APK: config.NFPMAPK{
+						Signature: config.NFPMAPKSignature{
+							KeyFile: "/does/not/exist.gpg",
+						},
+					},
+				},
+			},
+		},
+	})
+	ctx.Version = "1.0.0"
+	ctx.Git = context.GitInfo{CurrentTag: "v1.0.0"}
+	for _, goos := range []string{"linux", "darwin"} {
+		for _, goarch := range []string{"amd64", "386"} {
+			ctx.Artifacts.Add(&artifact.Artifact{
+				Name:   "mybin",
+				Path:   binPath,
+				Goarch: goarch,
+				Goos:   goos,
+				Type:   artifact.Binary,
+				Extra: map[string]interface{}{
+					"ID": "default",
+				},
+			})
+		}
+	}
+
+	t.Run("skip sign not set", func(t *testing.T) {
+		require.Contains(
+			t,
+			Pipe{}.Run(ctx).Error(),
+			`nfpm failed: failed to create signatures: call to signer failed: signing error: reading PGP key file: open /does/not/exist.gpg: no such file or directory`,
+		)
+	})
+
+	t.Run("skip sign set", func(t *testing.T) {
+		ctx.SkipSign = true
+		require.NoError(t, Pipe{}.Run(ctx))
+	})
+}


### PR DESCRIPTION
<!-- If applied, this commit will... -->
Currently the following command will fail:

```
goreleaser release --snapshot --rm-dist --skip-sign
⨯ release failed after 4.74s error=nfpm failed: signing error: armored detach sign: reading PGP key file: open /tmp/key.gpg: no such file or directory
```

<!-- Why is this change being made? -->
If I do not want to sign the packages with the `--skip-sign` flag (just want to build the rpm,debs etc...)  the command should not fail when there is no signing key available.
<!-- # Provide links to any relevant tickets, URLs or other resources -->
I am not sure if the fix is in the correct place :man_shrugging: Maybe there is a better way to do it.
