### PR TITLE
refactor(test): use testing.TB Cleanup and Tempdir

### DIFF
--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -9,16 +9,14 @@ import (
 )
 
 func TestBuild(t *testing.T) {
-	_, back := setup(t)
-	defer back()
+	setup(t)
 	var cmd = newBuildCmd()
 	cmd.cmd.SetArgs([]string{"--snapshot", "--timeout=1m", "--parallelism=2", "--deprecated"})
 	require.NoError(t, cmd.cmd.Execute())
 }
 
 func TestBuildInvalidConfig(t *testing.T) {
-	_, back := setup(t)
-	defer back()
+	setup(t)
 	createFile(t, "goreleaser.yml", "foo: bar")
 	var cmd = newBuildCmd()
 	cmd.cmd.SetArgs([]string{"--snapshot", "--timeout=1m", "--parallelism=2", "--deprecated"})
@@ -26,8 +24,7 @@ func TestBuildInvalidConfig(t *testing.T) {
 }
 
 func TestBuildBrokenProject(t *testing.T) {
-	_, back := setup(t)
-	defer back()
+	setup(t)
 	createFile(t, "main.go", "not a valid go file")
 	var cmd = newBuildCmd()
 	cmd.cmd.SetArgs([]string{"--snapshot", "--timeout=1m", "--parallelism=2"})

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -17,8 +17,7 @@ func TestConfigFlagNotSetButExists(t *testing.T) {
 		"goreleaser.yaml",
 	} {
 		t.Run(name, func(t *testing.T) {
-			folder, back := setup(t)
-			defer back()
+			var folder = setup(t)
 			require.NoError(t, os.Rename(
 				filepath.Join(folder, "goreleaser.yml"),
 				filepath.Join(folder, name),
@@ -31,8 +30,7 @@ func TestConfigFlagNotSetButExists(t *testing.T) {
 }
 
 func TestConfigFileDoesntExist(t *testing.T) {
-	folder, back := setup(t)
-	defer back()
+	var folder = setup(t)
 	err := os.Remove(filepath.Join(folder, "goreleaser.yml"))
 	require.NoError(t, err)
 	proj, err := loadConfig("")

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,7 +9,7 @@ import (
 )
 
 func TestInit(t *testing.T) {
-	var folder = mktemp(t)
+	var folder = t.TempDir()
 	var cmd = newInitCmd().cmd
 	var path = filepath.Join(folder, "foo.yaml")
 	cmd.SetArgs([]string{"-f", path})
@@ -19,7 +18,7 @@ func TestInit(t *testing.T) {
 }
 
 func TestInitFileExists(t *testing.T) {
-	var folder = mktemp(t)
+	var folder = t.TempDir()
 	var cmd = newInitCmd().cmd
 	var path = filepath.Join(folder, "twice.yaml")
 	cmd.SetArgs([]string{"-f", path})
@@ -29,16 +28,10 @@ func TestInitFileExists(t *testing.T) {
 }
 
 func TestInitFileError(t *testing.T) {
-	var folder = mktemp(t)
+	var folder = t.TempDir()
 	var cmd = newInitCmd().cmd
 	var path = filepath.Join(folder, "nope.yaml")
 	require.NoError(t, os.Chmod(folder, 0000))
 	cmd.SetArgs([]string{"-f", path})
 	require.EqualError(t, cmd.Execute(), "open "+path+": permission denied")
-}
-
-func mktemp(t *testing.T) string {
-	folder, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	return folder
 }

--- a/cmd/release_test.go
+++ b/cmd/release_test.go
@@ -9,16 +9,14 @@ import (
 )
 
 func TestRelease(t *testing.T) {
-	_, back := setup(t)
-	defer back()
+	setup(t)
 	var cmd = newReleaseCmd()
 	cmd.cmd.SetArgs([]string{"--snapshot", "--timeout=1m", "--parallelism=2", "--deprecated"})
 	require.NoError(t, cmd.cmd.Execute())
 }
 
 func TestReleaseInvalidConfig(t *testing.T) {
-	_, back := setup(t)
-	defer back()
+	setup(t)
 	createFile(t, "goreleaser.yml", "foo: bar")
 	var cmd = newReleaseCmd()
 	cmd.cmd.SetArgs([]string{"--snapshot", "--timeout=1m", "--parallelism=2", "--deprecated"})
@@ -26,8 +24,7 @@ func TestReleaseInvalidConfig(t *testing.T) {
 }
 
 func TestReleaseBrokenProject(t *testing.T) {
-	_, back := setup(t)
-	defer back()
+	setup(t)
 	createFile(t, "main.go", "not a valid go file")
 	var cmd = newReleaseCmd()
 	cmd.cmd.SetArgs([]string{"--snapshot", "--timeout=1m", "--parallelism=2"})

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -41,8 +41,7 @@ func TestRootCmdExitCode(t *testing.T) {
 }
 
 func TestRootRelease(t *testing.T) {
-	_, back := setup(t)
-	defer back()
+	setup(t)
 	var mem = &exitMemento{}
 	var cmd = newRootCmd("", mem.Exit)
 	cmd.Execute([]string{})
@@ -50,8 +49,7 @@ func TestRootRelease(t *testing.T) {
 }
 
 func TestRootReleaseDebug(t *testing.T) {
-	_, back := setup(t)
-	defer back()
+	setup(t)
 	var mem = &exitMemento{}
 	var cmd = newRootCmd("", mem.Exit)
 	cmd.Execute([]string{"r", "--debug"})

--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -155,8 +155,7 @@ func TestGroupByPlatform(t *testing.T) {
 }
 
 func TestChecksum(t *testing.T) {
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var file = filepath.Join(folder, "subject")
 	require.NoError(t, ioutil.WriteFile(file, []byte("lorem ipsum"), 0644))
 

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -149,8 +149,7 @@ func TestInvalidTargets(t *testing.T) {
 }
 
 func TestBuild(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	writeGoodMain(t, folder)
 	var config = config.Project{
 		Builds: []config.Build{
@@ -310,8 +309,7 @@ func TestBuild(t *testing.T) {
 }
 
 func TestBuildCodeInSubdir(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	subdir := filepath.Join(folder, "bar")
 	err := os.Mkdir(subdir, 0755)
 	require.NoError(t, err)
@@ -343,8 +341,7 @@ func TestBuildCodeInSubdir(t *testing.T) {
 }
 
 func TestBuildWithDotGoDir(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	require.NoError(t, os.Mkdir(filepath.Join(folder, ".go"), 0755))
 	writeGoodMain(t, folder)
 	var config = config.Project{
@@ -370,8 +367,7 @@ func TestBuildWithDotGoDir(t *testing.T) {
 }
 
 func TestBuildFailed(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	writeGoodMain(t, folder)
 	var config = config.Project{
 		Builds: []config.Build{
@@ -395,8 +391,7 @@ func TestBuildFailed(t *testing.T) {
 }
 
 func TestBuildInvalidTarget(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	writeGoodMain(t, folder)
 	var target = "linux"
 	var config = config.Project{
@@ -421,8 +416,7 @@ func TestBuildInvalidTarget(t *testing.T) {
 }
 
 func TestRunInvalidAsmflags(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	writeGoodMain(t, folder)
 	var config = config.Project{
 		Builds: []config.Build{
@@ -444,8 +438,7 @@ func TestRunInvalidAsmflags(t *testing.T) {
 }
 
 func TestRunInvalidGcflags(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	writeGoodMain(t, folder)
 	var config = config.Project{
 		Builds: []config.Build{
@@ -467,8 +460,7 @@ func TestRunInvalidGcflags(t *testing.T) {
 }
 
 func TestRunInvalidLdflags(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	writeGoodMain(t, folder)
 	var config = config.Project{
 		Builds: []config.Build{
@@ -491,8 +483,7 @@ func TestRunInvalidLdflags(t *testing.T) {
 }
 
 func TestRunInvalidFlags(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	writeGoodMain(t, folder)
 	var config = config.Project{
 		Builds: []config.Build{
@@ -513,8 +504,7 @@ func TestRunInvalidFlags(t *testing.T) {
 }
 
 func TestRunPipeWithoutMainFunc(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	writeMainWithoutMainFunc(t, folder)
 	var config = config.Project{
 		Builds: []config.Build{
@@ -556,8 +546,7 @@ func TestRunPipeWithoutMainFunc(t *testing.T) {
 }
 
 func TestRunPipeWithMainFuncNotInMainGoFile(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	require.NoError(t, ioutil.WriteFile(
 		filepath.Join(folder, "foo.go"),
 		[]byte("package main\nfunc main() {println(0)}"),
@@ -717,8 +706,7 @@ func TestBuildModTimestamp(t *testing.T) {
 	// round to seconds since this will be a unix timestamp
 	modTime := time.Now().AddDate(-1, 0, 0).Round(1 * time.Second).UTC()
 
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	writeGoodMain(t, folder)
 
 	var config = config.Project{

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -3,7 +3,6 @@ package exec
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,9 +29,7 @@ func TestExecute(t *testing.T) {
 
 	// Preload artifacts
 	ctx.Artifacts = artifact.New()
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
-	defer os.RemoveAll(folder)
+	var folder = t.TempDir()
 	for _, a := range []struct {
 		id  string
 		ext string

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestRepoName(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:goreleaser/goreleaser.git")
 	repo, err := git.ExtractRepoFromConfig()

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -25,8 +25,7 @@ func TestGit(t *testing.T) {
 }
 
 func TestGitWarning(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitCommit(t, "foo")
 	testlib.GitBranch(t, "tags/1.2.2")

--- a/internal/http/http_test.go
+++ b/internal/http/http_test.go
@@ -219,8 +219,7 @@ func TestUpload(t *testing.T) {
 	ctx.Env["TEST_A_USERNAME"] = "u2"
 	ctx.Version = "2.1.0"
 	ctx.Artifacts = artifact.New()
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	for _, a := range []struct {
 		ext string
 		typ artifact.Type

--- a/internal/pipe/archive/archive_test.go
+++ b/internal/pipe/archive/archive_test.go
@@ -795,18 +795,19 @@ func TestRunPipeSameArchiveFilename(t *testing.T) {
 }
 
 func TestDuplicateFilesInsideArchive(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
+	var folder = t.TempDir()
+
+	f, err := ioutil.TempFile(folder, "")
 	require.NoError(t, err)
 	defer f.Close()
-	defer os.Remove(f.Name())
 
-	ff, err := ioutil.TempFile("", "")
+	ff, err := ioutil.TempFile(folder, "")
 	require.NoError(t, err)
 	defer ff.Close()
-	defer os.Remove(ff.Name())
 
 	a := NewEnhancedArchive(archive.New(f), "")
 	defer a.Close()
+
 	require.NoError(t, a.Add("foo", ff.Name()))
 	require.EqualError(t, a.Add("foo", ff.Name()), "file foo already exists in the archive")
 }

--- a/internal/pipe/archive/archive_test.go
+++ b/internal/pipe/archive/archive_test.go
@@ -31,8 +31,7 @@ func createFakeBinary(t *testing.T, dist, arch, bin string) {
 }
 
 func TestRunPipe(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	for _, format := range []string{"tar.gz", "zip"} {
 		t.Run("Archive format "+format, func(tt *testing.T) {
 			var dist = filepath.Join(folder, format+"_dist")
@@ -180,8 +179,7 @@ func TestRunPipe(t *testing.T) {
 }
 
 func TestRunPipeDifferentBinaryCount(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	for _, arch := range []string{"darwinamd64", "linuxamd64"} {
@@ -252,8 +250,7 @@ func TestRunPipeDifferentBinaryCount(t *testing.T) {
 }
 
 func TestRunPipeNoBinaries(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	var ctx = context.New(config.Project{
@@ -301,8 +298,7 @@ func tarFiles(t *testing.T, path string) []string {
 }
 
 func TestRunPipeBinary(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "darwinamd64"), 0755))
@@ -390,8 +386,7 @@ func TestRunPipeDistRemoved(t *testing.T) {
 }
 
 func TestRunPipeInvalidGlob(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "darwinamd64"), 0755))
@@ -428,8 +423,7 @@ func TestRunPipeInvalidGlob(t *testing.T) {
 }
 
 func TestRunPipeInvalidNameTemplate(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "darwinamd64"), 0755))
@@ -463,8 +457,7 @@ func TestRunPipeInvalidNameTemplate(t *testing.T) {
 }
 
 func TestRunPipeInvalidFilesNameTemplate(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "darwinamd64"), 0755))
@@ -501,8 +494,7 @@ func TestRunPipeInvalidFilesNameTemplate(t *testing.T) {
 }
 
 func TestRunPipeInvalidWrapInDirectoryTemplate(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "darwinamd64"), 0755))
@@ -537,8 +529,7 @@ func TestRunPipeInvalidWrapInDirectoryTemplate(t *testing.T) {
 }
 
 func TestRunPipeWrap(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "darwinamd64"), 0755))
@@ -670,8 +661,7 @@ func TestFormatFor(t *testing.T) {
 }
 
 func TestBinaryOverride(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "darwinamd64"), 0755))
@@ -748,8 +738,7 @@ func TestBinaryOverride(t *testing.T) {
 }
 
 func TestRunPipeSameArchiveFilename(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "darwinamd64"), 0755))

--- a/internal/pipe/artifactory/artifactory_test.go
+++ b/internal/pipe/artifactory/artifactory_test.go
@@ -55,15 +55,13 @@ func TestRunPipe_ModeBinary(t *testing.T) {
 	setup()
 	defer teardown()
 
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
-	err = ioutil.WriteFile(binPath, d1, 0666)
-	require.NoError(t, err)
+	require.NoError(t, ioutil.WriteFile(binPath, d1, 0666))
 
 	// Dummy artifactories
 	mux.HandleFunc("/example-repo-local/mybin/darwin/amd64/mybin", func(w http.ResponseWriter, r *http.Request) {
@@ -214,8 +212,7 @@ func TestRunPipe_ModeArchive(t *testing.T) {
 	setup()
 	defer teardown()
 
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	tarfile, err := os.Create(filepath.Join(folder, "bin.tar.gz"))
 	require.NoError(t, err)
 	debfile, err := os.Create(filepath.Join(folder, "bin.deb"))
@@ -316,8 +313,7 @@ func TestRunPipe_ModeArchive(t *testing.T) {
 }
 
 func TestRunPipe_ArtifactoryDown(t *testing.T) {
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	tarfile, err := os.Create(filepath.Join(folder, "bin.tar.gz"))
 	require.NoError(t, err)
 
@@ -350,8 +346,7 @@ func TestRunPipe_ArtifactoryDown(t *testing.T) {
 }
 
 func TestRunPipe_TargetTemplateError(t *testing.T) {
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 
@@ -390,15 +385,13 @@ func TestRunPipe_BadCredentials(t *testing.T) {
 	setup()
 	defer teardown()
 
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
-	err = ioutil.WriteFile(binPath, d1, 0666)
-	require.NoError(t, err)
+	require.NoError(t, ioutil.WriteFile(binPath, d1, 0666))
 
 	// Dummy artifactories
 	mux.HandleFunc("/example-repo-local/mybin/darwin/amd64/mybin", func(w http.ResponseWriter, r *http.Request) {
@@ -443,7 +436,7 @@ func TestRunPipe_BadCredentials(t *testing.T) {
 	})
 
 	require.NoError(t, Pipe{}.Default(ctx))
-	err = Pipe{}.Publish(ctx)
+	var err = Pipe{}.Publish(ctx)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Bad credentials")
 }
@@ -452,15 +445,13 @@ func TestRunPipe_UnparsableErrorResponse(t *testing.T) {
 	setup()
 	defer teardown()
 
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
-	err = ioutil.WriteFile(binPath, d1, 0666)
-	require.NoError(t, err)
+	require.NoError(t, ioutil.WriteFile(binPath, d1, 0666))
 
 	// Dummy artifactories
 	mux.HandleFunc("/example-repo-local/mybin/darwin/amd64/mybin", func(w http.ResponseWriter, r *http.Request) {
@@ -539,15 +530,13 @@ func TestRunPipe_FileNotFound(t *testing.T) {
 }
 
 func TestRunPipe_UnparsableTarget(t *testing.T) {
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
-	err = ioutil.WriteFile(binPath, d1, 0666)
-	require.NoError(t, err)
+	require.NoError(t, ioutil.WriteFile(binPath, d1, 0666))
 
 	var ctx = context.New(config.Project{
 		ProjectName: "mybin",
@@ -605,8 +594,7 @@ func TestRunPipe_SkipWhenPublishFalse(t *testing.T) {
 }
 
 func TestRunPipe_DirUpload(t *testing.T) {
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))

--- a/internal/pipe/blob/blob_minio_test.go
+++ b/internal/pipe/blob/blob_minio_test.go
@@ -24,8 +24,7 @@ import (
 
 func TestMinioUpload(t *testing.T) {
 	var listen = randomListen(t)
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	srcpath := filepath.Join(folder, "source.tar.gz")
 	tgzpath := filepath.Join(folder, "bin.tar.gz")
 	debpath := filepath.Join(folder, "bin.deb")
@@ -93,15 +92,13 @@ func TestMinioUpload(t *testing.T) {
 
 func TestMinioUploadCustomBucketID(t *testing.T) {
 	var listen = randomListen(t)
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	tgzpath := filepath.Join(folder, "bin.tar.gz")
 	debpath := filepath.Join(folder, "bin.deb")
 	require.NoError(t, ioutil.WriteFile(tgzpath, []byte("fake\ntargz"), 0744))
 	require.NoError(t, ioutil.WriteFile(debpath, []byte("fake\ndeb"), 0744))
 	// Set custom BUCKET_ID env variable.
-	err = os.Setenv("BUCKET_ID", "test")
-	require.NoError(t, err)
+	require.NoError(t, os.Setenv("BUCKET_ID", "test"))
 	var ctx = context.New(config.Project{
 		Dist:        folder,
 		ProjectName: "testupload",
@@ -133,14 +130,11 @@ func TestMinioUploadCustomBucketID(t *testing.T) {
 
 func TestMinioUploadInvalidCustomBucketID(t *testing.T) {
 	var listen = randomListen(t)
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	tgzpath := filepath.Join(folder, "bin.tar.gz")
 	debpath := filepath.Join(folder, "bin.deb")
 	require.NoError(t, ioutil.WriteFile(tgzpath, []byte("fake\ntargz"), 0744))
 	require.NoError(t, ioutil.WriteFile(debpath, []byte("fake\ndeb"), 0744))
-	// Set custom BUCKET_ID env variable.
-	require.NoError(t, err)
 	var ctx = context.New(config.Project{
 		Dist:        folder,
 		ProjectName: "testupload",
@@ -172,8 +166,7 @@ func TestMinioUploadInvalidCustomBucketID(t *testing.T) {
 
 func TestMinioUploadSkipPublish(t *testing.T) {
 	var listen = randomListen(t)
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	srcpath := filepath.Join(folder, "source.tar.gz")
 	tgzpath := filepath.Join(folder, "bin.tar.gz")
 	debpath := filepath.Join(folder, "bin.deb")

--- a/internal/pipe/blob/blob_test.go
+++ b/internal/pipe/blob/blob_test.go
@@ -122,8 +122,7 @@ func TestPipe_PublishExtraFiles(t *testing.T) {
 func pipePublish(t *testing.T, extra []config.ExtraFile) {
 	gcloudCredentials, _ := filepath.Abs("./testdata/credentials.json")
 
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	tgzpath := filepath.Join(folder, "bin.tar.gz")
 	debpath := filepath.Join(folder, "bin.deb")
 	require.NoError(t, ioutil.WriteFile(tgzpath, []byte("fake\ntargz"), 0744))

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -174,8 +174,7 @@ func TestRunPipe(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			folder, err := ioutil.TempDir("", "goreleasertest")
-			require.NoError(t, err)
+			var folder = t.TempDir()
 			var ctx = &context.Context{
 				Git: context.GitInfo{
 					CurrentTag: "v1.0.1",
@@ -232,7 +231,7 @@ func TestRunPipe(t *testing.T) {
 				},
 			})
 
-			_, err = os.Create(path)
+			_, err := os.Create(path)
 			require.NoError(t, err)
 			client := &DummyClient{}
 			var distFile = filepath.Join(folder, name+".rb")
@@ -255,8 +254,7 @@ func TestRunPipe(t *testing.T) {
 }
 
 func TestRunPipeNameTemplate(t *testing.T) {
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var ctx = &context.Context{
 		Git: context.GitInfo{
 			CurrentTag: "v1.0.1",
@@ -297,7 +295,7 @@ func TestRunPipeNameTemplate(t *testing.T) {
 		},
 	})
 
-	_, err = os.Create(path)
+	_, err := os.Create(path)
 	require.NoError(t, err)
 	client := &DummyClient{}
 	var distFile = filepath.Join(folder, "foo_is_bar.rb")
@@ -318,8 +316,7 @@ func TestRunPipeNameTemplate(t *testing.T) {
 }
 
 func TestRunPipeMultipleBrewsWithSkip(t *testing.T) {
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var ctx = &context.Context{
 		Git: context.GitInfo{
 			CurrentTag: "v1.0.1",
@@ -382,7 +379,7 @@ func TestRunPipeMultipleBrewsWithSkip(t *testing.T) {
 		},
 	})
 
-	_, err = os.Create(path)
+	_, err := os.Create(path)
 	require.NoError(t, err)
 
 	var cli = &DummyClient{}
@@ -409,8 +406,7 @@ func TestRunPipeForMultipleArmVersions(t *testing.T) {
 			ctx.Config.Brews[0].Goarm = "7"
 		},
 	} {
-		folder, err := ioutil.TempDir("", "goreleasertest")
-		require.NoError(t, err)
+		var folder = t.TempDir()
 		var ctx = &context.Context{
 			TokenType: context.TokenTypeGitHub,
 			Git: context.GitInfo{
@@ -723,8 +719,7 @@ func TestRunPipeBinaryRelease(t *testing.T) {
 }
 
 func TestRunPipeNoUpload(t *testing.T) {
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var ctx = context.New(config.Project{
 		Dist:        folder,
 		ProjectName: "foo",
@@ -741,7 +736,7 @@ func TestRunPipeNoUpload(t *testing.T) {
 	ctx.TokenType = context.TokenTypeGitHub
 	ctx.Git = context.GitInfo{CurrentTag: "v1.0.1"}
 	var path = filepath.Join(folder, "whatever.tar.gz")
-	_, err = os.Create(path)
+	_, err := os.Create(path)
 	require.NoError(t, err)
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "bin",
@@ -775,8 +770,7 @@ func TestRunPipeNoUpload(t *testing.T) {
 }
 
 func TestRunEmptyTokenType(t *testing.T) {
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var ctx = context.New(config.Project{
 		Dist:        folder,
 		ProjectName: "foo",
@@ -792,7 +786,7 @@ func TestRunEmptyTokenType(t *testing.T) {
 	})
 	ctx.Git = context.GitInfo{CurrentTag: "v1.0.1"}
 	var path = filepath.Join(folder, "whatever.tar.gz")
-	_, err = os.Create(path)
+	_, err := os.Create(path)
 	require.NoError(t, err)
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "bin",
@@ -810,8 +804,7 @@ func TestRunEmptyTokenType(t *testing.T) {
 }
 
 func TestRunTokenTypeNotImplementedForBrew(t *testing.T) {
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var ctx = context.New(config.Project{
 		Dist:        folder,
 		ProjectName: "foo",
@@ -828,7 +821,7 @@ func TestRunTokenTypeNotImplementedForBrew(t *testing.T) {
 	ctx.TokenType = context.TokenTypeGitea
 	ctx.Git = context.GitInfo{CurrentTag: "v1.0.1"}
 	var path = filepath.Join(folder, "whatever.tar.gz")
-	_, err = os.Create(path)
+	_, err := os.Create(path)
 	require.NoError(t, err)
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "bin",

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -846,8 +846,7 @@ func TestRunTokenTypeNotImplementedForBrew(t *testing.T) {
 }
 
 func TestDefaultBinInstallUniqueness(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 
 	var ctx = &context.Context{
 		TokenType: context.TokenTypeGitHub,
@@ -877,8 +876,7 @@ func TestDefaultBinInstallUniqueness(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 
 	var ctx = &context.Context{
 		TokenType: context.TokenTypeGitHub,

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -731,7 +731,7 @@ func TestBuildOptionsForTarget(t *testing.T) {
 }
 
 func TestHookComplex(t *testing.T) {
-	var tmpDir = testlib.Mktmp(t)
+	var tmp = testlib.Mktmp(t)
 
 	require.NoError(t, runHook(context.New(config.Project{}), api.Options{}, []string{}, config.BuildHooks{
 		{

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -63,8 +63,7 @@ func TestPipeDescription(t *testing.T) {
 }
 
 func TestBuild(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	var config = config.Project{
 		Dist: folder,
 		Builds: []config.Build{
@@ -92,8 +91,7 @@ func TestBuild(t *testing.T) {
 }
 
 func TestRunPipe(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	var config = config.Project{
 		Dist: folder,
 		Builds: []config.Build{
@@ -115,8 +113,7 @@ func TestRunPipe(t *testing.T) {
 }
 
 func TestRunFullPipe(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	var pre = filepath.Join(folder, "pre")
 	var post = filepath.Join(folder, "post")
 	var config = config.Project{
@@ -152,8 +149,7 @@ func TestRunFullPipe(t *testing.T) {
 }
 
 func TestRunFullPipeFail(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	var pre = filepath.Join(folder, "pre")
 	var post = filepath.Join(folder, "post")
 	var config = config.Project{
@@ -184,8 +180,7 @@ func TestRunFullPipeFail(t *testing.T) {
 }
 
 func TestRunPipeFailingHooks(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	var cfg = config.Project{
 		Dist: folder,
 		Builds: []config.Build{
@@ -221,8 +216,7 @@ func TestDefaultNoBuilds(t *testing.T) {
 }
 
 func TestDefaultFail(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	var config = config.Project{
 		Dist: folder,
 		Builds: []config.Build{
@@ -359,8 +353,7 @@ func TestDefaultPartialBuilds(t *testing.T) {
 }
 
 func TestDefaultFillSingleBuild(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 
 	var ctx = &context.Context{
 		Config: config.Project{
@@ -376,8 +369,7 @@ func TestDefaultFillSingleBuild(t *testing.T) {
 }
 
 func TestDefaultFailSingleBuild(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	var config = config.Project{
 		Dist: folder,
 		SingleBuild: config.Build{
@@ -390,8 +382,7 @@ func TestDefaultFailSingleBuild(t *testing.T) {
 }
 
 func TestSkipBuild(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	var config = config.Project{
 		Dist: folder,
 		Builds: []config.Build{
@@ -631,9 +622,7 @@ touch "$BAR"`
 }
 
 func TestBuild_hooksKnowGoosGoarch(t *testing.T) {
-	tmpDir, back := testlib.Mktmp(t)
-	defer back()
-
+	var tmpDir = testlib.Mktmp(t)
 	build := config.Build{
 		Lang:   "fake",
 		Goarch: []string{"amd64"},
@@ -717,8 +706,7 @@ func TestPipeOnBuild_invalidBinaryTpl(t *testing.T) {
 }
 
 func TestBuildOptionsForTarget(t *testing.T) {
-	tmpDir, back := testlib.Mktmp(t)
-	defer back()
+	var tmpDir = testlib.Mktmp(t)
 
 	build := config.Build{
 		ID:     "testid",
@@ -745,8 +733,7 @@ func TestBuildOptionsForTarget(t *testing.T) {
 }
 
 func TestHookComplex(t *testing.T) {
-	tmp, back := testlib.Mktmp(t)
-	defer back()
+	var tmpDir = testlib.Mktmp(t)
 
 	require.NoError(t, runHook(context.New(config.Project{}), api.Options{}, []string{}, config.BuildHooks{
 		{
@@ -770,8 +757,7 @@ func TestHookInvalidShelCommand(t *testing.T) {
 }
 
 func TestRunHookFailWithLogs(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	var config = config.Project{
 		Dist: folder,
 		Builds: []config.Build{

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -437,8 +437,7 @@ func TestTemplate(t *testing.T) {
 }
 
 func TestRunHookEnvs(t *testing.T) {
-	tmp, back := testlib.Mktmp(t)
-	defer back()
+	var tmp = testlib.Mktmp(t)
 
 	var build = config.Build{
 		Env: []string{
@@ -653,8 +652,7 @@ func TestBuild_hooksKnowGoosGoarch(t *testing.T) {
 }
 
 func TestPipeOnBuild_hooksRunPerTarget(t *testing.T) {
-	tmpDir, back := testlib.Mktmp(t)
-	defer back()
+	var tmpDir = testlib.Mktmp(t)
 
 	build := config.Build{
 		Lang:   "fake",

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -326,7 +326,7 @@ func TestChangelogOnBranchWithSameNameAsTag(t *testing.T) {
 func TestChangeLogWithReleaseHeader(t *testing.T) {
 	current, err := os.Getwd()
 	require.NoError(t, err)
-	var tmpDir = testlib.Mktmp(t)
+	var tmpdir = testlib.Mktmp(t)
 	require.NoError(t, os.Symlink(current+"/testdata", tmpdir+"/testdata"))
 	testlib.GitInit(t)
 	var msgs = []string{
@@ -351,7 +351,7 @@ func TestChangeLogWithReleaseHeader(t *testing.T) {
 func TestChangeLogWithTemplatedReleaseHeader(t *testing.T) {
 	current, err := os.Getwd()
 	require.NoError(t, err)
-	var tmpDir = testlib.Mktmp(t)
+	var tmpdir = testlib.Mktmp(t)
 	require.NoError(t, os.Symlink(current+"/testdata", tmpdir+"/testdata"))
 	testlib.GitInit(t)
 	var msgs = []string{
@@ -375,7 +375,7 @@ func TestChangeLogWithTemplatedReleaseHeader(t *testing.T) {
 func TestChangeLogWithReleaseFooter(t *testing.T) {
 	current, err := os.Getwd()
 	require.NoError(t, err)
-	var tmpDir = testlib.Mktmp(t)
+	var tmpdir = testlib.Mktmp(t)
 	require.NoError(t, os.Symlink(current+"/testdata", tmpdir+"/testdata"))
 	testlib.GitInit(t)
 	var msgs = []string{
@@ -401,7 +401,7 @@ func TestChangeLogWithReleaseFooter(t *testing.T) {
 func TestChangeLogWithTemplatedReleaseFooter(t *testing.T) {
 	current, err := os.Getwd()
 	require.NoError(t, err)
-	var tmpDir = testlib.Mktmp(t)
+	var tmpdir = testlib.Mktmp(t)
 	require.NoError(t, os.Symlink(current+"/testdata", tmpdir+"/testdata"))
 	testlib.GitInit(t)
 	var msgs = []string{
@@ -427,7 +427,7 @@ func TestChangeLogWithTemplatedReleaseFooter(t *testing.T) {
 func TestChangeLogWithoutReleaseFooter(t *testing.T) {
 	current, err := os.Getwd()
 	require.NoError(t, err)
-	var tmpDir = testlib.Mktmp(t)
+	var tmpdir = testlib.Mktmp(t)
 	require.NoError(t, os.Symlink(current+"/testdata", tmpdir+"/testdata"))
 	testlib.GitInit(t)
 	var msgs = []string{

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -74,8 +74,7 @@ func TestSnapshot(t *testing.T) {
 }
 
 func TestChangelog(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitCommit(t, "first")
 	testlib.GitTag(t, "v0.0.1")
@@ -118,8 +117,7 @@ func TestChangelog(t *testing.T) {
 }
 
 func TestChangelogPreviousTagEnv(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitCommit(t, "first")
 	testlib.GitTag(t, "v0.0.1")
@@ -142,8 +140,7 @@ func TestChangelogPreviousTagEnv(t *testing.T) {
 }
 
 func TestChangelogForGitlab(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitCommit(t, "first")
 	testlib.GitTag(t, "v0.0.1")
@@ -187,8 +184,7 @@ func TestChangelogForGitlab(t *testing.T) {
 }
 
 func TestChangelogSort(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitCommit(t, "whatever")
 	testlib.GitTag(t, "v0.9.9")
@@ -254,8 +250,7 @@ func TestChangelogInvalidSort(t *testing.T) {
 }
 
 func TestChangelogOfFirstRelease(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	var msgs = []string{
 		"initial commit",
@@ -277,8 +272,7 @@ func TestChangelogOfFirstRelease(t *testing.T) {
 }
 
 func TestChangelogFilterInvalidRegex(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitCommit(t, "commitssss")
 	testlib.GitTag(t, "v0.0.3")
@@ -298,8 +292,7 @@ func TestChangelogFilterInvalidRegex(t *testing.T) {
 }
 
 func TestChangelogNoTags(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitCommit(t, "first")
 	var ctx = context.New(config.Project{})
@@ -308,8 +301,7 @@ func TestChangelogNoTags(t *testing.T) {
 }
 
 func TestChangelogOnBranchWithSameNameAsTag(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	var msgs = []string{
 		"initial commit",
@@ -334,8 +326,7 @@ func TestChangelogOnBranchWithSameNameAsTag(t *testing.T) {
 func TestChangeLogWithReleaseHeader(t *testing.T) {
 	current, err := os.Getwd()
 	require.NoError(t, err)
-	tmpdir, back := testlib.Mktmp(t)
-	defer back()
+	var tmpDir = testlib.Mktmp(t)
 	require.NoError(t, os.Symlink(current+"/testdata", tmpdir+"/testdata"))
 	testlib.GitInit(t)
 	var msgs = []string{
@@ -360,8 +351,7 @@ func TestChangeLogWithReleaseHeader(t *testing.T) {
 func TestChangeLogWithTemplatedReleaseHeader(t *testing.T) {
 	current, err := os.Getwd()
 	require.NoError(t, err)
-	tmpdir, back := testlib.Mktmp(t)
-	defer back()
+	var tmpDir = testlib.Mktmp(t)
 	require.NoError(t, os.Symlink(current+"/testdata", tmpdir+"/testdata"))
 	testlib.GitInit(t)
 	var msgs = []string{
@@ -385,8 +375,7 @@ func TestChangeLogWithTemplatedReleaseHeader(t *testing.T) {
 func TestChangeLogWithReleaseFooter(t *testing.T) {
 	current, err := os.Getwd()
 	require.NoError(t, err)
-	tmpdir, back := testlib.Mktmp(t)
-	defer back()
+	var tmpDir = testlib.Mktmp(t)
 	require.NoError(t, os.Symlink(current+"/testdata", tmpdir+"/testdata"))
 	testlib.GitInit(t)
 	var msgs = []string{
@@ -412,8 +401,7 @@ func TestChangeLogWithReleaseFooter(t *testing.T) {
 func TestChangeLogWithTemplatedReleaseFooter(t *testing.T) {
 	current, err := os.Getwd()
 	require.NoError(t, err)
-	tmpdir, back := testlib.Mktmp(t)
-	defer back()
+	var tmpDir = testlib.Mktmp(t)
 	require.NoError(t, os.Symlink(current+"/testdata", tmpdir+"/testdata"))
 	testlib.GitInit(t)
 	var msgs = []string{
@@ -439,8 +427,7 @@ func TestChangeLogWithTemplatedReleaseFooter(t *testing.T) {
 func TestChangeLogWithoutReleaseFooter(t *testing.T) {
 	current, err := os.Getwd()
 	require.NoError(t, err)
-	tmpdir, back := testlib.Mktmp(t)
-	defer back()
+	var tmpDir = testlib.Mktmp(t)
 	require.NoError(t, os.Symlink(current+"/testdata", tmpdir+"/testdata"))
 	testlib.GitInit(t)
 	var msgs = []string{

--- a/internal/pipe/checksums/checksums_test.go
+++ b/internal/pipe/checksums/checksums_test.go
@@ -46,8 +46,7 @@ func TestPipe(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			folder, err := ioutil.TempDir("", "goreleasertest")
-			require.NoError(t, err)
+			var folder = t.TempDir()
 			var file = filepath.Join(folder, binary)
 			require.NoError(t, ioutil.WriteFile(file, []byte("some string"), 0644))
 			var ctx = context.New(
@@ -104,8 +103,7 @@ func TestPipe(t *testing.T) {
 }
 
 func TestPipeSkipTrue(t *testing.T) {
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var ctx = context.New(
 		config.Project{
 			Dist: folder,
@@ -114,14 +112,13 @@ func TestPipeSkipTrue(t *testing.T) {
 			},
 		},
 	)
-	err = Pipe{}.Run(ctx)
+	var err = Pipe{}.Run(ctx)
 	testlib.AssertSkipped(t, err)
 	require.EqualError(t, err, `checksum.disable is set`)
 }
 
 func TestPipeFileNotExist(t *testing.T) {
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var ctx = context.New(
 		config.Project{
 			Dist: folder,
@@ -136,7 +133,7 @@ func TestPipeFileNotExist(t *testing.T) {
 		Path: "/nope",
 		Type: artifact.UploadableBinary,
 	})
-	err = Pipe{}.Run(ctx)
+	var err = Pipe{}.Run(ctx)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "/nope: no such file or directory")
 }
@@ -152,8 +149,7 @@ func TestPipeInvalidNameTemplate(t *testing.T) {
 		"{{.Env.NOPE}}":           `template: tmpl:1:6: executing "tmpl" at <.Env.NOPE>: map has no entry for key "NOPE"`,
 	} {
 		t.Run(template, func(tt *testing.T) {
-			folder, err := ioutil.TempDir("", "goreleasertest")
-			require.NoError(tt, err)
+			var folder = t.TempDir()
 			var ctx = context.New(
 				config.Project{
 					Dist:        folder,
@@ -183,8 +179,7 @@ func TestPipeCouldNotOpenChecksumsTxt(t *testing.T) {
 	_, err = binFile.WriteString("fake artifact")
 	require.NoError(t, err)
 
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var file = filepath.Join(folder, "checksums.txt")
 	require.NoError(t, ioutil.WriteFile(file, []byte("some string"), 0000))
 	var ctx = context.New(

--- a/internal/pipe/defaults/defaults_test.go
+++ b/internal/pipe/defaults/defaults_test.go
@@ -14,8 +14,7 @@ func TestDescription(t *testing.T) {
 }
 
 func TestFillBasicData(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:goreleaser/goreleaser.git")
 
@@ -44,8 +43,7 @@ func TestFillBasicData(t *testing.T) {
 }
 
 func TestFillPartial(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:goreleaser/goreleaser.git")
 

--- a/internal/pipe/dist/dist_test.go
+++ b/internal/pipe/dist/dist_test.go
@@ -1,7 +1,6 @@
 package dist
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,8 +11,7 @@ import (
 )
 
 func TestDistDoesNotExist(t *testing.T) {
-	folder, err := ioutil.TempDir("", "disttest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(
 		t,
@@ -28,11 +26,10 @@ func TestDistDoesNotExist(t *testing.T) {
 }
 
 func TestPopulatedDistExists(t *testing.T) {
-	folder, err := ioutil.TempDir("", "disttest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
-	_, err = os.Create(filepath.Join(dist, "mybin"))
+	_, err := os.Create(filepath.Join(dist, "mybin"))
 	require.NoError(t, err)
 	var ctx = &context.Context{
 		Config: config.Project{
@@ -47,8 +44,7 @@ func TestPopulatedDistExists(t *testing.T) {
 }
 
 func TestEmptyDistExists(t *testing.T) {
-	folder, err := ioutil.TempDir("", "disttest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	var ctx = &context.Context{
@@ -57,7 +53,7 @@ func TestEmptyDistExists(t *testing.T) {
 		},
 	}
 	require.NoError(t, Pipe{}.Run(ctx))
-	_, err = os.Stat(dist)
+	_, err := os.Stat(dist)
 	require.False(t, os.IsNotExist(err))
 }
 

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -1076,8 +1076,8 @@ func TestLinkTwoLevelDirectory(t *testing.T) {
 	const testFile = "test"
 
 	require.NoError(t, os.Mkdir(srcLevel2, 0755))
-	require.NoError(t, ioutil.WriteFile(srcDir+"/"+testFile, []byte("foo"), 0644))
-	require.NoError(t, ioutil.WriteFile(srcLevel2+"/"+testFile, []byte("foo"), 0644))
+	require.NoError(t, ioutil.WriteFile(filepath.Join(srcDir, testFile), []byte("foo"), 0644))
+	require.NoError(t, ioutil.WriteFile(filepath.Join(srcLevel2, testFile), []byte("foo"), 0644))
 
 	require.NoError(t, link(srcDir, dstDir))
 

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -729,12 +729,11 @@ func TestRunPipe(t *testing.T) {
 
 	for name, docker := range table {
 		t.Run(name, func(tt *testing.T) {
-			folder, err := ioutil.TempDir("", "dockertest")
-			require.NoError(tt, err)
+			var folder = t.TempDir()
 			var dist = filepath.Join(folder, "dist")
 			require.NoError(tt, os.Mkdir(dist, 0755))
 			require.NoError(tt, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
-			_, err = os.Create(filepath.Join(dist, "mybin", "mybin"))
+			_, err := os.Create(filepath.Join(dist, "mybin", "mybin"))
 			require.NoError(tt, err)
 			_, err = os.Create(filepath.Join(dist, "mybin", "anotherbin"))
 			require.NoError(tt, err)
@@ -1062,94 +1061,28 @@ func TestLinkFile(t *testing.T) {
 }
 
 func TestLinkDirectory(t *testing.T) {
-	const srcDir = "/tmp/testdir"
+	var srcDir = t.TempDir()
+	var dstDir = t.TempDir()
 	const testFile = "test"
-	const dstDir = "/tmp/linkedDir"
-
-	err := os.Mkdir(srcDir, 0755)
-	if err != nil {
-		t.Log(fmt.Sprintf("Cannot create dir: %s", srcDir))
-		t.Fail()
-	}
-	err = ioutil.WriteFile(srcDir+"/"+testFile, []byte("foo"), 0644)
-	if err != nil {
-		t.Log("Cannot setup test file")
-		t.Fail()
-	}
-	err = link(srcDir, dstDir)
-	if err != nil {
-		t.Log("Failed to link: ", err)
-		t.Fail()
-	}
-	if inode(srcDir+"/"+testFile) != inode(dstDir+"/"+testFile) {
-		t.Log("Inodes do not match, destination file is not a link")
-		t.Fail()
-	}
-
-	// cleanup
-	err = os.RemoveAll(srcDir)
-	if err != nil {
-		t.Log(fmt.Sprintf("Cannot remove dir: %s", srcDir))
-		t.Fail()
-	}
-	err = os.RemoveAll(dstDir)
-	if err != nil {
-		t.Log(fmt.Sprintf("Cannot remove dir: %s", dstDir))
-		t.Fail()
-	}
+	require.NoError(t, ioutil.WriteFile(filepath.Join(srcDir, testFile), []byte("foo"), 0644))
+	require.NoError(t, link(srcDir, dstDir))
+	require.Equal(t, inode(filepath.Join(srcDir, testFile)), inode(filepath.Join(dstDir, testFile)))
 }
 
 func TestLinkTwoLevelDirectory(t *testing.T) {
-	const srcDir = "/tmp/testdir"
-	const srcLevel2 = srcDir + "/level2"
+	var srcDir = t.TempDir()
+	var dstDir = t.TempDir()
+	var srcLevel2 = filepath.Join(srcDir, "level2")
 	const testFile = "test"
-	const dstDir = "/tmp/linkedDir"
 
-	err := os.Mkdir(srcDir, 0755)
-	if err != nil {
-		t.Log(fmt.Sprintf("Cannot create dir: %s", srcDir))
-		t.Fail()
-	}
-	err = os.Mkdir(srcLevel2, 0755)
-	if err != nil {
-		t.Log(fmt.Sprintf("Cannot create dir: %s", srcLevel2))
-		t.Fail()
-	}
-	err = ioutil.WriteFile(srcDir+"/"+testFile, []byte("foo"), 0644)
-	if err != nil {
-		t.Log("Cannot setup test file")
-		t.Fail()
-	}
-	err = ioutil.WriteFile(srcLevel2+"/"+testFile, []byte("foo"), 0644)
-	if err != nil {
-		t.Log("Cannot setup test file")
-		t.Fail()
-	}
-	err = link(srcDir, dstDir)
-	if err != nil {
-		t.Log("Failed to link: ", err)
-		t.Fail()
-	}
-	if inode(srcDir+"/"+testFile) != inode(dstDir+"/"+testFile) {
-		t.Log("Inodes do not match")
-		t.Fail()
-	}
-	if inode(srcLevel2+"/"+testFile) != inode(dstDir+"/level2/"+testFile) {
-		t.Log("Inodes do not match")
-		t.Fail()
-	}
+	require.NoError(t, os.Mkdir(srcLevel2, 0755))
+	require.NoError(t, ioutil.WriteFile(srcDir+"/"+testFile, []byte("foo"), 0644))
+	require.NoError(t, ioutil.WriteFile(srcLevel2+"/"+testFile, []byte("foo"), 0644))
 
-	// cleanup
-	err = os.RemoveAll(srcDir)
-	if err != nil {
-		t.Log(fmt.Sprintf("Cannot remove dir: %s", srcDir))
-		t.Fail()
-	}
-	err = os.RemoveAll(dstDir)
-	if err != nil {
-		t.Log(fmt.Sprintf("Cannot remove dir: %s", dstDir))
-		t.Fail()
-	}
+	require.NoError(t, link(srcDir, dstDir))
+
+	require.Equal(t, inode(filepath.Join(srcDir, testFile)), inode(filepath.Join(dstDir, testFile)))
+	require.Equal(t, inode(filepath.Join(srcLevel2, testFile)), inode(filepath.Join(dstDir, "level2", testFile)))
 }
 
 func inode(file string) uint64 {

--- a/internal/pipe/effectiveconfig/config_test.go
+++ b/internal/pipe/effectiveconfig/config_test.go
@@ -17,8 +17,7 @@ func TestPipeDescription(t *testing.T) {
 }
 
 func Test(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	var ctx = context.New(

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -19,8 +19,7 @@ func TestDescription(t *testing.T) {
 }
 
 func TestNotAGitFolder(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}
@@ -28,8 +27,7 @@ func TestNotAGitFolder(t *testing.T) {
 }
 
 func TestSingleCommit(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	testlib.GitCommit(t, "commit1")
@@ -42,8 +40,7 @@ func TestSingleCommit(t *testing.T) {
 }
 
 func TestBranch(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	testlib.GitCommit(t, "test-branch-commit")
@@ -57,8 +54,7 @@ func TestBranch(t *testing.T) {
 }
 
 func TestNoRemote(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitCommit(t, "commit1")
 	testlib.GitTag(t, "v0.0.1")
@@ -69,8 +65,7 @@ func TestNoRemote(t *testing.T) {
 }
 
 func TestNewRepository(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	var ctx = &context.Context{
 		Config: config.Project{},
@@ -83,8 +78,7 @@ func TestNewRepository(t *testing.T) {
 // only contains simple commits and no tags. In this case you have
 // to set the --snapshot flag otherwise an error is returned.
 func TestNoTagsNoSnapshot(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	testlib.GitCommit(t, "first")
@@ -94,8 +88,7 @@ func TestNoTagsNoSnapshot(t *testing.T) {
 }
 
 func TestDirty(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	dummy, err := os.Create(filepath.Join(folder, "dummy"))
@@ -124,8 +117,7 @@ func TestDirty(t *testing.T) {
 }
 
 func TestTagIsNotLastCommit(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	testlib.GitCommit(t, "commit3")
@@ -137,8 +129,7 @@ func TestTagIsNotLastCommit(t *testing.T) {
 }
 
 func TestValidState(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	testlib.GitCommit(t, "commit3")
@@ -152,8 +143,7 @@ func TestValidState(t *testing.T) {
 }
 
 func TestSnapshotNoTags(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	testlib.GitAdd(t)
@@ -165,8 +155,7 @@ func TestSnapshotNoTags(t *testing.T) {
 }
 
 func TestSnapshotNoCommits(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	var ctx = context.New(config.Project{})
@@ -176,8 +165,7 @@ func TestSnapshotNoCommits(t *testing.T) {
 }
 
 func TestSnapshotWithoutRepo(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	var ctx = context.New(config.Project{})
 	ctx.Snapshot = true
 	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
@@ -185,8 +173,7 @@ func TestSnapshotWithoutRepo(t *testing.T) {
 }
 
 func TestSnapshotDirty(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	testlib.GitAdd(t)
@@ -208,8 +195,7 @@ func TestGitNotInPath(t *testing.T) {
 }
 
 func TestTagFromCI(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	testlib.GitCommit(t, "commit1")
@@ -249,8 +235,7 @@ func TestCommitDate(t *testing.T) {
 	// round to seconds since this is expressed in a Unix timestamp
 	commitDate := time.Now().AddDate(-1, 0, 0).Round(1 * time.Second)
 
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	testlib.GitCommitWithDate(t, "commit1", commitDate)

--- a/internal/pipe/milestone/milestone_test.go
+++ b/internal/pipe/milestone/milestone_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestDefaultWithRepoConfig(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:githubowner/githubrepo.git")
 
@@ -38,8 +37,7 @@ func TestDefaultWithRepoConfig(t *testing.T) {
 }
 
 func TestDefaultWithRepoRemote(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:githubowner/githubrepo.git")
 
@@ -65,8 +63,7 @@ func TestDefaultWithNameTemplate(t *testing.T) {
 }
 
 func TestDefaultWithoutGitRepo(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}
@@ -76,8 +73,7 @@ func TestDefaultWithoutGitRepo(t *testing.T) {
 }
 
 func TestDefaultWithoutGitRepoOrigin(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}
@@ -88,8 +84,7 @@ func TestDefaultWithoutGitRepoOrigin(t *testing.T) {
 }
 
 func TestDefaultWithoutGitRepoSnapshot(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -1,7 +1,6 @@
 package nfpm
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -73,13 +72,12 @@ func TestRunPipeInvalidFormat(t *testing.T) {
 }
 
 func TestRunPipe(t *testing.T) {
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
-	_, err = os.Create(binPath)
+	_, err := os.Create(binPath)
 	require.NoError(t, err)
 	var ctx = context.New(config.Project{
 		ProjectName: "mybin",
@@ -212,8 +210,7 @@ func TestNoBuildsFound(t *testing.T) {
 }
 
 func TestCreateFileDoesntExist(t *testing.T) {
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
@@ -251,8 +248,7 @@ func TestCreateFileDoesntExist(t *testing.T) {
 }
 
 func TestInvalidConfig(t *testing.T) {
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
@@ -352,13 +348,12 @@ func TestOverrides(t *testing.T) {
 }
 
 func TestDebSpecificConfig(t *testing.T) {
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
-	_, err = os.Create(binPath)
+	_, err := os.Create(binPath)
 	require.NoError(t, err)
 	var ctx = context.New(config.Project{
 		ProjectName: "mybin",
@@ -423,13 +418,12 @@ func TestDebSpecificConfig(t *testing.T) {
 }
 
 func TestRPMSpecificConfig(t *testing.T) {
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
-	_, err = os.Create(binPath)
+	_, err := os.Create(binPath)
 	require.NoError(t, err)
 	var ctx = context.New(config.Project{
 		ProjectName: "mybin",
@@ -494,13 +488,12 @@ func TestRPMSpecificConfig(t *testing.T) {
 }
 
 func TestAPKSpecificConfig(t *testing.T) {
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
-	_, err = os.Create(binPath)
+	_, err := os.Create(binPath)
 	require.NoError(t, err)
 	var ctx = context.New(config.Project{
 		ProjectName: "mybin",
@@ -582,13 +575,12 @@ func TestSeveralNFPMsWithTheSameID(t *testing.T) {
 }
 
 func TestMeta(t *testing.T) {
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
-	_, err = os.Create(binPath)
+	_, err := os.Create(binPath)
 	require.NoError(t, err)
 	var ctx = context.New(config.Project{
 		ProjectName: "mybin",

--- a/internal/pipe/release/release_test.go
+++ b/internal/pipe/release/release_test.go
@@ -322,8 +322,7 @@ func TestPipeDisabled(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:goreleaser/goreleaser.git")
 
@@ -335,8 +334,7 @@ func TestDefault(t *testing.T) {
 }
 
 func TestDefaultWithGitlab(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@gitlab.com:gitlabowner/gitlabrepo.git")
 
@@ -348,8 +346,7 @@ func TestDefaultWithGitlab(t *testing.T) {
 }
 
 func TestDefaultWithGitea(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@gitea.example.com:giteaowner/gitearepo.git")
 
@@ -361,8 +358,7 @@ func TestDefaultWithGitea(t *testing.T) {
 }
 
 func TestDefaultPreReleaseAuto(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:goreleaser/goreleaser.git")
 
@@ -422,8 +418,7 @@ func TestDefaultPreReleaseAuto(t *testing.T) {
 }
 
 func TestDefaultPipeDisabled(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:goreleaser/goreleaser.git")
 
@@ -439,8 +434,7 @@ func TestDefaultPipeDisabled(t *testing.T) {
 }
 
 func TestDefaultFilled(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:goreleaser/goreleaser.git")
 
@@ -461,8 +455,7 @@ func TestDefaultFilled(t *testing.T) {
 }
 
 func TestDefaultNotAGitRepo(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}
@@ -472,8 +465,7 @@ func TestDefaultNotAGitRepo(t *testing.T) {
 }
 
 func TestDefaultGitRepoWithoutOrigin(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}
@@ -484,8 +476,7 @@ func TestDefaultGitRepoWithoutOrigin(t *testing.T) {
 }
 
 func TestDefaultNotAGitRepoSnapshot(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}
@@ -496,8 +487,7 @@ func TestDefaultNotAGitRepoSnapshot(t *testing.T) {
 }
 
 func TestDefaultGitRepoWithoutRemote(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 	var ctx = &context.Context{
 		Config: config.Project{},
 	}

--- a/internal/pipe/release/release_test.go
+++ b/internal/pipe/release/release_test.go
@@ -23,8 +23,7 @@ func TestPipeDescription(t *testing.T) {
 }
 
 func TestRunPipeWithoutIDsThenDoesNotFilter(t *testing.T) {
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	tarfile, err := os.Create(filepath.Join(folder, "bin.tar.gz"))
 	require.NoError(t, err)
 	srcfile, err := os.Create(filepath.Join(folder, "source.tar.gz"))
@@ -99,8 +98,7 @@ func TestRunPipeWithoutIDsThenDoesNotFilter(t *testing.T) {
 }
 
 func TestRunPipeWithIDsThenFilters(t *testing.T) {
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	tarfile, err := os.Create(filepath.Join(folder, "bin.tar.gz"))
 	require.NoError(t, err)
 	debfile, err := os.Create(filepath.Join(folder, "bin.deb"))
@@ -210,8 +208,7 @@ func TestRunPipeWithFileThatDontExist(t *testing.T) {
 }
 
 func TestRunPipeUploadFailure(t *testing.T) {
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	tarfile, err := os.Create(filepath.Join(folder, "bin.tar.gz"))
 	require.NoError(t, err)
 	var config = config.Project{
@@ -282,8 +279,7 @@ func TestRunPipeExtraOverride(t *testing.T) {
 }
 
 func TestRunPipeUploadRetry(t *testing.T) {
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	tarfile, err := os.Create(filepath.Join(folder, "bin.tar.gz"))
 	require.NoError(t, err)
 	var config = config.Project{

--- a/internal/pipe/scoop/scoop_test.go
+++ b/internal/pipe/scoop/scoop_test.go
@@ -24,8 +24,7 @@ func TestDescription(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	_, back := testlib.Mktmp(t)
-	defer back()
+	testlib.Mktmp(t)
 
 	var ctx = &context.Context{
 		TokenType: context.TokenTypeGitHub,
@@ -61,8 +60,7 @@ func TestDefault(t *testing.T) {
 }
 
 func Test_doRun(t *testing.T) {
-	folder, back := testlib.Mktmp(t)
-	defer back()
+	var folder = testlib.Mktmp(t)
 	var file = filepath.Join(folder, "archive")
 	require.NoError(t, ioutil.WriteFile(file, []byte("lorem ipsum"), 0644))
 

--- a/internal/pipe/scoop/scoop_test.go
+++ b/internal/pipe/scoop/scoop_test.go
@@ -742,8 +742,7 @@ func Test_doRun(t *testing.T) {
 }
 
 func Test_buildManifest(t *testing.T) {
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var file = filepath.Join(folder, "archive")
 	require.NoError(t, ioutil.WriteFile(file, []byte("lorem ipsum"), 0644))
 
@@ -974,8 +973,7 @@ func Test_buildManifest(t *testing.T) {
 }
 
 func TestWrapInDirectory(t *testing.T) {
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var file = filepath.Join(folder, "archive")
 	require.NoError(t, ioutil.WriteFile(file, []byte("lorem ipsum"), 0644))
 	var ctx = &context.Context{

--- a/internal/pipe/snapcraft/snapcraft_test.go
+++ b/internal/pipe/snapcraft/snapcraft_test.go
@@ -45,12 +45,9 @@ func TestRunPipeMissingInfo(t *testing.T) {
 }
 
 func TestRunPipe(t *testing.T) {
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
-	defer os.RemoveAll(folder)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
-	require.NoError(t, err)
 	var ctx = context.New(config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
@@ -88,12 +85,9 @@ func TestRunPipe(t *testing.T) {
 }
 
 func TestRunPipeInvalidNameTemplate(t *testing.T) {
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
-	defer os.RemoveAll(folder)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
-	require.NoError(t, err)
 	var ctx = context.New(config.Project{
 		ProjectName: "foo",
 		Dist:        dist,
@@ -113,12 +107,9 @@ func TestRunPipeInvalidNameTemplate(t *testing.T) {
 }
 
 func TestRunPipeWithName(t *testing.T) {
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
-	defer os.RemoveAll(folder)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
-	require.NoError(t, err)
 	var ctx = context.New(config.Project{
 		ProjectName: "testprojectname",
 		Dist:        dist,
@@ -150,12 +141,9 @@ func TestRunPipeWithName(t *testing.T) {
 }
 
 func TestRunPipeMetadata(t *testing.T) {
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
-	defer os.RemoveAll(folder)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
-	require.NoError(t, err)
 	var ctx = context.New(config.Project{
 		ProjectName: "testprojectname",
 		Dist:        dist,
@@ -219,12 +207,9 @@ func TestNoSnapcraftInPath(t *testing.T) {
 }
 
 func TestRunNoArguments(t *testing.T) {
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
-	defer os.RemoveAll(folder)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
-	require.NoError(t, err)
 	var ctx = context.New(config.Project{
 		ProjectName: "testprojectname",
 		Dist:        dist,
@@ -256,12 +241,9 @@ func TestRunNoArguments(t *testing.T) {
 }
 
 func TestCompleter(t *testing.T) {
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
-	defer os.RemoveAll(folder)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
-	require.NoError(t, err)
 	var ctx = context.New(config.Project{
 		ProjectName: "testprojectname",
 		Dist:        dist,
@@ -296,12 +278,9 @@ func TestCompleter(t *testing.T) {
 }
 
 func TestCommand(t *testing.T) {
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
-	defer os.RemoveAll(folder)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
-	require.NoError(t, err)
 	var ctx = context.New(config.Project{
 		ProjectName: "testprojectname",
 		Dist:        dist,
@@ -334,12 +313,9 @@ func TestCommand(t *testing.T) {
 }
 
 func TestExtraFile(t *testing.T) {
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
-	defer os.RemoveAll(folder)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
-	require.NoError(t, err)
 	var ctx = context.New(config.Project{
 		ProjectName: "testprojectname",
 		Dist:        dist,

--- a/internal/pipe/sourcearchive/source_test.go
+++ b/internal/pipe/sourcearchive/source_test.go
@@ -16,8 +16,7 @@ import (
 func TestArchive(t *testing.T) {
 	for _, format := range []string{"tar.gz", "tar", "zip"} {
 		t.Run(format, func(t *testing.T) {
-			tmp, back := testlib.Mktmp(t)
-			defer back()
+			var tmp = testlib.Mktmp(t)
 			require.NoError(t, os.Mkdir("dist", 0744))
 
 			testlib.GitInit(t)

--- a/internal/pipe/upload/upload_test.go
+++ b/internal/pipe/upload/upload_test.go
@@ -56,15 +56,13 @@ func TestRunPipe_ModeBinary(t *testing.T) {
 	setup()
 	defer teardown()
 
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
-	err = ioutil.WriteFile(binPath, d1, 0666)
-	require.NoError(t, err)
+	require.NoError(t, ioutil.WriteFile(binPath, d1, 0666))
 
 	// Dummy http server
 	mux.HandleFunc("/example-repo-local/mybin/darwin/amd64/mybin", func(w http.ResponseWriter, r *http.Request) {
@@ -148,8 +146,7 @@ func TestRunPipe_ModeArchive(t *testing.T) {
 	setup()
 	defer teardown()
 
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	tarfile, err := os.Create(filepath.Join(folder, "bin.tar.gz"))
 	require.NoError(t, err)
 	debfile, err := os.Create(filepath.Join(folder, "bin.deb"))
@@ -219,15 +216,13 @@ func TestRunPipe_ModeBinary_CustomArtifactName(t *testing.T) {
 	setup()
 	defer teardown()
 
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
-	err = ioutil.WriteFile(binPath, d1, 0666)
-	require.NoError(t, err)
+	require.NoError(t, ioutil.WriteFile(binPath, d1, 0666))
 
 	// Dummy http server
 	mux.HandleFunc("/example-repo-local/mybin/darwin/amd64/mybin;deb.distribution=xenial", func(w http.ResponseWriter, r *http.Request) {
@@ -286,8 +281,7 @@ func TestRunPipe_ModeArchive_CustomArtifactName(t *testing.T) {
 	setup()
 	defer teardown()
 
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	tarfile, err := os.Create(filepath.Join(folder, "bin.tar.gz"))
 	require.NoError(t, err)
 	debfile, err := os.Create(filepath.Join(folder, "bin.deb"))
@@ -355,8 +349,7 @@ func TestRunPipe_ModeArchive_CustomArtifactName(t *testing.T) {
 }
 
 func TestRunPipe_ArtifactoryDown(t *testing.T) {
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	tarfile, err := os.Create(filepath.Join(folder, "bin.tar.gz"))
 	require.NoError(t, err)
 
@@ -388,8 +381,7 @@ func TestRunPipe_ArtifactoryDown(t *testing.T) {
 }
 
 func TestRunPipe_TargetTemplateError(t *testing.T) {
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 
@@ -420,7 +412,7 @@ func TestRunPipe_TargetTemplateError(t *testing.T) {
 		Goos:   "darwin",
 		Type:   artifact.UploadableBinary,
 	})
-	err = Pipe{}.Publish(ctx)
+	var err = Pipe{}.Publish(ctx)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), `upload: error while building the target url: template: tmpl:1: unexpected "/" in operand`)
 }
@@ -429,15 +421,13 @@ func TestRunPipe_BadCredentials(t *testing.T) {
 	setup()
 	defer teardown()
 
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
-	err = ioutil.WriteFile(binPath, d1, 0666)
-	require.NoError(t, err)
+	require.NoError(t, ioutil.WriteFile(binPath, d1, 0666))
 
 	// Dummy http server
 	mux.HandleFunc("/example-repo-local/mybin/darwin/amd64/mybin", func(w http.ResponseWriter, r *http.Request) {
@@ -476,7 +466,7 @@ func TestRunPipe_BadCredentials(t *testing.T) {
 		Type:   artifact.UploadableBinary,
 	})
 
-	err = Pipe{}.Publish(ctx)
+	var err = Pipe{}.Publish(ctx)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Unauthorized")
 }
@@ -513,15 +503,13 @@ func TestRunPipe_FileNotFound(t *testing.T) {
 }
 
 func TestRunPipe_UnparsableTarget(t *testing.T) {
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
-	err = ioutil.WriteFile(binPath, d1, 0666)
-	require.NoError(t, err)
+	require.NoError(t, ioutil.WriteFile(binPath, d1, 0666))
 
 	var ctx = context.New(config.Project{
 		ProjectName: "mybin",
@@ -578,8 +566,7 @@ func TestRunPipe_SkipWhenPublishFalse(t *testing.T) {
 }
 
 func TestRunPipe_DirUpload(t *testing.T) {
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	var dist = filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))

--- a/internal/testlib/git.go
+++ b/internal/testlib/git.go
@@ -9,7 +9,7 @@ import (
 )
 
 // GitInit inits a new git project.
-func GitInit(t *testing.T) {
+func GitInit(t testing.TB) {
 	out, err := fakeGit("init")
 	require.NoError(t, err)
 	require.Contains(t, out, "Initialized empty Git repository")
@@ -17,19 +17,19 @@ func GitInit(t *testing.T) {
 }
 
 // GitRemoteAdd adds the given url as remote.
-func GitRemoteAdd(t *testing.T, url string) {
+func GitRemoteAdd(t testing.TB, url string) {
 	out, err := fakeGit("remote", "add", "origin", url)
 	require.NoError(t, err)
 	require.Empty(t, out)
 }
 
 // GitCommit creates a git commits.
-func GitCommit(t *testing.T, msg string) {
+func GitCommit(t testing.TB, msg string) {
 	GitCommitWithDate(t, msg, time.Time{})
 }
 
 // GitCommitWithDate creates a git commit with a commit date.
-func GitCommitWithDate(t *testing.T, msg string, commitDate time.Time) {
+func GitCommitWithDate(t testing.TB, msg string, commitDate time.Time) {
 	env := (map[string]string)(nil)
 	if !commitDate.IsZero() {
 		env = map[string]string{
@@ -42,21 +42,21 @@ func GitCommitWithDate(t *testing.T, msg string, commitDate time.Time) {
 }
 
 // GitTag creates a git tag.
-func GitTag(t *testing.T, tag string) {
+func GitTag(t testing.TB, tag string) {
 	out, err := fakeGit("tag", tag)
 	require.NoError(t, err)
 	require.Empty(t, out)
 }
 
 // GitBranch creates a git branch.
-func GitBranch(t *testing.T, branch string) {
+func GitBranch(t testing.TB, branch string) {
 	out, err := fakeGit("branch", branch)
 	require.NoError(t, err)
 	require.Empty(t, out)
 }
 
 // GitAdd adds all files to stage.
-func GitAdd(t *testing.T) {
+func GitAdd(t testing.TB {
 	out, err := fakeGit("add", "-A")
 	require.NoError(t, err)
 	require.Empty(t, out)
@@ -78,7 +78,7 @@ func fakeGit(args ...string) (string, error) {
 }
 
 // GitCheckoutBranch allows us to change the active branch that we're using.
-func GitCheckoutBranch(t *testing.T, name string) {
+func GitCheckoutBranch(t testing.TB, name string) {
 	out, err := fakeGit("checkout", "-b", name)
 	require.NoError(t, err)
 	require.Empty(t, out)

--- a/internal/testlib/git.go
+++ b/internal/testlib/git.go
@@ -56,7 +56,7 @@ func GitBranch(t testing.TB, branch string) {
 }
 
 // GitAdd adds all files to stage.
-func GitAdd(t testing.TB {
+func GitAdd(t testing.TB) {
 	out, err := fakeGit("add", "-A")
 	require.NoError(t, err)
 	require.Empty(t, out)

--- a/internal/testlib/git_test.go
+++ b/internal/testlib/git_test.go
@@ -5,8 +5,7 @@ import (
 )
 
 func TestGit(t *testing.T) {
-	_, back := Mktmp(t)
-	defer back()
+	TestMkTemp(t)
 	GitInit(t)
 	GitAdd(t)
 	GitCommit(t, "commit1")

--- a/internal/testlib/mktemp.go
+++ b/internal/testlib/mktemp.go
@@ -2,7 +2,6 @@
 package testlib
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -11,13 +10,13 @@ import (
 
 // Mktmp creates a new tempdir, cd into it and provides a back function that
 // cd into the previous directory.
-func Mktmp(t *testing.T) (folder string, back func()) {
-	folder, err := ioutil.TempDir("", "goreleasertest")
-	require.NoError(t, err)
+func Mktmp(t testing.TB) string {
+	var folder = t.TempDir()
 	current, err := os.Getwd()
 	require.NoError(t, err)
 	require.NoError(t, os.Chdir(folder))
-	return folder, func() {
+	t.Cleanup(func() {
 		require.NoError(t, os.Chdir(current))
-	}
+	})
+	return folder
 }

--- a/internal/testlib/mktemp_test.go
+++ b/internal/testlib/mktemp_test.go
@@ -1,19 +1,11 @@
 package testlib
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestMkTemp(t *testing.T) {
-	current, err := os.Getwd()
-	require.NoError(t, err)
-	folder, back := Mktmp(t)
-	require.NotEmpty(t, folder)
-	back()
-	newCurrent, err := os.Getwd()
-	require.NoError(t, err)
-	require.Equal(t, current, newCurrent)
+	require.NotEmpty(t, Mktmp(t))
 }

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -1,7 +1,6 @@
 package archive
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -9,8 +8,7 @@ import (
 )
 
 func TestArchive(t *testing.T) {
-	folder, err := ioutil.TempDir("", "archivetest")
-	require.NoError(t, err)
+	var folder = t.TempDir()
 	empty, err := os.Create(folder + "/empty.txt")
 	require.NoError(t, err)
 	require.NoError(t, os.Mkdir(folder+"/folder-inside", 0755))

--- a/pkg/archive/gzip/gzip_test.go
+++ b/pkg/archive/gzip/gzip_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestGzFile(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
+	var tmp = t.TempDir()
 	f, err := os.Create(filepath.Join(tmp, "test.gz"))
 	require.NoError(t, err)
 	defer f.Close() // nolint: errcheck

--- a/pkg/archive/targz/targz_test.go
+++ b/pkg/archive/targz/targz_test.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,8 +12,7 @@ import (
 )
 
 func TestTarGzFile(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
+	var tmp = t.TempDir()
 	f, err := os.Create(filepath.Join(tmp, "test.tar.gz"))
 	require.NoError(t, err)
 	defer f.Close() // nolint: errcheck

--- a/pkg/archive/tarxz/tarxz_test.go
+++ b/pkg/archive/tarxz/tarxz_test.go
@@ -3,7 +3,6 @@ package tarxz
 import (
 	"archive/tar"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,8 +12,7 @@ import (
 )
 
 func TestTarXzFile(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
+	var tmp = t.TempDir()
 	f, err := os.Create(filepath.Join(tmp, "test.tar.xz"))
 	require.NoError(t, err)
 	defer f.Close() // nolint: errcheck

--- a/pkg/archive/zip/zip_test.go
+++ b/pkg/archive/zip/zip_test.go
@@ -3,7 +3,6 @@ package zip
 import (
 	"archive/zip"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,8 +11,7 @@ import (
 )
 
 func TestZipFile(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
+	var tmp = t.TempDir()
 	f, err := os.Create(filepath.Join(tmp, "test.zip"))
 	require.NoError(t, err)
 	fmt.Println(f.Name())


### PR DESCRIPTION
- use `testing.TB#Cleanup` instead of `defer`
- use `testing.TB#Tempdir` instead of `ioutil.Tempdir`


This also fixes **A LOT** of resource leaks... so many places creating tmp folders and not cleaning them up... 😭 