### PR TITLE
docs: unify naming of .goreleaser.yml file

### DIFF
--- a/cmd/testdata/good.yml
+++ b/cmd/testdata/good.yml
@@ -1,4 +1,4 @@
-# This is an example goreleaser.yaml file with some sane defaults.
+# This is an example .goreleaser.yml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
 before:
   hooks:

--- a/internal/static/config.go
+++ b/internal/static/config.go
@@ -5,7 +5,7 @@ package static
 
 // ExampleConfig is the config used within goreleaser init.
 // nolint: gochecknoglobals
-const ExampleConfig = `# This is an example goreleaser.yaml file with some sane defaults.
+const ExampleConfig = `# This is an example .goreleaser.yml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
 before:
   hooks:

--- a/www/docs/customization/archive.md
+++ b/www/docs/customization/archive.md
@@ -98,7 +98,7 @@ on the archive section.
 A working hack is to use something like this:
 
 ```yaml
-# goreleaser.yml
+# .goreleaser.yml
 archives:
 - files:
   - none*
@@ -119,7 +119,7 @@ Presumably, you'll want that file to be the binary, so, your archive section
 will probably look like this:
 
 ```yaml
-# goreleaser.yml
+# .goreleaser.yml
 archives:
 - format: gz
   files:
@@ -138,7 +138,7 @@ extracted with something like `gzip -d file.gz`.
 You can do that by setting `format` to `binary`:
 
 ```yaml
-# goreleaser.yml
+# .goreleaser.yml
 archives:
 - format: binary
 ```

--- a/www/docs/customization/build.md
+++ b/www/docs/customization/build.md
@@ -132,7 +132,7 @@ builds:
 Here is an example with multiple binaries:
 
 ```yaml
-# goreleaser.yml
+# .goreleaser.yml
 builds:
   - main: ./cmd/cli/cli.go
     id: "cli"
@@ -243,7 +243,7 @@ Environment variables are inherited and overridden in the following order:
  very likely to fail.
 
  You can solve this by running `go mod download` before calling `goreleaser` or
- by adding a [hook][] doing that on your `.goreleaser.yaml` file:
+ by adding a [hook][] doing that on your `.goreleaser.yml` file:
 
  ```yaml
  before:

--- a/www/docs/customization/docker_manifest.md
+++ b/www/docs/customization/docker_manifest.md
@@ -81,7 +81,7 @@ Then, on our GoReleaser config file, we need to define both the `dockers` and
 the `docker_manifests` section:
 
 ```yaml
-# goreleaser.yml
+# .goreleaser.yml
 builds:
 - env:
   - CGO_ENABLED=0

--- a/www/docs/customization/env.md
+++ b/www/docs/customization/env.md
@@ -5,7 +5,7 @@ title: Environment Variables
 Global environment variables to be passed down to all hooks and builds.
 
 This is useful for `GO111MODULE`, for example. You can have your
-`.goreleaser.yaml` file like the following:
+`.goreleaser.yml` file like the following:
 
 ```yaml
 # .goreleaser.yml

--- a/www/docs/customization/sign.md
+++ b/www/docs/customization/sign.md
@@ -18,7 +18,7 @@ with [GnuPG](https://www.gnupg.org/) and your default key. To enable signing
 just add
 
 ```yaml
-# goreleaser.yml
+# .goreleaser.yml
 signs:
   - artifacts: checksum
 ```
@@ -86,7 +86,7 @@ If what you want to use does not do it, you can always hack by setting the
 command to `sh -c`. For example:
 
 ```yaml
-# goreleaser.yml
+# .goreleaser.yml
 signs:
 - cmd: sh
   args:

--- a/www/docs/deprecations.md
+++ b/www/docs/deprecations.md
@@ -383,7 +383,7 @@ FPM is deprecated in favor of nfpm, which is a simpler alternative written
 in Go. The objective is to remove the ruby dependency thus simplify the
 CI/CD pipelines.
 
-Just replace the `fpm` keyword by `nfpm` in your `goreleaser.yaml` file.
+Just replace the `fpm` keyword by `nfpm` in your `.goreleaser.yml` file.
 
 === "Before"
     ```yaml

--- a/www/docs/quick-start.md
+++ b/www/docs/quick-start.md
@@ -13,7 +13,7 @@ func main() {
 }
 ```
 
-Run `goreleaser init` to create an example `.goreleaser.yaml` file:
+Run `goreleaser init` to create an example `.goreleaser.yml` file:
 
 ```sh
 goreleaser init


### PR DESCRIPTION
Since multiple filenames for the config file are allowed, we find several different usages of the file names in the docs:
- .goreleaser.yml
- goreleaser.yml
- .goreleaser.yaml
- goreleaser.yaml

I find that using a single filename in the docs is more intuitive for new users. Hence I replaced all occurrences of the filename with `.goreleaser.yml`.

Feel free to request changes for individual occurrences of the file name.
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->

<!-- # Provide links to any relevant tickets, URLs or other resources -->
