### PR TITLE
docs: add changie to changelog generators

### DIFF
--- a/www/docs/customization/release.md
+++ b/www/docs/customization/release.md
@@ -196,6 +196,7 @@ goreleaser --release-notes <(some_changelog_generator)
 Some changelog generators you can use:
 
 - [buchanae/github-release-notes](https://github.com/buchanae/github-release-notes)
+- [miniscruff/changie](https://github.com/miniscruff/changie)
 
 !!! info
     If you create the release before running GoReleaser, and the


### PR DESCRIPTION
Adds a link to changie an alternative changelog generator.
Changie uses goreleaser for releases so it is, at least a little, tested.

Not sure if anything else was needed for doc changes.