### PR TITLE
Add `--goos` and `--goarch` flags.

### DIFF
--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -74,4 +74,24 @@ func TestBuildFlags(t *testing.T) {
 			},
 		}).RmDist)
 	})
+
+	t.Run("goos", func(t *testing.T) {
+		ctx := setup(buildOpts{
+			sharedBuildOpts: sharedBuildOpts{
+				buildGoos: []string{"linux", "darwin"},
+			}})
+
+		require.Equal(t, ctx.BuildGoos[0], "linux")
+		require.Equal(t, ctx.BuildGoos[1], "darwin")
+	})
+
+	t.Run("goarch", func(t *testing.T) {
+		ctx := setup(buildOpts{
+			sharedBuildOpts: sharedBuildOpts{
+				buildGoarch: []string{"x86", "arm64"},
+			}})
+
+		require.Equal(t, ctx.BuildGoarch[0], "x86")
+		require.Equal(t, ctx.BuildGoarch[1], "arm64")
+	})
 }

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -38,7 +38,9 @@ func TestBuildFlags(t *testing.T) {
 
 	t.Run("snapshot", func(t *testing.T) {
 		var ctx = setup(buildOpts{
-			snapshot: true,
+			sharedBuildOpts: sharedBuildOpts{
+				snapshot: true,
+			},
 		})
 		require.True(t, ctx.Snapshot)
 		require.True(t, ctx.SkipValidate)
@@ -47,7 +49,9 @@ func TestBuildFlags(t *testing.T) {
 
 	t.Run("skips", func(t *testing.T) {
 		var ctx = setup(buildOpts{
-			skipValidate:  true,
+			sharedBuildOpts: sharedBuildOpts{
+				skipValidate: true,
+			},
 			skipPostHooks: true,
 		})
 		require.True(t, ctx.SkipValidate)
@@ -57,13 +61,17 @@ func TestBuildFlags(t *testing.T) {
 
 	t.Run("parallelism", func(t *testing.T) {
 		require.Equal(t, 1, setup(buildOpts{
-			parallelism: 1,
+			sharedBuildOpts: sharedBuildOpts{
+				parallelism: 1,
+			},
 		}).Parallelism)
 	})
 
 	t.Run("rm dist", func(t *testing.T) {
 		require.True(t, setup(buildOpts{
-			rmDist: true,
+			sharedBuildOpts: sharedBuildOpts{
+				rmDist: true,
+			},
 		}).RmDist)
 	})
 }

--- a/cmd/release_test.go
+++ b/cmd/release_test.go
@@ -38,7 +38,9 @@ func TestReleaseFlags(t *testing.T) {
 
 	t.Run("snapshot", func(t *testing.T) {
 		var ctx = setup(releaseOpts{
-			snapshot: true,
+			sharedBuildOpts: sharedBuildOpts{
+				snapshot: true,
+			},
 		})
 		require.True(t, ctx.Snapshot)
 		require.True(t, ctx.SkipPublish)
@@ -47,9 +49,11 @@ func TestReleaseFlags(t *testing.T) {
 
 	t.Run("skips", func(t *testing.T) {
 		var ctx = setup(releaseOpts{
-			skipPublish:  true,
-			skipSign:     true,
-			skipValidate: true,
+			skipPublish: true,
+			skipSign:    true,
+			sharedBuildOpts: sharedBuildOpts{
+				skipValidate: true,
+			},
 		})
 		require.True(t, ctx.SkipSign)
 		require.True(t, ctx.SkipPublish)
@@ -58,7 +62,9 @@ func TestReleaseFlags(t *testing.T) {
 
 	t.Run("parallelism", func(t *testing.T) {
 		require.Equal(t, 1, setup(releaseOpts{
-			parallelism: 1,
+			sharedBuildOpts: sharedBuildOpts{
+				parallelism: 1,
+			},
 		}).Parallelism)
 	})
 
@@ -78,7 +84,9 @@ func TestReleaseFlags(t *testing.T) {
 
 	t.Run("rm dist", func(t *testing.T) {
 		require.True(t, setup(releaseOpts{
-			rmDist: true,
+			sharedBuildOpts: sharedBuildOpts{
+				rmDist: true,
+			},
 		}).RmDist)
 	})
 }

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -86,6 +86,10 @@ type Context struct {
 	Deprecated         bool
 	Parallelism        int
 	Semver             Semver
+
+	// List of Goos and Goarch to build.
+	BuildGoos   []string
+	BuildGoarch []string
 }
 
 // Semver represents a semantic version.


### PR DESCRIPTION
This PR refactors flag code and adds the `--goos` and `--goarch` flags. The flags let the user specify a set of OSes and architectures to build from the command line. See https://github.com/goreleaser/goreleaser/issues/1852.