### PR TITLE
feat(http): support custom headers in http upload

### DIFF
--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -240,6 +240,11 @@ func uploadAsset(ctx *context.Context, upload *config.Upload, artifact *artifact
 	log.Debugf("generated target url: %s", targetURL)
 
 	var headers = map[string]string{}
+	if upload.CustomHeaders != nil {
+		for name, value := range upload.CustomHeaders {
+			headers[name] = value
+		}
+	}
 	if upload.ChecksumHeader != "" {
 		sum, err := artifact.Checksum("sha256")
 		if err != nil {

--- a/internal/http/http_test.go
+++ b/internal/http/http_test.go
@@ -469,6 +469,21 @@ func TestUpload(t *testing.T) {
 			},
 			checks(check{"/blah/2.1.0/a.ubi", "u2", "x", content, map[string]string{"-x-sha256": "5e2bf57d3f40c4b6df69daf1936cb766f832374b4fc0259a7cbff06e2f70f269"}}),
 		},
+		{"custom-headers", true, true, false, false,
+			func(s *httptest.Server) (*context.Context, config.Upload) {
+				return ctx, config.Upload{
+					Mode:     ModeBinary,
+					Name:     "a",
+					Target:   s.URL + "/{{.ProjectName}}/{{.Version}}/",
+					Username: "u2",
+					CustomHeaders: map[string]string{
+						"x-custom-header-name": "custom-header-value",
+					},
+					TrustedCerts: cert(s),
+				}
+			},
+			checks(check{"/blah/2.1.0/a.ubi", "u2", "x", content, map[string]string{"x-custom-header-name": "custom-header-value"}}),
+		},
 	}
 
 	uploadAndCheck := func(t *testing.T, setup func(*httptest.Server) (*context.Context, config.Upload), wantErrPlain, wantErrTLS bool, check func(r []*h.Request) error, srv *httptest.Server) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -543,17 +543,18 @@ type Blob struct {
 
 // Upload configuration.
 type Upload struct {
-	Name               string   `yaml:",omitempty"`
-	IDs                []string `yaml:"ids,omitempty"`
-	Target             string   `yaml:",omitempty"`
-	Username           string   `yaml:",omitempty"`
-	Mode               string   `yaml:",omitempty"`
-	Method             string   `yaml:",omitempty"`
-	ChecksumHeader     string   `yaml:"checksum_header,omitempty"`
-	TrustedCerts       string   `yaml:"trusted_certificates,omitempty"`
-	Checksum           bool     `yaml:",omitempty"`
-	Signature          bool     `yaml:",omitempty"`
-	CustomArtifactName bool     `yaml:"custom_artifact_name,omitempty"`
+	Name               string            `yaml:",omitempty"`
+	IDs                []string          `yaml:"ids,omitempty"`
+	Target             string            `yaml:",omitempty"`
+	Username           string            `yaml:",omitempty"`
+	Mode               string            `yaml:",omitempty"`
+	Method             string            `yaml:",omitempty"`
+	ChecksumHeader     string            `yaml:"checksum_header,omitempty"`
+	TrustedCerts       string            `yaml:"trusted_certificates,omitempty"`
+	Checksum           bool              `yaml:",omitempty"`
+	Signature          bool              `yaml:",omitempty"`
+	CustomArtifactName bool              `yaml:"custom_artifact_name,omitempty"`
+	CustomHeaders      map[string]string `yaml:"custom_headers,omitempty"`
 }
 
 // Publisher configuration.

--- a/www/docs/customization/upload.md
+++ b/www/docs/customization/upload.md
@@ -161,6 +161,11 @@ uploads:
     # Default is empty.
     checksum_header: -X-SHA256-Sum
 
+    # A map of custom headers e.g. to support required content types or auth schemes.
+    # Default is empty.
+    custom_headers:
+      JOB-TOKEN: {{ .Env.CI_JOB_TOKEN }}
+
     # Upload checksums (defaults to false)
     checksum: true
 


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

This commit will add an additional field to elements under `uploads:`, allowing the user to specify custom headers for the `PUT` (or other mode) request.

<!-- Why is this change being made? -->

GitLab has a Generic Packages Repository which allows uploads using various auth methods, one being the CI job token. However, it must be specified not as basic authentication but rather as a custom header, namely `JOB-TOKEN: $CI_JOB_TOKEN`. This change supports specifying that header as well as any other headers required by various upload destinations.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

See also: https://docs.gitlab.com/ee/user/packages/generic_packages/index.html#publish-a-generic-package-by-using-cicd