### PR TITLE
feat(http): resolve custom header template expressions

### DIFF
--- a/internal/http/http_test.go
+++ b/internal/http/http_test.go
@@ -484,6 +484,21 @@ func TestUpload(t *testing.T) {
 			},
 			checks(check{"/blah/2.1.0/a.ubi", "u2", "x", content, map[string]string{"x-custom-header-name": "custom-header-value"}}),
 		},
+		{"invalid-template-custom-headers", true, true, true, true,
+			func(s *httptest.Server) (*context.Context, config.Upload) {
+				return ctx, config.Upload{
+					Mode:     ModeBinary,
+					Name:     "a",
+					Target:   s.URL + "/{{.ProjectName}}/{{.Version}}/",
+					Username: "u2",
+					CustomHeaders: map[string]string{
+						"x-custom-header-name": "{{ .Env.NONEXISTINGVARIABLE and some bad expressions }}",
+					},
+					TrustedCerts: cert(s),
+				}
+			},
+			checks(),
+		},
 	}
 
 	uploadAndCheck := func(t *testing.T, setup func(*httptest.Server) (*context.Context, config.Upload), wantErrPlain, wantErrTLS bool, check func(r []*h.Request) error, srv *httptest.Server) {

--- a/internal/http/http_test.go
+++ b/internal/http/http_test.go
@@ -484,7 +484,22 @@ func TestUpload(t *testing.T) {
 			},
 			checks(check{"/blah/2.1.0/a.ubi", "u2", "x", content, map[string]string{"x-custom-header-name": "custom-header-value"}}),
 		},
-		{"invalid-template-custom-headers", true, true, true, true,
+		{"custom-headers-with-template", true, true, false, false,
+			func(s *httptest.Server) (*context.Context, config.Upload) {
+				return ctx, config.Upload{
+					Mode:     ModeBinary,
+					Name:     "a",
+					Target:   s.URL + "/{{.ProjectName}}/{{.Version}}/",
+					Username: "u2",
+					CustomHeaders: map[string]string{
+						"x-project-name": "{{ .ProjectName }}",
+					},
+					TrustedCerts: cert(s),
+				}
+			},
+			checks(check{"/blah/2.1.0/a.ubi", "u2", "x", content, map[string]string{"x-project-name": "blah"}}),
+		},
+		{"invalid-template-in-custom-headers", true, true, true, true,
 			func(s *httptest.Server) (*context.Context, config.Upload) {
 				return ctx, config.Upload{
 					Mode:     ModeBinary,

--- a/www/docs/customization/upload.md
+++ b/www/docs/customization/upload.md
@@ -164,7 +164,7 @@ uploads:
     # A map of custom headers e.g. to support required content types or auth schemes.
     # Default is empty.
     custom_headers:
-      JOB-TOKEN: {{ .Env.CI_JOB_TOKEN }}
+      JOB-TOKEN: "{{ .Env.CI_JOB_TOKEN }}"
 
     # Upload checksums (defaults to false)
     checksum: true


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

If applied, this commit will allow the user to employ template expressions in the values of `uploads.custom_headers` map values, e.g.:

```yaml
uploads:
  - name: gitlab
    mode: binary
    target: "{{ .Env.CI_API_V4_URL }}/projects/{{ .Env.CI_PROJECT_ID }}/packages/generic/{{ .ProjectName }}/{{ .Version }}/"
    username: gitlab-ci-token
    method: PUT
    custom_headers:
      JOB-TOKEN: "{{ .Env.CI_JOB_TOKEN }}"
      PRIVATE-TOKEN: "{{ .Env.GITLAB_TOKEN }}"
```

Prior to this change, only literal expressions were supported, and so my docs example in #2002 was actually not functioning.

<!-- # Provide links to any relevant tickets, URLs or other resources -->
