### PR TITLE
feat: add `--build-id` flag for build command.

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -20,6 +20,7 @@ type buildCmd struct {
 
 type buildOpts struct {
 	config        string
+	buildIDs      []string
 	snapshot      bool
 	skipValidate  bool
 	skipPostHooks bool
@@ -65,6 +66,7 @@ func newBuildCmd() *buildCmd {
 	cmd.Flags().BoolVar(&root.opts.rmDist, "rm-dist", false, "Remove the dist folder before building")
 	cmd.Flags().IntVarP(&root.opts.parallelism, "parallelism", "p", runtime.NumCPU(), "Amount tasks to run concurrently")
 	cmd.Flags().DurationVar(&root.opts.timeout, "timeout", 30*time.Minute, "Timeout to the entire build process")
+	cmd.Flags().StringSliceVar(&root.opts.buildIDs, "build-id", nil, "Build only the passed IDs (default empty). This is specified as a comma-separated list of IDs.")
 	cmd.Flags().BoolVar(&root.opts.deprecated, "deprecated", false, "Force print the deprecation message - tests only")
 	_ = cmd.Flags().MarkHidden("deprecated")
 
@@ -102,6 +104,7 @@ func setupBuildContext(ctx *context.Context, options buildOpts) *context.Context
 	ctx.SkipPostBuildHooks = options.skipPostHooks
 	ctx.RmDist = options.rmDist
 	ctx.SkipTokenCheck = true
+	ctx.BuildIDs = options.buildIDs
 
 	// test only
 	ctx.Deprecated = options.deprecated

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -15,6 +15,20 @@ func TestBuild(t *testing.T) {
 	require.NoError(t, cmd.cmd.Execute())
 }
 
+func TestBuildWithSpecifcId(t *testing.T) {
+	setup(t)
+	var cmd = newBuildCmd()
+	cmd.cmd.SetArgs([]string{"--snapshot", "--timeout=1m", "--parallelism=2", "--deprecated", "--build-id=fake"})
+	require.NoError(t, cmd.cmd.Execute())
+}
+
+func TestBuildWithSpecifcIdNotExists(t *testing.T) {
+	setup(t)
+	var cmd = newBuildCmd()
+	cmd.cmd.SetArgs([]string{"--snapshot", "--timeout=1m", "--parallelism=2", "--deprecated", "--build-id=notexists"})
+	require.NoError(t, cmd.cmd.Execute())
+}
+
 func TestBuildInvalidConfig(t *testing.T) {
 	setup(t)
 	createFile(t, "goreleaser.yml", "foo: bar")
@@ -65,5 +79,14 @@ func TestBuildFlags(t *testing.T) {
 		require.True(t, setup(buildOpts{
 			rmDist: true,
 		}).RmDist)
+	})
+
+	t.Run("build-id", func(t *testing.T) {
+		ctx := setup(buildOpts{
+			buildIDs: []string{"id1", "id2"},
+		})
+
+		require.Equal(t, ctx.BuildIDs[0], "id1")
+		require.Equal(t, ctx.BuildIDs[1], "id2")
 	})
 }

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -707,8 +707,8 @@ func TestBuildOptionsForTarget(t *testing.T) {
 	var tmpDir = testlib.Mktmp(t)
 
 	testCases := []struct {
-		name  string
-		build config.Build
+		name         string
+		build        config.Build
 		expectedOpts *api.Options
 	}{
 		{

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -86,6 +86,7 @@ type Context struct {
 	Deprecated         bool
 	Parallelism        int
 	Semver             Semver
+	BuildIDs           []string
 }
 
 // Semver represents a semantic version.


### PR DESCRIPTION
## If applied, this commit will...
This proposal of this PR is to add the `--build-id` flag for build command to build only the passed IDs.

## Why is this change being made?
This change is being made to choose which of the builds in the `YAML` file will be executed.

For example...
```yaml
builds:
  - main: ./cmd/main.go
    id: main
    env:
      - CGO_ENABLED=0
  - main: ./configs/main.go
    id: conf
```
When you run the command `goreleaser build --build-id=main ...` only the build with ID main will be executed.

<!-- # Provide links to any relevant tickets, URLs or other resources -->
