### PR TITLE
fix: update snapcraft command from 'push' to 'upload'

### DIFF
--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -320,7 +320,7 @@ func push(ctx *context.Context, snap *artifact.Artifact) error {
 	log.Info("pushing snap")
 	// TODO: customize --release based on snap.Grade?
 	/* #nosec */
-	var cmd = exec.CommandContext(ctx, "snapcraft", "push", "--release=stable", snap.Path)
+	var cmd = exec.CommandContext(ctx, "snapcraft", "upload", "--release=stable", snap.Path)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		if strings.Contains(string(out), reviewWaitMsg) {
 			log.Warn(reviewWaitMsg)


### PR DESCRIPTION
As per deprecation message from snapcraft [here](https://github.com/achannarasappa/ticker/runs/1859510333?check_suite_focus=true#step:7:150), the `push` command has been replaced by the `upload` command.