### PR TITLE
fix: brew: check cpu

### DIFF
--- a/internal/pipe/brew/template.go
+++ b/internal/pipe/brew/template.go
@@ -50,7 +50,7 @@ class {{ .Name }} < Formula
   {{- end }}
   {{- printf "\n" }}
   {{- if .MacOSAmd64.DownloadURL }}
-  if OS.mac?
+  if OS.mac? && Hardware::CPU.intel?
     url "{{ .MacOSAmd64.DownloadURL }}"
     {{- if .DownloadStrategy }}, :using => {{ .DownloadStrategy }}{{- end }}
     sha256 "{{ .MacOSAmd64.SHA256 }}"

--- a/internal/pipe/brew/testdata/custom_block.rb.golden
+++ b/internal/pipe/brew/testdata/custom_block.rb.golden
@@ -8,7 +8,7 @@ class CustomBlock < Formula
   version "1.0.1"
   bottle :unneeded
 
-  if OS.mac?
+  if OS.mac? && Hardware::CPU.intel?
     url "https://dummyhost/download/v1.0.1/bin.tar.gz"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   end

--- a/internal/pipe/brew/testdata/custom_download_strategy.rb.golden
+++ b/internal/pipe/brew/testdata/custom_download_strategy.rb.golden
@@ -8,7 +8,7 @@ class CustomDownloadStrategy < Formula
   version "1.0.1"
   bottle :unneeded
 
-  if OS.mac?
+  if OS.mac? && Hardware::CPU.intel?
     url "https://dummyhost/download/v1.0.1/bin.tar.gz", :using => GitHubPrivateRepositoryReleaseDownloadStrategy
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   end

--- a/internal/pipe/brew/testdata/custom_require.rb.golden
+++ b/internal/pipe/brew/testdata/custom_require.rb.golden
@@ -9,7 +9,7 @@ class CustomRequire < Formula
   version "1.0.1"
   bottle :unneeded
 
-  if OS.mac?
+  if OS.mac? && Hardware::CPU.intel?
     url "https://dummyhost/download/v1.0.1/bin.tar.gz", :using => CustomDownloadStrategy
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   end

--- a/internal/pipe/brew/testdata/default.rb.golden
+++ b/internal/pipe/brew/testdata/default.rb.golden
@@ -8,7 +8,7 @@ class Default < Formula
   version "1.0.1"
   bottle :unneeded
 
-  if OS.mac?
+  if OS.mac? && Hardware::CPU.intel?
     url "https://dummyhost/download/v1.0.1/bin.tar.gz"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   end

--- a/internal/pipe/brew/testdata/default_gitlab.rb.golden
+++ b/internal/pipe/brew/testdata/default_gitlab.rb.golden
@@ -8,7 +8,7 @@ class DefaultGitlab < Formula
   version "1.0.1"
   bottle :unneeded
 
-  if OS.mac?
+  if OS.mac? && Hardware::CPU.intel?
     url "https://dummyhost/download/v1.0.1/bin.tar.gz"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   end

--- a/internal/pipe/brew/testdata/foo_is_bar.rb.golden
+++ b/internal/pipe/brew/testdata/foo_is_bar.rb.golden
@@ -8,7 +8,7 @@ class FooIsBar < Formula
   version "1.0.1"
   bottle :unneeded
 
-  if OS.mac?
+  if OS.mac? && Hardware::CPU.intel?
     url "https://dummyhost/download/v1.0.1/bin.tar.gz"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   end

--- a/internal/pipe/brew/testdata/multiple_armv5.rb.golden
+++ b/internal/pipe/brew/testdata/multiple_armv5.rb.golden
@@ -8,7 +8,7 @@ class MultipleArmv5 < Formula
   version "1.0.1"
   bottle :unneeded
 
-  if OS.mac?
+  if OS.mac? && Hardware::CPU.intel?
     url "https://dummyhost/download/v1.0.1/bin.tar.gz"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   end

--- a/internal/pipe/brew/testdata/multiple_armv6.rb.golden
+++ b/internal/pipe/brew/testdata/multiple_armv6.rb.golden
@@ -8,7 +8,7 @@ class MultipleArmv6 < Formula
   version "1.0.1"
   bottle :unneeded
 
-  if OS.mac?
+  if OS.mac? && Hardware::CPU.intel?
     url "https://dummyhost/download/v1.0.1/bin.tar.gz"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   end

--- a/internal/pipe/brew/testdata/multiple_armv7.rb.golden
+++ b/internal/pipe/brew/testdata/multiple_armv7.rb.golden
@@ -8,7 +8,7 @@ class MultipleArmv7 < Formula
   version "1.0.1"
   bottle :unneeded
 
-  if OS.mac?
+  if OS.mac? && Hardware::CPU.intel?
     url "https://dummyhost/download/v1.0.1/bin.tar.gz"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   end

--- a/internal/pipe/brew/testdata/test.rb.golden
+++ b/internal/pipe/brew/testdata/test.rb.golden
@@ -9,7 +9,7 @@ class Test < Formula
   license "MIT"
   bottle :unneeded
 
-  if OS.mac?
+  if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_x86_64.tar.gz"
     sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c68"
   end


### PR DESCRIPTION
since now there are both amd64 and arm64 downloads for macs, I think its better to guard the amd64 download with a "if intel" check...