### PR TITLE
test: use main as git branch for tests

### DIFF
--- a/internal/testlib/git.go
+++ b/internal/testlib/git.go
@@ -10,7 +10,7 @@ import (
 
 // GitInit inits a new git project.
 func GitInit(t testing.TB) {
-	out, err := fakeGit("init")
+	out, err := fakeGit("init", "-b", "main")
 	require.NoError(t, err)
 	require.Contains(t, out, "Initialized empty Git repository")
 	require.NoError(t, err)
@@ -38,7 +38,7 @@ func GitCommitWithDate(t testing.TB, msg string, commitDate time.Time) {
 	}
 	out, err := fakeGitEnv(env, "commit", "--allow-empty", "-m", msg)
 	require.NoError(t, err)
-	require.Contains(t, out, "master", msg)
+	require.Contains(t, out, "main", msg)
 }
 
 // GitTag creates a git tag.


### PR DESCRIPTION
some users might setup `git` locally to default to main, which would cause the tests to fail...

this pr sets the branch to git init so it works regardless of user config.