### PR TITLE
fix: log semver errors when snapshot

### DIFF
--- a/internal/deprecate/deprecate.go
+++ b/internal/deprecate/deprecate.go
@@ -3,7 +3,9 @@
 package deprecate
 
 import (
+	"bytes"
 	"strings"
+	"text/template"
 
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/cli"
@@ -15,6 +17,11 @@ const baseURL = "https://goreleaser.com/deprecations#"
 
 // Notice warns the user about the deprecation of the given property.
 func Notice(ctx *context.Context, property string) {
+	NoticeCustom(ctx, property, "`{{ .Property }}` should not be used anymore, check {{ .URL }} for more info")
+}
+
+// Notice warns the user about the deprecation of the given property.
+func NoticeCustom(ctx *context.Context, property, tmpl string) {
 	ctx.Deprecated = true
 	cli.Default.Padding += 3
 	defer func() {
@@ -25,9 +32,17 @@ func Notice(ctx *context.Context, property string) {
 		".", "",
 		"_", "",
 	).Replace(property)
-	log.Warn(color.New(color.Bold, color.FgHiYellow).Sprintf(
-		"DEPRECATED: `%s` should not be used anymore, check %s for more info.",
-		property,
-		url,
-	))
+	var out bytes.Buffer
+	if err := template.Must(template.New("deprecation").Parse("DEPRECATED: "+tmpl)).Execute(&out, templateData{
+		URL:      url,
+		Property: property,
+	}); err != nil {
+		panic(err) // this should never happen
+	}
+	log.Warn(color.New(color.Bold, color.FgHiYellow).Sprintf(out.String()))
+}
+
+type templateData struct {
+	URL      string
+	Property string
 }

--- a/internal/deprecate/testdata/output.txt.golden
+++ b/internal/deprecate/testdata/output.txt.golden
@@ -1,3 +1,3 @@
    • first                    
-   • DEPRECATED: `foo.bar.whatever` should not be used anymore, check https://goreleaser.com/deprecations#foobarwhatever for more info.
+   • DEPRECATED: `foo.bar.whatever` should not be used anymore, check https://goreleaser.com/deprecations#foobarwhatever for more info
    • last                     

--- a/internal/deprecate/testdata/output_custom.txt.golden
+++ b/internal/deprecate/testdata/output_custom.txt.golden
@@ -1,0 +1,3 @@
+   • first                    
+   • DEPRECATED: some custom template with a url https://goreleaser.com/deprecations#something-else
+   • last                     

--- a/internal/pipe/semver/semver.go
+++ b/internal/pipe/semver/semver.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/apex/log"
+	"github.com/goreleaser/goreleaser/internal/deprecate"
 	"github.com/goreleaser/goreleaser/internal/pipe"
 	"github.com/goreleaser/goreleaser/pkg/context"
 )
@@ -22,9 +22,11 @@ func (Pipe) Run(ctx *context.Context) error {
 	sv, err := semver.NewVersion(ctx.Git.CurrentTag)
 	if err != nil {
 		if ctx.Snapshot || ctx.SkipValidate {
-			log.WithError(err).
-				WithField("tag", ctx.Git.CurrentTag).
-				Warn("current tag is not a semantic tag, which may cause other things to fail later")
+			deprecate.NoticeCustom(
+				ctx,
+				"skipping-semver-validations",
+				fmt.Sprintf("'%s' is not SemVer-compatible and may cause other issues in the pipeline, check {{ .URL }} for more info", ctx.Git.CurrentTag),
+			)
 		}
 		if ctx.Snapshot {
 			return pipe.ErrSnapshotEnabled

--- a/internal/pipe/semver/semver.go
+++ b/internal/pipe/semver/semver.go
@@ -21,16 +21,18 @@ func (Pipe) String() string {
 func (Pipe) Run(ctx *context.Context) error {
 	sv, err := semver.NewVersion(ctx.Git.CurrentTag)
 	if err != nil {
+		if ctx.Snapshot || ctx.SkipValidate {
+			log.WithError(err).
+				WithField("tag", ctx.Git.CurrentTag).
+				Warn("current tag is not a semantic tag, which may cause other things to fail later")
+		}
 		if ctx.Snapshot {
 			return pipe.ErrSnapshotEnabled
 		}
 		if ctx.SkipValidate {
-			log.WithError(err).
-				WithField("tag", ctx.Git.CurrentTag).
-				Warn("current tag is not a semantic tag")
 			return pipe.ErrSkipValidateEnabled
 		}
-		return fmt.Errorf("failed to parse tag %s as semver: %w", ctx.Git.CurrentTag, err)
+		return fmt.Errorf("failed to parse tag '%s' as semver: %w", ctx.Git.CurrentTag, err)
 	}
 	ctx.Semver = context.Semver{
 		Major:      sv.Major(),

--- a/internal/pipe/semver/semver_test.go
+++ b/internal/pipe/semver/semver_test.go
@@ -15,7 +15,7 @@ func TestDescription(t *testing.T) {
 }
 
 func TestValidSemver(t *testing.T) {
-	var ctx = context.New(config.Project{})
+	ctx := context.New(config.Project{})
 	ctx.Git.CurrentTag = "v1.5.2-rc1"
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Equal(t, context.Semver{
@@ -27,15 +27,15 @@ func TestValidSemver(t *testing.T) {
 }
 
 func TestInvalidSemver(t *testing.T) {
-	var ctx = context.New(config.Project{})
+	ctx := context.New(config.Project{})
 	ctx.Git.CurrentTag = "aaaav1.5.2-rc1"
-	var err = Pipe{}.Run(ctx)
+	err := Pipe{}.Run(ctx)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to parse tag aaaav1.5.2-rc1 as semver")
+	require.Contains(t, err.Error(), "failed to parse tag 'aaaav1.5.2-rc1' as semver")
 }
 
 func TestInvalidSemverOnSnapshots(t *testing.T) {
-	var ctx = context.New(config.Project{})
+	ctx := context.New(config.Project{})
 	ctx.Git.CurrentTag = "aaaav1.5.2-rc1"
 	ctx.Snapshot = true
 	require.EqualError(t, Pipe{}.Run(ctx), pipe.ErrSnapshotEnabled.Error())
@@ -48,7 +48,7 @@ func TestInvalidSemverOnSnapshots(t *testing.T) {
 }
 
 func TestInvalidSemverSkipValidate(t *testing.T) {
-	var ctx = context.New(config.Project{})
+	ctx := context.New(config.Project{})
 	ctx.Git.CurrentTag = "aaaav1.5.2-rc1"
 	ctx.SkipValidate = true
 	require.EqualError(t, Pipe{}.Run(ctx), pipe.ErrSkipValidateEnabled.Error())

--- a/www/docs/deprecations.md
+++ b/www/docs/deprecations.md
@@ -15,6 +15,15 @@ goreleaser check
 
 ## Active deprecation notices
 
+### Skipping SemVer Validations
+
+> since 2021-02-28 (v0.158.0)
+
+GoReleaser skips SemVer validations when run with `--skip-validations` or `--snapshot`.
+This causes other problems later, such as [invalid Linux packages](https://github.com/goreleaser/goreleaser/issues/2081).
+Because of that, once this deprecation expires, GoReleaser will hard fail on non-semver versions, as stated on our
+[limitations page](https://goreleaser.com/limitations/semver/).
+
 ### builds for darwin/arm64
 
 > since 2021-02-17 (v0.157.0)


### PR DESCRIPTION
closes #2081

make skipping semver checks deprecated, so we can remove those ifs soon.