### PR TITLE
fix: nfpm config validation

### DIFF
--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -196,8 +196,8 @@ func create(ctx *context.Context, fpm config.NFPM, format, arch string, binaries
 			dst := filepath.Join(fpm.Bindir, binary.Name)
 			log.WithField("src", src).WithField("dst", dst).Debug("adding binary to package")
 			contents = append(contents, &files.Content{
-				Source:      src,
-				Destination: dst,
+				Source:      filepath.ToSlash(src),
+				Destination: filepath.ToSlash(dst),
 			})
 		}
 	}

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -808,10 +808,14 @@ func TestSkipSign(t *testing.T) {
 	}
 
 	t.Run("skip sign not set", func(t *testing.T) {
+		contains := "open /does/not/exist.gpg: no such file or directory"
+		if runtime.GOOS == "windows" {
+			contains = "open /does/not/exist.gpg: The system cannot find the path specified."
+		}
 		require.Contains(
 			t,
 			Pipe{}.Run(ctx).Error(),
-			`open /does/not/exist.gpg: no such file or directory`,
+			contains,
 		)
 	})
 


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

This commit will let windows users to validate nfpm configuration successfully

<!-- Why is this change being made? -->

When validating nfpm configuration windows paths separators ("\\\\") were removed by goreleaser/fileglob. info.Contents source and destination were modified using filepath.ToSlash(). This changes does not impact non-windows users.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

Related issue: https://github.com/goreleaser/goreleaser/issues/2068

Edit: other packages tests still fail but they are related to os-specific behaviors, internal/pipe/nfpm now succeeds.