### PR TITLE
feat: add layout to Snapcraft pipe

### DIFF
--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -43,6 +43,7 @@ type Metadata struct {
 	Grade         string `yaml:",omitempty"`
 	Confinement   string `yaml:",omitempty"`
 	Architectures []string
+	Layout        map[string]LayoutMetadata `yaml:",omitempty"`
 	Apps          map[string]AppMetadata
 	Plugs         map[string]interface{} `yaml:",omitempty"`
 }
@@ -54,6 +55,13 @@ type AppMetadata struct {
 	Daemon           string   `yaml:",omitempty"`
 	Completer        string   `yaml:",omitempty"`
 	RestartCondition string   `yaml:"restart-condition,omitempty"`
+}
+
+type LayoutMetadata struct {
+	Symlink  string `yaml:",omitempty"`
+	Bind     string `yaml:",omitempty"`
+	BindFile string `yaml:"bind-file,omitempty"`
+	Type     string `yaml:",omitempty"`
 }
 
 const defaultNameTemplate = "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
@@ -199,6 +207,7 @@ func create(ctx *context.Context, snap config.Snapcraft, arch string, binaries [
 		Grade:         snap.Grade,
 		Confinement:   snap.Confinement,
 		Architectures: []string{arch},
+		Layout:        map[string]LayoutMetadata{},
 		Apps:          map[string]AppMetadata{},
 	}
 
@@ -213,6 +222,15 @@ func create(ctx *context.Context, snap config.Snapcraft, arch string, binaries [
 	metadata.Name = ctx.Config.ProjectName
 	if snap.Name != "" {
 		metadata.Name = snap.Name
+	}
+
+	for targetPath, layout := range snap.Layout {
+		metadata.Layout[targetPath] = LayoutMetadata{
+			Symlink:  layout.Symlink,
+			Bind:     layout.Bind,
+			BindFile: layout.BindFile,
+			Type:     layout.Type,
+		}
 	}
 
 	// if the user didn't specify any apps then

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -439,23 +439,31 @@ type SnapcraftAppMetadata struct {
 	RestartCondition string `yaml:"restart_condition,omitempty"`
 }
 
+type SnapcraftLayoutMetadata struct {
+	Symlink  string `yaml:",omitempty"`
+	Bind     string `yaml:",omitempty"`
+	BindFile string `yaml:"bind-file,omitempty"`
+	Type     string `yaml:",omitempty"`
+}
+
 // Snapcraft config.
 type Snapcraft struct {
 	NameTemplate string            `yaml:"name_template,omitempty"`
 	Replacements map[string]string `yaml:",omitempty"`
 	Publish      bool              `yaml:",omitempty"`
 
-	ID          string                          `yaml:",omitempty"`
-	Builds      []string                        `yaml:",omitempty"`
-	Name        string                          `yaml:",omitempty"`
-	Summary     string                          `yaml:",omitempty"`
-	Description string                          `yaml:",omitempty"`
-	Base        string                          `yaml:",omitempty"`
-	License     string                          `yaml:",omitempty"`
-	Grade       string                          `yaml:",omitempty"`
-	Confinement string                          `yaml:",omitempty"`
-	Apps        map[string]SnapcraftAppMetadata `yaml:",omitempty"`
-	Plugs       map[string]interface{}          `yaml:",omitempty"`
+	ID          string                             `yaml:",omitempty"`
+	Builds      []string                           `yaml:",omitempty"`
+	Name        string                             `yaml:",omitempty"`
+	Summary     string                             `yaml:",omitempty"`
+	Description string                             `yaml:",omitempty"`
+	Base        string                             `yaml:",omitempty"`
+	License     string                             `yaml:",omitempty"`
+	Grade       string                             `yaml:",omitempty"`
+	Confinement string                             `yaml:",omitempty"`
+	Layout      map[string]SnapcraftLayoutMetadata `yaml:",omitempty"`
+	Apps        map[string]SnapcraftAppMetadata    `yaml:",omitempty"`
+	Plugs       map[string]interface{}             `yaml:",omitempty"`
 
 	Files []SnapcraftExtraFiles `yaml:"extra_files,omitempty"`
 }

--- a/www/docs/customization/snapcraft.md
+++ b/www/docs/customization/snapcraft.md
@@ -98,6 +98,19 @@ snapcrafts:
         destination: bin/drumroll.wrapper
         mode: 0755
 
+    # With layouts, you can make elements in $SNAP, $SNAP_DATA, $SNAP_COMMON
+    # accessible from locations such as /usr, /var and /etc. This helps when using
+    # pre-compiled binaries and libraries that expect to find files and
+    # directories outside of locations referenced by $SNAP or $SNAP_DATA.
+    # More info about layout here:
+    # https://snapcraft.io/docs/snap-layouts
+    # More info about environment variables here:
+    # https://snapcraft.io/docs/security-sandboxing
+    # Default is empty.
+    layout:
+      /etc/drumroll:
+        bind: $SNAP_DATA/etc
+
     # Each binary built by GoReleaser is an app inside the snap. In this section
     # you can declare extra details for those binaries. It is optional.
     apps:


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

**Why is this change being made?**

I am a goreleaser user.

I use goreleaser to build my own application: [meepo](https://github.com/PeerXu/meepo).

When try to build snap with strict confinement, service can not read configure files in isolated environment.

I figure out how to solve the problem, it should be use `layout`, for mapping files to sandbox.

**# Provide links to any relevant tickets, URLs or other resources**

[Use layout](https://snapcraft.io/docs/snap-layouts)
