### PR TITLE
docs: Add info on skip_upload to scoop 

### DIFF
--- a/www/docs/customization/scoop.md
+++ b/www/docs/customization/scoop.md
@@ -46,8 +46,7 @@ scoop:
   license: MIT
 
   # Setting this will prevent goreleaser to actually try to commit the updated
-  # manifest - instead, the manifest file will be stored on the dist folder only,
-  # leaving the responsibility of publishing it to the user.
+  # manifest leaving the responsibility of publishing it to the user.
   # If set to auto, the release will not be uploaded to the scoop bucket
   # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
   # Default is false.

--- a/www/docs/customization/scoop.md
+++ b/www/docs/customization/scoop.md
@@ -45,6 +45,14 @@ scoop:
   # Default is empty.
   license: MIT
 
+  # Setting this will prevent goreleaser to actually try to commit the updated
+  # manifest - instead, the manifest file will be stored on the dist folder only,
+  # leaving the responsibility of publishing it to the user.
+  # If set to auto, the release will not be uploaded to the scoop bucket
+  # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
+  # Default is false.
+  skip_upload: true
+
   # Persist data between application updates
   persist:
   - "data"


### PR DESCRIPTION
Scoop supports `skip_upload`, just like Brew, but it was missing in the docs.