### PR TITLE
feat: support snapcraft layout

### DIFF
--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -43,6 +43,7 @@ type Metadata struct {
 	Grade         string `yaml:",omitempty"`
 	Confinement   string `yaml:",omitempty"`
 	Architectures []string
+	Layout        map[string]LayoutMetadata `yaml:",omitempty"`
 	Apps          map[string]AppMetadata
 	Plugs         map[string]interface{} `yaml:",omitempty"`
 }
@@ -54,6 +55,13 @@ type AppMetadata struct {
 	Daemon           string   `yaml:",omitempty"`
 	Completer        string   `yaml:",omitempty"`
 	RestartCondition string   `yaml:"restart-condition,omitempty"`
+}
+
+type LayoutMetadata struct {
+	Symlink  string `yaml:",omitempty"`
+	Bind     string `yaml:",omitempty"`
+	BindFile string `yaml:"bind-file,omitempty"`
+	Type     string `yaml:",omitempty"`
 }
 
 const defaultNameTemplate = "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
@@ -199,6 +207,7 @@ func create(ctx *context.Context, snap config.Snapcraft, arch string, binaries [
 		Grade:         snap.Grade,
 		Confinement:   snap.Confinement,
 		Architectures: []string{arch},
+		Layout:        map[string]LayoutMetadata{},
 		Apps:          map[string]AppMetadata{},
 	}
 
@@ -213,6 +222,15 @@ func create(ctx *context.Context, snap config.Snapcraft, arch string, binaries [
 	metadata.Name = ctx.Config.ProjectName
 	if snap.Name != "" {
 		metadata.Name = snap.Name
+	}
+
+	for targetPath, layout := range snap.Layout {
+		metadata.Layout[targetPath] = LayoutMetadata{
+			Symlink:  layout.Symlink,
+			Bind:     layout.Bind,
+			BindFile: layout.BindFile,
+			Type:     layout.Type,
+		}
 	}
 
 	// if the user didn't specify any apps then

--- a/internal/pipe/snapcraft/snapcraft_test.go
+++ b/internal/pipe/snapcraft/snapcraft_test.go
@@ -153,6 +153,9 @@ func TestRunPipeMetadata(t *testing.T) {
 				NameTemplate: "foo_{{.Arch}}",
 				Summary:      "test summary",
 				Description:  "test description",
+				Layout: map[string]config.SnapcraftLayoutMetadata{
+					"/etc/testprojectname": {Bind: "$SNAP_DATA/etc"},
+				},
 				Apps: map[string]config.SnapcraftAppMetadata{
 					"foo": {
 						Plugs:            []string{"home", "network", "personal-files"},
@@ -187,6 +190,7 @@ func TestRunPipeMetadata(t *testing.T) {
 	require.Equal(t, "foo --foo --bar", metadata.Apps["foo"].Command)
 	require.Equal(t, map[interface{}]interface{}{"read": []interface{}{"$HOME/test"}}, metadata.Plugs["personal-files"])
 	require.Equal(t, "always", metadata.Apps["foo"].RestartCondition)
+	require.Equal(t, "$SNAP_DATA/etc", metadata.Layout["/etc/testprojectname"].Bind)
 }
 
 func TestNoSnapcraftInPath(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -439,23 +439,31 @@ type SnapcraftAppMetadata struct {
 	RestartCondition string `yaml:"restart_condition,omitempty"`
 }
 
+type SnapcraftLayoutMetadata struct {
+	Symlink  string `yaml:",omitempty"`
+	Bind     string `yaml:",omitempty"`
+	BindFile string `yaml:"bind-file,omitempty"`
+	Type     string `yaml:",omitempty"`
+}
+
 // Snapcraft config.
 type Snapcraft struct {
 	NameTemplate string            `yaml:"name_template,omitempty"`
 	Replacements map[string]string `yaml:",omitempty"`
 	Publish      bool              `yaml:",omitempty"`
 
-	ID          string                          `yaml:",omitempty"`
-	Builds      []string                        `yaml:",omitempty"`
-	Name        string                          `yaml:",omitempty"`
-	Summary     string                          `yaml:",omitempty"`
-	Description string                          `yaml:",omitempty"`
-	Base        string                          `yaml:",omitempty"`
-	License     string                          `yaml:",omitempty"`
-	Grade       string                          `yaml:",omitempty"`
-	Confinement string                          `yaml:",omitempty"`
-	Apps        map[string]SnapcraftAppMetadata `yaml:",omitempty"`
-	Plugs       map[string]interface{}          `yaml:",omitempty"`
+	ID          string                             `yaml:",omitempty"`
+	Builds      []string                           `yaml:",omitempty"`
+	Name        string                             `yaml:",omitempty"`
+	Summary     string                             `yaml:",omitempty"`
+	Description string                             `yaml:",omitempty"`
+	Base        string                             `yaml:",omitempty"`
+	License     string                             `yaml:",omitempty"`
+	Grade       string                             `yaml:",omitempty"`
+	Confinement string                             `yaml:",omitempty"`
+	Layout      map[string]SnapcraftLayoutMetadata `yaml:",omitempty"`
+	Apps        map[string]SnapcraftAppMetadata    `yaml:",omitempty"`
+	Plugs       map[string]interface{}             `yaml:",omitempty"`
 
 	Files []SnapcraftExtraFiles `yaml:"extra_files,omitempty"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -442,7 +442,7 @@ type SnapcraftAppMetadata struct {
 type SnapcraftLayoutMetadata struct {
 	Symlink  string `yaml:",omitempty"`
 	Bind     string `yaml:",omitempty"`
-	BindFile string `yaml:"bind-file,omitempty"`
+	BindFile string `yaml:"bind_file,omitempty"`
 	Type     string `yaml:",omitempty"`
 }
 

--- a/www/docs/customization/snapcraft.md
+++ b/www/docs/customization/snapcraft.md
@@ -102,13 +102,33 @@ snapcrafts:
     # accessible from locations such as /usr, /var and /etc. This helps when using
     # pre-compiled binaries and libraries that expect to find files and
     # directories outside of locations referenced by $SNAP or $SNAP_DATA.
+    # About snap environment variables:
+    # * HOME: set to SNAP_USER_DATA for all commands
+    # * SNAP: read-only install directory
+    # * SNAP_ARCH: the architecture of device (eg, amd64, arm64, armhf, i386, etc)
+    # * SNAP_DATA: writable area for a particular revision of the snap
+    # * SNAP_COMMON: writable area common across all revisions of the snap
+    # * SNAP_LIBRARY_PATH: additional directories which should be added to LD_LIBRARY_PATH
+    # * SNAP_NAME: snap name
+    # * SNAP_INSTANCE_NAME: snap instance name incl. instance key if one is set (snapd 2.36+)
+    # * SNAP_INSTANCE_KEY: instance key if any (snapd 2.36+)
+    # * SNAP_REVISION: store revision of the snap
+    # * SNAP_USER_DATA: per-user writable area for a particular revision of the snap
+    # * SNAP_USER_COMMON: per-user writable area common across all revisions of the snap
+    # * SNAP_VERSION: snap version (from snap.yaml)
     # More info about layout here:
     # https://snapcraft.io/docs/snap-layouts
-    # More info about environment variables here:
-    # https://snapcraft.io/docs/security-sandboxing
     # Default is empty.
     layout:
+      # The path you want to access in sandbox.
       /etc/drumroll:
+
+        # Which outside file or directory you want to map to sandbox.
+        # Valid keys are:
+        # * bind - Bind-mount a directory.
+        # * bind_file - Bind-mount a file.
+        # * symlink - Create a symbolic link.
+        # * type - Mount a private temporary in-memory filesystem.
         bind: $SNAP_DATA/etc
 
     # Each binary built by GoReleaser is an app inside the snap. In this section

--- a/www/docs/customization/snapcraft.md
+++ b/www/docs/customization/snapcraft.md
@@ -98,6 +98,19 @@ snapcrafts:
         destination: bin/drumroll.wrapper
         mode: 0755
 
+    # With layouts, you can make elements in $SNAP, $SNAP_DATA, $SNAP_COMMON
+    # accessible from locations such as /usr, /var and /etc. This helps when using
+    # pre-compiled binaries and libraries that expect to find files and
+    # directories outside of locations referenced by $SNAP or $SNAP_DATA.
+    # More info about layout here:
+    # https://snapcraft.io/docs/snap-layouts
+    # More info about environment variables here:
+    # https://snapcraft.io/docs/security-sandboxing
+    # Default is empty.
+    layout:
+      /etc/drumroll:
+        bind: $SNAP_DATA/etc
+
     # Each binary built by GoReleaser is an app inside the snap. In this section
     # you can declare extra details for those binaries. It is optional.
     apps:


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

**If applied, this commit will...**

Goreleaser will support snapcraft layout.

bind to #2106 

**Why is this change being made?**

I am a goreleaser user.

I use goreleaser to build my own application: [meepo](https://github.com/PeerXu/meepo).

When try to build snap with strict confinement, service can not read configure files in isolated environment.

I figure out how to solve the problem, it should be use `layout`, for mapping files to sandbox.

But goreleaser not support snapcraft layout now, so I want it support the feature.

**# Provide links to any relevant tickets, URLs or other resources**

[Use layout](https://snapcraft.io/docs/snap-layouts)
