### PR TITLE
fix: make snap tests more stable

### DIFF
--- a/internal/pipe/snapcraft/snapcraft_test.go
+++ b/internal/pipe/snapcraft/snapcraft_test.go
@@ -32,7 +32,8 @@ func TestRunPipeMissingInfo(t *testing.T) {
 		pipe.Skip("no summary nor description were provided"): {},
 	} {
 		t.Run(fmt.Sprintf("testing if %v happens", eerr), func(t *testing.T) {
-			var ctx = &context.Context{
+			require.NoError(t, os.Setenv("HOME", t.TempDir()))
+			ctx := &context.Context{
 				Config: config.Project{
 					Snapcrafts: []config.Snapcraft{
 						snap,
@@ -45,10 +46,11 @@ func TestRunPipeMissingInfo(t *testing.T) {
 }
 
 func TestRunPipe(t *testing.T) {
-	var folder = t.TempDir()
-	var dist = filepath.Join(folder, "dist")
-	require.NoError(t, os.Mkdir(dist, 0755))
-	var ctx = context.New(config.Project{
+	require.NoError(t, os.Setenv("HOME", t.TempDir()))
+	folder := t.TempDir()
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+	ctx := context.New(config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		Snapcrafts: []config.Snapcraft{
@@ -85,10 +87,11 @@ func TestRunPipe(t *testing.T) {
 }
 
 func TestRunPipeInvalidNameTemplate(t *testing.T) {
-	var folder = t.TempDir()
-	var dist = filepath.Join(folder, "dist")
-	require.NoError(t, os.Mkdir(dist, 0755))
-	var ctx = context.New(config.Project{
+	require.NoError(t, os.Setenv("HOME", t.TempDir()))
+	folder := t.TempDir()
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+	ctx := context.New(config.Project{
 		ProjectName: "foo",
 		Dist:        dist,
 		Snapcrafts: []config.Snapcraft{
@@ -107,10 +110,11 @@ func TestRunPipeInvalidNameTemplate(t *testing.T) {
 }
 
 func TestRunPipeWithName(t *testing.T) {
-	var folder = t.TempDir()
-	var dist = filepath.Join(folder, "dist")
-	require.NoError(t, os.Mkdir(dist, 0755))
-	var ctx = context.New(config.Project{
+	require.NoError(t, os.Setenv("HOME", t.TempDir()))
+	folder := t.TempDir()
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+	ctx := context.New(config.Project{
 		ProjectName: "testprojectname",
 		Dist:        dist,
 		Snapcrafts: []config.Snapcraft{
@@ -141,10 +145,11 @@ func TestRunPipeWithName(t *testing.T) {
 }
 
 func TestRunPipeMetadata(t *testing.T) {
-	var folder = t.TempDir()
-	var dist = filepath.Join(folder, "dist")
-	require.NoError(t, os.Mkdir(dist, 0755))
-	var ctx = context.New(config.Project{
+	require.NoError(t, os.Setenv("HOME", t.TempDir()))
+	folder := t.TempDir()
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+	ctx := context.New(config.Project{
 		ProjectName: "testprojectname",
 		Dist:        dist,
 		Snapcrafts: []config.Snapcraft{
@@ -194,12 +199,13 @@ func TestRunPipeMetadata(t *testing.T) {
 }
 
 func TestNoSnapcraftInPath(t *testing.T) {
-	var path = os.Getenv("PATH")
+	require.NoError(t, os.Setenv("HOME", t.TempDir()))
+	path := os.Getenv("PATH")
 	defer func() {
 		require.NoError(t, os.Setenv("PATH", path))
 	}()
 	require.NoError(t, os.Setenv("PATH", ""))
-	var ctx = context.New(config.Project{
+	ctx := context.New(config.Project{
 		Snapcrafts: []config.Snapcraft{
 			{
 				Summary:     "dummy",
@@ -211,10 +217,11 @@ func TestNoSnapcraftInPath(t *testing.T) {
 }
 
 func TestRunNoArguments(t *testing.T) {
-	var folder = t.TempDir()
-	var dist = filepath.Join(folder, "dist")
-	require.NoError(t, os.Mkdir(dist, 0755))
-	var ctx = context.New(config.Project{
+	require.NoError(t, os.Setenv("HOME", t.TempDir()))
+	folder := t.TempDir()
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+	ctx := context.New(config.Project{
 		ProjectName: "testprojectname",
 		Dist:        dist,
 		Snapcrafts: []config.Snapcraft{
@@ -245,10 +252,11 @@ func TestRunNoArguments(t *testing.T) {
 }
 
 func TestCompleter(t *testing.T) {
-	var folder = t.TempDir()
-	var dist = filepath.Join(folder, "dist")
-	require.NoError(t, os.Mkdir(dist, 0755))
-	var ctx = context.New(config.Project{
+	require.NoError(t, os.Setenv("HOME", t.TempDir()))
+	folder := t.TempDir()
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+	ctx := context.New(config.Project{
 		ProjectName: "testprojectname",
 		Dist:        dist,
 		Snapcrafts: []config.Snapcraft{
@@ -282,10 +290,11 @@ func TestCompleter(t *testing.T) {
 }
 
 func TestCommand(t *testing.T) {
-	var folder = t.TempDir()
-	var dist = filepath.Join(folder, "dist")
-	require.NoError(t, os.Mkdir(dist, 0755))
-	var ctx = context.New(config.Project{
+	require.NoError(t, os.Setenv("HOME", t.TempDir()))
+	folder := t.TempDir()
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+	ctx := context.New(config.Project{
 		ProjectName: "testprojectname",
 		Dist:        dist,
 		Snapcrafts: []config.Snapcraft{
@@ -317,10 +326,11 @@ func TestCommand(t *testing.T) {
 }
 
 func TestExtraFile(t *testing.T) {
-	var folder = t.TempDir()
-	var dist = filepath.Join(folder, "dist")
-	require.NoError(t, os.Mkdir(dist, 0755))
-	var ctx = context.New(config.Project{
+	require.NoError(t, os.Setenv("HOME", t.TempDir()))
+	folder := t.TempDir()
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+	ctx := context.New(config.Project{
 		ProjectName: "testprojectname",
 		Dist:        dist,
 		Snapcrafts: []config.Snapcraft{
@@ -332,7 +342,7 @@ func TestExtraFile(t *testing.T) {
 					{
 						Source:      "testdata/extra-file.txt",
 						Destination: "a/b/c/extra-file.txt",
-						Mode:        0755,
+						Mode:        0o755,
 					},
 					{
 						Source: "testdata/extra-file-2.txt",
@@ -352,18 +362,18 @@ func TestExtraFile(t *testing.T) {
 	destFile, err := os.Stat(filepath.Join(dist, "foo_amd64", "prime", "a", "b", "c", "extra-file.txt"))
 	require.NoError(t, err)
 	require.Equal(t, inode(srcFile), inode(destFile))
-	require.Equal(t, destFile.Mode(), os.FileMode(0755))
+	require.Equal(t, destFile.Mode(), os.FileMode(0o755))
 
 	srcFile, err = os.Stat("testdata/extra-file-2.txt")
 	require.NoError(t, err)
 	destFileWithDefaults, err := os.Stat(filepath.Join(dist, "foo_amd64", "prime", "testdata", "extra-file-2.txt"))
 	require.NoError(t, err)
-	require.Equal(t, destFileWithDefaults.Mode(), os.FileMode(0644))
+	require.Equal(t, destFileWithDefaults.Mode(), os.FileMode(0o644))
 	require.Equal(t, inode(srcFile), inode(destFileWithDefaults))
 }
 
 func TestDefault(t *testing.T) {
-	var ctx = context.New(config.Project{
+	ctx := context.New(config.Project{
 		Builds: []config.Build{
 			{
 				ID: "foo",
@@ -379,7 +389,8 @@ func TestDefault(t *testing.T) {
 }
 
 func TestPublish(t *testing.T) {
-	var ctx = context.New(config.Project{})
+	require.NoError(t, os.Setenv("HOME", t.TempDir()))
+	ctx := context.New(config.Project{})
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "mybin",
 		Path:   "nope.snap",
@@ -392,7 +403,7 @@ func TestPublish(t *testing.T) {
 }
 
 func TestPublishSkip(t *testing.T) {
-	var ctx = context.New(config.Project{})
+	ctx := context.New(config.Project{})
 	ctx.SkipPublish = true
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "mybin",
@@ -405,7 +416,7 @@ func TestPublishSkip(t *testing.T) {
 }
 
 func TestDefaultSet(t *testing.T) {
-	var ctx = context.New(config.Project{
+	ctx := context.New(config.Project{
 		Snapcrafts: []config.Snapcraft{
 			{
 				NameTemplate: "foo",
@@ -420,9 +431,9 @@ func addBinaries(t *testing.T, ctx *context.Context, name, dist string) {
 	t.Helper()
 	for _, goos := range []string{"linux", "darwin"} {
 		for _, goarch := range []string{"amd64", "386", "arm6"} {
-			var folder = goos + goarch
-			require.NoError(t, os.MkdirAll(filepath.Join(dist, folder), 0755))
-			var binPath = filepath.Join(dist, folder, name)
+			folder := goos + goarch
+			require.NoError(t, os.MkdirAll(filepath.Join(dist, folder), 0o755))
+			binPath := filepath.Join(dist, folder, name)
 			_, err := os.Create(binPath)
 			require.NoError(t, err)
 			ctx.Artifacts.Add(&artifact.Artifact{
@@ -440,7 +451,7 @@ func addBinaries(t *testing.T, ctx *context.Context, name, dist string) {
 }
 
 func TestSeveralSnapssWithTheSameID(t *testing.T) {
-	var ctx = &context.Context{
+	ctx := &context.Context{
 		Config: config.Project{
 			Snapcrafts: []config.Snapcraft{
 				{


### PR DESCRIPTION
sometimes we get [this](https://github.com/goreleaser/goreleaser/runs/2130960709#step:9:87), which seems to be an issue in snap itself.

maybe setting a different home folder helps... no idea, can't reproduce locally...