### PR TITLE
Add trimprefix function to template package

### DIFF
--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -166,11 +166,12 @@ func (t *Template) Apply(s string) (string, error) {
 			"time": func(s string) string {
 				return time.Now().UTC().Format(s)
 			},
-			"tolower": strings.ToLower,
-			"toupper": strings.ToUpper,
-			"trim":    strings.TrimSpace,
-			"dir":     filepath.Dir,
-			"abs":     filepath.Abs,
+			"tolower":    strings.ToLower,
+			"toupper":    strings.ToUpper,
+			"trim":       strings.TrimSpace,
+			"trimprefix": strings.TrimPrefix,
+			"dir":        filepath.Dir,
+			"abs":        filepath.Abs,
 		}).
 		Parse(s)
 	if err != nil {

--- a/internal/tmpl/tmpl_test.go
+++ b/internal/tmpl/tmpl_test.go
@@ -189,6 +189,11 @@ func TestFuncMap(t *testing.T) {
 			Expected: "test",
 		},
 		{
+			Template: `{{ trimprefix "v1.2.4" "v" }}`,
+			Name:     "trimprefix",
+			Expected: "1.2.4",
+		},
+		{
 			Template: `{{ toupper "test" }}`,
 			Name:     "toupper",
 			Expected: "TEST",

--- a/www/docs/customization/templates.md
+++ b/www/docs/customization/templates.md
@@ -62,6 +62,7 @@ On all fields, you have these available functions:
 | `tolower "V1.2"`        | makes input string lowercase. See [ToLower](https://golang.org/pkg/strings/#ToLower)                                           |
 | `toupper "v1.2"`        | makes input string uppercase. See [ToUpper](https://golang.org/pkg/strings/#ToUpper)                                           |
 | `trim " v1.2  "`        | removes all leading and trailing white space. See [TrimSpace](https://golang.org/pkg/strings/#TrimSpace)                       |
+| `trimprefix "v1.2" "v"` | removes provided leading prefix string, if present. See [TrimSpace](https://golang.org/pkg/strings/#TrimPrefix)                |
 | `dir .Path`             | returns all but the last element of path, typically the path's directory. See [Dir](https://golang.org/pkg/path/filepath/#Dir) |
 | `abs .ArtifactPath`     | returns an absolute representation of path. See [Abs](https://golang.org/pkg/path/filepath/#Abs)                               |
 


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

This allows templates to trim prefixes. Particularly useful for removing the v prefix from versions.

<!-- Why is this change being made? -->

## Why ?

`.Version` for a release has the v prefix stripped. I would expect the same for the snapshot. From https://goreleaser.com/customization/templates/:

> the version being released (v prefix stripped),
> or {{ .Tag }}-SNAPSHOT-{{ .ShortCommit }} in case of snapshot release

At present, any other templates where I use `.Version` but need to re-add the v prefix (because it might be relevant in a URL for example) ends up having a double prefix e.g. `vv0.5.4-SNAPSHOT-0b768c4`.

`trimprefix` would be useful in this case so that users can trim prefixes in their custom templates.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

See the discussion for some context: [should tag in snapshot's default .Version have a v prefix ?](https://github.com/goreleaser/goreleaser/discussions/2114)
