### PR TITLE
fix: docker manifest on draft release

### DIFF
--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -155,9 +155,6 @@ func process(ctx *context.Context, docker config.Docker, artifacts []*artifact.A
 	if ctx.SkipPublish {
 		return pipe.ErrSkipPublishEnabled
 	}
-	if ctx.Config.Release.Draft {
-		return pipe.Skip("release is marked as draft")
-	}
 	if strings.TrimSpace(docker.SkipPush) == "auto" && ctx.Semver.Prerelease != "" {
 		return pipe.Skip("prerelease detected with 'auto' push, skipping docker publish")
 	}

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -1002,6 +1002,18 @@ func TestDefaultDockerfile(t *testing.T) {
 	require.Equal(t, "Dockerfile", ctx.Config.Dockers[1].Dockerfile)
 }
 
+func TestDraftRelease(t *testing.T) {
+	var ctx = &context.Context{
+		Config: config.Project{
+			Release: config.Release{
+				Draft: true,
+			},
+		},
+	}
+
+	require.False(t, pipe.IsSkip(Pipe{}.Publish(ctx)))
+}
+
 func TestDefaultNoDockers(t *testing.T) {
 	var ctx = &context.Context{
 		Config: config.Project{


### PR DESCRIPTION
docker manifests exepcted to be pushed on draft.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->

<!-- # Provide links to any relevant tickets, URLs or other resources -->
