### PR TITLE
fix: default gomips

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -57,6 +57,9 @@ func (*Builder) WithDefaults(build config.Build) (config.Build, error) {
 		if len(build.Goarm) == 0 {
 			build.Goarm = []string{"6"}
 		}
+		if len(build.Gomips) == 0 {
+			build.Gomips = []string{"hardfloat"}
+		}
 		targets, err := matrix(build)
 		build.Targets = targets
 		if err != nil {

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -266,6 +266,7 @@ func TestDefaultEmptyBuild(t *testing.T) {
 	require.Equal(t, []string{"linux", "darwin"}, build.Goos)
 	require.Equal(t, []string{"amd64", "arm64", "386"}, build.Goarch)
 	require.Equal(t, []string{"6"}, build.Goarm)
+	require.Equal(t, []string{"hardfloat"}, build.Gomips)
 	require.Len(t, build.Ldflags, 1)
 	require.Equal(t, "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser", build.Ldflags[0])
 }

--- a/www/docs/customization/build.md
+++ b/www/docs/customization/build.md
@@ -85,7 +85,7 @@ builds:
 
     # GOMIPS and GOMIPS64 to build when GOARCH is mips, mips64, mipsle or mips64le.
     # For more info refer to: https://golang.org/doc/install/source#environment
-    # Default is empty.
+    # Default is only hardfloat.
     gomips:
       - hardfloat
       - softfloat


### PR DESCRIPTION
default to hardfloat, as in `go build`.

an empty gomips was causing goreleaser to fail validation as well.

closes https://github.com/goreleaser/goreleaser/discussions/2105