### PR TITLE
fix: update go-gitlab to fix upload file issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0
 	github.com/ulikunitz/xz v0.5.10
-	github.com/xanzy/go-gitlab v0.47.0
+	github.com/xanzy/go-gitlab v0.47.1-0.20210328064532-c7d8031f590e
 	gocloud.dev v0.22.0
 	golang.org/x/oauth2 v0.0.0-20201203001011-0b49973bad19
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9

--- a/go.sum
+++ b/go.sum
@@ -513,8 +513,8 @@ github.com/ulikunitz/xz v0.5.7/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oW
 github.com/ulikunitz/xz v0.5.9/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/xanzy/go-gitlab v0.47.0 h1:nC35CNaGr9skHkJq1HMYZ58R7gZsy7SO37SkA2RIHbM=
-github.com/xanzy/go-gitlab v0.47.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
+github.com/xanzy/go-gitlab v0.47.1-0.20210328064532-c7d8031f590e h1:niHNl0dejumbhoAaZlvISJeZTctKRtQ7rzQEw2ZNT7E=
+github.com/xanzy/go-gitlab v0.47.1-0.20210328064532-c7d8031f590e/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=


### PR DESCRIPTION
Gitlab.com has some changed (bug?) recently that returns 500 internal server error if the filename contains "/".
Update go-gitlab dependency to get the workaround from upstream: https://github.com/xanzy/go-gitlab/pull/1113.


> If applied, this commit will...

Fix the uploading error for Gitlab.com.

> Why is this change being made?

To update go-gitlab dependency to get the workaround from upstream.

> Provide links to any relevant tickets, URLs or other resources

* https://github.com/xanzy/go-gitlab/pull/1113
