### PR TITLE
fix: ignore non-arm64/386 builds when building Scoop manifest

### DIFF
--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -193,9 +193,18 @@ func dataFor(ctx *context.Context, cl client.Client, artifacts []*artifact.Artif
 	}
 
 	for _, artifact := range artifacts {
-		var arch = "64bit"
-		if artifact.Goarch == "386" {
+		if artifact.Goos != "windows" {
+			continue
+		}
+
+		var arch string
+		switch {
+		case artifact.Goarch == "386":
 			arch = "32bit"
+		case artifact.Goarch == "amd64":
+			arch = "64bit"
+		default:
+			continue
 		}
 
 		url, err := tmpl.New(ctx).

--- a/internal/pipe/scoop/scoop_test.go
+++ b/internal/pipe/scoop/scoop_test.go
@@ -942,6 +942,23 @@ func Test_buildManifest(t *testing.T) {
 					},
 				},
 				{
+					Name:   "foo_1.0.1_windows_arm.tar.gz",
+					Goos:   "windows",
+					Goarch: "arm",
+					Path:   file,
+					Extra: map[string]interface{}{
+						"ArtifactUploadHash": "820ead5d9d2266c728dce6d4d55b6460",
+						"Builds": []*artifact.Artifact{
+							{
+								Name: "foo.exe",
+							},
+							{
+								Name: "bar.exe",
+							},
+						},
+					},
+				},
+				{
 					Name:   "foo_1.0.1_windows_386.tar.gz",
 					Goos:   "windows",
 					Goarch: "386",


### PR DESCRIPTION
Fixes #2171, see issue for details.