### PR TITLE
fix: handle build.main being a go file when using gomod.proxy

### DIFF
--- a/internal/pipe/gomod/gomod.go
+++ b/internal/pipe/gomod/gomod.go
@@ -24,6 +24,8 @@ const (
 	go116NotAGoModuleError = "command-line-arguments"
 )
 
+var errNotAMainPackage = errors.New("build.main needs to be a package")
+
 // Pipe for env.
 type Pipe struct{}
 
@@ -119,6 +121,13 @@ func (e ErrProxy) Unwrap() error {
 }
 
 func proxyBuild(ctx *context.Context, build *config.Build) error {
+	if strings.HasSuffix(build.Main, ".go") {
+		return newDetailedErrProxy(
+			errNotAMainPackage,
+			fmt.Sprintf("please change builds.%s.main to a package instead of %s", build.ID, build.Main),
+		)
+	}
+
 	mainPackage := path.Join(ctx.ModulePath, build.Main)
 	template := tmpl.New(ctx).WithExtraFields(tmpl.Fields{
 		"Main":    mainPackage,

--- a/internal/pipe/gomod/gomod_test.go
+++ b/internal/pipe/gomod/gomod_test.go
@@ -208,10 +208,12 @@ func TestGoModProxy(t *testing.T) {
 
 		fakeGoModAndSum(t, mod)
 		require.NoError(t, Pipe{}.Default(ctx))
-		err := Pipe{}.Run(ctx)
-		require.ErrorAs(t, err, &ErrProxy{})
-		require.ErrorIs(t, err, errNotAMainPackage)
-		require.EqualError(t, err, "failed to proxy module: build.main needs to be a package: please change builds.foo.main to a package instead of main.go")
+		require.NoError(t, Pipe{}.Run(ctx))
+		requireGoMod(t, mod, ctx.Git.CurrentTag)
+		requireMainGo(t, mod)
+		require.Equal(t, mod, ctx.Config.Builds[0].Main)
+		require.Equal(t, filepath.Join(dist, "proxy", "foo"), ctx.Config.Builds[0].Dir)
+		require.Equal(t, mod, ctx.ModulePath)
 	})
 }
 

--- a/www/docs/customization/build.md
+++ b/www/docs/customization/build.md
@@ -24,8 +24,10 @@ builds:
     dir: go
 
     # Path to main.go file or main package.
+    # Notice: when used with `gomod.proxy`, this must be a package.
+    #
     # Default is `.`.
-    main: ./cmd/main.go
+    main: ./cmd/my-app
 
     # Binary name.
     # Can be a path (e.g. `bin/app`) to wrap the binary in a directory.
@@ -134,7 +136,7 @@ Here is an example with multiple binaries:
 ```yaml
 # .goreleaser.yml
 builds:
-  - main: ./cmd/cli/cli.go
+  - main: ./cmd/cli
     id: "cli"
     binary: cli
     goos:
@@ -142,7 +144,7 @@ builds:
       - darwin
       - windows
 
-  - main: ./cmd/worker/worker.go
+  - main: ./cmd/worker
     id: "worker"
     binary: worker
     goos:
@@ -150,7 +152,7 @@ builds:
       - darwin
       - windows
 
-  - main: ./cmd/tracker/tracker.go
+  - main: ./cmd/tracker
     id: "tracker"
     binary: tracker
     goos:

--- a/www/docs/customization/gomod.md
+++ b/www/docs/customization/gomod.md
@@ -15,6 +15,7 @@ Configuration options available are described bellow.
 gomod:
   # Proxy a module from proxy.golang.org, making the builds verifiable.
   # This will only be effective if running against a tag. Snapshots will ignore this setting.
+  # PS: for this to work you `build.main` must be a package, not a `.go` file.
   #
   # Default is false.
   proxy: true


### PR DESCRIPTION
refs https://github.com/go-task/task/pull/462#issuecomment-821886239

having `build.main` point to a `main.go` file, for example, instead of package would break things. 

trying to guess the package by removing the last element of the path if it ends with `.go`, also throwing a warning when that happens.