### PR TITLE
feat: build single target and/or build id

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"runtime"
 	"time"
@@ -22,6 +23,7 @@ type buildCmd struct {
 
 type buildOpts struct {
 	config        string
+	id            string
 	snapshot      bool
 	skipValidate  bool
 	skipPostHooks bool
@@ -69,6 +71,7 @@ func newBuildCmd() *buildCmd {
 	cmd.Flags().IntVarP(&root.opts.parallelism, "parallelism", "p", runtime.NumCPU(), "Amount tasks to run concurrently")
 	cmd.Flags().DurationVar(&root.opts.timeout, "timeout", 30*time.Minute, "Timeout to the entire build process")
 	cmd.Flags().BoolVar(&root.opts.singleTarget, "single-target", false, "Builds only for current GOOS and GOARCH")
+	cmd.Flags().StringVar(&root.opts.id, "id", "", "Builds only the specified build id")
 	cmd.Flags().BoolVar(&root.opts.deprecated, "deprecated", false, "Force print the deprecation message - tests only")
 	_ = cmd.Flags().MarkHidden("deprecated")
 
@@ -83,7 +86,9 @@ func buildProject(options buildOpts) (*context.Context, error) {
 	}
 	ctx, cancel := context.NewWithTimeout(cfg, options.timeout)
 	defer cancel()
-	setupBuildContext(ctx, options)
+	if err := setupBuildContext(ctx, options); err != nil {
+		return nil, err
+	}
 	return ctx, ctrlc.Default.Run(ctx, func() error {
 		for _, pipe := range pipeline.BuildPipeline {
 			if err := middleware.Logging(
@@ -98,7 +103,7 @@ func buildProject(options buildOpts) (*context.Context, error) {
 	})
 }
 
-func setupBuildContext(ctx *context.Context, options buildOpts) *context.Context {
+func setupBuildContext(ctx *context.Context, options buildOpts) error {
 	ctx.Parallelism = options.parallelism
 	log.Debugf("parallelism: %v", ctx.Parallelism)
 	ctx.Snapshot = options.snapshot
@@ -108,26 +113,58 @@ func setupBuildContext(ctx *context.Context, options buildOpts) *context.Context
 	ctx.SkipTokenCheck = true
 
 	if options.singleTarget {
-		goos := os.Getenv("GOOS")
-		if goos == "" {
-			goos = runtime.GOOS
-		}
-		goarch := os.Getenv("GOARCH")
-		if goarch == "" {
-			goarch = runtime.GOARCH
-		}
-		log.Infof("building only for %s/%s", goos, goarch)
-		if len(ctx.Config.Builds) == 0 {
-			ctx.Config.Builds = append(ctx.Config.Builds, config.Build{})
-		}
-		for i := range ctx.Config.Builds {
-			build := &ctx.Config.Builds[i]
-			build.Goos = []string{goos}
-			build.Goarch = []string{goarch}
+		setupBuildSingleTarget(ctx)
+	}
+
+	if options.id != "" {
+		if err := setupBuildID(ctx, options.id); err != nil {
+			return err
 		}
 	}
 
 	// test only
 	ctx.Deprecated = options.deprecated
-	return ctx
+	return nil
+}
+
+func setupBuildSingleTarget(ctx *context.Context) {
+	goos := os.Getenv("GOOS")
+	if goos == "" {
+		goos = runtime.GOOS
+	}
+	goarch := os.Getenv("GOARCH")
+	if goarch == "" {
+		goarch = runtime.GOARCH
+	}
+	log.Infof("building only for %s/%s", goos, goarch)
+	if len(ctx.Config.Builds) == 0 {
+		ctx.Config.Builds = append(ctx.Config.Builds, config.Build{})
+	}
+	for i := range ctx.Config.Builds {
+		build := &ctx.Config.Builds[i]
+		build.Goos = []string{goos}
+		build.Goarch = []string{goarch}
+	}
+}
+
+func setupBuildID(ctx *context.Context, id string) error {
+	if len(ctx.Config.Builds) < 2 {
+		log.Warn("single build in config, '--id' ignored")
+		return nil
+	}
+
+	var keep []config.Build
+	for _, build := range ctx.Config.Builds {
+		if build.ID == id {
+			keep = append(keep, build)
+			break
+		}
+	}
+
+	if len(keep) == 0 {
+		return fmt.Errorf("no builds with id '%s'", id)
+	}
+
+	ctx.Config.Builds = keep
+	return nil
 }


### PR DESCRIPTION
a rather simple way to implement a "single target build" approach.

- `goreleaser build --single-target`: builds only `runtime`'s `GOOS`/`GOARCH`
- `GOOS=linux GOARCH=darwin goreleaser build --single-target`: builds for specified `GOOS`/`GOARCH` environment variables
- `goreleaser build --single-target --id foo`: builds only `runtime`'s `GOOS`/`GOARCH` and build id `foo`

Cool things about this:
- no need to mess with anything but the command line
- known interface (GOOS/GOARCH envs)

Notes:
- if `--id` is passed but we have either 0 (default config) or 1 build configs, it is ignored (but warns)

What do you think?

--

closes https://github.com/goreleaser/goreleaser/pull/1987
closes https://github.com/goreleaser/goreleaser/issues/1852
closes https://github.com/goreleaser/goreleaser/pull/2032