### PR TITLE
Do not send an empty discussion category name

### DIFF
--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -144,8 +144,11 @@ func (c *githubClient) CreateRelease(ctx *context.Context, body string) (string,
 		Body:                   github.String(body),
 		Draft:                  github.Bool(ctx.Config.Release.Draft),
 		Prerelease:             github.Bool(ctx.PreRelease),
-		DiscussionCategoryName: github.String(ctx.Config.Release.DiscussionCategoryName),
 	}
+	if ctx.Config.Release.DiscussionCategoryName != "" {
+		data.DiscussionCategoryName = github.String(ctx.Config.Release.DiscussionCategoryName)
+	}
+	
 	release, _, err = c.client.Repositories.GetReleaseByTag(
 		ctx,
 		ctx.Config.Release.GitHub.Owner,


### PR DESCRIPTION
If the discussion category name is not specified in the config file, do not send it in to the request

This is a quick fix, and possibly it would be better to make `DiscussionCategoryName` a pointer.

Fixes #2181 

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->

<!-- # Provide links to any relevant tickets, URLs or other resources -->
