### PR TITLE
refactor: use os and io packages intead of ioutil when possible

### DIFF
--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -51,7 +50,7 @@ func setup(tb testing.TB) string {
 
 func createFile(tb testing.TB, filename, contents string) {
 	tb.Helper()
-	require.NoError(tb, ioutil.WriteFile(filename, []byte(contents), 0o644))
+	require.NoError(tb, os.WriteFile(filename, []byte(contents), 0o644))
 }
 
 func createMainGo(tb testing.TB) {

--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -3,6 +3,7 @@ package artifact
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -157,7 +158,7 @@ func TestGroupByPlatform(t *testing.T) {
 func TestChecksum(t *testing.T) {
 	folder := t.TempDir()
 	file := filepath.Join(folder, "subject")
-	require.NoError(t, ioutil.WriteFile(file, []byte("lorem ipsum"), 0o644))
+	require.NoError(t, os.WriteFile(file, []byte("lorem ipsum"), 0o644))
 
 	artifact := Artifact{
 		Path: file,

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -2,7 +2,6 @@ package golang
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -553,12 +552,12 @@ func TestRunPipeWithProxiedRepo(t *testing.T) {
 	folder := testlib.Mktmp(t)
 	proxied := filepath.Join(folder, "dist/proxy/default")
 	require.NoError(t, os.MkdirAll(proxied, 0o750))
-	require.NoError(t, ioutil.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(proxied, "main.go"),
 		[]byte("// +build: main\npackage main\nimport github.com/goreleaser/goreleaser"),
 		0o666,
 	))
-	require.NoError(t, ioutil.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(proxied, "go.mod"),
 		[]byte("module foo\nrequire github.com/goreleaser/goreleaser v0.161.1"),
 		0o666,
@@ -592,7 +591,7 @@ func TestRunPipeWithProxiedRepo(t *testing.T) {
 
 func TestRunPipeWithMainFuncNotInMainGoFile(t *testing.T) {
 	folder := testlib.Mktmp(t)
-	require.NoError(t, ioutil.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(folder, "foo.go"),
 		[]byte("package main\nfunc main() {println(0)}"),
 		0o644,
@@ -821,7 +820,7 @@ func TestBuildModTimestamp(t *testing.T) {
 
 func writeMainWithoutMainFunc(t *testing.T, folder string) {
 	t.Helper()
-	require.NoError(t, ioutil.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(folder, "main.go"),
 		[]byte("package main\nconst a = 2\nfunc notMain() {println(0)}"),
 		0o644,
@@ -830,7 +829,7 @@ func writeMainWithoutMainFunc(t *testing.T, folder string) {
 
 func writeGoodMain(t *testing.T, folder string) {
 	t.Helper()
-	require.NoError(t, ioutil.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(folder, "main.go"),
 		[]byte("package main\nvar a = 1\nfunc main() {println(0)}"),
 		0o644,

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -2,7 +2,7 @@ package exec
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -44,7 +44,7 @@ func TestExecute(t *testing.T) {
 		{"signature", "sig", artifact.Signature},
 	} {
 		var file = filepath.Join(folder, "a."+a.ext)
-		require.NoError(t, ioutil.WriteFile(file, []byte("lorem ipsum"), 0644))
+		require.NoError(t, os.WriteFile(file, []byte("lorem ipsum"), 0644))
 		ctx.Artifacts.Add(&artifact.Artifact{
 			Name:   "a." + a.ext,
 			Goos:   "linux",

--- a/internal/pipe/artifactory/artifactory.go
+++ b/internal/pipe/artifactory/artifactory.go
@@ -4,7 +4,7 @@ package artifactory
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	h "net/http"
 
 	"github.com/goreleaser/goreleaser/internal/http"
@@ -81,7 +81,7 @@ func checkResponse(r *h.Response) error {
 		return nil
 	}
 	errorResponse := &errorResponse{Response: r}
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err == nil && data != nil {
 		err := json.Unmarshal(data, errorResponse)
 		if err != nil {

--- a/internal/pipe/artifactory/artifactory_test.go
+++ b/internal/pipe/artifactory/artifactory_test.go
@@ -2,7 +2,6 @@ package artifactory
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -63,7 +62,7 @@ func TestRunPipe_ModeBinary(t *testing.T) {
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0o755))
 	binPath := filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
-	require.NoError(t, ioutil.WriteFile(binPath, d1, 0o666))
+	require.NoError(t, os.WriteFile(binPath, d1, 0o666))
 
 	// Dummy artifactories
 	mux.HandleFunc("/example-repo-local/mybin/darwin/amd64/mybin", func(w http.ResponseWriter, r *http.Request) {
@@ -396,7 +395,7 @@ func TestRunPipe_BadCredentials(t *testing.T) {
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0o755))
 	binPath := filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
-	require.NoError(t, ioutil.WriteFile(binPath, d1, 0o666))
+	require.NoError(t, os.WriteFile(binPath, d1, 0o666))
 
 	// Dummy artifactories
 	mux.HandleFunc("/example-repo-local/mybin/darwin/amd64/mybin", func(w http.ResponseWriter, r *http.Request) {
@@ -456,7 +455,7 @@ func TestRunPipe_UnparsableErrorResponse(t *testing.T) {
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0o755))
 	binPath := filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
-	require.NoError(t, ioutil.WriteFile(binPath, d1, 0o666))
+	require.NoError(t, os.WriteFile(binPath, d1, 0o666))
 
 	// Dummy artifactories
 	mux.HandleFunc("/example-repo-local/mybin/darwin/amd64/mybin", func(w http.ResponseWriter, r *http.Request) {
@@ -541,7 +540,7 @@ func TestRunPipe_UnparsableTarget(t *testing.T) {
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0o755))
 	binPath := filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
-	require.NoError(t, ioutil.WriteFile(binPath, d1, 0o666))
+	require.NoError(t, os.WriteFile(binPath, d1, 0o666))
 
 	ctx := context.New(config.Project{
 		ProjectName: "mybin",

--- a/internal/pipe/blob/blob_minio_test.go
+++ b/internal/pipe/blob/blob_minio_test.go
@@ -6,7 +6,6 @@ package blob
 
 import (
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -29,10 +28,10 @@ func TestMinioUpload(t *testing.T) {
 	tgzpath := filepath.Join(folder, "bin.tar.gz")
 	debpath := filepath.Join(folder, "bin.deb")
 	checkpath := filepath.Join(folder, "check.txt")
-	require.NoError(t, ioutil.WriteFile(checkpath, []byte("fake checksums"), 0o744))
-	require.NoError(t, ioutil.WriteFile(srcpath, []byte("fake\nsrc"), 0o744))
-	require.NoError(t, ioutil.WriteFile(tgzpath, []byte("fake\ntargz"), 0o744))
-	require.NoError(t, ioutil.WriteFile(debpath, []byte("fake\ndeb"), 0o744))
+	require.NoError(t, os.WriteFile(checkpath, []byte("fake checksums"), 0o744))
+	require.NoError(t, os.WriteFile(srcpath, []byte("fake\nsrc"), 0o744))
+	require.NoError(t, os.WriteFile(tgzpath, []byte("fake\ntargz"), 0o744))
+	require.NoError(t, os.WriteFile(debpath, []byte("fake\ndeb"), 0o744))
 	ctx := context.New(config.Project{
 		Dist:        folder,
 		ProjectName: "testupload",
@@ -95,8 +94,8 @@ func TestMinioUploadCustomBucketID(t *testing.T) {
 	folder := t.TempDir()
 	tgzpath := filepath.Join(folder, "bin.tar.gz")
 	debpath := filepath.Join(folder, "bin.deb")
-	require.NoError(t, ioutil.WriteFile(tgzpath, []byte("fake\ntargz"), 0o744))
-	require.NoError(t, ioutil.WriteFile(debpath, []byte("fake\ndeb"), 0o744))
+	require.NoError(t, os.WriteFile(tgzpath, []byte("fake\ntargz"), 0o744))
+	require.NoError(t, os.WriteFile(debpath, []byte("fake\ndeb"), 0o744))
 	// Set custom BUCKET_ID env variable.
 	require.NoError(t, os.Setenv("BUCKET_ID", "test"))
 	ctx := context.New(config.Project{
@@ -133,8 +132,8 @@ func TestMinioUploadInvalidCustomBucketID(t *testing.T) {
 	folder := t.TempDir()
 	tgzpath := filepath.Join(folder, "bin.tar.gz")
 	debpath := filepath.Join(folder, "bin.deb")
-	require.NoError(t, ioutil.WriteFile(tgzpath, []byte("fake\ntargz"), 0o744))
-	require.NoError(t, ioutil.WriteFile(debpath, []byte("fake\ndeb"), 0o744))
+	require.NoError(t, os.WriteFile(tgzpath, []byte("fake\ntargz"), 0o744))
+	require.NoError(t, os.WriteFile(debpath, []byte("fake\ndeb"), 0o744))
 	ctx := context.New(config.Project{
 		Dist:        folder,
 		ProjectName: "testupload",
@@ -171,10 +170,10 @@ func TestMinioUploadSkipPublish(t *testing.T) {
 	tgzpath := filepath.Join(folder, "bin.tar.gz")
 	debpath := filepath.Join(folder, "bin.deb")
 	checkpath := filepath.Join(folder, "check.txt")
-	require.NoError(t, ioutil.WriteFile(checkpath, []byte("fake checksums"), 0o744))
-	require.NoError(t, ioutil.WriteFile(srcpath, []byte("fake\nsrc"), 0o744))
-	require.NoError(t, ioutil.WriteFile(tgzpath, []byte("fake\ntargz"), 0o744))
-	require.NoError(t, ioutil.WriteFile(debpath, []byte("fake\ndeb"), 0o744))
+	require.NoError(t, os.WriteFile(checkpath, []byte("fake checksums"), 0o744))
+	require.NoError(t, os.WriteFile(srcpath, []byte("fake\nsrc"), 0o744))
+	require.NoError(t, os.WriteFile(tgzpath, []byte("fake\ntargz"), 0o744))
+	require.NoError(t, os.WriteFile(debpath, []byte("fake\ndeb"), 0o744))
 	ctx := context.New(config.Project{
 		Dist:        folder,
 		ProjectName: "testupload",

--- a/internal/pipe/blob/blob_test.go
+++ b/internal/pipe/blob/blob_test.go
@@ -1,7 +1,6 @@
 package blob
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -126,8 +125,8 @@ func pipePublish(t *testing.T, extra []config.ExtraFile) {
 	var folder = t.TempDir()
 	tgzpath := filepath.Join(folder, "bin.tar.gz")
 	debpath := filepath.Join(folder, "bin.deb")
-	require.NoError(t, ioutil.WriteFile(tgzpath, []byte("fake\ntargz"), 0744))
-	require.NoError(t, ioutil.WriteFile(debpath, []byte("fake\ndeb"), 0744))
+	require.NoError(t, os.WriteFile(tgzpath, []byte("fake\ntargz"), 0744))
+	require.NoError(t, os.WriteFile(debpath, []byte("fake\ndeb"), 0744))
 
 	// Azure Blob Context
 	var azblobctx = context.New(config.Project{

--- a/internal/pipe/blob/upload.go
+++ b/internal/pipe/blob/upload.go
@@ -3,8 +3,8 @@ package blob
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"path"
 
 	"github.com/apex/log"
@@ -166,7 +166,7 @@ func newUploader(ctx *context.Context) uploader {
 }
 
 func getData(ctx *context.Context, conf config.Blob, path string) ([]byte, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return data, fmt.Errorf("failed to open file %s: %w", path, err)
 	}

--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -161,7 +161,7 @@ func doRun(ctx *context.Context, brew config.Homebrew, cl client.Client) error {
 	filename := brew.Name + ".rb"
 	path := filepath.Join(ctx.Config.Dist, filename)
 	log.WithField("formula", path).Info("writing")
-	if err := ioutil.WriteFile(path, []byte(content), 0o644); err != nil { //nolint: gosec
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil { //nolint: gosec
 		return fmt.Errorf("failed to write brew formula: %w", err)
 	}
 

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -93,10 +93,10 @@ func TestFullFormulae(t *testing.T) {
 
 	var golden = "testdata/test.rb.golden"
 	if *update {
-		err := ioutil.WriteFile(golden, []byte(formulae), 0655)
+		err := os.WriteFile(golden, []byte(formulae), 0655)
 		require.NoError(t, err)
 	}
-	bts, err := ioutil.ReadFile(golden)
+	bts, err := os.ReadFile(golden)
 	require.NoError(t, err)
 	require.Equal(t, string(bts), formulae)
 }
@@ -113,10 +113,10 @@ func TestFullFormulaeLinuxOnly(t *testing.T) {
 
 	var golden = "testdata/test_linux_only.rb.golden"
 	if *update {
-		err := ioutil.WriteFile(golden, []byte(formulae), 0655)
+		err := os.WriteFile(golden, []byte(formulae), 0655)
 		require.NoError(t, err)
 	}
-	bts, err := ioutil.ReadFile(golden)
+	bts, err := os.ReadFile(golden)
 	require.NoError(t, err)
 	require.Equal(t, string(bts), formulae)
 }
@@ -247,13 +247,13 @@ func TestRunPipe(t *testing.T) {
 			require.True(t, client.CreatedFile)
 			var golden = fmt.Sprintf("testdata/%s.rb.golden", name)
 			if *update {
-				require.NoError(t, ioutil.WriteFile(golden, []byte(client.Content), 0655))
+				require.NoError(t, os.WriteFile(golden, []byte(client.Content), 0655))
 			}
-			bts, err := ioutil.ReadFile(golden)
+			bts, err := os.ReadFile(golden)
 			require.NoError(t, err)
 			require.Equal(t, string(bts), client.Content)
 
-			distBts, err := ioutil.ReadFile(distFile)
+			distBts, err := os.ReadFile(distFile)
 			require.NoError(t, err)
 			require.Equal(t, string(bts), string(distBts))
 		})
@@ -312,13 +312,13 @@ func TestRunPipeNameTemplate(t *testing.T) {
 	require.True(t, client.CreatedFile)
 	var golden = "testdata/foo_is_bar.rb.golden"
 	if *update {
-		require.NoError(t, ioutil.WriteFile(golden, []byte(client.Content), 0655))
+		require.NoError(t, os.WriteFile(golden, []byte(client.Content), 0655))
 	}
-	bts, err := ioutil.ReadFile(golden)
+	bts, err := os.ReadFile(golden)
 	require.NoError(t, err)
 	require.Equal(t, string(bts), client.Content)
 
-	distBts, err := ioutil.ReadFile(distFile)
+	distBts, err := os.ReadFile(distFile)
 	require.NoError(t, err)
 	require.Equal(t, string(bts), string(distBts))
 }
@@ -518,13 +518,13 @@ func TestRunPipeForMultipleArmVersions(t *testing.T) {
 		require.True(t, client.CreatedFile)
 		var golden = fmt.Sprintf("testdata/%s.rb.golden", name)
 		if *update {
-			require.NoError(t, ioutil.WriteFile(golden, []byte(client.Content), 0655))
+			require.NoError(t, os.WriteFile(golden, []byte(client.Content), 0655))
 		}
-		bts, err := ioutil.ReadFile(golden)
+		bts, err := os.ReadFile(golden)
 		require.NoError(t, err)
 		require.Equal(t, string(bts), client.Content)
 
-		distBts, err := ioutil.ReadFile(distFile)
+		distBts, err := os.ReadFile(distFile)
 		require.NoError(t, err)
 		require.Equal(t, string(bts), string(distBts))
 	}

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -3,7 +3,6 @@ package build
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,7 +38,7 @@ func (f *fakeBuilder) Build(ctx *context.Context, build config.Build, options ap
 	if err := os.MkdirAll(filepath.Dir(options.Path), 0755); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(options.Path, []byte("foo"), 0755); err != nil {
+	if err := os.WriteFile(options.Path, []byte("foo"), 0755); err != nil {
 		return err
 	}
 	ctx.Artifacts.Add(&artifact.Artifact{
@@ -609,7 +608,7 @@ func TestRunHookEnvs(t *testing.T) {
 	t.Run("build env inside shell", func(t *testing.T) {
 		var shell = `#!/bin/sh -e
 touch "$BAR"`
-		err := ioutil.WriteFile(filepath.Join(tmp, "test.sh"), []byte(shell), 0750)
+		err := os.WriteFile(filepath.Join(tmp, "test.sh"), []byte(shell), 0750)
 		require.NoError(t, err)
 		err = runHook(context.New(config.Project{
 			Builds: []config.Build{
@@ -708,8 +707,8 @@ func TestBuildOptionsForTarget(t *testing.T) {
 	var tmpDir = testlib.Mktmp(t)
 
 	testCases := []struct {
-		name  string
-		build config.Build
+		name         string
+		build        config.Build
 		expectedOpts *api.Options
 	}{
 		{

--- a/internal/pipe/changelog/changelog.go
+++ b/internal/pipe/changelog/changelog.go
@@ -4,7 +4,6 @@ package changelog
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -112,11 +111,11 @@ func (Pipe) Run(ctx *context.Context) error {
 
 	path := filepath.Join(ctx.Config.Dist, "CHANGELOG.md")
 	log.WithField("changelog", path).Info("writing")
-	return ioutil.WriteFile(path, []byte(ctx.ReleaseNotes), 0o644) //nolint: gosec
+	return os.WriteFile(path, []byte(ctx.ReleaseNotes), 0o644) //nolint: gosec
 }
 
 func loadFromFile(file string) (string, error) {
-	bts, err := ioutil.ReadFile(file)
+	bts, err := os.ReadFile(file)
 	if err != nil {
 		return "", err
 	}

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -1,7 +1,6 @@
 package changelog
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -111,7 +110,7 @@ func TestChangelog(t *testing.T) {
 	require.NotContains(t, ctx.ReleaseNotes, "cArs")
 	require.NotContains(t, ctx.ReleaseNotes, "from goreleaser/some-branch")
 
-	bts, err := ioutil.ReadFile(filepath.Join(folder, "CHANGELOG.md"))
+	bts, err := os.ReadFile(filepath.Join(folder, "CHANGELOG.md"))
 	require.NoError(t, err)
 	require.NotEmpty(t, string(bts))
 }
@@ -178,7 +177,7 @@ func TestChangelogForGitlab(t *testing.T) {
 	require.NotContains(t, ctx.ReleaseNotes, "cArs")
 	require.NotContains(t, ctx.ReleaseNotes, "from goreleaser/some-branch")
 
-	bts, err := ioutil.ReadFile(filepath.Join(folder, "CHANGELOG.md"))
+	bts, err := os.ReadFile(filepath.Join(folder, "CHANGELOG.md"))
 	require.NoError(t, err)
 	require.NotEmpty(t, string(bts))
 }

--- a/internal/pipe/checksums/checksums_test.go
+++ b/internal/pipe/checksums/checksums_test.go
@@ -2,6 +2,7 @@ package checksums
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -49,7 +50,7 @@ func TestPipe(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var folder = t.TempDir()
 			var file = filepath.Join(folder, binary)
-			require.NoError(t, ioutil.WriteFile(file, []byte("some string"), 0644))
+			require.NoError(t, os.WriteFile(file, []byte("some string"), 0644))
 			var ctx = context.New(
 				config.Project{
 					Dist:        folder,
@@ -93,7 +94,7 @@ func TestPipe(t *testing.T) {
 				artifacts = append(artifacts, a.Name)
 			}
 			require.Contains(t, artifacts, checksums, binary)
-			bts, err := ioutil.ReadFile(filepath.Join(folder, checksums))
+			bts, err := os.ReadFile(filepath.Join(folder, checksums))
 			require.NoError(t, err)
 			for _, want := range tt.want {
 				require.Contains(t, string(bts), "61d034473102d7dac305902770471fd50f4c5b26f6831a56dd90b5184b3c30fc  "+want)
@@ -184,7 +185,7 @@ func TestPipeCouldNotOpenChecksumsTxt(t *testing.T) {
 	require.NoError(t, err)
 
 	var file = filepath.Join(folder, "checksums.txt")
-	require.NoError(t, ioutil.WriteFile(file, []byte("some string"), 0000))
+	require.NoError(t, os.WriteFile(file, []byte("some string"), 0000))
 	var ctx = context.New(
 		config.Project{
 			Dist: folder,

--- a/internal/pipe/dist/dist.go
+++ b/internal/pipe/dist/dist.go
@@ -4,7 +4,6 @@ package dist
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/apex/log"
@@ -33,7 +32,7 @@ func (Pipe) Run(ctx *context.Context) (err error) {
 		}
 		return err
 	}
-	files, err := ioutil.ReadDir(ctx.Config.Dist)
+	files, err := os.ReadDir(ctx.Config.Dist)
 	if err != nil {
 		return
 	}

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -1188,7 +1188,7 @@ func TestLinkFile(t *testing.T) {
 	dst := filepath.Join(dir, "dst")
 	fmt.Println("src:", src.Name())
 	fmt.Println("dst:", dst)
-	require.NoError(t, ioutil.WriteFile(src.Name(), []byte("foo"), 0o644))
+	require.NoError(t, os.WriteFile(src.Name(), []byte("foo"), 0o644))
 	require.NoError(t, link(src.Name(), dst))
 	require.Equal(t, inode(src.Name()), inode(dst))
 }
@@ -1197,7 +1197,7 @@ func TestLinkDirectory(t *testing.T) {
 	srcDir := t.TempDir()
 	dstDir := t.TempDir()
 	const testFile = "test"
-	require.NoError(t, ioutil.WriteFile(filepath.Join(srcDir, testFile), []byte("foo"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, testFile), []byte("foo"), 0o644))
 	require.NoError(t, link(srcDir, dstDir))
 	require.Equal(t, inode(filepath.Join(srcDir, testFile)), inode(filepath.Join(dstDir, testFile)))
 }
@@ -1209,8 +1209,8 @@ func TestLinkTwoLevelDirectory(t *testing.T) {
 	const testFile = "test"
 
 	require.NoError(t, os.Mkdir(srcLevel2, 0o755))
-	require.NoError(t, ioutil.WriteFile(filepath.Join(srcDir, testFile), []byte("foo"), 0o644))
-	require.NoError(t, ioutil.WriteFile(filepath.Join(srcLevel2, testFile), []byte("foo"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, testFile), []byte("foo"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(srcLevel2, testFile), []byte("foo"), 0o644))
 
 	require.NoError(t, link(srcDir, dstDir))
 

--- a/internal/pipe/effectiveconfig/config.go
+++ b/internal/pipe/effectiveconfig/config.go
@@ -1,7 +1,7 @@
 package effectiveconfig
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/apex/log"
@@ -25,5 +25,5 @@ func (Pipe) Run(ctx *context.Context) (err error) {
 		return err
 	}
 	log.WithField("config", path).Info("writing")
-	return ioutil.WriteFile(path, bts, 0644) //nolint: gosec
+	return os.WriteFile(path, bts, 0644) //nolint: gosec
 }

--- a/internal/pipe/effectiveconfig/config_test.go
+++ b/internal/pipe/effectiveconfig/config_test.go
@@ -1,7 +1,6 @@
 package effectiveconfig
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,7 +15,7 @@ func TestPipeDescription(t *testing.T) {
 	require.NotEmpty(t, Pipe{}.String())
 }
 
-func Test(t *testing.T) {
+func TestRun(t *testing.T) {
 	var folder = testlib.Mktmp(t)
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0755))
@@ -26,7 +25,7 @@ func Test(t *testing.T) {
 		},
 	)
 	require.NoError(t, Pipe{}.Run(ctx))
-	bts, err := ioutil.ReadFile(filepath.Join(dist, "config.yaml"))
+	bts, err := os.ReadFile(filepath.Join(dist, "config.yaml"))
 	require.NoError(t, err)
 	require.NotEmpty(t, string(bts))
 }

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -98,7 +97,7 @@ func TestDirty(t *testing.T) {
 	testlib.GitAdd(t)
 	testlib.GitCommit(t, "commit2")
 	testlib.GitTag(t, "v0.0.1")
-	require.NoError(t, ioutil.WriteFile(dummy.Name(), []byte("lorem ipsum"), 0o644))
+	require.NoError(t, os.WriteFile(dummy.Name(), []byte("lorem ipsum"), 0o644))
 	t.Run("all checks up", func(t *testing.T) {
 		err := Pipe{}.Run(context.New(config.Project{}))
 		require.Error(t, err)
@@ -207,7 +206,7 @@ func TestSnapshotDirty(t *testing.T) {
 	testlib.GitAdd(t)
 	testlib.GitCommit(t, "whatever")
 	testlib.GitTag(t, "v0.0.1")
-	require.NoError(t, ioutil.WriteFile(filepath.Join(folder, "foo"), []byte("foobar"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(folder, "foo"), []byte("foobar"), 0o644))
 	ctx := context.New(config.Project{})
 	ctx.Snapshot = true
 	testlib.AssertSkipped(t, Pipe{}.Run(ctx))

--- a/internal/pipe/release/body_test.go
+++ b/internal/pipe/release/body_test.go
@@ -2,7 +2,7 @@ package release
 
 import (
 	"flag"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/internal/artifact"
@@ -32,9 +32,9 @@ func TestDescribeBody(t *testing.T) {
 
 	var golden = "testdata/release1.golden"
 	if *update {
-		_ = ioutil.WriteFile(golden, out.Bytes(), 0755)
+		_ = os.WriteFile(golden, out.Bytes(), 0755)
 	}
-	bts, err := ioutil.ReadFile(golden)
+	bts, err := os.ReadFile(golden)
 	require.NoError(t, err)
 	require.Equal(t, string(bts), out.String())
 }
@@ -71,9 +71,9 @@ func TestDescribeBodyWithDockerManifest(t *testing.T) {
 
 	var golden = "testdata/release3.golden"
 	if *update {
-		_ = ioutil.WriteFile(golden, out.Bytes(), 0755)
+		_ = os.WriteFile(golden, out.Bytes(), 0755)
 	}
-	bts, err := ioutil.ReadFile(golden)
+	bts, err := os.ReadFile(golden)
 	require.NoError(t, err)
 	require.Equal(t, string(bts), out.String())
 }
@@ -88,9 +88,9 @@ func TestDescribeBodyNoDockerImagesNoBrews(t *testing.T) {
 
 	var golden = "testdata/release2.golden"
 	if *update {
-		_ = ioutil.WriteFile(golden, out.Bytes(), 0655)
+		_ = os.WriteFile(golden, out.Bytes(), 0655)
 	}
-	bts, err := ioutil.ReadFile(golden)
+	bts, err := os.ReadFile(golden)
 	require.NoError(t, err)
 
 	require.Equal(t, string(bts), out.String())

--- a/internal/pipe/release/release_test.go
+++ b/internal/pipe/release/release_test.go
@@ -3,7 +3,7 @@ package release
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -559,7 +559,7 @@ func (c *DummyClient) Upload(ctx *context.Context, releaseID string, artifact *a
 		c.UploadedFilePaths = map[string]string{}
 	}
 	// ensure file is read to better mimic real behavior
-	_, err := ioutil.ReadAll(file)
+	_, err := io.ReadAll(file)
 	if err != nil {
 		return fmt.Errorf("unexpected error: %w", err)
 	}

--- a/internal/pipe/scoop/scoop_test.go
+++ b/internal/pipe/scoop/scoop_test.go
@@ -3,7 +3,6 @@ package scoop
 import (
 	ctx "context"
 	"flag"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -62,7 +61,7 @@ func TestDefault(t *testing.T) {
 func Test_doRun(t *testing.T) {
 	var folder = testlib.Mktmp(t)
 	var file = filepath.Join(folder, "archive")
-	require.NoError(t, ioutil.WriteFile(file, []byte("lorem ipsum"), 0644))
+	require.NoError(t, os.WriteFile(file, []byte("lorem ipsum"), 0644))
 
 	type errChecker func(*testing.T, error)
 	var shouldErr = func(msg string) errChecker {
@@ -746,7 +745,7 @@ func Test_doRun(t *testing.T) {
 func Test_buildManifest(t *testing.T) {
 	var folder = t.TempDir()
 	var file = filepath.Join(folder, "archive")
-	require.NoError(t, ioutil.WriteFile(file, []byte("lorem ipsum"), 0644))
+	require.NoError(t, os.WriteFile(file, []byte("lorem ipsum"), 0644))
 
 	tests := []struct {
 		filename string
@@ -982,9 +981,9 @@ func Test_buildManifest(t *testing.T) {
 			require.NoError(t, err)
 
 			if *update {
-				require.NoError(t, ioutil.WriteFile(tt.filename, out.Bytes(), 0655))
+				require.NoError(t, os.WriteFile(tt.filename, out.Bytes(), 0655))
 			}
-			bts, err := ioutil.ReadFile(tt.filename)
+			bts, err := os.ReadFile(tt.filename)
 			require.NoError(t, err)
 			require.Equal(t, string(bts), out.String())
 		})
@@ -994,7 +993,7 @@ func Test_buildManifest(t *testing.T) {
 func TestWrapInDirectory(t *testing.T) {
 	var folder = t.TempDir()
 	var file = filepath.Join(folder, "archive")
-	require.NoError(t, ioutil.WriteFile(file, []byte("lorem ipsum"), 0644))
+	require.NoError(t, os.WriteFile(file, []byte("lorem ipsum"), 0644))
 	var ctx = &context.Context{
 		TokenType: context.TokenTypeGitLab,
 		Git: context.GitInfo{
@@ -1063,9 +1062,9 @@ func TestWrapInDirectory(t *testing.T) {
 
 	var golden = "testdata/test_buildmanifest_wrap.json.golden"
 	if *update {
-		require.NoError(t, ioutil.WriteFile(golden, out.Bytes(), 0655))
+		require.NoError(t, os.WriteFile(golden, out.Bytes(), 0655))
 	}
-	bts, err := ioutil.ReadFile(golden)
+	bts, err := os.ReadFile(golden)
 	require.NoError(t, err)
 	require.Equal(t, string(bts), out.String())
 }

--- a/internal/pipe/sign/sign_test.go
+++ b/internal/pipe/sign/sign_test.go
@@ -3,7 +3,6 @@ package sign
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -395,11 +394,11 @@ func testSign(tb testing.TB, ctx *context.Context, signaturePaths []string, sign
 	require.NoError(tb, os.Mkdir(filepath.Join(tmpdir, "linux_amd64"), os.ModePerm))
 	for _, f := range artifacts {
 		file := filepath.Join(tmpdir, f)
-		require.NoError(tb, ioutil.WriteFile(file, []byte("foo"), 0o644))
+		require.NoError(tb, os.WriteFile(file, []byte("foo"), 0o644))
 	}
-	require.NoError(tb, ioutil.WriteFile(filepath.Join(tmpdir, "linux_amd64", "artifact4"), []byte("foo"), 0o644))
+	require.NoError(tb, os.WriteFile(filepath.Join(tmpdir, "linux_amd64", "artifact4"), []byte("foo"), 0o644))
 	artifacts = append(artifacts, "linux_amd64/artifact4")
-	require.NoError(tb, ioutil.WriteFile(filepath.Join(tmpdir, "artifact5.tar.gz"), []byte("foo"), 0o644))
+	require.NoError(tb, os.WriteFile(filepath.Join(tmpdir, "artifact5.tar.gz"), []byte("foo"), 0o644))
 	artifacts = append(artifacts, "artifact5.tar.gz")
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name: "artifact1",

--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -4,7 +4,6 @@ package snapcraft
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -306,7 +305,7 @@ func create(ctx *context.Context, snap config.Snapcraft, arch string, binaries [
 	}
 
 	log.WithField("file", file).Debugf("writing metadata file")
-	if err = ioutil.WriteFile(file, out, 0644); err != nil { //nolint: gosec
+	if err = os.WriteFile(file, out, 0644); err != nil { //nolint: gosec
 		return err
 	}
 

--- a/internal/pipe/snapcraft/snapcraft_test.go
+++ b/internal/pipe/snapcraft/snapcraft_test.go
@@ -2,7 +2,6 @@ package snapcraft
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -129,7 +128,7 @@ func TestRunPipeWithName(t *testing.T) {
 	ctx.Version = "v1.2.3"
 	addBinaries(t, ctx, "foo", dist)
 	require.NoError(t, Pipe{}.Run(ctx))
-	yamlFile, err := ioutil.ReadFile(filepath.Join(dist, "foo_amd64", "prime", "meta", "snap.yaml"))
+	yamlFile, err := os.ReadFile(filepath.Join(dist, "foo_amd64", "prime", "meta", "snap.yaml"))
 	require.NoError(t, err)
 	var metadata Metadata
 	err = yaml.Unmarshal(yamlFile, &metadata)
@@ -177,7 +176,7 @@ func TestRunPipeMetadata(t *testing.T) {
 	ctx.Version = "v1.2.3"
 	addBinaries(t, ctx, "foo", dist)
 	require.NoError(t, Pipe{}.Run(ctx))
-	yamlFile, err := ioutil.ReadFile(filepath.Join(dist, "foo_amd64", "prime", "meta", "snap.yaml"))
+	yamlFile, err := os.ReadFile(filepath.Join(dist, "foo_amd64", "prime", "meta", "snap.yaml"))
 	require.NoError(t, err)
 	var metadata Metadata
 	err = yaml.Unmarshal(yamlFile, &metadata)
@@ -236,7 +235,7 @@ func TestRunNoArguments(t *testing.T) {
 	ctx.Version = "v1.2.3"
 	addBinaries(t, ctx, "foo", dist)
 	require.NoError(t, Pipe{}.Run(ctx))
-	yamlFile, err := ioutil.ReadFile(filepath.Join(dist, "foo_amd64", "prime", "meta", "snap.yaml"))
+	yamlFile, err := os.ReadFile(filepath.Join(dist, "foo_amd64", "prime", "meta", "snap.yaml"))
 	require.NoError(t, err)
 	var metadata Metadata
 	err = yaml.Unmarshal(yamlFile, &metadata)
@@ -272,7 +271,7 @@ func TestCompleter(t *testing.T) {
 	addBinaries(t, ctx, "foo", dist)
 	addBinaries(t, ctx, "bar", dist)
 	require.NoError(t, Pipe{}.Run(ctx))
-	yamlFile, err := ioutil.ReadFile(filepath.Join(dist, "foo_amd64", "prime", "meta", "snap.yaml"))
+	yamlFile, err := os.ReadFile(filepath.Join(dist, "foo_amd64", "prime", "meta", "snap.yaml"))
 	require.NoError(t, err)
 	var metadata Metadata
 	err = yaml.Unmarshal(yamlFile, &metadata)
@@ -308,7 +307,7 @@ func TestCommand(t *testing.T) {
 	ctx.Version = "v1.2.3"
 	addBinaries(t, ctx, "foo", dist)
 	require.NoError(t, Pipe{}.Run(ctx))
-	yamlFile, err := ioutil.ReadFile(filepath.Join(dist, "foo_amd64", "prime", "meta", "snap.yaml"))
+	yamlFile, err := os.ReadFile(filepath.Join(dist, "foo_amd64", "prime", "meta", "snap.yaml"))
 	require.NoError(t, err)
 	var metadata Metadata
 	err = yaml.Unmarshal(yamlFile, &metadata)

--- a/internal/pipe/sourcearchive/source_test.go
+++ b/internal/pipe/sourcearchive/source_test.go
@@ -1,7 +1,6 @@
 package sourcearchive
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,8 +19,8 @@ func TestArchive(t *testing.T) {
 			require.NoError(t, os.Mkdir("dist", 0744))
 
 			testlib.GitInit(t)
-			require.NoError(t, ioutil.WriteFile("code.txt", []byte("not really code"), 0655))
-			require.NoError(t, ioutil.WriteFile("README.md", []byte("# my dope fake project"), 0655))
+			require.NoError(t, os.WriteFile("code.txt", []byte("not really code"), 0655))
+			require.NoError(t, os.WriteFile("README.md", []byte("# my dope fake project"), 0655))
 			testlib.GitAdd(t)
 			testlib.GitCommit(t, "feat: first")
 

--- a/internal/pipe/upload/upload_test.go
+++ b/internal/pipe/upload/upload_test.go
@@ -2,7 +2,6 @@ package upload
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	h "net/http"
 	"net/http/httptest"
@@ -64,7 +63,7 @@ func TestRunPipe_ModeBinary(t *testing.T) {
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
-	require.NoError(t, ioutil.WriteFile(binPath, d1, 0666))
+	require.NoError(t, os.WriteFile(binPath, d1, 0666))
 
 	// Dummy http server
 	mux.HandleFunc("/example-repo-local/mybin/darwin/amd64/mybin", func(w http.ResponseWriter, r *http.Request) {
@@ -226,7 +225,7 @@ func TestRunPipe_ModeBinary_CustomArtifactName(t *testing.T) {
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
-	require.NoError(t, ioutil.WriteFile(binPath, d1, 0666))
+	require.NoError(t, os.WriteFile(binPath, d1, 0666))
 
 	// Dummy http server
 	mux.HandleFunc("/example-repo-local/mybin/darwin/amd64/mybin;deb.distribution=xenial", func(w http.ResponseWriter, r *http.Request) {
@@ -434,7 +433,7 @@ func TestRunPipe_BadCredentials(t *testing.T) {
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
-	require.NoError(t, ioutil.WriteFile(binPath, d1, 0666))
+	require.NoError(t, os.WriteFile(binPath, d1, 0666))
 
 	// Dummy http server
 	mux.HandleFunc("/example-repo-local/mybin/darwin/amd64/mybin", func(w http.ResponseWriter, r *http.Request) {
@@ -516,7 +515,7 @@ func TestRunPipe_UnparsableTarget(t *testing.T) {
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0755))
 	var binPath = filepath.Join(dist, "mybin", "mybin")
 	d1 := []byte("hello\ngo\n")
-	require.NoError(t, ioutil.WriteFile(binPath, d1, 0666))
+	require.NoError(t, os.WriteFile(binPath, d1, 0666))
 
 	var ctx = context.New(config.Project{
 		ProjectName: "mybin",

--- a/pkg/archive/gzip/gzip_test.go
+++ b/pkg/archive/gzip/gzip_test.go
@@ -2,7 +2,7 @@ package gzip
 
 import (
 	"compress/gzip"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,7 +37,7 @@ func TestGzFile(t *testing.T) {
 
 	require.Equal(t, "sub1/sub2/subfoo.txt", gzf.Name)
 
-	bts, err := ioutil.ReadAll(gzf)
+	bts, err := io.ReadAll(gzf)
 	require.NoError(t, err)
 	require.Equal(t, "sub\n", string(bts))
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,7 +4,6 @@ package config
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -645,7 +644,7 @@ func Load(file string) (config Project, err error) {
 
 // LoadReader config via io.Reader.
 func LoadReader(fd io.Reader) (config Project, err error) {
-	data, err := ioutil.ReadAll(fd)
+	data, err := io.ReadAll(fd)
 	if err != nil {
 		return config, err
 	}


### PR DESCRIPTION
some methods were deprecated on go 1.16 and simply call their counterparts on `os` and `io` packages...