### PR TITLE
fix: skip releasing to brew when skipping publishing

### DIFF
--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -48,6 +48,9 @@ func (Pipe) String() string {
 
 // Publish brew formula.
 func (Pipe) Publish(ctx *context.Context) error {
+	if ctx.SkipPublish {
+		return pipe.ErrSkipPublishEnabled
+	}
 	// we keep GitHub as default for now, in line with releases
 	if string(ctx.TokenType) == "" {
 		ctx.TokenType = context.TokenTypeGitHub

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/internal/client"
+	"github.com/goreleaser/goreleaser/internal/pipe"
 	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
@@ -851,6 +852,16 @@ func TestRunTokenTypeNotImplementedForBrew(t *testing.T) {
 	})
 	client := &DummyClient{NotImplemented: true}
 	require.Equal(t, ErrTokenTypeNotImplementedForBrew{TokenType: "gitea"}, doRun(ctx, ctx.Config.Brews[0], client))
+}
+
+func TestRunPipe_SkipWhenPublishFalse(t *testing.T) {
+	ctx := context.New(config.Project{})
+	ctx.SkipPublish = true
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	err := Pipe{}.Publish(ctx)
+	require.True(t, pipe.IsSkip(err))
+	require.EqualError(t, err, pipe.ErrSkipPublishEnabled.Error())
 }
 
 func TestDefault(t *testing.T) {


### PR DESCRIPTION
This fixes an issues that causes builds to still try to release to brew
even though the `--skip-publish` flag was passed