### PR TITLE
docs: fixed typo

### DIFF
--- a/www/docs/customization/docker.md
+++ b/www/docs/customization/docker.md
@@ -142,7 +142,7 @@ This will build and public the following images:
 
 ## Keeping docker images updated for current major
 
-Some users might want to when version to push docker tags `:v1`, `:v1.6`,
+Some users might want to push docker tags `:v1`, `:v1.6`,
 `:v1.6.4` and `:latest` when `v1.6.4` (for example) is built. That can be
 accomplished by using multiple `image_templates`:
 


### PR DESCRIPTION
Fixes typo in docker tags section

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->
Fix typos in the docs.

<!-- Why is this change being made? -->
Cleaning up syntax/phrasing that was used in the docker tags section of the docs.

<!-- # Provide links to any relevant tickets, URLs or other resources -->
