### PR TITLE
fix: allow underscores in formula name

### DIFF
--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -323,8 +323,13 @@ func split(s string) []string {
 	return strings
 }
 
+// formulaNameFor transforms the formula name into a form
+// that more resembles a valid Ruby class name
+// e.g. foo_bar@v6.0.0-rc is turned into FooBarATv6_0_0RC
+// The order of these replacements is important
 func formulaNameFor(name string) string {
 	name = strings.ReplaceAll(name, "-", " ")
+	name = strings.ReplaceAll(name, "_", " ")
 	name = strings.ReplaceAll(name, ".", "_")
 	name = strings.ReplaceAll(name, "@", "AT")
 	return strings.ReplaceAll(strings.Title(name), " ", "")

--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -325,7 +325,7 @@ func split(s string) []string {
 
 func formulaNameFor(name string) string {
 	name = strings.ReplaceAll(name, "-", " ")
-	name = strings.ReplaceAll(name, "_", " ")
+	name = strings.ReplaceAll(name, ".", "_")
 	name = strings.ReplaceAll(name, "@", "AT")
 	return strings.ReplaceAll(strings.Title(name), " ", "")
 }

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -27,8 +27,8 @@ func TestNameWithDash(t *testing.T) {
 	require.Equal(t, formulaNameFor("some-binary"), "SomeBinary")
 }
 
-func TestNameWithUnderline(t *testing.T) {
-	require.Equal(t, formulaNameFor("some_binary"), "SomeBinary")
+func TestNameWithDots(t *testing.T) {
+	require.Equal(t, formulaNameFor("some_binaryv0.0.0"), "SomeBinaryv0_0_0")
 }
 
 func TestNameWithAT(t *testing.T) {

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -27,8 +27,12 @@ func TestNameWithDash(t *testing.T) {
 	require.Equal(t, formulaNameFor("some-binary"), "SomeBinary")
 }
 
+func TestNameWithUnderline(t *testing.T) {
+	require.Equal(t, formulaNameFor("some_binary"), "SomeBinary")
+}
+
 func TestNameWithDots(t *testing.T) {
-	require.Equal(t, formulaNameFor("some_binaryv0.0.0"), "SomeBinaryv0_0_0")
+	require.Equal(t, formulaNameFor("binaryv0.0.0"), "Binaryv0_0_0")
 }
 
 func TestNameWithAT(t *testing.T) {


### PR DESCRIPTION
I was trying to create two formulas per release. One signifying the latest and
another with the version explicitly: formula.rb and formula@v0.0.0.rb

The filenames are fine but the formula name for the explicit version
was created as FormulaATv0.0.0 which isn't valid Ruby.

Looking at the function history I couldn't find why underscores were being replaced
since underscores are valid for Ruby identifiers. I opted to replace dots in a formula with
underscores

- https://github.com/goreleaser/goreleaser/commit/1399a396036ea246522a4cbae7aef376d6dbbda2
- https://ruby-doc.org/docs/ruby-doc-bundle/Manual/man-1.4/syntax.html#ident

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->

<!-- # Provide links to any relevant tickets, URLs or other resources -->
