### PR TITLE
chore(ci): remove codecov token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,6 @@ jobs:
         name: Upload coverage
         uses: codecov/codecov-action@v1.5.0
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.txt
       -
         name: Check


### PR DESCRIPTION
Remove codecov token to address https://about.codecov.io/security-update/ (no need to use it as the repo is public). Need to also remove the secret in the repo settings.