### PR TITLE
fix(ci): use official login action and switch to github secret for ghcr

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,25 +68,27 @@ jobs:
         name: Diff
         run: git diff
       -
-        name: Docker Login
-        if: success() && startsWith(github.ref, 'refs/tags/v')
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-        run: |
-          echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
-          echo "${GITHUB_TOKEN}" | docker login ghcr.io --username $GITHUB_ACTOR --password-stdin
+        name: Login to Docker Hub
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Login to GitHub Container Registry
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Snapcraft Login
-        if: success() && startsWith(github.ref, 'refs/tags/v')
-        env:
-          SNAPCRAFT_LOGIN: ${{ secrets.SNAPCRAFT_LOGIN }}
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          snapcraft login --with <(echo "$SNAPCRAFT_LOGIN")
+          snapcraft login --with <(echo "${{ secrets.SNAPCRAFT_LOGIN }}")
       -
         name: GoReleaser
-        if: success()
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
         run: |
@@ -95,8 +97,3 @@ jobs:
           elif [[ $GITHUB_REF == refs/heads/master ]]; then
             ./goreleaser --snapshot
           fi
-      -
-        name: Clear
-        if: always() && startsWith(github.ref, 'refs/tags/v')
-        run: |
-          rm -f ${HOME}/.docker/config.json


### PR DESCRIPTION
Use the official [docker/login-action](https://github.com/docker/login-action) to login against [Docker Hub](https://github.com/docker/login-action#docker-hub) and [GHCR](https://github.com/docker/login-action#github-container-registry).

[Container registry now supports GITHUB_TOKEN](https://github.blog/changelog/2021-03-24-packages-container-registry-now-supports-github_token/) so no need to use a PAT anymore :)

You may need to manage write and read access of GitHub Actions for repositories in the container settings:

![image](https://i2.wp.com/user-images.githubusercontent.com/2134/111272974-7ebea280-85f0-11eb-9605-45cbb80518ce.gif?ssl=1)
