### PR TITLE
Twitter announcer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/caarlos0/ctrlc v1.0.0
 	github.com/caarlos0/go-shellwords v1.0.12
 	github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e
+	github.com/dghubble/go-twitter v0.0.0-20201011215211-4b180d0cc78d
+	github.com/dghubble/oauth1 v0.7.0
 	github.com/fatih/color v1.11.0
 	github.com/google/go-github/v35 v35.2.0
 	github.com/goreleaser/fileglob v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -157,6 +157,8 @@ github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e h1:V9a67dfYqPLAvzk5h
 github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e/go.mod h1:9IOqJGCPMSc6E5ydlp5NIonxObaeu/Iub/X03EKPVYo=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e h1:hHg27A0RSSp2Om9lubZpiMgVbvn39bsUmW9U5h0twqc=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=
+github.com/cenkalti/backoff v2.1.1+incompatible h1:tKJnvO2kl0zmb/jA5UKAt4VoEVw1qxKWjE/Bpp46npY=
+github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -181,6 +183,12 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denisenkom/go-mssqldb v0.9.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mzjeJY=
+github.com/dghubble/go-twitter v0.0.0-20201011215211-4b180d0cc78d h1:sBKr0A8iQ1qAOozedZ8Aox+Jpv+TeP1Qv7dcQyW8V+M=
+github.com/dghubble/go-twitter v0.0.0-20201011215211-4b180d0cc78d/go.mod h1:xfg4uS5LEzOj8PgZV7SQYRHbG7jPUnelEiaAVJxmhJE=
+github.com/dghubble/oauth1 v0.7.0 h1:AlpZdbRiJM4XGHIlQ8BuJ/wlpGwFEJNnB4Mc+78tA/w=
+github.com/dghubble/oauth1 v0.7.0/go.mod h1:8pFdfPkv/jr8mkChVbNVuJ0suiHe278BtWI4Tk1ujxk=
+github.com/dghubble/sling v1.3.0 h1:pZHjCJq4zJvc6qVQ5wN1jo5oNZlNE0+8T/h0XeXBUKU=
+github.com/dghubble/sling v1.3.0/go.mod h1:XXShWaBWKzNLhu2OxikSNFrlsvowtz4kyRuXUG7oQKY=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=

--- a/internal/pipe/announce/announce.go
+++ b/internal/pipe/announce/announce.go
@@ -1,0 +1,20 @@
+package announce
+
+import (
+	"context"
+	"fmt"
+)
+
+// Pipe that announces releases on social media platforms
+type Pipe struct{}
+
+func (Pipe) String() string {
+	return "announcing"
+}
+
+// Announcer should be implemented by pipes that want to announce a release.
+type Announcer interface {
+	fmt.Stringer
+
+	Announce(ctx *context.Context) error
+}

--- a/internal/pipe/announce/announce.go
+++ b/internal/pipe/announce/announce.go
@@ -1,15 +1,55 @@
 package announce
 
 import (
-	"context"
 	"fmt"
+	"github.com/apex/log"
+	"github.com/dghubble/go-twitter/twitter"
+	"github.com/dghubble/oauth1"
+	"github.com/goreleaser/goreleaser/internal/pipe"
+	"github.com/goreleaser/goreleaser/internal/tmpl"
+	"github.com/goreleaser/goreleaser/pkg/context"
 )
 
 // Pipe that announces releases on social media platforms
 type Pipe struct{}
 
+func (p Pipe) Run(ctx *context.Context) error {
+	if !ctx.Config.Twitter.Announce {
+		return pipe.ErrSkipPublishEnabled
+	}
+
+	config := oauth1.NewConfig(ctx.Config.Twitter.ConsumerKey, ctx.Config.Twitter.ConsumerSecret)
+	token := oauth1.NewToken(ctx.Config.Twitter.AccessToken, ctx.Config.Twitter.AccessSecret)
+	// http.Client will automatically authorize Requests
+	httpClient := config.Client(oauth1.NoContext, token)
+
+	// Twitter client
+	client := twitter.NewClient(httpClient)
+
+	msg := ctx.Config.Twitter.MessageTemplate
+
+	parsedMsg, err := tmpl.New(ctx).
+		Apply(msg)
+
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	log.WithField("message", parsedMsg).Info("sending tweet")
+
+	// Send a Tweet
+	_, _, err = client.Statuses.Update(parsedMsg, nil)
+
+	if err != nil {
+		log.WithError(err)
+		return err
+	}
+	return nil
+}
+
 func (Pipe) String() string {
-	return "announcing"
+	return "twitter announcement"
 }
 
 // Announcer should be implemented by pipes that want to announce a release.
@@ -17,4 +57,9 @@ type Announcer interface {
 	fmt.Stringer
 
 	Announce(ctx *context.Context) error
+}
+
+// Default sets the pipe defaults.
+func (Pipe) Default(ctx *context.Context) error {
+	return nil
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -4,6 +4,7 @@ package pipeline
 import (
 	"fmt"
 
+	"github.com/goreleaser/goreleaser/internal/pipe/announce"
 	"github.com/goreleaser/goreleaser/internal/pipe/gomod"
 	"github.com/goreleaser/goreleaser/internal/pipe/semver"
 	"github.com/goreleaser/goreleaser/internal/pipe/sourcearchive"
@@ -27,7 +28,7 @@ import (
 	"github.com/goreleaser/goreleaser/pkg/context"
 )
 
-// Piper defines a pipe, which can be part of a pipeline (a serie of pipes).
+// Piper defines a pipe, which can be part of a pipeline (a series of pipes).
 type Piper interface {
 	fmt.Stringer
 
@@ -63,4 +64,5 @@ var Pipeline = append(
 	sign.Pipe{},          // sign artifacts
 	docker.Pipe{},        // create and push docker images
 	publish.Pipe{},       // publishes artifacts
+	announce.Pipe{},
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -638,6 +638,13 @@ type GoMod struct {
 	GoBinary string   `yaml:",omitempty"`
 }
 
+type Twitter struct {
+	ConsumerKey    string `yaml:",omitempty"`
+	ConsumerSecret string `yaml:"omitempty"`
+	AccessToken    string `yaml:"omitempty"`
+	AccessSecret   string `yaml:"omitempty"`
+}
+
 // Load config file.
 func Load(file string) (config Project, err error) {
 	f, err := os.Open(file) // #nosec

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -618,6 +618,7 @@ type Project struct {
 	Before          Before           `yaml:",omitempty"`
 	Source          Source           `yaml:",omitempty"`
 	GoMod           GoMod            `yaml:"gomod,omitempty"`
+	Twitter         Twitter          `yaml:"twitter,omitempty"`
 
 	// this is a hack ¯\_(ツ)_/¯
 	SingleBuild Build `yaml:"build,omitempty"`
@@ -639,10 +640,12 @@ type GoMod struct {
 }
 
 type Twitter struct {
-	ConsumerKey    string `yaml:",omitempty"`
-	ConsumerSecret string `yaml:"omitempty"`
-	AccessToken    string `yaml:"omitempty"`
-	AccessSecret   string `yaml:"omitempty"`
+	Announce        bool   `yaml:"announce,omitempty"`
+	ConsumerKey     string `yaml:"consumer_key,omitempty"`
+	ConsumerSecret  string `yaml:"consumer_secret,omitempty"`
+	AccessToken     string `yaml:"access_token,omitempty"`
+	AccessSecret    string `yaml:"access_secret,omitempty"`
+	MessageTemplate string `yaml:"message_template,omitempty"`
 }
 
 // Load config file.


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->
Allow users the ability to announce via Twitter once they have completed a release.

<!-- Why is this change being made? -->
This change was requested by owner in issue #2150 

<!-- # Provide links to any relevant tickets, URLs or other resources -->
Issue #2150 
