### PR TITLE
docs: fix config field

### DIFF
--- a/www/docs/customization/nfpm.md
+++ b/www/docs/customization/nfpm.md
@@ -216,7 +216,7 @@ nfpms:
       rpm:
         replacements:
           amd64: x86_64
-        name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Arch }}"
+        file_name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Arch }}"
         files:
           "tmp/man.gz": "/usr/share/man/man8/app.8.gz"
         config_files:


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->
field `name_template` not found in type config.NFPMOverridables, but it's `file_name_template` found.
<!-- # Provide links to any relevant tickets, URLs or other resources -->
