### PR TITLE
feat: add support for name templates to NFPM contents

### DIFF
--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -341,6 +341,14 @@ func create(ctx *context.Context, fpm config.NFPM, format, arch string, binaries
 	return nil
 }
 
+func sources(contents files.Contents) []string {
+	result := make([]string, 0, len(contents))
+	for _, f := range contents {
+		result = append(result, f.Source)
+	}
+	return result
+}
+
 func destinations(contents files.Contents) []string {
 	result := make([]string, 0, len(contents))
 	for _, f := range contents {

--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -192,8 +192,13 @@ func create(ctx *context.Context, fpm config.NFPM, format, arch string, binaries
 		if err != nil {
 			return err
 		}
-		content.Source = src
-		contents = append(contents, content)
+		contents = append(contents, &files.Content{
+			Source:      src,
+			Destination: content.Destination,
+			Type:        content.Type,
+			Packager:    content.Packager,
+			FileInfo:    content.FileInfo,
+		})
 	}
 
 	// FPM meta package should not contain binaries at all

--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -341,14 +341,6 @@ func create(ctx *context.Context, fpm config.NFPM, format, arch string, binaries
 	return nil
 }
 
-func sources(contents files.Contents) []string {
-	result := make([]string, 0, len(contents))
-	for _, f := range contents {
-		result = append(result, f.Source)
-	}
-	return result
-}
-
 func destinations(contents files.Contents) []string {
 	result := make([]string, 0, len(contents))
 	for _, f := range contents {

--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -174,19 +174,27 @@ func create(ctx *context.Context, fpm config.NFPM, format, arch string, binaries
 	if err != nil {
 		return err
 	}
-	name, err := tmpl.New(ctx).
+	tmpl := tmpl.New(ctx).
 		WithArtifact(binaries[0], overridden.Replacements).
 		WithExtraFields(tmpl.Fields{
 			"Release":     fpm.Release,
 			"Epoch":       fpm.Epoch,
 			"PackageName": fpm.PackageName,
-		}).
-		Apply(overridden.FileNameTemplate)
+		})
+	name, err := tmpl.Apply(overridden.FileNameTemplate)
 	if err != nil {
 		return err
 	}
 
-	contents := append(files.Contents{}, overridden.Contents...)
+	contents := files.Contents{}
+	for _, content := range overridden.Contents {
+		src, err := tmpl.Apply(content.Source)
+		if err != nil {
+			return err
+		}
+		content.Source = src
+		contents = append(contents, content)
+	}
 
 	// FPM meta package should not contain binaries at all
 	if !fpm.Meta {

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -130,7 +130,7 @@ func TestRunPipe(t *testing.T) {
 							Type:        "symlink",
 						},
 						{
-							Source:      "/etc/{{ .Os }}/nope.conf",
+							Source:      "./testdata/testfile-{{ .Arch }}.txt",
 							Destination: "/etc/nope3.conf",
 						},
 					},
@@ -166,6 +166,14 @@ func TestRunPipe(t *testing.T) {
 		require.Equal(t, pkg.Name, "foo_1.0.0_Tux_"+pkg.Goarch+"-10-20."+format)
 		require.Equal(t, pkg.ExtraOr("ID", ""), "someid")
 		require.ElementsMatch(t, []string{
+			"./testdata/testfile.txt",
+			"./testdata/testfile.txt",
+			"./testdata/testfile.txt",
+			"/etc/nope.conf",
+			"./testdata/testfile-" + pkg.Goarch + ".txt",
+			binPath,
+		}, sources(pkg.ExtraOr("Files", files.Contents{}).(files.Contents)))
+		require.ElementsMatch(t, []string{
 			"/usr/share/testfile.txt",
 			"/etc/nope.conf",
 			"/etc/nope-rpm.conf",
@@ -173,14 +181,6 @@ func TestRunPipe(t *testing.T) {
 			"/etc/nope3.conf",
 			"/usr/bin/mybin",
 		}, destinations(pkg.ExtraOr("Files", files.Contents{}).(files.Contents)))
-		require.ElementsMatch(t, []string{
-			"./testdata/testfile.txt",
-			"./testdata/testfile.txt",
-			"./testdata/testfile.txt",
-			"/etc/nope.conf",
-			"/etc/" + pkg.Goos + "/nope.conf",
-			binPath,
-		}, sources(pkg.ExtraOr("Files", files.Contents{}).(files.Contents)))
 	}
 	require.Len(t, ctx.Config.NFPMs[0].Contents, 5, "should not modify the config file list")
 }

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -245,7 +245,7 @@ func TestRunPipeInvalidContentsSourceTemplate(t *testing.T) {
 			"ID": "default",
 		},
 	})
-	require.EqualError(t, Pipe{}.Run(ctx), `failed to find files to archive: failed to apply template {{.asdsd}: template: tmpl:1: unexpected "}" in operand`)
+	require.EqualError(t, Pipe{}.Run(ctx), `template: tmpl:1: unexpected "}" in operand`)
 }
 
 func TestNoBuildsFound(t *testing.T) {
@@ -948,4 +948,12 @@ func TestSkipSign(t *testing.T) {
 		ctx.SkipSign = true
 		require.NoError(t, Pipe{}.Run(ctx))
 	})
+}
+
+func sources(contents files.Contents) []string {
+	result := make([]string, 0, len(contents))
+	for _, f := range contents {
+		result = append(result, f.Source)
+	}
+	return result
 }

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -129,6 +129,10 @@ func TestRunPipe(t *testing.T) {
 							Destination: "/etc/nope2.conf",
 							Type:        "symlink",
 						},
+						{
+							Source:      "/etc/{{ .Os }}/nope.conf",
+							Destination: "/etc/nope3.conf",
+						},
 					},
 					Replacements: map[string]string{
 						"linux": "Tux",
@@ -166,10 +170,19 @@ func TestRunPipe(t *testing.T) {
 			"/etc/nope.conf",
 			"/etc/nope-rpm.conf",
 			"/etc/nope2.conf",
+			"/etc/nope3.conf",
 			"/usr/bin/mybin",
 		}, destinations(pkg.ExtraOr("Files", files.Contents{}).(files.Contents)))
+		require.ElementsMatch(t, []string{
+			"./testdata/testfile.txt",
+			"./testdata/testfile.txt",
+			"./testdata/testfile.txt",
+			"/etc/nope.conf",
+			"/etc/" + pkg.Goos + "/nope.conf",
+			binPath,
+		}, sources(pkg.ExtraOr("Files", files.Contents{}).(files.Contents)))
 	}
-	require.Len(t, ctx.Config.NFPMs[0].Contents, 4, "should not modify the config file list")
+	require.Len(t, ctx.Config.NFPMs[0].Contents, 5, "should not modify the config file list")
 }
 
 func TestInvalidNameTemplate(t *testing.T) {
@@ -199,6 +212,40 @@ func TestInvalidNameTemplate(t *testing.T) {
 		},
 	})
 	require.Contains(t, Pipe{}.Run(ctx).Error(), `template: tmpl:1: unexpected "}" in operand`)
+}
+
+func TestRunPipeInvalidContentsSourceTemplate(t *testing.T) {
+	ctx := &context.Context{
+		Parallelism: runtime.NumCPU(),
+		Artifacts:   artifact.New(),
+		Config: config.Project{
+			NFPMs: []config.NFPM{
+				{
+					NFPMOverridables: config.NFPMOverridables{
+						PackageName: "foo",
+						Contents: []*files.Content{
+							{
+								Source:      "{{.asdsd}",
+								Destination: "testfile",
+							},
+						},
+					},
+					Formats: []string{"deb"},
+					Builds:  []string{"default"},
+				},
+			},
+		},
+	}
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name:   "mybin",
+		Goos:   "linux",
+		Goarch: "amd64",
+		Type:   artifact.Binary,
+		Extra: map[string]interface{}{
+			"ID": "default",
+		},
+	})
+	require.EqualError(t, Pipe{}.Run(ctx), `failed to find files to archive: failed to apply template {{.asdsd}: template: tmpl:1: unexpected "}" in operand`)
 }
 
 func TestNoBuildsFound(t *testing.T) {

--- a/internal/pipe/nfpm/testdata/testfile-386.txt
+++ b/internal/pipe/nfpm/testdata/testfile-386.txt
@@ -1,0 +1,1 @@
+this is a test file

--- a/internal/pipe/nfpm/testdata/testfile-amd64.txt
+++ b/internal/pipe/nfpm/testdata/testfile-amd64.txt
@@ -1,0 +1,1 @@
+this is a test file

--- a/www/docs/customization/nfpm.md
+++ b/www/docs/customization/nfpm.md
@@ -148,6 +148,10 @@ nfpms:
         dst: /etc/bar.conf
         type: "config|noreplace"
 
+      # The src attribute also supports name templates
+      - src: path/{{ .Os }}-{{ .Arch }}/bar.conf
+        dst: /etc/foo/bar.conf
+
       # These files are not actually present in the package, but the file names
       # are added to the package header. From the RPM directives documentation:
       #


### PR DESCRIPTION
Hi,
this will fix #1637. It adds support for name templates in NFPM content declarations.
E.g.:
```
nfpms:
  - id: publish
    ...
    bindir: /usr/bin
    formats:
      - deb
      - rpm
    contents:
      - src: bin/foo-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}/*
        dst: /usr/bin/foo/
```