### PR TITLE
feat: Scoop pipe - Write the manifest before skips, like Brew pipe.

### DIFF
--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -106,11 +108,17 @@ func doRun(ctx *context.Context, cl client.Client) error {
 		return err
 	}
 
-	if ctx.SkipPublish {
-		return pipe.ErrSkipPublishEnabled
+	filename := filepath.Join(ctx.Config.Dist, path)
+	log.WithField("manifest", path).Info("writing")
+	if err := os.WriteFile(filename, content.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("failed to write scoop manifest: %w", err)
 	}
+
 	if strings.TrimSpace(scoop.SkipUpload) == "true" {
 		return pipe.Skip("scoop.skip_upload is true")
+	}
+	if ctx.SkipPublish {
+		return pipe.ErrSkipPublishEnabled
 	}
 	if strings.TrimSpace(scoop.SkipUpload) == "auto" && ctx.Semver.Prerelease != "" {
 		return pipe.Skip("release is prerelease")

--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -109,7 +109,7 @@ func doRun(ctx *context.Context, cl client.Client) error {
 	}
 
 	filename := filepath.Join(ctx.Config.Dist, path)
-	log.WithField("manifest", path).Info("writing")
+	log.WithField("manifest", filename).Info("writing")
 	if err := os.WriteFile(filename, content.Bytes(), 0o644); err != nil {
 		return fmt.Errorf("failed to write scoop manifest: %w", err)
 	}


### PR DESCRIPTION
<!-- If applied, this commit will... -->

This change makes the scoop pipe write out the manifest before the skip conditions.

<!-- Why is this change being made? -->

By writing the manifest before the skip section of the pipe, you can do dry runs of the scoop pipeline. This is how the brew pipe does it.

Example behavior before change:
```
    ...
      • homebrew tap formula
         • writing                   formula=dist/app.rb
         • pipe skipped              error=brew.skip_upload is set
      • scoop manifests  
         • pipe skipped              error=scoop.skip_upload is true
    ...
```
After
``` 
    ...
      • homebrew tap formula
         • writing                   formula=dist/app.rb
         • pipe skipped              error=brew.skip_upload is set
      • scoop manifests  
         • writing                   manifest=app.json
         • pipe skipped              error=scoop.skip_upload is true
    ...
```
