### PR TITLE
feat: --skip-announce

### DIFF
--- a/cmd/release.go
+++ b/cmd/release.go
@@ -30,6 +30,7 @@ type releaseOpts struct {
 	skipPublish       bool
 	skipSign          bool
 	skipValidate      bool
+	skipAnnounce      bool
 	rmDist            bool
 	deprecated        bool
 	parallelism       int
@@ -72,8 +73,9 @@ func newReleaseCmd() *releaseCmd {
 	cmd.Flags().StringVar(&root.opts.releaseNotesTmpl, "release-notes-tmpl", "", "Load custom release notes from a templated markdown file (overrides --release-notes)")
 	cmd.Flags().StringVar(&root.opts.releaseHeaderTmpl, "release-header-tmpl", "", "Load custom release notes header from a templated markdown file (overrides --release-header)")
 	cmd.Flags().StringVar(&root.opts.releaseFooterTmpl, "release-footer-tmpl", "", "Load custom release notes footer from a templated markdown file (overrides --release-footer)")
-	cmd.Flags().BoolVar(&root.opts.snapshot, "snapshot", false, "Generate an unversioned snapshot release, skipping all validations and without publishing any artifacts")
+	cmd.Flags().BoolVar(&root.opts.snapshot, "snapshot", false, "Generate an unversioned snapshot release, skipping all validations and without publishing any artifacts (implies --skip-publish, --skip-announce and --skip-validate)")
 	cmd.Flags().BoolVar(&root.opts.skipPublish, "skip-publish", false, "Skips publishing artifacts")
+	cmd.Flags().BoolVar(&root.opts.skipAnnounce, "skip-announce", false, "Skips announcing releases (implies --skip-validate)")
 	cmd.Flags().BoolVar(&root.opts.skipSign, "skip-sign", false, "Skips signing the artifacts")
 	cmd.Flags().BoolVar(&root.opts.skipValidate, "skip-validate", false, "Skips several sanity checks")
 	cmd.Flags().BoolVar(&root.opts.rmDist, "rm-dist", false, "Remove the dist folder before building")
@@ -122,6 +124,7 @@ func setupReleaseContext(ctx *context.Context, options releaseOpts) *context.Con
 	ctx.ReleaseFooterTmpl = options.releaseFooterTmpl
 	ctx.Snapshot = options.snapshot
 	ctx.SkipPublish = ctx.Snapshot || options.skipPublish
+	ctx.SkipAnnounce = ctx.Snapshot || options.skipPublish || options.skipAnnounce
 	ctx.SkipValidate = ctx.Snapshot || options.skipValidate
 	ctx.SkipSign = options.skipSign
 	ctx.RmDist = options.rmDist

--- a/cmd/release_test.go
+++ b/cmd/release_test.go
@@ -42,7 +42,8 @@ func TestReleaseFlags(t *testing.T) {
 		})
 		require.True(t, ctx.Snapshot)
 		require.True(t, ctx.SkipPublish)
-		require.True(t, ctx.SkipPublish)
+		require.True(t, ctx.SkipValidate)
+		require.True(t, ctx.SkipAnnounce)
 	})
 
 	t.Run("skips", func(t *testing.T) {
@@ -53,7 +54,8 @@ func TestReleaseFlags(t *testing.T) {
 		})
 		require.True(t, ctx.SkipSign)
 		require.True(t, ctx.SkipPublish)
-		require.True(t, ctx.SkipPublish)
+		require.True(t, ctx.SkipValidate)
+		require.True(t, ctx.SkipAnnounce)
 	})
 
 	t.Run("parallelism", func(t *testing.T) {

--- a/internal/pipe/pipe.go
+++ b/internal/pipe/pipe.go
@@ -14,6 +14,9 @@ var ErrSnapshotEnabled = Skip("disabled during snapshot mode")
 // It means that the part of a Piper that publishes its artifacts was not run.
 var ErrSkipPublishEnabled = Skip("publishing is disabled")
 
+// ErrSkipAnnounceEnabled happens if --skip-announce is set.
+var ErrSkipAnnounceEnabled = Skip("announcing is disabled")
+
 // ErrSkipSignEnabled happens if --skip-sign is set.
 // It means that the part of a Piper that signs some things was not run.
 var ErrSkipSignEnabled = Skip("artifact signing is disabled")

--- a/internal/pipe/twitter/twitter.go
+++ b/internal/pipe/twitter/twitter.go
@@ -33,6 +33,9 @@ func (Pipe) Default(ctx *context.Context) error {
 }
 
 func (Pipe) Announce(ctx *context.Context) error {
+	if ctx.SkipAnnounce {
+		return pipe.ErrSkipAnnounceEnabled
+	}
 	if !ctx.Config.Announce.Twitter.Enabled {
 		return pipe.ErrSkipDisabledPipe
 	}

--- a/internal/pipe/twitter/twitter_test.go
+++ b/internal/pipe/twitter/twitter_test.go
@@ -48,3 +48,15 @@ func TestAnnounceMissingEnv(t *testing.T) {
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.EqualError(t, Pipe{}.Announce(ctx), `announce: failed to announce to twitter: env: environment variable "TWITTER_CONSUMER_KEY" should not be empty`)
 }
+
+func TestAnnounceSkipAnnounce(t *testing.T) {
+	ctx := context.New(config.Project{
+		Announce: config.Announce{
+			Twitter: config.Twitter{
+				Enabled: true,
+			},
+		},
+	})
+	ctx.SkipAnnounce = true
+	testlib.AssertSkipped(t, Pipe{}.Announce(ctx))
+}

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -84,6 +84,7 @@ type Context struct {
 	Snapshot           bool
 	SkipPostBuildHooks bool
 	SkipPublish        bool
+	SkipAnnounce       bool
 	SkipSign           bool
 	SkipValidate       bool
 	RmDist             bool

--- a/www/docs/cmd/goreleaser_release.md
+++ b/www/docs/cmd/goreleaser_release.md
@@ -19,10 +19,11 @@ goreleaser release [flags]
       --release-notes string         Load custom release notes from a markdown file
       --release-notes-tmpl string    Load custom release notes from a templated markdown file (overrides --release-notes)
       --rm-dist                      Remove the dist folder before building
+      --skip-announce                Skips announcing releases (implies --skip-validate)
       --skip-publish                 Skips publishing artifacts
       --skip-sign                    Skips signing the artifacts
       --skip-validate                Skips several sanity checks
-      --snapshot                     Generate an unversioned snapshot release, skipping all validations and without publishing any artifacts
+      --snapshot                     Generate an unversioned snapshot release, skipping all validations and without publishing any artifacts (implies --skip-publish, --skip-announce and --skip-validate)
       --timeout duration             Timeout to the entire release process (default 30m0s)
 ```
 


### PR DESCRIPTION
adds --skip-announce flag and also skips announcing on --skip-publish and --snapshot

refs #2248
