### PR TITLE
feat: builds.output_path

### DIFF
--- a/internal/pipe/build/build.go
+++ b/internal/pipe/build/build.go
@@ -186,10 +186,17 @@ func buildOptionsForTarget(ctx *context.Context, build config.Build, target stri
 
 	build.Binary = binary
 	name := build.Binary + ext
+	outputPath := fmt.Sprintf("%s_%s", build.ID, target)
+	if build.OutputPath != "" {
+		outputPath, err = tmpl.New(ctx).WithBuildOptions(buildOpts).Apply(build.OutputPath)
+		if err != nil {
+			return nil, err
+		}
+	}
 	path, err := filepath.Abs(
 		filepath.Join(
 			ctx.Config.Dist,
-			fmt.Sprintf("%s_%s", build.ID, target),
+			outputPath,
 			name,
 		),
 	)

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -747,6 +747,24 @@ func TestBuildOptionsForTarget(t *testing.T) {
 				Arch:   "amd64",
 			},
 		},
+		{
+			name: "binary name with Os and Arch template variables and output directory",
+			build: config.Build{
+				ID:     "testid",
+				Binary: "testbinary_{{.Os}}_{{.Arch}}",
+				Targets: []string{
+					"linux_amd64",
+				},
+				OutputPath: "outputpath/{{.Os}}/{{.Arch}}",
+			},
+			expectedOpts: &api.Options{
+				Name:   "testbinary_linux_amd64",
+				Path:   filepath.Join(tmpDir, "outputpath", "linux", "amd64", "testbinary_linux_amd64"),
+				Target: "linux_amd64",
+				Os:     "linux",
+				Arch:   "amd64",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -203,6 +203,7 @@ type Build struct {
 	ModTimestamp string         `yaml:"mod_timestamp,omitempty"`
 	Skip         bool           `yaml:",omitempty"`
 	GoBinary     string         `yaml:",omitempty"`
+	OutputPath   string         `yaml:"output_path,omitempty"`
 }
 
 type HookConfig struct {

--- a/www/docs/customization/build.md
+++ b/www/docs/customization/build.md
@@ -126,6 +126,12 @@ builds:
     # Useful for library projects.
     # Default is false
     skip: false
+
+    # If defined, the created binary of a (matrix) build is 
+    # saved to the specified directory. The directory is always a sub-directory 
+    # of the dist folder. If the binary attribute itself is a path,
+    # the binary is saved in the path underneath the path specified here.
+    output_path: "my-path/{{.Os}}/{{.Arch}}"
 ```
 
 !!! tip


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

This Pull Request will add the option `output_path` to a build definition in the `config.yaml` file.

<!-- Why is this change being made? -->

This will add the ability to fully control the path of the created binary by `goreleaser`.  This comes in handy, when you create for example a (ZIP) archive, for distributing Terraform providers inside a CI/CD pipeline and you use `goreleaser` as a matrix build tool.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

