### PR TITLE
fix(ci): brew dependencies

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -110,6 +110,8 @@ brews:
       system "#{bin}/goreleaser -v"
     dependencies:
     - name: go
+      type: optional
+    - name: git
     install: |-
       bin.install "goreleaser"
       bash_completion.install "completions/goreleaser.bash" => "goreleaser"


### PR DESCRIPTION
- go should be optional, as it can be installed in other ways
- git is actually required