### PR TITLE
feat(nfpm): allow to template contents.dst

### DIFF
--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -192,9 +192,13 @@ func create(ctx *context.Context, fpm config.NFPM, format, arch string, binaries
 		if err != nil {
 			return err
 		}
+		dst, err := tmpl.Apply(content.Destination)
+		if err != nil {
+			return err
+		}
 		contents = append(contents, &files.Content{
 			Source:      src,
-			Destination: content.Destination,
+			Destination: dst,
 			Type:        content.Type,
 			Packager:    content.Packager,
 			FileInfo:    content.FileInfo,

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -131,7 +131,7 @@ func TestRunPipe(t *testing.T) {
 						},
 						{
 							Source:      "./testdata/testfile-{{ .Arch }}.txt",
-							Destination: "/etc/nope3.conf",
+							Destination: "/etc/nope3_{{ .ProjectName }}.conf",
 						},
 					},
 					Replacements: map[string]string{
@@ -178,7 +178,7 @@ func TestRunPipe(t *testing.T) {
 			"/etc/nope.conf",
 			"/etc/nope-rpm.conf",
 			"/etc/nope2.conf",
-			"/etc/nope3.conf",
+			"/etc/nope3_mybin.conf",
 			"/usr/bin/mybin",
 		}, destinations(pkg.ExtraOr("Files", files.Contents{}).(files.Contents)))
 	}
@@ -186,32 +186,71 @@ func TestRunPipe(t *testing.T) {
 }
 
 func TestInvalidNameTemplate(t *testing.T) {
-	ctx := &context.Context{
-		Parallelism: runtime.NumCPU(),
-		Artifacts:   artifact.New(),
-		Config: config.Project{
-			NFPMs: []config.NFPM{
-				{
-					NFPMOverridables: config.NFPMOverridables{
-						PackageName:      "foo",
-						FileNameTemplate: "{{.Foo}",
+	var makeCtx = func() *context.Context {
+		ctx := &context.Context{
+			Version:     "1.2.3",
+			Parallelism: runtime.NumCPU(),
+			Artifacts:   artifact.New(),
+			Config: config.Project{
+				NFPMs: []config.NFPM{
+					{
+						Formats: []string{"deb"},
+						Builds:  []string{"default"},
 					},
-					Formats: []string{"deb"},
-					Builds:  []string{"default"},
 				},
 			},
-		},
+		}
+		ctx.Artifacts.Add(&artifact.Artifact{
+			Name:   "mybin",
+			Goos:   "linux",
+			Goarch: "amd64",
+			Type:   artifact.Binary,
+			Extra: map[string]interface{}{
+				"ID": "default",
+			},
+		})
+		return ctx
 	}
-	ctx.Artifacts.Add(&artifact.Artifact{
-		Name:   "mybin",
-		Goos:   "linux",
-		Goarch: "amd64",
-		Type:   artifact.Binary,
-		Extra: map[string]interface{}{
-			"ID": "default",
-		},
+
+	t.Run("filename_template", func(t *testing.T) {
+		ctx := makeCtx()
+		ctx.Config.NFPMs[0].NFPMOverridables = config.NFPMOverridables{
+			PackageName:      "foo",
+			FileNameTemplate: "{{.Foo}",
+		}
+		require.Contains(t, Pipe{}.Run(ctx).Error(), `template: tmpl:1: unexpected "}" in operand`)
 	})
-	require.Contains(t, Pipe{}.Run(ctx).Error(), `template: tmpl:1: unexpected "}" in operand`)
+
+	t.Run("source", func(t *testing.T) {
+		ctx := makeCtx()
+		ctx.Config.NFPMs[0].NFPMOverridables = config.NFPMOverridables{
+			PackageName:      "foo",
+			FileNameTemplate: "Foo",
+			Contents: files.Contents{
+				{
+					Source:      "{{ .NOPE_SOURCE }}",
+					Destination: "/foo",
+				},
+			},
+		}
+		require.Contains(t, Pipe{}.Run(ctx).Error(), `template: tmpl:1:3: executing "tmpl" at <.NOPE_SOURCE>: map has no entry for key "NOPE_SOURCE"`)
+	})
+
+	t.Run("target", func(t *testing.T) {
+		ctx := makeCtx()
+		ctx.Config.NFPMs[0].NFPMOverridables = config.NFPMOverridables{
+			PackageName:      "foo",
+			FileNameTemplate: "Foo",
+			Contents: files.Contents{
+				{
+					Source:      "./testdata/testfile.txt",
+					Destination: "{{ .NOPE_TARGET }}",
+				},
+			},
+		}
+		require.Contains(t, Pipe{}.Run(ctx).Error(), `template: tmpl:1:3: executing "tmpl" at <.NOPE_TARGET>: map has no entry for key "NOPE_TARGET"`)
+	})
+
 }
 
 func TestRunPipeInvalidContentsSourceTemplate(t *testing.T) {

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -186,7 +186,7 @@ func TestRunPipe(t *testing.T) {
 }
 
 func TestInvalidNameTemplate(t *testing.T) {
-	var makeCtx = func() *context.Context {
+	makeCtx := func() *context.Context {
 		ctx := &context.Context{
 			Version:     "1.2.3",
 			Parallelism: runtime.NumCPU(),
@@ -250,7 +250,6 @@ func TestInvalidNameTemplate(t *testing.T) {
 		}
 		require.Contains(t, Pipe{}.Run(ctx).Error(), `template: tmpl:1:3: executing "tmpl" at <.NOPE_TARGET>: map has no entry for key "NOPE_TARGET"`)
 	})
-
 }
 
 func TestRunPipeInvalidContentsSourceTemplate(t *testing.T) {

--- a/www/docs/customization/nfpm.md
+++ b/www/docs/customization/nfpm.md
@@ -148,9 +148,9 @@ nfpms:
         dst: /etc/bar.conf
         type: "config|noreplace"
 
-      # The src attribute also supports name templates
+      # The src and dst attributes also supports name templates
       - src: path/{{ .Os }}-{{ .Arch }}/bar.conf
-        dst: /etc/foo/bar.conf
+        dst: /etc/foo/bar-{{ .ProjectName }}.conf
 
       # These files are not actually present in the package, but the file names
       # are added to the package header. From the RPM directives documentation:

--- a/www/docs/deprecations.md
+++ b/www/docs/deprecations.md
@@ -1,4 +1,4 @@
-gm---
+---
 title: Deprecation notices
 ---
 

--- a/www/docs/deprecations.md
+++ b/www/docs/deprecations.md
@@ -1,4 +1,4 @@
----
+gm---
 title: Deprecation notices
 ---
 


### PR DESCRIPTION
allow to template contents.dst

should make the [goreleaser pro includes feature](https://goreleaser.com/customization/includes/) even better, e.g. https://raw.githubusercontent.com/caarlos0/.goreleaserfiles/main/package_with_completions.yml , but will probably also be useful for other usecases.