### PR TITLE
feat: remove :latest imgs from release notes

### DIFF
--- a/internal/pipe/release/body_test.go
+++ b/internal/pipe/release/body_test.go
@@ -17,6 +17,7 @@ func TestDescribeBody(t *testing.T) {
 	for _, d := range []string{
 		"goreleaser/goreleaser:0.40.0",
 		"goreleaser/goreleaser:latest",
+		"goreleaser/goreleaser",
 		"goreleaser/godownloader:v0.1.0",
 	} {
 		ctx.Artifacts.Add(&artifact.Artifact{
@@ -94,7 +95,7 @@ func TestDescribeBodyWithHeaderAndFooter(t *testing.T) {
 	})
 	ctx.ReleaseNotes = changelog
 	ctx.Artifacts.Add(&artifact.Artifact{
-		Name: "goreleaser/goreleaser:latest",
+		Name: "goreleaser/goreleaser:v1.2.3",
 		Type: artifact.DockerImage,
 	})
 	out, err := describeBody(ctx)

--- a/internal/pipe/release/testdata/TestDescribeBody.golden
+++ b/internal/pipe/release/testdata/TestDescribeBody.golden
@@ -4,5 +4,4 @@ feature2: other description
 ## Docker images
 
 - `docker pull goreleaser/goreleaser:0.40.0`
-- `docker pull goreleaser/goreleaser:latest`
 - `docker pull goreleaser/godownloader:v0.1.0`

--- a/internal/pipe/release/testdata/TestDescribeBodyWithDockerManifest.golden
+++ b/internal/pipe/release/testdata/TestDescribeBodyWithDockerManifest.golden
@@ -4,5 +4,4 @@ feature2: other description
 ## Docker images
 
 - `docker pull goreleaser/goreleaser:0.40.0`
-- `docker pull goreleaser/goreleaser:latest`
 - `docker pull goreleaser/godownloader:v0.1.0`

--- a/internal/pipe/release/testdata/TestDescribeBodyWithHeaderAndFooter.golden
+++ b/internal/pipe/release/testdata/TestDescribeBodyWithHeaderAndFooter.golden
@@ -6,7 +6,7 @@ feature2: other description
 
 ## Docker images
 
-- `docker pull goreleaser/goreleaser:latest`
+- `docker pull goreleaser/goreleaser:v1.2.3`
 
 ---
 


### PR DESCRIPTION
I was thinking... does it makes sense to add the `:latest` docker images to the release notes? After all, **it will be wrong** eventually anyway...

I'm thinking... maybe its better if we just don't print those imgs there?

wdyt?

