### PR TITLE
feat(ci): Add Windows installer build configuration & winget configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,3 +100,64 @@ jobs:
           elif [[ $GITHUB_REF == refs/heads/master ]]; then
             ./goreleaser --snapshot
           fi
+
+  build-win-installers:
+    name: Build installers
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: goreleaser
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        config:
+          - {
+              arch: x86_64, label: x64
+            }
+          - {
+              arch: i386, label: x86
+            }
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Get version name
+        id: get_version
+        uses: battila7/get-version-action@v2
+      -
+        name: Download executables
+        id: download_exe
+        shell: bash
+        run: |
+          hub release download "${GITHUB_REF#refs/tags/}" -i 'goreleaser_Windows_${{ matrix.config.arch }}.zip'
+          unzip -o *.zip && rm -v *.zip
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      -
+        name: Install GoMSI
+        run: choco install -y go-msi
+      -
+        name: Prepare PATH
+        shell: bash
+        run: |
+          echo "$WIX\\bin" >> $GITHUB_PATH
+          echo "C:\\Program Files\\go-msi" >> $GITHUB_PATH
+      -
+        name: Build MSI
+        shell: bash
+        id: build_msi
+        env:
+          ZIP_FILE: ${{ steps.download_exe.outputs.zip }}
+        run: |
+          mkdir -p build
+          msi="$(basename "$ZIP_FILE" ".zip").msi"
+          printf "::set-output name=msi::%s\n" "$msi"
+          go-msi make --msi "$PWD/$msi" --out "$PWD/build" --version ${{ steps.get_version.outputs.version }}
+          printf "::set-output name=msi::%s\n" *.msi
+      -
+        name: Upload MSI
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ steps.build_msi.outputs.msi }}
+          asset_name: goreleaser_Windows_${{ matrix.config.label }}_Setup.msi
+          tag: ${{ github.ref }}

--- a/wix.json
+++ b/wix.json
@@ -1,0 +1,31 @@
+{
+    "product": "Goreleaser",
+    "company": "Goreleaser",
+    "license": "LICENSE.md",
+    "files": {
+        "guid": "d503a6bc-fc43-4a9d-8155-f9c85223ec1c",
+        "items": [
+            "goreleaser.exe"
+        ]
+    },
+    "env": {
+        "guid": "ad47448f-1a46-455c-ba91-f6a9a2e436ae",
+        "vars": [
+            {
+                "name": "PATH",
+                "value": "[INSTALLDIR]",
+                "permanent": "yes",
+                "system": "no",
+                "action": "set",
+                "part": "last"
+            }
+        ]
+    },
+    "shortcuts": {},
+    "choco": {
+        "description": "Deliver Go binaries as fast and easily as possible",
+        "project-url": "https://github.com/goreleaser/goreleaser",
+        "tags": "go docker homebrew golang package deb rpm apk travis release-automation snapcraft",
+        "license-url": "https://github.com/goreleaser/goreleaser/blob/master/LICENSE.md"
+    }
+}


### PR DESCRIPTION
Hi,
I have done a winget publication for an own project a week ago, thus I know how to achieve it.
As winget requires installers for x86 and x64, I added a build step to build the installers for both architectures.
To publish Goreleaser to the [winget repo](https://github.com/microsoft/winget-pkgs), I have prepared the configuration files in a [fork of this repo](https://github.com/compose-generator/winget-pkgs/commit/19d4349c6fb4d10348cc837306cf016d628ec8e9). As soon as the next release is published, I can make a pr against the Microsoft repo.

Btw: I have no clue if the workflow runs through, just copied it from my projects workflow and changed it accordingly ;) I hope we can test that somehow ...