### PR TITLE
fix:  empty build.tags and build.ldflags

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -81,11 +81,6 @@ func (*Builder) Build(ctx *context.Context, build config.Build, options api.Opti
 		return err
 	}
 
-	cmd := []string{build.GoBinary, "build"}
-
-	env := append(ctx.Env.Strings(), build.Env...)
-	env = append(env, target.Env()...)
-
 	artifact := &artifact.Artifact{
 		Type:   artifact.Binary,
 		Path:   options.Path,
@@ -101,41 +96,14 @@ func (*Builder) Build(ctx *context.Context, build config.Build, options api.Opti
 		},
 	}
 
-	flags, err := processFlags(ctx, artifact, env, build.Flags, "")
+	env := append(ctx.Env.Strings(), build.Env...)
+	env = append(env, target.Env()...)
+
+	cmd, err := buildGoBuildLine(ctx, build, options, artifact, env)
 	if err != nil {
 		return err
 	}
-	cmd = append(cmd, flags...)
 
-	asmflags, err := processFlags(ctx, artifact, env, build.Asmflags, "-asmflags=")
-	if err != nil {
-		return err
-	}
-	cmd = append(cmd, asmflags...)
-
-	gcflags, err := processFlags(ctx, artifact, env, build.Gcflags, "-gcflags=")
-	if err != nil {
-		return err
-	}
-	cmd = append(cmd, gcflags...)
-
-	tags, err := processFlag(ctx, artifact, env, strings.Join(build.Tags, ","))
-	if err != nil {
-		return err
-	}
-	cmd = append(cmd, "-tags="+tags)
-
-	// flag prefix is skipped because ldflags need to output a single string
-	ldflags, err := processFlags(ctx, artifact, env, build.Ldflags, "")
-	if err != nil {
-		return err
-	}
-	// ldflags need to be single string in order to apply correctly
-	processedLdFlags := joinLdFlags(ldflags)
-
-	cmd = append(cmd, processedLdFlags)
-
-	cmd = append(cmd, "-o", options.Path, build.Main)
 	if err := run(ctx, cmd, env, build.Dir); err != nil {
 		return fmt.Errorf("failed to build for %s: %w", options.Target, err)
 	}
@@ -158,6 +126,46 @@ func (*Builder) Build(ctx *context.Context, build config.Build, options api.Opti
 
 	ctx.Artifacts.Add(artifact)
 	return nil
+}
+
+func buildGoBuildLine(ctx *context.Context, build config.Build, options api.Options, artifact *artifact.Artifact, env []string) ([]string, error) {
+	cmd := []string{build.GoBinary, "build"}
+	flags, err := processFlags(ctx, artifact, env, build.Flags, "")
+	if err != nil {
+		return cmd, err
+	}
+	cmd = append(cmd, flags...)
+
+	asmflags, err := processFlags(ctx, artifact, env, build.Asmflags, "-asmflags=")
+	if err != nil {
+		return cmd, err
+	}
+	cmd = append(cmd, asmflags...)
+
+	gcflags, err := processFlags(ctx, artifact, env, build.Gcflags, "-gcflags=")
+	if err != nil {
+		return cmd, err
+	}
+	cmd = append(cmd, gcflags...)
+
+	tags, err := processFlag(ctx, artifact, env, strings.Join(build.Tags, ","))
+	if err != nil {
+		return cmd, err
+	}
+	cmd = append(cmd, "-tags="+tags)
+
+	// flag prefix is skipped because ldflags need to output a single string
+	ldflags, err := processFlags(ctx, artifact, env, build.Ldflags, "")
+	if err != nil {
+		return cmd, err
+	}
+	// ldflags need to be single string in order to apply correctly
+	processedLdFlags := joinLdFlags(ldflags)
+
+	cmd = append(cmd, processedLdFlags)
+
+	cmd = append(cmd, "-o", options.Path, build.Main)
+	return cmd, nil
 }
 
 func processFlags(ctx *context.Context, a *artifact.Artifact, env, flags []string, flagPrefix string) ([]string, error) {

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -732,21 +732,6 @@ func TestProcessFlagsInvalid(t *testing.T) {
 	require.Nil(t, flags)
 }
 
-func TestJoinLdFlags(t *testing.T) {
-	tests := []struct {
-		input  []string
-		output string
-	}{
-		{[]string{"-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser"}, "-ldflags=-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser"},
-		{[]string{"-s -w", "-X main.version={{.Version}}"}, "-ldflags=-s -w -X main.version={{.Version}}"},
-	}
-
-	for _, test := range tests {
-		joinedLdFlags := joinLdFlags(test.input)
-		require.Equal(t, joinedLdFlags, test.output)
-	}
-}
-
 func TestBuildModTimestamp(t *testing.T) {
 	// round to seconds since this will be a unix timestamp
 	modTime := time.Now().AddDate(-1, 0, 0).Round(1 * time.Second).UTC()
@@ -813,6 +798,106 @@ func TestBuildModTimestamp(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, modTime.Equal(fi.ModTime()), "inconsistent mod times found when specifying ModTimestamp")
 	}
+}
+
+func TestBuildGoBuildLine(t *testing.T) {
+	t.Run("full", func(t *testing.T) {
+		config := config.Project{
+			Builds: []config.Build{
+				{
+					Main:     ".",
+					Asmflags: []string{"asmflag1", "asmflag2"},
+					Gcflags:  []string{"gcflag1", "gcflag2"},
+					Flags:    []string{"-flag1", "-flag2"},
+					Tags:     []string{"tag1", "tag2"},
+					Ldflags:  []string{"ldflag1", "ldflag2"},
+					GoBinary: "go",
+				},
+			},
+		}
+		ctx := context.New(config)
+
+		line, err := buildGoBuildLine(ctx, config.Builds[0], api.Options{
+			Path: "foo",
+		}, &artifact.Artifact{}, []string{})
+		require.NoError(t, err)
+		require.Equal(
+			t,
+			[]string{
+				"go", "build",
+				"-flag1", "-flag2",
+				"-asmflags=asmflag1", "-asmflags=asmflag2",
+				"-gcflags=gcflag1", "-gcflags=gcflag2",
+				"-tags=tag1,tag2",
+				"-ldflags=ldflag1 ldflag2",
+				"-o", "foo", ".",
+			},
+			line,
+		)
+	})
+
+	t.Run("simple", func(t *testing.T) {
+		config := config.Project{
+			Builds: []config.Build{
+				{
+					Main:     ".",
+					GoBinary: "go",
+				},
+			},
+		}
+		ctx := context.New(config)
+
+		line, err := buildGoBuildLine(ctx, config.Builds[0], api.Options{
+			Path: "foo",
+		}, &artifact.Artifact{}, []string{})
+		require.NoError(t, err)
+		require.Equal(t, strings.Fields("go build -o foo ."), line)
+	})
+
+	t.Run("ldflags1", func(t *testing.T) {
+		config := config.Project{
+			Builds: []config.Build{
+				{
+					Main:     ".",
+					Ldflags:  []string{"-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.builtBy=goreleaser"},
+					GoBinary: "go",
+				},
+			},
+		}
+		ctx := context.New(config)
+		ctx.Version = "v1.2.3"
+		ctx.Git.Commit = "aaa"
+
+		line, err := buildGoBuildLine(ctx, config.Builds[0], api.Options{
+			Path: "foo",
+		}, &artifact.Artifact{}, []string{})
+		require.NoError(t, err)
+		require.Equal(t, []string{
+			"go", "build",
+			"-ldflags=-s -w -X main.version=v1.2.3 -X main.commit=aaa -X main.builtBy=goreleaser",
+			"-o", "foo", ".",
+		}, line)
+	})
+
+	t.Run("ldflags2", func(t *testing.T) {
+		config := config.Project{
+			Builds: []config.Build{
+				{
+					Main:     ".",
+					Ldflags:  []string{"-s -w", "-X main.version={{.Version}}"},
+					GoBinary: "go",
+				},
+			},
+		}
+		ctx := context.New(config)
+		ctx.Version = "v1.2.3"
+
+		line, err := buildGoBuildLine(ctx, config.Builds[0], api.Options{
+			Path: "foo",
+		}, &artifact.Artifact{}, []string{})
+		require.NoError(t, err)
+		require.Equal(t, []string{"go", "build", "-ldflags=-s -w -X main.version=v1.2.3", "-o", "foo", "."}, line)
+	})
 }
 
 //


### PR DESCRIPTION
`-ldflags` and `-tags` are not repeatable, so mentioning them again with a zero value actually sets them to 0.

This should fix it

closes #2300
refs #2268 
refs #2262