### PR TITLE
pipe/release: template header and footer

### DIFF
--- a/internal/pipe/release/body.go
+++ b/internal/pipe/release/body.go
@@ -6,6 +6,7 @@ import (
 	"text/template"
 
 	"github.com/goreleaser/goreleaser/internal/artifact"
+	"github.com/goreleaser/goreleaser/internal/tmpl"
 	"github.com/goreleaser/goreleaser/pkg/context"
 )
 
@@ -44,15 +45,25 @@ func describeBody(ctx *context.Context) (bytes.Buffer, error) {
 			dockers = append(dockers, a.Name)
 		}
 	}
+
+	header, err := tmpl.New(ctx).Apply(ctx.Config.Release.Header)
+	if err != nil {
+		return out, err
+	}
+	footer, err := tmpl.New(ctx).Apply(ctx.Config.Release.Footer)
+	if err != nil {
+		return out, err
+	}
+
 	bodyTemplate := template.Must(template.New("release").Parse(bodyTemplateText))
-	err := bodyTemplate.Execute(&out, struct {
+	err = bodyTemplate.Execute(&out, struct {
 		Header       string
 		Footer       string
 		ReleaseNotes string
 		DockerImages []string
 	}{
-		Header:       ctx.Config.Release.Header,
-		Footer:       ctx.Config.Release.Footer,
+		Header:       header,
+		Footer:       footer,
 		ReleaseNotes: ctx.ReleaseNotes,
 		DockerImages: dockers,
 	})

--- a/internal/pipe/release/body_test.go
+++ b/internal/pipe/release/body_test.go
@@ -90,10 +90,11 @@ func TestDescribeBodyWithHeaderAndFooter(t *testing.T) {
 	ctx := context.New(config.Project{
 		Release: config.Release{
 			Header: "## Yada yada yada\nsomething\n",
-			Footer: "\n---\n\nGet GoReleaser Pro at https://goreleaser.com/pro",
+			Footer: "\n---\n\nGet images at docker.io/foo/bar:{{.Tag}}\n\n---\n\nGet GoReleaser Pro at https://goreleaser.com/pro",
 		},
 	})
 	ctx.ReleaseNotes = changelog
+	ctx.Git = context.GitInfo{CurrentTag: "v1.0"}
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name: "goreleaser/goreleaser:v1.2.3",
 		Type: artifact.DockerImage,

--- a/internal/pipe/release/testdata/TestDescribeBodyWithHeaderAndFooter.golden
+++ b/internal/pipe/release/testdata/TestDescribeBodyWithHeaderAndFooter.golden
@@ -10,4 +10,8 @@ feature2: other description
 
 ---
 
+Get images at docker.io/foo/bar:v1.0
+
+---
+
 Get GoReleaser Pro at https://goreleaser.com/pro


### PR DESCRIPTION
A continuation of #2267 - the header and footer in release configuration
can be templated as well to support more use cases like attaching
published docker image information(without using docker pipe).