### PR TITLE
fix: new gitlab releases throwing 404 due to API change #2334

### DIFF
--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -208,11 +208,11 @@ func (c *gitlabClient) CreateRelease(ctx *context.Context, body string) (release
 	name := title
 	tagName := ctx.Git.CurrentTag
 	release, resp, err := c.client.Releases.GetRelease(projectID, tagName)
-	if err != nil && (resp == nil || resp.StatusCode != 403) {
+	if err != nil && (resp != nil && resp.StatusCode != 403 && resp.StatusCode != 404) {
 		return "", err
 	}
 
-	if resp.StatusCode == 403 {
+	if resp.StatusCode == 403 || resp.StatusCode == 404 {
 		log.WithFields(log.Fields{
 			"err": err.Error(),
 		}).Debug("get release")


### PR DESCRIPTION
This commit fixes releases on gitlab.com.
Currently, new releases are not working, because the API returns `404` for non-existing releases, which causes goreleaser to throw an error and fail.

See also #2334 for more info.

Let me know what you think, thanks a lot!