### PR TITLE
feat: smaller releases.json

### DIFF
--- a/scripts/get-releases.sh
+++ b/scripts/get-releases.sh
@@ -21,10 +21,11 @@ generate() {
 	done
 
 	if test "$last_page" -eq "1"; then
-		cp -f "$tmp/1.json" "$file"
+		jq --compact-output 'map({tag_name: .tag_name})' "$tmp"/1.json >"$file"
 	else
-		jq '[inputs] | add' "$tmp"/*.json >"$file"
+		jq --compact-output '[inputs] | add | map({tag_name: .tag_name})' "$tmp"/*.json >"$file"
 	fi
+	du -hs "$file"
 }
 
 generate "https://api.github.com/repos/goreleaser/goreleaser/releases" "www/docs/static/releases.json"


### PR DESCRIPTION
got an email from vercel saying we used all our quota this month (actually, 3x more).

My bet is the releases json file, which is kinda big:

```sh
❯ du -hs *.json
492K	releases-pro.json
 12M	releases.json
```

It has all the releases content, but we just use the `tag_name` on our action cc/ @crazy-max 

Changed a bit, and now:

```sh
❯ du -hs www/docs/static/*.json
4.0K    www/docs/static/releases-pro.json
 12K    www/docs/static/releases.json
```

will merge this asap to prevent being blocked... please let me know if this breaks anything I'm not expecting.