### PR TITLE
fix: gitignore patching needs leading newline (#2349)

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -40,7 +40,7 @@ func newInitCmd() *initCmd {
 				return err
 			}
 			defer gitignore.Close()
-			if _, err := gitignore.WriteString("dist/\n"); err != nil {
+			if _, err := gitignore.WriteString("\ndist/\n"); err != nil {
 				return err
 			}
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -32,7 +32,7 @@ func TestInitGitIgnoreExists(t *testing.T) {
 
 	bts, err := os.ReadFile(".gitignore")
 	require.NoError(t, err)
-	require.Equal(t, "mybinary\ndist/\n", string(bts))
+	require.Equal(t, "mybinary\n\ndist/\n", string(bts))
 }
 
 func TestInitFileExists(t *testing.T) {


### PR DESCRIPTION
If applied, this commit will inject an extra leading newline when patching `.gitignore`, so that it works properly on existing `.gitignore` files that do not have trailing newlines (#2349)

**Why is this change being made?**

Per #2349, the current way breaks `.gitignore` files without a trailing newline.

closes #2349 
