### PR TITLE
feat: inc parts of semver, change snapshot default name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,6 +4,8 @@ before:
   hooks:
     - go mod tidy
     - ./scripts/completions.sh
+snapshot:
+  name_template: '{{ incpatch .Tag }}-next'
 gomod:
   proxy: true
 builds:

--- a/cmd/testdata/good.yml
+++ b/cmd/testdata/good.yml
@@ -19,7 +19,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  name_template: "{{ incpatch .Tag }}-next"
 changelog:
   sort: asc
   filters:

--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -32,9 +32,7 @@ func (Pipe) Run(ctx *context.Context) error {
 		return err
 	}
 	ctx.Git = info
-	if !ctx.Snapshot {
-		log.Infof("releasing %s, commit %s", info.CurrentTag, info.Commit)
-	}
+	log.Infof("building commit=%s, latest tag=", info.Commit, info.CurrentTag)
 	ctx.Version = strings.TrimPrefix(ctx.Git.CurrentTag, "v")
 	return validate(ctx)
 }

--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -32,7 +32,7 @@ func (Pipe) Run(ctx *context.Context) error {
 		return err
 	}
 	ctx.Git = info
-	log.Infof("building commit=%s, latest tag=", info.Commit, info.CurrentTag)
+	log.WithField("commit", info.Commit).WithField("latest tag", info.CurrentTag).Info("building...")
 	ctx.Version = strings.TrimPrefix(ctx.Git.CurrentTag, "v")
 	return validate(ctx)
 }

--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -32,6 +32,9 @@ func (Pipe) Run(ctx *context.Context) error {
 		return err
 	}
 	ctx.Git = info
+	if !ctx.Snapshot {
+		log.Infof("releasing %s, commit %s", info.CurrentTag, info.Commit)
+	}
 	ctx.Version = strings.TrimPrefix(ctx.Git.CurrentTag, "v")
 	return validate(ctx)
 }

--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -32,7 +32,6 @@ func (Pipe) Run(ctx *context.Context) error {
 		return err
 	}
 	ctx.Git = info
-	log.Infof("releasing %s, commit %s", info.CurrentTag, info.Commit)
 	ctx.Version = strings.TrimPrefix(ctx.Git.CurrentTag, "v")
 	return validate(ctx)
 }

--- a/internal/pipe/snapshot/snapshot.go
+++ b/internal/pipe/snapshot/snapshot.go
@@ -4,6 +4,7 @@ package snapshot
 import (
 	"fmt"
 
+	"github.com/apex/log"
 	"github.com/goreleaser/goreleaser/internal/pipe"
 	"github.com/goreleaser/goreleaser/internal/tmpl"
 	"github.com/goreleaser/goreleaser/pkg/context"
@@ -19,13 +20,14 @@ func (Pipe) String() string {
 // Default sets the pipe defaults.
 func (Pipe) Default(ctx *context.Context) error {
 	if ctx.Config.Snapshot.NameTemplate == "" {
-		ctx.Config.Snapshot.NameTemplate = "{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}"
+		ctx.Config.Snapshot.NameTemplate = "{{ incpatch .Tag }}"
 	}
 	return nil
 }
 
 func (Pipe) Run(ctx *context.Context) error {
 	if !ctx.Snapshot {
+		log.Infof("releasing %s, commit %s", ctx.Git.CurrentTag, ctx.Git.Commit)
 		return pipe.ErrSkipDisabledPipe
 	}
 	name, err := tmpl.New(ctx).Apply(ctx.Config.Snapshot.NameTemplate)
@@ -36,5 +38,6 @@ func (Pipe) Run(ctx *context.Context) error {
 		return fmt.Errorf("empty snapshot name")
 	}
 	ctx.Version = name
+	log.Infof("creating snapshot %s", ctx.Version)
 	return nil
 }

--- a/internal/pipe/snapshot/snapshot.go
+++ b/internal/pipe/snapshot/snapshot.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/apex/log"
+	"github.com/goreleaser/goreleaser/internal/pipe"
 	"github.com/goreleaser/goreleaser/internal/tmpl"
 	"github.com/goreleaser/goreleaser/pkg/context"
 )
@@ -19,12 +20,15 @@ func (Pipe) String() string {
 // Default sets the pipe defaults.
 func (Pipe) Default(ctx *context.Context) error {
 	if ctx.Config.Snapshot.NameTemplate == "" {
-		ctx.Config.Snapshot.NameTemplate = "{{ incpatch .Tag }}"
+		ctx.Config.Snapshot.NameTemplate = "{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}"
 	}
 	return nil
 }
 
 func (Pipe) Run(ctx *context.Context) error {
+	if !ctx.Snapshot {
+		return pipe.ErrSkipDisabledPipe
+	}
 	name, err := tmpl.New(ctx).Apply(ctx.Config.Snapshot.NameTemplate)
 	if err != nil {
 		return fmt.Errorf("failed to generate snapshot name: %w", err)

--- a/internal/pipe/snapshot/snapshot.go
+++ b/internal/pipe/snapshot/snapshot.go
@@ -37,6 +37,6 @@ func (Pipe) Run(ctx *context.Context) error {
 		return fmt.Errorf("empty snapshot name")
 	}
 	ctx.Version = name
-	log.Infof("creating snapshot %s", ctx.Version)
+	log.WithField("version", ctx.Version).Infof("building snapshot...")
 	return nil
 }

--- a/internal/pipe/snapshot/snapshot.go
+++ b/internal/pipe/snapshot/snapshot.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/apex/log"
-	"github.com/goreleaser/goreleaser/internal/pipe"
 	"github.com/goreleaser/goreleaser/internal/tmpl"
 	"github.com/goreleaser/goreleaser/pkg/context"
 )
@@ -26,10 +25,6 @@ func (Pipe) Default(ctx *context.Context) error {
 }
 
 func (Pipe) Run(ctx *context.Context) error {
-	if !ctx.Snapshot {
-		log.Infof("releasing %s, commit %s", ctx.Git.CurrentTag, ctx.Git.Commit)
-		return pipe.ErrSkipDisabledPipe
-	}
 	name, err := tmpl.New(ctx).Apply(ctx.Config.Snapshot.NameTemplate)
 	if err != nil {
 		return fmt.Errorf("failed to generate snapshot name: %w", err)

--- a/internal/pipe/snapshot/snapshot_test.go
+++ b/internal/pipe/snapshot/snapshot_test.go
@@ -20,7 +20,7 @@ func TestDefault(t *testing.T) {
 		},
 	}
 	require.NoError(t, Pipe{}.Default(ctx))
-	require.Equal(t, "{{ incpatch .Tag }}", ctx.Config.Snapshot.NameTemplate)
+	require.Equal(t, "{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}", ctx.Config.Snapshot.NameTemplate)
 }
 
 func TestDefaultSet(t *testing.T) {

--- a/internal/pipe/snapshot/snapshot_test.go
+++ b/internal/pipe/snapshot/snapshot_test.go
@@ -20,7 +20,7 @@ func TestDefault(t *testing.T) {
 		},
 	}
 	require.NoError(t, Pipe{}.Default(ctx))
-	require.Equal(t, "{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}", ctx.Config.Snapshot.NameTemplate)
+	require.Equal(t, "{{ incpatch .Tag }}", ctx.Config.Snapshot.NameTemplate)
 }
 
 func TestDefaultSet(t *testing.T) {

--- a/internal/static/config.go
+++ b/internal/static/config.go
@@ -29,7 +29,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  name_template: "{{ incpatch .Tag }}-next"
 changelog:
   sort: asc
   filters:

--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -10,6 +10,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/pkg/build"
 	"github.com/goreleaser/goreleaser/pkg/context"
@@ -166,6 +167,9 @@ func (t *Template) Apply(s string) (string, error) {
 			"trimprefix": strings.TrimPrefix,
 			"dir":        filepath.Dir,
 			"abs":        filepath.Abs,
+			"incmajor":   incMajor,
+			"incminor":   incMinor,
+			"incpatch":   incPatch,
 		}).
 		Parse(s)
 	if err != nil {
@@ -217,4 +221,23 @@ func replace(replacements map[string]string, original string) string {
 		return original
 	}
 	return result
+}
+
+func incMajor(v string) string {
+	return prefix(v) + semver.MustParse(v).IncMajor().String()
+}
+
+func incMinor(v string) string {
+	return prefix(v) + semver.MustParse(v).IncMinor().String()
+}
+
+func incPatch(v string) string {
+	return prefix(v) + semver.MustParse(v).IncPatch().String()
+}
+
+func prefix(v string) string {
+	if v != "" && v[0] == 'v' {
+		return "v"
+	}
+	return ""
 }

--- a/internal/tmpl/tmpl_test.go
+++ b/internal/tmpl/tmpl_test.go
@@ -48,6 +48,12 @@ func TestWithArtifact(t *testing.T) {
 		"binary":                           "{{.Binary}}",
 		"proj":                             "{{.ProjectName}}",
 		"github.com/goreleaser/goreleaser": "{{ .ModulePath }}",
+		"v2.0.0":                           "{{.Tag | incmajor }}",
+		"2.0.0":                            "{{.Version | incmajor }}",
+		"v1.3.0":                           "{{.Tag | incminor }}",
+		"1.3.0":                            "{{.Version | incminor }}",
+		"v1.2.4":                           "{{.Tag | incpatch }}",
+		"1.2.4":                            "{{.Version | incpatch }}",
 	} {
 		tmpl := tmpl
 		expect := expect

--- a/www/docs/customization/snapshots.md
+++ b/www/docs/customization/snapshots.md
@@ -16,8 +16,8 @@ snapshot:
   # Note that some pipes require this to be semantic version compliant (nfpm,
   # for example).
   #
-  # Default is `{{ incpatch .Tag }}`.
-  name_template: 1.2.3-SNAPSHOT-{{.Commit}}
+  # Default is `{{ .Tag }}-SNAPSHOT-{{.ShortCommit}}`.
+  name_template: '{{ incpatch .Tag }}-devel'
 ```
 
 ## How it works

--- a/www/docs/customization/snapshots.md
+++ b/www/docs/customization/snapshots.md
@@ -16,7 +16,7 @@ snapshot:
   # Note that some pipes require this to be semantic version compliant (nfpm,
   # for example).
   #
-  # Default is `{{ .Tag }}-SNAPSHOT-{{.ShortCommit}}`.
+  # Default is `{{ incpatch .Tag }}`.
   name_template: 1.2.3-SNAPSHOT-{{.Commit}}
 ```
 

--- a/www/docs/customization/templates.md
+++ b/www/docs/customization/templates.md
@@ -10,29 +10,32 @@ support templating.
 
 On fields that support templating, these fields are always available:
 
-| Key                | Description                                                                                                                  |
-|--------------------|------------------------------------------------------------------------------------------------------------------------------|
-| `.ProjectName`     | the project name                                                                                                             |
-| `.Version`         | the version being released (`v` prefix stripped),<br>or `{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}` in case of snapshot release |
-| `.Branch`          | the current git branch                                                                                                       |
-| `.PrefixedTag`     | the current git tag prefixed with the monorepo config tag prefix (if any)                                                    |
-| `.Tag`             | the current git tag                                                                                                          |
-| `.ShortCommit`     | the git commit short hash                                                                                                    |
-| `.FullCommit`      | the git commit full hash                                                                                                     |
-| `.Commit`          | the git commit hash (deprecated)                                                                                             |
-| `.CommitDate`      | the UTC commit date in RFC 3339 format                                                                                       |
-| `.CommitTimestamp` | the UTC commit date in Unix format                                                                                           |
-| `.GitURL`          | the git remote url                                                                                                           |
-| `.Major`           | the major part of the version (assuming `Tag` is a valid semver, else `0`)                                                   |
-| `.Minor`           | the minor part of the version (assuming `Tag` is a valid semver, else `0`)                                                   |
-| `.Patch`           | the patch part of the version (assuming `Tag` is a valid semver, else `0`)                                                   |
-| `.Prerelease`      | the prerelease part of the version, e.g. `beta` (assuming `Tag` is a valid semver)                                           |
-| `.RawVersion`      | Major.Minor.Patch (assuming `Tag` is a valid semver, else `0.0.0`)                                                           |
-| `.IsSnapshot`      | `true` if a snapshot is being released, `false` otherwise                                                                    |
-| `.Env`             | a map with system's environment variables                                                                                    |
-| `.Date`            | current UTC date in RFC 3339 format                                                                                          |
-| `.Timestamp`       | current UTC time in Unix format                                                                                              |
-| `.ModulePath`      | the go module path, as reported by `go list -m`                                                                              |
+| Key                 | Description                                                                                                                  |
+|---------------------|------------------------------------------------------------------------------------------------------------------------------|
+| `.ProjectName`      | the project name                                                                                                             |
+| `.Version`          | the version being released (`v` prefix stripped),<br>or `{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}` in case of snapshot release |
+| `.Branch`           | the current git branch                                                                                                       |
+| `.PrefixedTag`      | the current git tag prefixed with the monorepo config tag prefix (if any)                                                    |
+| `.Tag`              | the current git tag                                                                                                          |
+| `.ShortCommit`      | the git commit short hash                                                                                                    |
+| `.FullCommit`       | the git commit full hash                                                                                                     |
+| `.Commit`           | the git commit hash (deprecated)                                                                                             |
+| `.CommitDate`       | the UTC commit date in RFC 3339 format                                                                                       |
+| `.CommitTimestamp`  | the UTC commit date in Unix format                                                                                           |
+| `.GitURL`           | the git remote url                                                                                                           |
+| `.Major`            | the major part of the version (assuming `Tag` is a valid semver, else `0`)                                                   |
+| `.Minor`            | the minor part of the version (assuming `Tag` is a valid semver, else `0`)                                                   |
+| `.Patch`            | the patch part of the version (assuming `Tag` is a valid semver, else `0`)                                                   |
+| `.Prerelease`       | the prerelease part of the version, e.g. `beta` (assuming `Tag` is a valid semver)                                           |
+| `.RawVersion`       | Major.Minor.Patch (assuming `Tag` is a valid semver, else `0.0.0`)                                                           |
+| `.IsSnapshot`       | `true` if a snapshot is being released, `false` otherwise                                                                    |
+| `.Env`              | a map with system's environment variables                                                                                    |
+| `.Date`             | current UTC date in RFC 3339 format                                                                                          |
+| `.Timestamp`        | current UTC time in Unix format                                                                                              |
+| `.ModulePath`       | the go module path, as reported by `go list -m`                                                                              |
+| `incpatch "v1.2.4"` | increments the patch of the given version; will panic if not a semantic version                                              |
+| `incminor "v1.2.4"` | increments the minor of the given version; will panic if not a semantic version                                              |
+| `incmajor "v1.2.4"` | increments the major of the given version; will panic if not a semantic version                                              |
 
 On fields that are related to a single artifact (e.g., the binary name), you
 may have some extra fields:
@@ -64,7 +67,7 @@ On all fields, you have these available functions:
 | `tolower "V1.2"`        | makes input string lowercase. See [ToLower](https://golang.org/pkg/strings/#ToLower)                                           |
 | `toupper "v1.2"`        | makes input string uppercase. See [ToUpper](https://golang.org/pkg/strings/#ToUpper)                                           |
 | `trim " v1.2  "`        | removes all leading and trailing white space. See [TrimSpace](https://golang.org/pkg/strings/#TrimSpace)                       |
-| `trimprefix "v1.2" "v"` | removes provided leading prefix string, if present. See [TrimPrefix](https://golang.org/pkg/strings/#TrimPrefix)                |
+| `trimprefix "v1.2" "v"` | removes provided leading prefix string, if present. See [TrimPrefix](https://golang.org/pkg/strings/#TrimPrefix)               |
 | `dir .Path`             | returns all but the last element of path, typically the path's directory. See [Dir](https://golang.org/pkg/path/filepath/#Dir) |
 | `abs .ArtifactPath`     | returns an absolute representation of path. See [Abs](https://golang.org/pkg/path/filepath/#Abs)                               |
 


### PR DESCRIPTION
revives https://github.com/goreleaser/goreleaser/pull/1457 adding some new template functions:

- incpatch
- incminor
- incmajor

and change the `goreleaser init`  generated config snapshot name to `{{ incpatch .Tag }}-next`

refs https://github.com/goreleaser/goreleaser/issues/2355