### PR TITLE
feat(snapcraft): manage channel upload

### DIFF
--- a/internal/pipe/snapcraft/snapcraft_test.go
+++ b/internal/pipe/snapcraft/snapcraft_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/internal/artifact"
@@ -52,25 +51,28 @@ func TestRunPipe(t *testing.T) {
 		Dist:        dist,
 		Snapcrafts: []config.Snapcraft{
 			{
-				NameTemplate: "foo_{{.Arch}}",
-				Summary:      "test summary",
-				Description:  "test description",
-				Publish:      true,
-				Builds:       []string{"foo"},
+				NameTemplate:     "foo_{{.Arch}}",
+				Summary:          "test summary",
+				Description:      "test description",
+				Publish:          true,
+				Builds:           []string{"foo"},
+				ChannelTemplates: []string{"stable"},
 			},
 			{
-				NameTemplate: "foo_and_bar_{{.Arch}}",
-				Summary:      "test summary",
-				Description:  "test description",
-				Publish:      true,
-				Builds:       []string{"foo", "bar"},
+				NameTemplate:     "foo_and_bar_{{.Arch}}",
+				Summary:          "test summary",
+				Description:      "test description",
+				Publish:          true,
+				Builds:           []string{"foo", "bar"},
+				ChannelTemplates: []string{"stable"},
 			},
 			{
-				NameTemplate: "bar_{{.Arch}}",
-				Summary:      "test summary",
-				Description:  "test description",
-				Publish:      true,
-				Builds:       []string{"bar"},
+				NameTemplate:     "bar_{{.Arch}}",
+				Summary:          "test summary",
+				Description:      "test description",
+				Publish:          true,
+				Builds:           []string{"bar"},
+				ChannelTemplates: []string{"stable"},
 			},
 		},
 	})
@@ -92,10 +94,11 @@ func TestRunPipeInvalidNameTemplate(t *testing.T) {
 		Dist:        dist,
 		Snapcrafts: []config.Snapcraft{
 			{
-				NameTemplate: "foo_{{.Arch}",
-				Summary:      "test summary",
-				Description:  "test description",
-				Builds:       []string{"foo"},
+				NameTemplate:     "foo_{{.Arch}",
+				Summary:          "test summary",
+				Description:      "test description",
+				Builds:           []string{"foo"},
+				ChannelTemplates: []string{"stable"},
 			},
 		},
 	})
@@ -114,13 +117,14 @@ func TestRunPipeWithName(t *testing.T) {
 		Dist:        dist,
 		Snapcrafts: []config.Snapcraft{
 			{
-				NameTemplate: "foo_{{.Arch}}",
-				Name:         "testsnapname",
-				Base:         "core18",
-				License:      "MIT",
-				Summary:      "test summary",
-				Description:  "test description",
-				Builds:       []string{"foo"},
+				NameTemplate:     "foo_{{.Arch}}",
+				Name:             "testsnapname",
+				Base:             "core18",
+				License:          "MIT",
+				Summary:          "test summary",
+				Description:      "test description",
+				Builds:           []string{"foo"},
+				ChannelTemplates: []string{"stable"},
 			},
 		},
 	})
@@ -168,7 +172,8 @@ func TestRunPipeMetadata(t *testing.T) {
 						"read": []string{"$HOME/test"},
 					},
 				},
-				Builds: []string{"foo"},
+				Builds:           []string{"foo"},
+				ChannelTemplates: []string{"stable"},
 			},
 		},
 	})
@@ -227,7 +232,8 @@ func TestRunNoArguments(t *testing.T) {
 						Args:   "",
 					},
 				},
-				Builds: []string{"foo"},
+				Builds:           []string{"foo"},
+				ChannelTemplates: []string{"stable"},
 			},
 		},
 	})
@@ -262,7 +268,8 @@ func TestCompleter(t *testing.T) {
 						Completer: "testdata/foo-completer.bash",
 					},
 				},
-				Builds: []string{"foo", "bar"},
+				Builds:           []string{"foo", "bar"},
+				ChannelTemplates: []string{"stable"},
 			},
 		},
 	})
@@ -299,7 +306,8 @@ func TestCommand(t *testing.T) {
 						Command: "foo",
 					},
 				},
-				Builds: []string{"foo"},
+				Builds:           []string{"foo"},
+				ChannelTemplates: []string{"stable"},
 			},
 		},
 	})
@@ -337,7 +345,8 @@ func TestExtraFile(t *testing.T) {
 						Source: "testdata/extra-file-2.txt",
 					},
 				},
-				Builds: []string{"foo"},
+				Builds:           []string{"foo"},
+				ChannelTemplates: []string{"stable"},
 			},
 		},
 	})
@@ -350,7 +359,7 @@ func TestExtraFile(t *testing.T) {
 	require.NoError(t, err)
 	destFile, err := os.Stat(filepath.Join(dist, "foo_amd64", "prime", "a", "b", "c", "extra-file.txt"))
 	require.NoError(t, err)
-	require.Equal(t, inode(srcFile), inode(destFile))
+	require.Equal(t, srcFile.Size(), destFile.Size())
 	require.Equal(t, destFile.Mode(), os.FileMode(0o755))
 
 	srcFile, err = os.Stat("testdata/extra-file-2.txt")
@@ -358,7 +367,7 @@ func TestExtraFile(t *testing.T) {
 	destFileWithDefaults, err := os.Stat(filepath.Join(dist, "foo_amd64", "prime", "testdata", "extra-file-2.txt"))
 	require.NoError(t, err)
 	require.Equal(t, destFileWithDefaults.Mode(), os.FileMode(0o644))
-	require.Equal(t, inode(srcFile), inode(destFileWithDefaults))
+	require.Equal(t, srcFile.Size(), destFileWithDefaults.Size())
 }
 
 func TestDefault(t *testing.T) {
@@ -385,6 +394,9 @@ func TestPublish(t *testing.T) {
 		Goarch: "amd64",
 		Goos:   "linux",
 		Type:   artifact.PublishableSnapcraft,
+		Extra: map[string]interface{}{
+			releasesExtra: []string{"stable", "candidate"},
+		},
 	})
 	err := Pipe{}.Publish(ctx)
 	require.Contains(t, err.Error(), "failed to push nope.snap package")
@@ -399,6 +411,9 @@ func TestPublishSkip(t *testing.T) {
 		Goarch: "amd64",
 		Goos:   "linux",
 		Type:   artifact.PublishableSnapcraft,
+		Extra: map[string]interface{}{
+			releasesExtra: []string{"stable"},
+		},
 	})
 	testlib.AssertSkipped(t, Pipe{}.Publish(ctx))
 }
@@ -407,12 +422,69 @@ func TestDefaultSet(t *testing.T) {
 	ctx := context.New(config.Project{
 		Snapcrafts: []config.Snapcraft{
 			{
+				ID:           "devel",
 				NameTemplate: "foo",
+				Grade:        "devel",
+			},
+			{
+				ID:           "stable",
+				NameTemplate: "bar",
+				Grade:        "stable",
 			},
 		},
 	})
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "foo", ctx.Config.Snapcrafts[0].NameTemplate)
+	require.Equal(t, []string{"edge", "beta"}, ctx.Config.Snapcrafts[0].ChannelTemplates)
+	require.Equal(t, []string{"edge", "beta", "candidate", "stable"}, ctx.Config.Snapcrafts[1].ChannelTemplates)
+}
+
+func Test_processChannelsTemplates(t *testing.T) {
+	ctx := &context.Context{
+		Config: config.Project{
+			Builds: []config.Build{
+				{
+					ID: "default",
+				},
+			},
+			Snapcrafts: []config.Snapcraft{
+				{
+					Name: "mybin",
+					ChannelTemplates: []string{
+						"{{.Major}}.{{.Minor}}/stable",
+						"stable",
+					},
+				},
+			},
+		},
+	}
+
+	ctx.SkipPublish = true
+	ctx.Env = map[string]string{
+		"FOO": "123",
+	}
+	ctx.Version = "1.0.0"
+	ctx.Git = context.GitInfo{
+		CurrentTag: "v1.0.0",
+		Commit:     "a1b2c3d4",
+	}
+	ctx.Semver = context.Semver{
+		Major: 1,
+		Minor: 0,
+		Patch: 0,
+	}
+
+	require.NoError(t, Pipe{}.Default(ctx))
+
+	snap := ctx.Config.Snapcrafts[0]
+	require.Equal(t, "mybin", snap.Name)
+
+	channels, err := processChannelsTemplates(ctx, snap)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"1.0/stable",
+		"stable",
+	}, channels)
 }
 
 func addBinaries(t *testing.T, ctx *context.Context, name, dist string) {
@@ -474,9 +546,4 @@ func Test_isValidArch(t *testing.T) {
 			require.Equal(t, tt.want, isValidArch(tt.arch))
 		})
 	}
-}
-
-func inode(info os.FileInfo) uint64 {
-	stat := info.Sys().(*syscall.Stat_t)
-	return stat.Ino
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -503,18 +503,19 @@ type Snapcraft struct {
 	Replacements map[string]string `yaml:",omitempty"`
 	Publish      bool              `yaml:",omitempty"`
 
-	ID          string                             `yaml:",omitempty"`
-	Builds      []string                           `yaml:",omitempty"`
-	Name        string                             `yaml:",omitempty"`
-	Summary     string                             `yaml:",omitempty"`
-	Description string                             `yaml:",omitempty"`
-	Base        string                             `yaml:",omitempty"`
-	License     string                             `yaml:",omitempty"`
-	Grade       string                             `yaml:",omitempty"`
-	Confinement string                             `yaml:",omitempty"`
-	Layout      map[string]SnapcraftLayoutMetadata `yaml:",omitempty"`
-	Apps        map[string]SnapcraftAppMetadata    `yaml:",omitempty"`
-	Plugs       map[string]interface{}             `yaml:",omitempty"`
+	ID               string                             `yaml:",omitempty"`
+	Builds           []string                           `yaml:",omitempty"`
+	Name             string                             `yaml:",omitempty"`
+	Summary          string                             `yaml:",omitempty"`
+	Description      string                             `yaml:",omitempty"`
+	Base             string                             `yaml:",omitempty"`
+	License          string                             `yaml:",omitempty"`
+	Grade            string                             `yaml:",omitempty"`
+	ChannelTemplates []string                           `yaml:"channel_templates,omitempty"`
+	Confinement      string                             `yaml:",omitempty"`
+	Layout           map[string]SnapcraftLayoutMetadata `yaml:",omitempty"`
+	Apps             map[string]SnapcraftAppMetadata    `yaml:",omitempty"`
+	Plugs            map[string]interface{}             `yaml:",omitempty"`
 
 	Files []SnapcraftExtraFiles `yaml:"extra_files,omitempty"`
 }

--- a/www/docs/customization/snapcraft.md
+++ b/www/docs/customization/snapcraft.md
@@ -60,12 +60,27 @@ snapcrafts:
     # store.
     description: This is the best drum roll application out there. Install it and awe!
 
+    # Channels in store where snap will be pushed.
+    # Default depends on grade:
+    # * `stable` = ["edge", "beta", "candidate", "stable"]
+    # * `devel` = ["edge", "beta"]
+    # More info about channels here:
+    # https://snapcraft.io/docs/reference/channels
+    channel_templates:
+      - edge
+      - beta
+      - candidate
+      - stable
+      - {{ .Major }}.{{ .Minor }}/edge
+      - {{ .Major }}.{{ .Minor }}/beta
+      - {{ .Major }}.{{ .Minor }}/candidate
+      - {{ .Major }}.{{ .Minor }}/stable
+
     # A guardrail to prevent you from releasing a snap to all your users before
     # it is ready.
     # `devel` will let you release only to the `edge` and `beta` channels in the
     # store. `stable` will let you release also to the `candidate` and `stable`
-    # channels. More info about channels here:
-    # https://snapcraft.io/docs/reference/channels
+    # channels.
     grade: stable
 
     # Snaps can be setup to follow three different confinement policies:


### PR DESCRIPTION
By default, snap store manage "edge", "beta", "candidate" and "stable".
Default to all this channels when package is in grade stable. But only on
"edge" and "beta" for grade "devel".

This fix this TODO: https://github.com/goreleaser/goreleaser/blob/bf19dc1079887d31e58065771bb069953b1704d6/internal/pipe/snapcraft/snapcraft.go#L342