### PR TITLE
fix: copying file on docker pkg instead of hard linking

### DIFF
--- a/internal/gio/copy.go
+++ b/internal/gio/copy.go
@@ -20,7 +20,7 @@ func Copy(src, dst string) error {
 func CopyWithMode(src, dst string, mode os.FileMode) error {
 	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return fmt.Errorf("failed to copy %s to %s", src, dst)
+			return fmt.Errorf("failed to copy %s to %s: %w", src, dst, err)
 		}
 		// We have the following:
 		// - src = "a/b"

--- a/internal/gio/copy.go
+++ b/internal/gio/copy.go
@@ -1,0 +1,27 @@
+package gio
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// CopyFile copies src into dst with the given mode.
+func CopyFile(src, dst string, mode os.FileMode) error {
+	original, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("failed to open '%s': %w", src, err)
+	}
+	defer original.Close()
+
+	new, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return fmt.Errorf("failed to open '%s': %w", dst, err)
+	}
+	defer new.Close()
+
+	if _, err := io.Copy(new, original); err != nil {
+		return fmt.Errorf("failed to copy: %w", err)
+	}
+	return nil
+}

--- a/internal/gio/copy.go
+++ b/internal/gio/copy.go
@@ -4,19 +4,45 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/apex/log"
 )
 
-// CopyFileWithSrcMode copies src into dst with src's file mode.
-func CopyFileWithSrcMode(src, dst string) error {
-	st, err := os.Stat(src)
-	if err != nil {
-		return fmt.Errorf("failed to stat %s: %w", src, err)
-	}
-	return CopyFile(src, dst, st.Mode())
+// Copy recursively copies src into dst with src's file modes.
+func Copy(src, dst string) error {
+	return CopyWithMode(src, dst, 0)
 }
 
-// CopyFile copies src into dst with the given mode.
-func CopyFile(src, dst string, mode os.FileMode) error {
+// CopyWithMode recursively copies src into dst with the given mode.
+// The given mode applies only to files. Their parent dirs will have the same mode as their src counterparts.
+func CopyWithMode(src, dst string, mode os.FileMode) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("failed to copy %s to %s", src, dst)
+		}
+		// We have the following:
+		// - src = "a/b"
+		// - dst = "dist/linuxamd64/b"
+		// - path = "a/b/c.txt"
+		// So we join "a/b" with "c.txt" and use it as the destination.
+		dst := filepath.Join(dst, strings.Replace(path, src, "", 1))
+		log.WithFields(log.Fields{
+			"src": path,
+			"dst": dst,
+		}).Debug("copying file")
+		if info.IsDir() {
+			return os.MkdirAll(dst, info.Mode())
+		}
+		if mode != 0 {
+			return copyFile(path, dst, mode)
+		}
+		return copyFile(path, dst, info.Mode())
+	})
+}
+
+func copyFile(src, dst string, mode os.FileMode) error {
 	original, err := os.Open(src)
 	if err != nil {
 		return fmt.Errorf("failed to open '%s': %w", src, err)

--- a/internal/gio/copy.go
+++ b/internal/gio/copy.go
@@ -6,6 +6,15 @@ import (
 	"os"
 )
 
+// CopyFileWithSrcMode copies src into dst with src's file mode.
+func CopyFileWithSrcMode(src, dst string) error {
+	st, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("failed to stat %s: %w", src, err)
+	}
+	return CopyFile(src, dst, st.Mode())
+}
+
 // CopyFile copies src into dst with the given mode.
 func CopyFile(src, dst string, mode os.FileMode) error {
 	original, err := os.Open(src)

--- a/internal/gio/copy_test.go
+++ b/internal/gio/copy_test.go
@@ -17,13 +17,12 @@ func TestCopy(t *testing.T) {
 	require.True(t, equal)
 }
 
-
 func TestEqualFilesModeChanged(t *testing.T) {
 	tmp := t.TempDir()
 	a := "testdata/somefile.txt"
 	b := tmp + "/somefile.txt"
 	require.NoError(t, CopyFileWithSrcMode(a, b))
-	require.NoError(t,os.Chmod(b, 0755))
+	require.NoError(t, os.Chmod(b, 0o755))
 	equal, err := EqualFiles(a, b)
 	require.NoError(t, err)
 	require.False(t, equal)
@@ -34,7 +33,7 @@ func TestEqualFilesContentsChanged(t *testing.T) {
 	a := "testdata/somefile.txt"
 	b := tmp + "/somefile.txt"
 	require.NoError(t, CopyFileWithSrcMode(a, b))
-	require.NoError(t,os.WriteFile(b, []byte("hello world"), 0644))
+	require.NoError(t, os.WriteFile(b, []byte("hello world"), 0o644))
 	equal, err := EqualFiles(a, b)
 	require.NoError(t, err)
 	require.False(t, equal)
@@ -43,8 +42,8 @@ func TestEqualFilesContentsChanged(t *testing.T) {
 func TestEqualFilesDontExist(t *testing.T) {
 	a := "testdata/nope.txt"
 	b := "testdata/somefile.txt"
-	c:="testdata/notadir/lala"
-	require.Error(t, CopyFileWithSrcMode(a,b))
-	require.Error(t, CopyFile(a,b, 0644))
-	require.Error(t, CopyFileWithSrcMode(b,c))
+	c := "testdata/notadir/lala"
+	require.Error(t, CopyFileWithSrcMode(a, b))
+	require.Error(t, CopyFile(a, b, 0o644))
+	require.Error(t, CopyFileWithSrcMode(b, c))
 }

--- a/internal/gio/copy_test.go
+++ b/internal/gio/copy_test.go
@@ -1,7 +1,6 @@
 package gio
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -50,8 +49,6 @@ func TestCopyFile(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, src.Close())
 	dst := filepath.Join(dir, "dst")
-	fmt.Println("src:", src.Name())
-	fmt.Println("dst:", dst)
 	require.NoError(t, os.WriteFile(src.Name(), []byte("foo"), 0o644))
 	require.NoError(t, Copy(src.Name(), dst))
 	requireEqualFiles(t, src.Name(), dst)

--- a/internal/gio/copy_test.go
+++ b/internal/gio/copy_test.go
@@ -95,4 +95,3 @@ func requireNotEqualFiles(tb testing.TB, a, b string) {
 	require.NoError(tb, err)
 	require.False(tb, eq, "%s == %s", a, b)
 }
-

--- a/internal/gio/copy_test.go
+++ b/internal/gio/copy_test.go
@@ -1,7 +1,10 @@
 package gio
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,39 +14,86 @@ func TestCopy(t *testing.T) {
 	tmp := t.TempDir()
 	a := "testdata/somefile.txt"
 	b := tmp + "/somefile.txt"
-	require.NoError(t, CopyFileWithSrcMode(a, b))
-	equal, err := EqualFiles(a, b)
-	require.NoError(t, err)
-	require.True(t, equal)
+	require.NoError(t, Copy(a, b))
+	requireEqualFiles(t, a, b)
 }
 
 func TestEqualFilesModeChanged(t *testing.T) {
 	tmp := t.TempDir()
 	a := "testdata/somefile.txt"
 	b := tmp + "/somefile.txt"
-	require.NoError(t, CopyFileWithSrcMode(a, b))
+	require.NoError(t, Copy(a, b))
 	require.NoError(t, os.Chmod(b, 0o755))
-	equal, err := EqualFiles(a, b)
-	require.NoError(t, err)
-	require.False(t, equal)
+	requireNotEqualFiles(t, a, b)
 }
 
 func TestEqualFilesContentsChanged(t *testing.T) {
 	tmp := t.TempDir()
 	a := "testdata/somefile.txt"
 	b := tmp + "/somefile.txt"
-	require.NoError(t, CopyFileWithSrcMode(a, b))
+	require.NoError(t, Copy(a, b))
 	require.NoError(t, os.WriteFile(b, []byte("hello world"), 0o644))
-	equal, err := EqualFiles(a, b)
-	require.NoError(t, err)
-	require.False(t, equal)
+	requireNotEqualFiles(t, a, b)
 }
 
 func TestEqualFilesDontExist(t *testing.T) {
 	a := "testdata/nope.txt"
 	b := "testdata/somefile.txt"
 	c := "testdata/notadir/lala"
-	require.Error(t, CopyFileWithSrcMode(a, b))
-	require.Error(t, CopyFile(a, b, 0o644))
-	require.Error(t, CopyFileWithSrcMode(b, c))
+	require.Error(t, Copy(a, b))
+	require.Error(t, CopyWithMode(a, b, 0o644))
+	require.Error(t, Copy(b, c))
 }
+
+func TestCopyFile(t *testing.T) {
+	dir := t.TempDir()
+	src, err := ioutil.TempFile(dir, "src")
+	require.NoError(t, err)
+	require.NoError(t, src.Close())
+	dst := filepath.Join(dir, "dst")
+	fmt.Println("src:", src.Name())
+	fmt.Println("dst:", dst)
+	require.NoError(t, os.WriteFile(src.Name(), []byte("foo"), 0o644))
+	require.NoError(t, Copy(src.Name(), dst))
+	requireEqualFiles(t, src.Name(), dst)
+}
+
+func TestCopyDirectory(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+	const testFile = "test"
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, testFile), []byte("foo"), 0o644))
+	require.NoError(t, Copy(srcDir, dstDir))
+	requireEqualFiles(t, filepath.Join(srcDir, testFile), filepath.Join(dstDir, testFile))
+}
+
+func TestCopyTwoLevelDirectory(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+	srcLevel2 := filepath.Join(srcDir, "level2")
+	const testFile = "test"
+
+	require.NoError(t, os.Mkdir(srcLevel2, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, testFile), []byte("foo"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(srcLevel2, testFile), []byte("foo"), 0o644))
+
+	require.NoError(t, Copy(srcDir, dstDir))
+
+	requireEqualFiles(t, filepath.Join(srcDir, testFile), filepath.Join(dstDir, testFile))
+	requireEqualFiles(t, filepath.Join(srcLevel2, testFile), filepath.Join(dstDir, "level2", testFile))
+}
+
+func requireEqualFiles(tb testing.TB, a, b string) {
+	tb.Helper()
+	eq, err := EqualFiles(a, b)
+	require.NoError(tb, err)
+	require.True(tb, eq, "%s != %s", a, b)
+}
+
+func requireNotEqualFiles(tb testing.TB, a, b string) {
+	tb.Helper()
+	eq, err := EqualFiles(a, b)
+	require.NoError(tb, err)
+	require.False(tb, eq, "%s == %s", a, b)
+}
+

--- a/internal/gio/copy_test.go
+++ b/internal/gio/copy_test.go
@@ -1,0 +1,50 @@
+package gio
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopy(t *testing.T) {
+	tmp := t.TempDir()
+	a := "testdata/somefile.txt"
+	b := tmp + "/somefile.txt"
+	require.NoError(t, CopyFileWithSrcMode(a, b))
+	equal, err := EqualFiles(a, b)
+	require.NoError(t, err)
+	require.True(t, equal)
+}
+
+
+func TestEqualFilesModeChanged(t *testing.T) {
+	tmp := t.TempDir()
+	a := "testdata/somefile.txt"
+	b := tmp + "/somefile.txt"
+	require.NoError(t, CopyFileWithSrcMode(a, b))
+	require.NoError(t,os.Chmod(b, 0755))
+	equal, err := EqualFiles(a, b)
+	require.NoError(t, err)
+	require.False(t, equal)
+}
+
+func TestEqualFilesContentsChanged(t *testing.T) {
+	tmp := t.TempDir()
+	a := "testdata/somefile.txt"
+	b := tmp + "/somefile.txt"
+	require.NoError(t, CopyFileWithSrcMode(a, b))
+	require.NoError(t,os.WriteFile(b, []byte("hello world"), 0644))
+	equal, err := EqualFiles(a, b)
+	require.NoError(t, err)
+	require.False(t, equal)
+}
+
+func TestEqualFilesDontExist(t *testing.T) {
+	a := "testdata/nope.txt"
+	b := "testdata/somefile.txt"
+	c:="testdata/notadir/lala"
+	require.Error(t, CopyFileWithSrcMode(a,b))
+	require.Error(t, CopyFile(a,b, 0644))
+	require.Error(t, CopyFileWithSrcMode(b,c))
+}

--- a/internal/gio/copy_test.go
+++ b/internal/gio/copy_test.go
@@ -22,8 +22,7 @@ func TestEqualFilesModeChanged(t *testing.T) {
 	tmp := t.TempDir()
 	a := "testdata/somefile.txt"
 	b := tmp + "/somefile.txt"
-	require.NoError(t, Copy(a, b))
-	require.NoError(t, os.Chmod(b, 0o755))
+	require.NoError(t, CopyWithMode(a, b, 0o755))
 	requireNotEqualFiles(t, a, b)
 }
 

--- a/internal/gio/hash.go
+++ b/internal/gio/hash.go
@@ -1,0 +1,42 @@
+package gio
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+)
+
+func EqualFiles(a, b string) (bool, error) {
+	am, as, err := sha256sum(a)
+	if err != nil {
+		return false, fmt.Errorf("could not hash %s: %w", a, err)
+	}
+	bm, bs, err := sha256sum(b)
+	if err != nil {
+		return false, fmt.Errorf("could not hash %s: %w", b, err)
+	}
+	return as == bs && am == bm, nil
+}
+
+func sha256sum(path string) (fs.FileMode, string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return 0, "", err
+	}
+
+	st, err := f.Stat()
+	if err != nil {
+		return 0, "", err
+	}
+
+	return st.Mode(), hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/gio/hash.go
+++ b/internal/gio/hash.go
@@ -9,6 +9,7 @@ import (
 	"os"
 )
 
+// EqualFiles returns true if both files sha256sums and their modes are equal.
 func EqualFiles(a, b string) (bool, error) {
 	am, as, err := sha256sum(a)
 	if err != nil {

--- a/internal/gio/testdata/somefile.txt
+++ b/internal/gio/testdata/somefile.txt
@@ -1,0 +1,1 @@
+adasasd

--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -153,19 +153,19 @@ func process(ctx *context.Context, docker config.Docker, artifacts []*artifact.A
 	log.Debug("tempdir: " + tmp)
 
 	if err := gio.Copy(docker.Dockerfile, filepath.Join(tmp, "Dockerfile")); err != nil {
-		return fmt.Errorf("failed to link dockerfile: %w", err)
+		return fmt.Errorf("failed to copy dockerfile: %w", err)
 	}
 	for _, file := range docker.Files {
 		if err := os.MkdirAll(filepath.Join(tmp, filepath.Dir(file)), 0o755); err != nil {
-			return fmt.Errorf("failed to link extra file '%s': %w", file, err)
+			return fmt.Errorf("failed to copy extra file '%s': %w", file, err)
 		}
 		if err := gio.Copy(file, filepath.Join(tmp, file)); err != nil {
-			return fmt.Errorf("failed to link extra file '%s': %w", file, err)
+			return fmt.Errorf("failed to copy extra file '%s': %w", file, err)
 		}
 	}
 	for _, art := range artifacts {
 		if err := gio.Copy(art.Path, filepath.Join(tmp, filepath.Base(art.Path))); err != nil {
-			return fmt.Errorf("failed to link artifact: %w", err)
+			return fmt.Errorf("failed to copy artifact: %w", err)
 		}
 	}
 

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -854,7 +854,7 @@ func TestRunPipe(t *testing.T) {
 				},
 			},
 			assertImageLabels: noLabels,
-			assertError:       shouldErr(`/wont-exist: no such file or directory`),
+			assertError:       shouldErr(`wont-exist: no such file or directory`),
 			extraPrepare: func(t *testing.T, ctx *context.Context) {
 				t.Helper()
 				ctx.Artifacts.Add(&artifact.Artifact{

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -824,7 +824,7 @@ func TestRunPipe(t *testing.T) {
 				},
 			},
 			assertImageLabels: noLabels,
-			assertError:       shouldErr(`failed to link dockerfile`),
+			assertError:       shouldErr(`failed to copy dockerfile`),
 		},
 		"extra_file_doesnt_exist": {
 			dockers: []config.Docker{
@@ -839,7 +839,7 @@ func TestRunPipe(t *testing.T) {
 				},
 			},
 			assertImageLabels: noLabels,
-			assertError:       shouldErr(`failed to link extra file 'testdata/nope.txt'`),
+			assertError:       shouldErr(`failed to copy extra file 'testdata/nope.txt'`),
 		},
 		"binary doesnt exist": {
 			dockers: []config.Docker{
@@ -852,7 +852,7 @@ func TestRunPipe(t *testing.T) {
 				},
 			},
 			assertImageLabels: noLabels,
-			assertError:       shouldErr(`wont-exist: no such file or directory`),
+			assertError:       shouldErr(`failed to copy wont-exist`),
 			extraPrepare: func(t *testing.T, ctx *context.Context) {
 				t.Helper()
 				ctx.Artifacts.Add(&artifact.Artifact{

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -3,7 +3,6 @@ package docker
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,7 +11,6 @@ import (
 
 	"github.com/apex/log"
 	"github.com/goreleaser/goreleaser/internal/artifact"
-	"github.com/goreleaser/goreleaser/internal/gio"
 	"github.com/goreleaser/goreleaser/internal/pipe"
 	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/goreleaser/goreleaser/pkg/config"
@@ -1303,49 +1301,4 @@ func Test_processImageTemplates(t *testing.T) {
 		"gcr.io/image:v1.0.0-123",
 		"gcr.io/image:v1.0",
 	}, images)
-}
-
-func TestCopyFile(t *testing.T) {
-	dir := t.TempDir()
-	src, err := ioutil.TempFile(dir, "src")
-	require.NoError(t, err)
-	require.NoError(t, src.Close())
-	dst := filepath.Join(dir, "dst")
-	fmt.Println("src:", src.Name())
-	fmt.Println("dst:", dst)
-	require.NoError(t, os.WriteFile(src.Name(), []byte("foo"), 0o644))
-	require.NoError(t, copyDir(src.Name(), dst))
-	requireEqualFiles(t, src.Name(), dst)
-}
-
-func TestCopyDirectory(t *testing.T) {
-	srcDir := t.TempDir()
-	dstDir := t.TempDir()
-	const testFile = "test"
-	require.NoError(t, os.WriteFile(filepath.Join(srcDir, testFile), []byte("foo"), 0o644))
-	require.NoError(t, copyDir(srcDir, dstDir))
-	requireEqualFiles(t, filepath.Join(srcDir, testFile), filepath.Join(dstDir, testFile))
-}
-
-func TestCopyTwoLevelDirectory(t *testing.T) {
-	srcDir := t.TempDir()
-	dstDir := t.TempDir()
-	srcLevel2 := filepath.Join(srcDir, "level2")
-	const testFile = "test"
-
-	require.NoError(t, os.Mkdir(srcLevel2, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(srcDir, testFile), []byte("foo"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(srcLevel2, testFile), []byte("foo"), 0o644))
-
-	require.NoError(t, copyDir(srcDir, dstDir))
-
-	requireEqualFiles(t, filepath.Join(srcDir, testFile), filepath.Join(dstDir, testFile))
-	requireEqualFiles(t, filepath.Join(srcLevel2, testFile), filepath.Join(dstDir, "level2", testFile))
-}
-
-func requireEqualFiles(tb testing.TB, a, b string) {
-	tb.Helper()
-	eq, err := gio.EqualFiles(a, b)
-	require.NoError(tb, err)
-	require.True(tb, eq, "%s != %s", a, b)
 }

--- a/internal/pipe/snapcraft/snapcraft_test.go
+++ b/internal/pipe/snapcraft/snapcraft_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/goreleaser/goreleaser/internal/artifact"
+	"github.com/goreleaser/goreleaser/internal/gio"
 	"github.com/goreleaser/goreleaser/internal/pipe"
 	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/goreleaser/goreleaser/pkg/config"
@@ -355,19 +356,8 @@ func TestExtraFile(t *testing.T) {
 	addBinaries(t, ctx, "foo", dist)
 	require.NoError(t, Pipe{}.Run(ctx))
 
-	srcFile, err := os.Stat("testdata/extra-file.txt")
-	require.NoError(t, err)
-	destFile, err := os.Stat(filepath.Join(dist, "foo_amd64", "prime", "a", "b", "c", "extra-file.txt"))
-	require.NoError(t, err)
-	require.Equal(t, srcFile.Size(), destFile.Size())
-	require.Equal(t, destFile.Mode(), os.FileMode(0o755))
-
-	srcFile, err = os.Stat("testdata/extra-file-2.txt")
-	require.NoError(t, err)
-	destFileWithDefaults, err := os.Stat(filepath.Join(dist, "foo_amd64", "prime", "testdata", "extra-file-2.txt"))
-	require.NoError(t, err)
-	require.Equal(t, destFileWithDefaults.Mode(), os.FileMode(0o644))
-	require.Equal(t, srcFile.Size(), destFileWithDefaults.Size())
+	requireEqualFiles(t, "testdata/extra-file.txt", filepath.Join(dist, "foo_amd64", "prime", "a", "b", "c", "extra-file.txt"))
+	requireEqualFiles(t, "testdata/extra-file-2.txt", filepath.Join(dist, "foo_amd64", "prime", "testdata", "extra-file-2.txt"))
 }
 
 func TestDefault(t *testing.T) {
@@ -546,4 +536,11 @@ func Test_isValidArch(t *testing.T) {
 			require.Equal(t, tt.want, isValidArch(tt.arch))
 		})
 	}
+}
+
+func requireEqualFiles(tb testing.TB, a, b string) {
+	tb.Helper()
+	eq, err := gio.EqualFiles(a, b)
+	require.NoError(tb, err)
+	require.True(tb, eq, "%s != %s", a, b)
 }


### PR DESCRIPTION
since we are now copying instead of hard-linking the files on the snapcraft pipe, let's do the same for the docker pipe.

This also means we can deduplicate some code!

refs #2358
