### PR TITLE
fix: return an err with stdout/err when a command failed

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -1,7 +1,6 @@
 package golang
 
 import (
-	"errors"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -196,8 +195,7 @@ func run(ctx *context.Context, command, env []string, dir string) error {
 	cmd.Dir = dir
 	log.Debug("running")
 	if out, err := cmd.CombinedOutput(); err != nil {
-		log.WithError(err).Debug("failed")
-		return errors.New(string(out))
+		return fmt.Errorf("%w: %s", err, string(out))
 	}
 	return nil
 }

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -251,7 +251,7 @@ func TestExecute(t *testing.T) {
 				},
 			},
 			// stderr is sent to output via logger
-			fmt.Errorf(`publishing: %s failed: exit status 1`, MockCmd),
+			fmt.Errorf(`publishing: %s failed: exit status 1: test error`, MockCmd),
 		},
 	}
 

--- a/internal/pipe/docker/api.go
+++ b/internal/pipe/docker/api.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os/exec"
 	"sync"
@@ -43,7 +44,7 @@ type manifester interface {
 }
 
 // nolint: unparam
-func runCommand(ctx context.Context, dir, binary string, args ...string) ([]byte, error) {
+func runCommand(ctx context.Context, dir, binary string, args ...string) error {
 	fields := log.Fields{
 		"cmd": append([]string{binary}, args[0]),
 		"cwd": dir,
@@ -59,6 +60,8 @@ func runCommand(ctx context.Context, dir, binary string, args ...string) ([]byte
 	cmd.Stdout = io.MultiWriter(logext.NewWriter(fields, logext.Info), w)
 
 	log.WithFields(fields).Debug("running")
-	err := cmd.Run()
-	return b.Bytes(), err
+	if err := cmd.Run(); err != nil {
+		return  fmt.Errorf("%w: %s", err, b.String())
+	}
+	return  nil
 }

--- a/internal/pipe/docker/api.go
+++ b/internal/pipe/docker/api.go
@@ -61,7 +61,7 @@ func runCommand(ctx context.Context, dir, binary string, args ...string) error {
 
 	log.WithFields(fields).Debug("running")
 	if err := cmd.Run(); err != nil {
-		return  fmt.Errorf("%w: %s", err, b.String())
+		return fmt.Errorf("%w: %s", err, b.String())
 	}
-	return  nil
+	return nil
 }

--- a/internal/pipe/docker/api_docker.go
+++ b/internal/pipe/docker/api_docker.go
@@ -17,7 +17,7 @@ func init() {
 type dockerManifester struct{}
 
 func (m dockerManifester) Create(ctx context.Context, manifest string, images, flags []string) error {
-	_= runCommand(ctx, ".", "docker", "manifest", "rm", manifest)
+	_ = runCommand(ctx, ".", "docker", "manifest", "rm", manifest)
 
 	args := []string{"manifest", "create", manifest}
 	args = append(args, images...)

--- a/internal/pipe/docker/api_docker.go
+++ b/internal/pipe/docker/api_docker.go
@@ -17,13 +17,13 @@ func init() {
 type dockerManifester struct{}
 
 func (m dockerManifester) Create(ctx context.Context, manifest string, images, flags []string) error {
-	_, _ = runCommand(ctx, ".", "docker", "manifest", "rm", manifest)
+	_= runCommand(ctx, ".", "docker", "manifest", "rm", manifest)
 
 	args := []string{"manifest", "create", manifest}
 	args = append(args, images...)
 	args = append(args, flags...)
 
-	if _, err := runCommand(ctx, ".", "docker", args...); err != nil {
+	if err := runCommand(ctx, ".", "docker", args...); err != nil {
 		return fmt.Errorf("failed to create %s: %w", manifest, err)
 	}
 	return nil
@@ -32,7 +32,7 @@ func (m dockerManifester) Create(ctx context.Context, manifest string, images, f
 func (m dockerManifester) Push(ctx context.Context, manifest string, flags []string) error {
 	args := []string{"manifest", "push", manifest}
 	args = append(args, flags...)
-	if _, err := runCommand(ctx, ".", "docker", args...); err != nil {
+	if err := runCommand(ctx, ".", "docker", args...); err != nil {
 		return fmt.Errorf("failed to push %s: %w", manifest, err)
 	}
 	return nil
@@ -43,14 +43,14 @@ type dockerImager struct {
 }
 
 func (i dockerImager) Push(ctx context.Context, image string, flags []string) error {
-	if _, err := runCommand(ctx, ".", "docker", "push", image); err != nil {
+	if err := runCommand(ctx, ".", "docker", "push", image); err != nil {
 		return fmt.Errorf("failed to push %s: %w", image, err)
 	}
 	return nil
 }
 
 func (i dockerImager) Build(ctx context.Context, root string, images, flags []string) error {
-	if _, err := runCommand(ctx, root, "docker", i.buildCommand(images, flags)...); err != nil {
+	if err := runCommand(ctx, root, "docker", i.buildCommand(images, flags)...); err != nil {
 		return fmt.Errorf("failed to build %s: %w", images[0], err)
 	}
 	return nil

--- a/internal/pipe/sign/sign.go
+++ b/internal/pipe/sign/sign.go
@@ -164,7 +164,7 @@ func signone(ctx *context.Context, cfg config.Sign, a *artifact.Artifact) (*arti
 	}
 	log.WithFields(fields).Info("signing")
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("sign: %s failed: %w: %s", cfg.Cmd,err, b.String())
+		return nil, fmt.Errorf("sign: %s failed: %w: %s", cfg.Cmd, err, b.String())
 	}
 
 	artifactPathBase, _ := filepath.Split(a.Path)

--- a/internal/pipe/sign/sign.go
+++ b/internal/pipe/sign/sign.go
@@ -1,6 +1,7 @@
 package sign
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/goreleaser/goreleaser/internal/artifact"
+	"github.com/goreleaser/goreleaser/internal/gio"
 	"github.com/goreleaser/goreleaser/internal/ids"
 	"github.com/goreleaser/goreleaser/internal/logext"
 	"github.com/goreleaser/goreleaser/internal/pipe"
@@ -153,14 +155,16 @@ func signone(ctx *context.Context, cfg config.Sign, a *artifact.Artifact) (*arti
 	// tells the scanner to ignore this.
 	// #nosec
 	cmd := exec.CommandContext(ctx, cfg.Cmd, args...)
-	cmd.Stderr = logext.NewWriter(fields, logext.Error)
-	cmd.Stdout = logext.NewWriter(fields, logext.Info)
+	var b bytes.Buffer
+	w := gio.Safe(&b)
+	cmd.Stderr = io.MultiWriter(logext.NewWriter(fields, logext.Error), w)
+	cmd.Stdout = io.MultiWriter(logext.NewWriter(fields, logext.Info), w)
 	if stdin != nil {
 		cmd.Stdin = stdin
 	}
 	log.WithFields(fields).Info("signing")
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("sign: %s failed", cfg.Cmd)
+		return nil, fmt.Errorf("sign: %s failed: %w: %s", cfg.Cmd,err, b.String())
 	}
 
 	artifactPathBase, _ := filepath.Split(a.Path)

--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -327,7 +327,7 @@ func create(ctx *context.Context, snap config.Snapcraft, arch string, binaries [
 	/* #nosec */
 	cmd := exec.CommandContext(ctx, "snapcraft", "pack", primeDir, "--output", snapFile)
 	if out, err = cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to generate snap package: %s", string(out))
+		return fmt.Errorf("failed to generate snap package: %w: %s",err, string(out))
 	}
 	if !snap.Publish {
 		return nil
@@ -362,7 +362,7 @@ func push(ctx *context.Context, snap *artifact.Artifact) error {
 		if strings.Contains(string(out), reviewWaitMsg) || strings.Contains(string(out), humanReviewMsg) || strings.Contains(string(out), needsReviewMsg) {
 			log.Warn(reviewWaitMsg)
 		} else {
-			return fmt.Errorf("failed to push %s package: %s", snap.Path, string(out))
+			return fmt.Errorf("failed to push %s package: %w: %s", snap.Path,err, string(out))
 		}
 	}
 	snap.Type = artifact.Snapcraft

--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -327,7 +327,7 @@ func create(ctx *context.Context, snap config.Snapcraft, arch string, binaries [
 	/* #nosec */
 	cmd := exec.CommandContext(ctx, "snapcraft", "pack", primeDir, "--output", snapFile)
 	if out, err = cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to generate snap package: %w: %s",err, string(out))
+		return fmt.Errorf("failed to generate snap package: %w: %s", err, string(out))
 	}
 	if !snap.Publish {
 		return nil
@@ -362,7 +362,7 @@ func push(ctx *context.Context, snap *artifact.Artifact) error {
 		if strings.Contains(string(out), reviewWaitMsg) || strings.Contains(string(out), humanReviewMsg) || strings.Contains(string(out), needsReviewMsg) {
 			log.Warn(reviewWaitMsg)
 		} else {
-			return fmt.Errorf("failed to push %s package: %w: %s", snap.Path,err, string(out))
+			return fmt.Errorf("failed to push %s package: %w: %s", snap.Path, err, string(out))
 		}
 	}
 	snap.Type = artifact.Snapcraft


### PR DESCRIPTION
improved output when a `exec.Command` fails, adding its output to the error