### PR TITLE
feat: skip push docker prerelease or stable

### DIFF
--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -185,8 +185,11 @@ func process(ctx *context.Context, docker config.Docker, artifacts []*artifact.A
 	if ctx.SkipPublish {
 		return pipe.ErrSkipPublishEnabled
 	}
-	if strings.TrimSpace(docker.SkipPush) == "auto" && ctx.Semver.Prerelease != "" {
-		return pipe.Skip("prerelease detected with 'auto' push, skipping docker publish")
+	if strings.TrimSpace(docker.SkipPush) == "prerelease" && ctx.Semver.Prerelease != "" {
+		return pipe.Skip("prerelease detected with 'prerelase' push, skipping docker publish")
+	}
+	if strings.TrimSpace(docker.SkipPush) == "stable" && ctx.Semver.Prerelease == "" {
+		return pipe.Skip("stable release detected with 'stable' push, skipping docker publish")
 	}
 	for _, img := range images {
 		ctx.Artifacts.Add(&artifact.Artifact{

--- a/internal/pipe/docker/manifest.go
+++ b/internal/pipe/docker/manifest.go
@@ -49,8 +49,12 @@ func (ManifestPipe) Publish(ctx *context.Context) error {
 				return pipe.Skip("docker_manifest.skip_push is set")
 			}
 
-			if strings.TrimSpace(manifest.SkipPush) == "auto" && ctx.Semver.Prerelease != "" {
-				return pipe.Skip("prerelease detected with 'auto' push, skipping docker manifest")
+			if strings.TrimSpace(manifest.SkipPush) == "prerelease" && ctx.Semver.Prerelease != "" {
+				return pipe.Skip("prerelease detected with 'prerelease' push, skipping docker manifest")
+			}
+
+			if strings.TrimSpace(manifest.SkipPush) == "stable" && ctx.Semver.Prerelease == "" {
+				return pipe.Skip("stable release detected with 'stable' push, skipping docker manifest")
 			}
 
 			name, err := manifestName(ctx, manifest)

--- a/www/docs/customization/docker_manifest.md
+++ b/www/docs/customization/docker_manifest.md
@@ -113,13 +113,13 @@ builds:
 dockers:
 - image_templates:
   - "foo/bar:{{ .Version }}-amd64"
-  use_buildx: true
+  use: buildx
   dockerfile: Dockerfile
   build_flag_templates:
   - "--platform=linux/amd64"
 - image_templates:
   - "foo/bar:{{ .Version }}-arm64v8"
-  use_buildx: true
+  use: buildx
   goarch: arm64
   dockerfile: Dockerfile
   build_flag_templates:


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

Replace `skip_push` `auto` flag  in `docker` and `docker_manifest` with `prerelease` and `stable` flags.

<!-- Why is this change being made? -->
I have a need to skip push when either it is `prerelease` or not, this is the case
```
- name_template: repo/image:{{ .Major }}.{{ .Minor }}.{{ .Patch }}
  image_templates:
  - repo/image:{{ .Version }}-amd64
  - repo/image:{{ .Version }}-armv7
  - repo/image:{{ .Version }}-arm64v8
  skip_push: prerelease
- name_template: repo/image:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-{{ .Prerelease }}
  image_templates:
  - repo/image:{{ .Version }}-amd64
  - repo/image:{{ .Version }}-armv7
  - repo/image:{{ .Version }}-arm64v8
  skip_push: stable
  ```
First one should be pushed if its stable release and skipped if its a prerelease, other one vice versa.

Maybe I missed something and this can be accomplished in some other way?
<!-- # Provide links to any relevant tickets, URLs or other resources -->
