### PR TITLE
fix: upload gcs blobs to bucket root

### DIFF
--- a/internal/pipe/blob/upload.go
+++ b/internal/pipe/blob/upload.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/apex/log"
 	"github.com/goreleaser/goreleaser/internal/artifact"
@@ -67,6 +68,7 @@ func doUpload(ctx *context.Context, conf config.Blob) error {
 	if err != nil {
 		return err
 	}
+	folder = strings.TrimPrefix(folder, "/")
 
 	bucketURL, err := urlFor(ctx, conf)
 	if err != nil {


### PR DESCRIPTION
Currently, when trying to upload files to the root of a gcs bucket using the config below it actually creates a directory called `/` with all the files inside it.

```yml
blobs:
  - provider: gs
    bucket: my-bucket-name
    ids:
      - myapp
    folder: '/'
```      

This fix allows uploading to the root of a gcs bucket.