### PR TITLE
fix: make scoop write .json when --skip-publish

### DIFF
--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -34,10 +34,6 @@ func (Pipe) String() string {
 
 // Publish scoop manifest.
 func (Pipe) Publish(ctx *context.Context) error {
-	if ctx.SkipPublish {
-		return pipe.ErrSkipPublishEnabled
-	}
-
 	client, err := client.New(ctx)
 	if err != nil {
 		return err

--- a/internal/pipe/scoop/scoop_test.go
+++ b/internal/pipe/scoop/scoop_test.go
@@ -1072,8 +1072,7 @@ func TestRunPipeScoopWithSkipPublish(t *testing.T) {
 	require.EqualError(t, doRun(ctx, cli), pipe.ErrSkipPublishEnabled.Error())
 
 	distFile := filepath.Join(folder, ctx.Config.Scoop.Name+".json")
-	_, err = os.Stat(distFile)
-	require.NoError(t, err, "file should exist: "+distFile)
+	require.FileExists(t, distFile)
 }
 
 func TestWrapInDirectory(t *testing.T) {

--- a/internal/pipe/scoop/scoop_test.go
+++ b/internal/pipe/scoop/scoop_test.go
@@ -997,8 +997,7 @@ func Test_buildManifest(t *testing.T) {
 	}
 }
 
-func TestRunPipeScoopWithSkip(t *testing.T) {
-	folder := t.TempDir()
+func getScoopPipeSkipCtx(folder string) (*context.Context, string) {
 	ctx := &context.Context{
 		Git: context.GitInfo{
 			CurrentTag: "v1.0.1",
@@ -1022,11 +1021,12 @@ func TestRunPipeScoopWithSkip(t *testing.T) {
 				Description: "A run pipe test formula",
 				Homepage:    "https://github.com/goreleaser",
 				Name:        "run-pipe",
-				SkipUpload:  "true",
 			},
 		},
 	}
+
 	path := filepath.Join(folder, "bin.tar.gz")
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "bin.tar.gz",
 		Path:   path,
@@ -1039,12 +1039,37 @@ func TestRunPipeScoopWithSkip(t *testing.T) {
 		},
 	})
 
+	return ctx, path
+}
+
+func TestRunPipeScoopWithSkipUpload(t *testing.T) {
+	folder := t.TempDir()
+	ctx, path := getScoopPipeSkipCtx(folder)
+	ctx.Config.Scoop.SkipUpload = "true"
+
 	f, err := os.Create(path)
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
 	cli := &DummyClient{}
 	require.EqualError(t, doRun(ctx, cli), `scoop.skip_upload is true`)
+
+	distFile := filepath.Join(folder, ctx.Config.Scoop.Name+".json")
+	_, err = os.Stat(distFile)
+	require.NoError(t, err, "file should exist: "+distFile)
+}
+
+func TestRunPipeScoopWithSkipPublish(t *testing.T) {
+	folder := t.TempDir()
+	ctx, path := getScoopPipeSkipCtx(folder)
+	ctx.SkipPublish = true
+
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	cli := &DummyClient{}
+	require.EqualError(t, doRun(ctx, cli), pipe.ErrSkipPublishEnabled.Error())
 
 	distFile := filepath.Join(folder, ctx.Config.Scoop.Name+".json")
 	_, err = os.Stat(distFile)


### PR DESCRIPTION
Don't skip the pipeline altogether but write
out the manifest.json file as the homebrew
pipeline does, only skip committing to the repo.

closes #2374
