### PR TITLE
fix: main check when using gomod.proxy 

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -70,10 +70,8 @@ func (*Builder) WithDefaults(build config.Build) (config.Build, error) {
 
 // Build builds a golang build.
 func (*Builder) Build(ctx *context.Context, build config.Build, options api.Options) error {
-	if !ctx.Config.GoMod.Proxy {
-		if err := checkMain(build); err != nil {
-			return err
-		}
+	if err := checkMain(build); err != nil {
+		return err
 	}
 	target, err := newBuildTarget(options.Target)
 	if err != nil {
@@ -233,11 +231,19 @@ func (b buildTarget) Env() []string {
 
 func checkMain(build config.Build) error {
 	main := build.Main
+	if build.UnproxiedMain != "" {
+		main = build.UnproxiedMain
+	}
+	dir := build.Dir
+	if build.UnproxiedDir != "" {
+		dir = build.UnproxiedDir
+	}
+
 	if main == "" {
 		main = "."
 	}
-	if build.Dir != "" {
-		main = filepath.Join(build.Dir, main)
+	if dir != "" {
+		main = filepath.Join(dir, main)
 	}
 	stat, ferr := os.Stat(main)
 	if ferr != nil {

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -509,6 +509,7 @@ func TestRunInvalidFlags(t *testing.T) {
 
 func TestRunPipeWithoutMainFunc(t *testing.T) {
 	newCtx := func(t *testing.T) *context.Context {
+		t.Helper()
 		folder := testlib.Mktmp(t)
 		writeMainWithoutMainFunc(t, folder)
 		config := config.Project{
@@ -559,7 +560,7 @@ func TestRunPipeWithoutMainFunc(t *testing.T) {
 		ctx.Config.GoMod.Proxy = true
 		ctx.Config.Builds[0].Dir = "dist/proxy/test"
 		ctx.Config.Builds[0].Main = "github.com/caarlos0/test"
-		ctx.Config.Builds[0].UnproxiedDir = ""
+		ctx.Config.Builds[0].UnproxiedDir = "."
 		ctx.Config.Builds[0].UnproxiedMain = "."
 		require.EqualError(t, Default.Build(ctx, ctx.Config.Builds[0], api.Options{
 			Target: runtimeTarget,

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -570,6 +570,9 @@ func TestRunPipeWithoutMainFunc(t *testing.T) {
 
 func TestRunPipeWithProxiedRepo(t *testing.T) {
 	folder := testlib.Mktmp(t)
+	out, err := exec.Command("git", "clone", "https://github.com/goreleaser/goreleaser", "-b", "v0.161.1", "--depth=1", ".").CombinedOutput()
+	require.NoError(t, err, string(out))
+
 	proxied := filepath.Join(folder, "dist/proxy/default")
 	require.NoError(t, os.MkdirAll(proxied, 0o750))
 	require.NoError(t, os.WriteFile(
@@ -586,6 +589,7 @@ import _ "github.com/goreleaser/goreleaser"
 		[]byte("module foo\nrequire github.com/goreleaser/goreleaser v0.161.1"),
 		0o666,
 	))
+
 	cmd := exec.Command("go", "mod", "tidy")
 	cmd.Dir = proxied
 	require.NoError(t, cmd.Run())
@@ -596,9 +600,11 @@ import _ "github.com/goreleaser/goreleaser"
 		},
 		Builds: []config.Build{
 			{
-				Binary: "foo",
-				Main:   "github.com/goreleaser/goreleaser",
-				Dir:    proxied,
+				Binary:        "foo",
+				Main:          "github.com/goreleaser/goreleaser",
+				Dir:           proxied,
+				UnproxiedMain: ".",
+				UnproxiedDir:  ".",
 				Targets: []string{
 					runtimeTarget,
 				},

--- a/internal/pipe/gomod/gomod.go
+++ b/internal/pipe/gomod/gomod.go
@@ -170,6 +170,8 @@ func proxyBuild(ctx *context.Context, build *config.Build) error {
 		return newDetailedErrProxy(err, string(out))
 	}
 
+	build.UnproxiedMain = build.Main
+	build.UnproxiedDir = build.Dir
 	build.Main = mainPackage
 	build.Dir = dir
 	return nil

--- a/internal/pipe/gomod/gomod_test.go
+++ b/internal/pipe/gomod/gomod_test.go
@@ -83,7 +83,9 @@ func TestGoModProxy(t *testing.T) {
 		requireGoMod(t, mod, ctx.Git.CurrentTag)
 		requireMainGo(t, mod)
 		require.Equal(t, mod, ctx.Config.Builds[0].Main)
+		require.Equal(t, ".", ctx.Config.Builds[0].UnproxiedMain)
 		require.Equal(t, filepath.Join(dist, "proxy", "foo"), ctx.Config.Builds[0].Dir)
+		require.Equal(t, "", ctx.Config.Builds[0].UnproxiedDir)
 		require.Equal(t, mod, ctx.ModulePath)
 	})
 

--- a/internal/pipe/gomod/gomod_test.go
+++ b/internal/pipe/gomod/gomod_test.go
@@ -70,6 +70,7 @@ func TestGoModProxy(t *testing.T) {
 					Goos:   []string{runtime.GOOS},
 					Goarch: []string{runtime.GOARCH},
 					Main:   ".",
+					Dir:    ".",
 				},
 			},
 		})
@@ -85,7 +86,7 @@ func TestGoModProxy(t *testing.T) {
 		require.Equal(t, mod, ctx.Config.Builds[0].Main)
 		require.Equal(t, ".", ctx.Config.Builds[0].UnproxiedMain)
 		require.Equal(t, filepath.Join(dist, "proxy", "foo"), ctx.Config.Builds[0].Dir)
-		require.Equal(t, "", ctx.Config.Builds[0].UnproxiedDir)
+		require.Equal(t, ".", ctx.Config.Builds[0].UnproxiedDir)
 		require.Equal(t, mod, ctx.ModulePath)
 	})
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -207,6 +207,8 @@ type Build struct {
 	Skip            bool           `yaml:",omitempty"`
 	GoBinary        string         `yaml:",omitempty"`
 	NoUniqueDistDir bool           `yaml:"no_unique_dist_dir,omitempty"`
+	UnproxiedMain   string         `yaml:"-"` // used by gomod.proxy
+	UnproxiedDir    string         `yaml:"-"` // used by gomod.proxy
 }
 
 type HookConfig struct {


### PR DESCRIPTION
we can't check for the `main` function in the actual proxied module, but we can at least check the code which, in theory, is the module being proxied.

this should avoid bad releases as I did for fork-cleaner, which was basically empty.

What happens now is that the `gomod` pipe overrides `Main` and `Dir` as before, but set the original values to `UnproxiedMain` and `UnproxiedDir`, and then the `build` pipe checks the main on the unproxied properties when they exist.