### PR TITLE
fix: Run 'go version' command in build.Dir

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -59,7 +59,11 @@ func (*Builder) WithDefaults(build config.Build) (config.Build, error) {
 		if len(build.Gomips) == 0 {
 			build.Gomips = []string{"hardfloat"}
 		}
-		targets, err := matrix(build, goVersion(build))
+		version, err := goVersion(build)
+		if err != nil {
+			return build, err
+		}
+		targets, err := matrix(build, version)
 		build.Targets = targets
 		if err != nil {
 			return build, err

--- a/internal/builders/golang/targets.go
+++ b/internal/builders/golang/targets.go
@@ -131,9 +131,14 @@ var (
 	go117re = regexp.MustCompile(`go version go1.1[7-9]`)
 )
 
-func goVersion(build config.Build) []byte {
-	bts, _ := exec.Command(build.GoBinary, "version").CombinedOutput()
-	return bts
+func goVersion(build config.Build) ([]byte, error) {
+	cmd := exec.Command(build.GoBinary, "version")
+	cmd.Dir = build.Dir // Set Dir to build directory in case of reletive path to GoBinary
+	bts, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine version of go binary (%s): %w", build.GoBinary, err)
+	}
+	return bts, nil
 }
 
 func valid(target target) bool {

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -330,6 +330,15 @@ func TestDefaultPartialBuilds(t *testing.T) {
 			},
 		},
 	}
+	// Create any 'Dir' paths necessary for builds.
+	cwd, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(cwd) })
+	os.Chdir(t.TempDir())
+	for _, b := range ctx.Config.Builds {
+		if b.Dir != "" {
+			os.Mkdir(b.Dir, 0o755)
+		}
+	}
 	require.NoError(t, Pipe{}.Default(ctx))
 	t.Run("build0", func(t *testing.T) {
 		build := ctx.Config.Builds[0]


### PR DESCRIPTION
Currently, the `goVersion` function is run without any directory set. This is problematic when a build uses the `dir` config in combination with the `gobinary` config. When `gobinary` is a relative path (like a script in the current repository), goVersion silently fails, returning an empty string.

This commit refactors `goVersion` to execute the command with `Dir` set to the `build.Dir`, in addition to now returning an error, so that issues may be bubbled up in the build log, rather than silently failing.

It also adds a new helper function to facilitate running `goVersion` by creating a temporary executable that outputs a given `version` string. This function is only currently used by `TestWithDefaults`.