### PR TITLE
fix: Change the init- and default-template for `snapshot.name_template`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ before:
     - go mod tidy
     - ./scripts/completions.sh
 snapshot:
-  name_template: '{{ incpatch .Tag }}-next'
+  name_template: '{{ incpatch .Version }}-next'
 gomod:
   proxy: true
 builds:

--- a/cmd/testdata/good.yml
+++ b/cmd/testdata/good.yml
@@ -19,7 +19,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Tag }}-next"
+  name_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:

--- a/internal/pipe/snapshot/snapshot.go
+++ b/internal/pipe/snapshot/snapshot.go
@@ -20,7 +20,7 @@ func (Pipe) String() string {
 // Default sets the pipe defaults.
 func (Pipe) Default(ctx *context.Context) error {
 	if ctx.Config.Snapshot.NameTemplate == "" {
-		ctx.Config.Snapshot.NameTemplate = "{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}"
+		ctx.Config.Snapshot.NameTemplate = "{{ .Version }}-SNAPSHOT-{{ .ShortCommit }}"
 	}
 	return nil
 }

--- a/internal/pipe/snapshot/snapshot_test.go
+++ b/internal/pipe/snapshot/snapshot_test.go
@@ -20,7 +20,7 @@ func TestDefault(t *testing.T) {
 		},
 	}
 	require.NoError(t, Pipe{}.Default(ctx))
-	require.Equal(t, "{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}", ctx.Config.Snapshot.NameTemplate)
+	require.Equal(t, "{{ .Version }}-SNAPSHOT-{{ .ShortCommit }}", ctx.Config.Snapshot.NameTemplate)
 }
 
 func TestDefaultSet(t *testing.T) {

--- a/internal/static/config.go
+++ b/internal/static/config.go
@@ -29,7 +29,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Tag }}-next"
+  name_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:

--- a/www/docs/customization/snapshots.md
+++ b/www/docs/customization/snapshots.md
@@ -16,7 +16,7 @@ snapshot:
   # Note that some pipes require this to be semantic version compliant (nfpm,
   # for example).
   #
-  # Default is `{{ .Tag }}-SNAPSHOT-{{.ShortCommit}}`.
+  # Default is `{{ .Version }}-SNAPSHOT-{{.ShortCommit}}`.
   name_template: '{{ incpatch .Version }}-devel'
 ```
 

--- a/www/docs/customization/snapshots.md
+++ b/www/docs/customization/snapshots.md
@@ -17,7 +17,7 @@ snapshot:
   # for example).
   #
   # Default is `{{ .Tag }}-SNAPSHOT-{{.ShortCommit}}`.
-  name_template: '{{ incpatch .Tag }}-devel'
+  name_template: '{{ incpatch .Version }}-devel'
 ```
 
 ## How it works

--- a/www/docs/customization/templates.md
+++ b/www/docs/customization/templates.md
@@ -13,7 +13,7 @@ On fields that support templating, these fields are always available:
 | Key                 | Description                                                                                                                  |
 |---------------------|------------------------------------------------------------------------------------------------------------------------------|
 | `.ProjectName`      | the project name                                                                                                             |
-| `.Version`          | the version being released (`v` prefix stripped),<br>or `{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}` in case of snapshot release |
+| `.Version`          | the version being released (`v` prefix stripped),<br>or what is configured in `snapshot.name_template` in case of a snapshot release (defaults to `{{ .Tag }}-SNAPSHOT-{{.ShortCommit}}`) |
 | `.Branch`           | the current git branch                                                                                                       |
 | `.PrefixedTag`      | the current git tag prefixed with the monorepo config tag prefix (if any)                                                    |
 | `.Tag`              | the current git tag                                                                                                          |

--- a/www/docs/customization/templates.md
+++ b/www/docs/customization/templates.md
@@ -13,7 +13,7 @@ On fields that support templating, these fields are always available:
 | Key                 | Description                                                                                                                  |
 |---------------------|------------------------------------------------------------------------------------------------------------------------------|
 | `.ProjectName`      | the project name                                                                                                             |
-| `.Version`          | the version being released (`v` prefix stripped),<br>or what is configured in `snapshot.name_template` in case of a snapshot release (defaults to `{{ .Tag }}-SNAPSHOT-{{.ShortCommit}}`) |
+| `.Version`          | the version being released (`v` prefix stripped),<br>or what is configured in `snapshot.name_template` in case of a snapshot release (defaults to `{{ .Version }}-SNAPSHOT-{{.ShortCommit}}`) |
 | `.Branch`           | the current git branch                                                                                                       |
 | `.PrefixedTag`      | the current git tag prefixed with the monorepo config tag prefix (if any)                                                    |
 | `.Tag`              | the current git tag                                                                                                          |


### PR DESCRIPTION
# If applied, this commit will...

This commit will change the default- and the init-template that is used for `snapshot.name_template`. If applied, this commit will prevent situations as described in #2415 for new projects and projects that don't overwrite `snapshot.name_template`.

# Why is this change being made?

The change is necessary to remove an odity:
In regular mode, `.Version` removes the `v` from the most recent git tag (e.g. `v1.2.3` becomes `1.2.3`). In snapshot mode however, what is defined as `snapshot.name_template` becomes the value of `.Version`. And before this commit `snapshot.name_template` is defined as a value that does not remove the `v` prefix.

This did lead to the following odd situation, given the most recent git tag is `v1.2.3`:

```
Regular Mode:  .Version =                            '1.2.3'
Snapshot Mode: .Version = '{{incpatch .Tag}}-next' = 'v1.2.4-next'
```

Notice the difference: In regular mode, `.Version` has no `v` prefix, whereas in snapshot mode, is has one.
Which lead to odd situations wherever `{{.Version}}` was used in other parts of the goreleaser configuration and for example to Docker tags like `org/image:vv1.2.3-next` in snapshot mode and `org/image:v1.2.3` in regular mode.

# Provide links to any relevant tickets, URLs or other resources

- #2415
