### PR TITLE
fix: build dir that dont exist yet

### DIFF
--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -88,6 +88,36 @@ func TestWithDefaults(t *testing.T) {
 			},
 			goBinary: "go",
 		},
+		"empty with custom dir": {
+			build: config.Build{
+				ID:     "foo2",
+				Binary: "foo",
+				Dir:    "./testdata",
+			},
+			targets: []string{
+				"linux_amd64",
+				"linux_386",
+				"linux_arm64",
+				"darwin_amd64",
+				"darwin_arm64",
+			},
+			goBinary: "go",
+		},
+		"empty with custom dir that doest exist": {
+			build: config.Build{
+				ID:     "foo2",
+				Binary: "foo",
+				Dir:    "./nope",
+			},
+			targets: []string{
+				"linux_amd64",
+				"linux_386",
+				"linux_arm64",
+				"darwin_amd64",
+				"darwin_arm64",
+			},
+			goBinary: "go",
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			if testcase.build.GoBinary != "" && testcase.build.GoBinary != "go" {

--- a/internal/builders/golang/targets.go
+++ b/internal/builders/golang/targets.go
@@ -2,6 +2,7 @@ package golang
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -133,7 +134,11 @@ var (
 
 func goVersion(build config.Build) ([]byte, error) {
 	cmd := exec.Command(build.GoBinary, "version")
-	cmd.Dir = build.Dir // Set Dir to build directory in case of reletive path to GoBinary
+	// If the build.Dir is acessible, set the cmd dir to it in case
+	// of reletive path to GoBinary
+	if _, err := os.Stat(build.Dir); err == nil {
+		cmd.Dir = build.Dir
+	}
 	bts, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("unable to determine version of go binary (%s): %w", build.GoBinary, err)


### PR DESCRIPTION
if the `build.dir` doesn't exist, ignore it while checking the go version.

IMHO, its unlikely that the before hook of a build will create a folder and set a go wrapper in there... 

For now I think we can just ignore the dir if we fail to stat it.

cc/ @jorng  

closes #2434