### PR TITLE
feat: support links inside archives

### DIFF
--- a/pkg/archive/targz/targz.go
+++ b/pkg/archive/targz/targz.go
@@ -43,7 +43,7 @@ func (a Archive) Add(f config.File) error {
 		return err
 	}
 	defer file.Close()
-	info, err := file.Stat()
+	info, err := os.Lstat(f.Source) // #nosec
 	if err != nil {
 		return err
 	}
@@ -65,6 +65,13 @@ func (a Archive) Add(f config.File) error {
 	if f.Info.Group != "" {
 		header.Gid = 0
 		header.Gname = f.Info.Group
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(f.Source)
+		if err != nil {
+			return err
+		}
+		header.Linkname = target
 	}
 	if err = a.tw.WriteHeader(header); err != nil {
 		return err

--- a/pkg/archive/targz/targz_test.go
+++ b/pkg/archive/targz/targz_test.go
@@ -50,6 +50,14 @@ func TestTarGzFile(t *testing.T) {
 		Source:      "../testdata/sub1/sub2/subfoo.txt",
 		Destination: "sub1/sub2/subfoo.txt",
 	}))
+	require.NoError(t, archive.Add(config.File{
+		Source:      "../testdata/regular.txt",
+		Destination: "regular.txt",
+	}))
+	require.NoError(t, archive.Add(config.File{
+		Source:      "../testdata/link.txt",
+		Destination: "link.txt",
+	}))
 
 	require.NoError(t, archive.Close())
 	require.Error(t, archive.Add(config.File{
@@ -84,6 +92,9 @@ func TestTarGzFile(t *testing.T) {
 			ex := next.FileInfo().Mode() | 0o111
 			require.Equal(t, next.FileInfo().Mode().String(), ex.String())
 		}
+		if next.Name == "link.txt" {
+			require.Equal(t, next.Linkname, "regular.txt")
+		}
 	}
 	require.Equal(t, []string{
 		"foo.txt",
@@ -92,6 +103,8 @@ func TestTarGzFile(t *testing.T) {
 		"sub1/executable",
 		"sub1/sub2",
 		"sub1/sub2/subfoo.txt",
+		"regular.txt",
+		"link.txt",
 	}, paths)
 }
 

--- a/pkg/archive/tarxz/tarxz_test.go
+++ b/pkg/archive/tarxz/tarxz_test.go
@@ -50,6 +50,14 @@ func TestTarXzFile(t *testing.T) {
 		Source:      "../testdata/sub1/sub2/subfoo.txt",
 		Destination: "sub1/sub2/subfoo.txt",
 	}))
+	require.NoError(t, archive.Add(config.File{
+		Source:      "../testdata/regular.txt",
+		Destination: "regular.txt",
+	}))
+	require.NoError(t, archive.Add(config.File{
+		Source:      "../testdata/link.txt",
+		Destination: "link.txt",
+	}))
 
 	require.NoError(t, archive.Close())
 	require.Error(t, archive.Add(config.File{
@@ -83,6 +91,9 @@ func TestTarXzFile(t *testing.T) {
 			ex := next.FileInfo().Mode() | 0o111
 			require.Equal(t, next.FileInfo().Mode().String(), ex.String())
 		}
+		if next.Name == "link.txt" {
+			require.Equal(t, next.Linkname, "regular.txt")
+		}
 	}
 	require.Equal(t, []string{
 		"foo.txt",
@@ -91,6 +102,8 @@ func TestTarXzFile(t *testing.T) {
 		"sub1/executable",
 		"sub1/sub2",
 		"sub1/sub2/subfoo.txt",
+		"regular.txt",
+		"link.txt",
 	}, paths)
 }
 

--- a/pkg/archive/testdata/link.txt
+++ b/pkg/archive/testdata/link.txt
@@ -1,0 +1,1 @@
+regular.txt

--- a/pkg/archive/zip/zip.go
+++ b/pkg/archive/zip/zip.go
@@ -39,7 +39,7 @@ func (a Archive) Add(f config.File) error {
 		return err
 	}
 	defer file.Close()
-	info, err := file.Stat()
+	info, err := os.Lstat(f.Source) // #nosec
 	if err != nil {
 		return err
 	}

--- a/pkg/archive/zip/zip_test.go
+++ b/pkg/archive/zip/zip_test.go
@@ -48,6 +48,14 @@ func TestZipFile(t *testing.T) {
 		Source:      "../testdata/sub1/sub2/subfoo.txt",
 		Destination: "sub1/sub2/subfoo.txt",
 	}))
+	require.NoError(t, archive.Add(config.File{
+		Source:      "../testdata/regular.txt",
+		Destination: "regular.txt",
+	}))
+	require.NoError(t, archive.Add(config.File{
+		Source:      "../testdata/link.txt",
+		Destination: "link.txt",
+	}))
 
 	require.NoError(t, archive.Close())
 	require.Error(t, archive.Add(config.File{
@@ -75,12 +83,17 @@ func TestZipFile(t *testing.T) {
 			ex := zf.Mode() | 0o111
 			require.Equal(t, zf.Mode().String(), ex.String())
 		}
+		if zf.Name == "link.txt" {
+			require.True(t, zf.FileInfo().Mode()&os.ModeSymlink != 0)
+		}
 	}
 	require.Equal(t, []string{
 		"foo.txt",
 		"sub1/bar.txt",
 		"sub1/executable",
 		"sub1/sub2/subfoo.txt",
+		"regular.txt",
+		"link.txt",
 	}, paths)
 }
 


### PR DESCRIPTION
closes #2430

support symlinks inside tar.gz, tar.xz and zip files.

probably not perfect, but good enough for now.