### PR TITLE
fix: clean user information from remote url if it contains username and token

### DIFF
--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"strconv"
@@ -82,10 +83,20 @@ func getGitInfo() (context.GitInfo, error) {
 	if err != nil {
 		return context.GitInfo{}, fmt.Errorf("couldn't get commit date: %w", err)
 	}
-	url, err := getURL()
+	gitURL, err := getURL()
 	if err != nil {
 		return context.GitInfo{}, fmt.Errorf("couldn't get remote URL: %w", err)
 	}
+
+	if strings.HasPrefix(gitURL, "https://") {
+		u, err := url.Parse(gitURL)
+		if err != nil {
+			return context.GitInfo{}, fmt.Errorf("couldn't parse remote URL: %w", err)
+		}
+		u.User = nil
+		gitURL = u.String()
+	}
+
 	tag, err := getTag()
 	if err != nil {
 		return context.GitInfo{
@@ -94,7 +105,7 @@ func getGitInfo() (context.GitInfo, error) {
 			FullCommit:  full,
 			ShortCommit: short,
 			CommitDate:  date,
-			URL:         url,
+			URL:         gitURL,
 			CurrentTag:  "v0.0.0",
 		}, ErrNoTag
 	}
@@ -105,7 +116,7 @@ func getGitInfo() (context.GitInfo, error) {
 		FullCommit:  full,
 		ShortCommit: short,
 		CommitDate:  date,
-		URL:         url,
+		URL:         gitURL,
 	}, nil
 }
 

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -115,6 +115,28 @@ func TestDirty(t *testing.T) {
 	})
 }
 
+func TestRemoteURLContainsWithUsernameAndToken(t *testing.T) {
+	testlib.Mktmp(t)
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "https://gitlab-ci-token:SyYhsAghYFTvMoxw7GAg@gitlab.private.com/platform/base/poc/kink.git/releases/tag/v0.1.4")
+	testlib.GitAdd(t)
+	testlib.GitCommit(t, "commit2")
+	testlib.GitTag(t, "v0.0.1")
+	ctx := context.New(config.Project{})
+	require.NoError(t, Pipe{}.Run(ctx))
+}
+
+func TestRemoteURLContainsWithUsernameAndTokenWithInvalidURL(t *testing.T) {
+	testlib.Mktmp(t)
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "https://gitlab-ci-token:SyYhsAghYFTvMoxw7GAggitlab.com/platform/base/poc/kink.git/releases/tag/v0.1.4")
+	testlib.GitAdd(t)
+	testlib.GitCommit(t, "commit2")
+	testlib.GitTag(t, "v0.0.1")
+	ctx := context.New(config.Project{})
+	require.Error(t, Pipe{}.Run(ctx))
+}
+
 func TestShallowClone(t *testing.T) {
 	folder := testlib.Mktmp(t)
 	require.NoError(


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>


<!-- If applied, this commit will... -->

Fix #2456 

<!-- Why is this change being made? -->

to avid showing user information in the message template if someone uses the {{ .GitURL }} within these templates.