### PR TITLE
feat(docker): add buildpacks support

### DIFF
--- a/internal/pipe/docker/api_buildpack.go
+++ b/internal/pipe/docker/api_buildpack.go
@@ -1,0 +1,45 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type buildPackImager struct {
+}
+
+func (i buildPackImager) Push(ctx context.Context, image string, flags []string) error {
+	if err := runCommand(ctx, ".", "docker", "push", image); err != nil {
+		return fmt.Errorf("failed to push %s: %w", image, err)
+	}
+	return nil
+}
+
+func (i buildPackImager) Build(ctx context.Context, root string, images, flags []string) error {
+	if err := runCommand(ctx, root, "pack", i.buildCommand(images, flags)...); err != nil {
+		return fmt.Errorf("failed to build %s: %w", images[0], err)
+	}
+	return nil
+}
+
+func (i buildPackImager) buildCommand(images, flags []string) []string {
+	base := []string{"build", images[0]}
+	for j := 1; j < len(images); j++ {
+		base = append(base, "-t", images[j])
+	}
+
+	builderConfigured := false
+	for _, flag := range flags {
+		if strings.HasPrefix(flag, "-B") || strings.HasPrefix(flag, "--builder") {
+			builderConfigured = true
+		}
+	}
+
+	if !builderConfigured {
+		flags = append(flags, "--builder=gcr.io/buildpacks/builder:v1")
+	}
+
+	base = append(base, flags...)
+	return base
+}

--- a/internal/pipe/docker/api_buildpack.go
+++ b/internal/pipe/docker/api_buildpack.go
@@ -6,8 +6,7 @@ import (
 	"strings"
 )
 
-type buildPackImager struct {
-}
+type buildPackImager struct{}
 
 func (i buildPackImager) Push(ctx context.Context, image string, flags []string) error {
 	return dockerImager{}.Push(ctx, image, flags)

--- a/internal/pipe/docker/api_buildpack.go
+++ b/internal/pipe/docker/api_buildpack.go
@@ -37,6 +37,5 @@ func (i buildPackImager) buildCommand(images, flags []string) []string {
 		flags = append(flags, "--builder=gcr.io/buildpacks/builder:v1")
 	}
 
-	base = append(base, flags...)
-	return base
+	return append(base, flags...)
 }

--- a/internal/pipe/docker/api_buildpack.go
+++ b/internal/pipe/docker/api_buildpack.go
@@ -10,10 +10,7 @@ type buildPackImager struct {
 }
 
 func (i buildPackImager) Push(ctx context.Context, image string, flags []string) error {
-	if err := runCommand(ctx, ".", "docker", "push", image); err != nil {
-		return fmt.Errorf("failed to push %s: %w", image, err)
-	}
-	return nil
+	return dockerImager{}.Push(ctx, image, flags)
 }
 
 func (i buildPackImager) Build(ctx context.Context, root string, images, flags []string) error {

--- a/internal/pipe/docker/api_buildpack.go
+++ b/internal/pipe/docker/api_buildpack.go
@@ -13,7 +13,7 @@ func (i buildPackImager) Push(ctx context.Context, image string, flags []string)
 }
 
 func (i buildPackImager) Build(ctx context.Context, root string, images, flags []string) error {
-	if err := runCommand(ctx, root, "pack", i.buildCommand(images, flags)...); err != nil {
+	if err := runCommand(ctx, "", "pack", i.buildCommand(images, flags)...); err != nil {
 		return fmt.Errorf("failed to build %s: %w", images[0], err)
 	}
 	return nil

--- a/internal/pipe/docker/api_buildpack_test.go
+++ b/internal/pipe/docker/api_buildpack_test.go
@@ -1,0 +1,47 @@
+package docker
+
+import "testing"
+
+func TestBuildCommandForBuildPack(t *testing.T) {
+	images := []string{"goreleaser/test_build_flag", "goreleaser/test_multiple_tags"}
+	tests := []struct {
+		name   string
+		flags  []string
+		buildx bool
+		expect []string
+	}{
+		{
+			name:   "no flags without builder",
+			flags:  []string{},
+			expect: []string{"build", images[0], "-t", images[1], "--builder=gcr.io/buildpacks/builder:v1"},
+		},
+		{
+			name:   "single flag without builder",
+			flags:  []string{"--clear-cache"},
+			expect: []string{"build", images[0], "-t", images[1], "--clear-cache", "--builder=gcr.io/buildpacks/builder:v1"},
+		},
+		{
+			name:   "multiple flags without builder",
+			flags:  []string{"--clear-cache", "--verbose"},
+			expect: []string{"build", images[0], "-t", images[1], "--clear-cache", "--verbose", "--builder=gcr.io/buildpacks/builder:v1"},
+		},
+		{
+			name:   "builder with --builder flag",
+			buildx: true,
+			flags:  []string{"--builder=heroku/buildpacks:20"},
+			expect: []string{"build", images[0], "-t", images[1], "--builder=heroku/buildpacks:20"},
+		},
+		{
+			name:   "builder with -B flag",
+			buildx: true,
+			flags:  []string{"-B=heroku/buildpacks:18"},
+			expect: []string{"build", images[0], "-t", images[1], "-B=heroku/buildpacks:18"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			imager := buildPackImager{}
+			require.Equal(t, tt.expect, imager.buildCommand(images, tt.flags))
+		})
+	}
+}

--- a/internal/pipe/docker/api_buildpack_test.go
+++ b/internal/pipe/docker/api_buildpack_test.go
@@ -1,13 +1,16 @@
 package docker
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestBuildCommandForBuildPack(t *testing.T) {
 	images := []string{"goreleaser/test_build_flag", "goreleaser/test_multiple_tags"}
 	tests := []struct {
 		name   string
 		flags  []string
-		buildx bool
 		expect []string
 	}{
 		{
@@ -27,13 +30,11 @@ func TestBuildCommandForBuildPack(t *testing.T) {
 		},
 		{
 			name:   "builder with --builder flag",
-			buildx: true,
 			flags:  []string{"--builder=heroku/buildpacks:20"},
 			expect: []string{"build", images[0], "-t", images[1], "--builder=heroku/buildpacks:20"},
 		},
 		{
 			name:   "builder with -B flag",
-			buildx: true,
 			flags:  []string{"-B=heroku/buildpacks:18"},
 			expect: []string{"build", images[0], "-t", images[1], "-B=heroku/buildpacks:18"},
 		},

--- a/internal/pipe/docker/api_docker.go
+++ b/internal/pipe/docker/api_docker.go
@@ -3,7 +3,6 @@ package docker
 import (
 	"context"
 	"fmt"
-	"strings"
 )
 
 func init() {
@@ -66,44 +65,6 @@ func (i dockerImager) buildCommand(images, flags []string) []string {
 	for _, image := range images {
 		base = append(base, "-t", image)
 	}
-	base = append(base, flags...)
-	return base
-}
-
-type buildPackImager struct {
-}
-
-func (i buildPackImager) Push(ctx context.Context, image string, flags []string) error {
-	if err := runCommand(ctx, ".", "docker", "push", image); err != nil {
-		return fmt.Errorf("failed to push %s: %w", image, err)
-	}
-	return nil
-}
-
-func (i buildPackImager) Build(ctx context.Context, root string, images, flags []string) error {
-	if err := runCommand(ctx, root, "pack", i.buildCommand(images, flags)...); err != nil {
-		return fmt.Errorf("failed to build %s: %w", images[0], err)
-	}
-	return nil
-}
-
-func (i buildPackImager) buildCommand(images, flags []string) []string {
-	base := []string{"build", images[0]}
-	for j := 1; j < len(images); j++ {
-		base = append(base, "-t", images[j])
-	}
-
-	builderConfigured := false
-	for _, flag := range flags {
-		if strings.HasPrefix(flag, "-B") || strings.HasPrefix(flag, "--builder") {
-			builderConfigured = true
-		}
-	}
-
-	if !builderConfigured {
-		flags = append(flags, "--builder=gcr.io/buildpacks/builder:v1")
-	}
-
 	base = append(base, flags...)
 	return base
 }

--- a/internal/pipe/docker/api_docker.go
+++ b/internal/pipe/docker/api_docker.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"context"
 	"fmt"
+	"strings"
 )
 
 func init() {
@@ -12,6 +13,7 @@ func init() {
 	registerImager(useBuildx, dockerImager{
 		buildx: true,
 	})
+	registerImager(useBuildPack, buildPackImager{})
 }
 
 type dockerManifester struct{}
@@ -64,6 +66,44 @@ func (i dockerImager) buildCommand(images, flags []string) []string {
 	for _, image := range images {
 		base = append(base, "-t", image)
 	}
+	base = append(base, flags...)
+	return base
+}
+
+type buildPackImager struct {
+}
+
+func (i buildPackImager) Push(ctx context.Context, image string, flags []string) error {
+	if err := runCommand(ctx, ".", "docker", "push", image); err != nil {
+		return fmt.Errorf("failed to push %s: %w", image, err)
+	}
+	return nil
+}
+
+func (i buildPackImager) Build(ctx context.Context, root string, images, flags []string) error {
+	if err := runCommand(ctx, root, "pack", i.buildCommand(images, flags)...); err != nil {
+		return fmt.Errorf("failed to build %s: %w", images[0], err)
+	}
+	return nil
+}
+
+func (i buildPackImager) buildCommand(images, flags []string) []string {
+	base := []string{"build", images[0]}
+	for j := 1; j < len(images); j++ {
+		base = append(base, "-t", images[j])
+	}
+
+	builderConfigured := false
+	for _, flag := range flags {
+		if strings.HasPrefix(flag, "-B") || strings.HasPrefix(flag, "--builder") {
+			builderConfigured = true
+		}
+	}
+
+	if !builderConfigured {
+		flags = append(flags, "--builder=gcr.io/buildpacks/builder:v1")
+	}
+
 	base = append(base, flags...)
 	return base
 }

--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -24,8 +24,9 @@ import (
 const (
 	dockerConfigExtra = "DockerConfig"
 
-	useBuildx = "buildx"
-	useDocker = "docker"
+	useBuildx    = "buildx"
+	useDocker    = "docker"
+	useBuildPack = "buildpack"
 )
 
 // Pipe for docker.

--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -26,7 +26,7 @@ const (
 
 	useBuildx    = "buildx"
 	useDocker    = "docker"
-	useBuildPack = "buildpack"
+	useBuildPack = "buildpacks"
 )
 
 // Pipe for docker.

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -929,6 +929,9 @@ func TestRunPipe(t *testing.T) {
 
 	for name, docker := range table {
 		for imager := range imagers {
+			if imager == useBuildPack { // buildpack tests are different
+				continue
+			}
 			t.Run(name+" on "+imager, func(t *testing.T) {
 				folder := t.TempDir()
 				dist := filepath.Join(folder, "dist")
@@ -1078,6 +1081,50 @@ func TestBuildCommand(t *testing.T) {
 			imager := dockerImager{
 				buildx: tt.buildx,
 			}
+			require.Equal(t, tt.expect, imager.buildCommand(images, tt.flags))
+		})
+	}
+}
+
+func TestBuildCommandForBuildPack(t *testing.T) {
+	images := []string{"goreleaser/test_build_flag", "goreleaser/test_multiple_tags"}
+	tests := []struct {
+		name   string
+		flags  []string
+		buildx bool
+		expect []string
+	}{
+		{
+			name:   "no flags without builder",
+			flags:  []string{},
+			expect: []string{"build", images[0], "-t", images[1], "--builder=gcr.io/buildpacks/builder:v1"},
+		},
+		{
+			name:   "single flag without builder",
+			flags:  []string{"--clear-cache"},
+			expect: []string{"build", images[0], "-t", images[1], "--clear-cache", "--builder=gcr.io/buildpacks/builder:v1"},
+		},
+		{
+			name:   "multiple flags without builder",
+			flags:  []string{"--clear-cache", "--verbose"},
+			expect: []string{"build", images[0], "-t", images[1], "--clear-cache", "--verbose", "--builder=gcr.io/buildpacks/builder:v1"},
+		},
+		{
+			name:   "builder with --builder flag",
+			buildx: true,
+			flags:  []string{"--builder=heroku/buildpacks:20"},
+			expect: []string{"build", images[0], "-t", images[1], "--builder=heroku/buildpacks:20"},
+		},
+		{
+			name:   "builder with -B flag",
+			buildx: true,
+			flags:  []string{"-B=heroku/buildpacks:18"},
+			expect: []string{"build", images[0], "-t", images[1], "-B=heroku/buildpacks:18"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			imager := buildPackImager{}
 			require.Equal(t, tt.expect, imager.buildCommand(images, tt.flags))
 		})
 	}

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -1086,50 +1086,6 @@ func TestBuildCommand(t *testing.T) {
 	}
 }
 
-func TestBuildCommandForBuildPack(t *testing.T) {
-	images := []string{"goreleaser/test_build_flag", "goreleaser/test_multiple_tags"}
-	tests := []struct {
-		name   string
-		flags  []string
-		buildx bool
-		expect []string
-	}{
-		{
-			name:   "no flags without builder",
-			flags:  []string{},
-			expect: []string{"build", images[0], "-t", images[1], "--builder=gcr.io/buildpacks/builder:v1"},
-		},
-		{
-			name:   "single flag without builder",
-			flags:  []string{"--clear-cache"},
-			expect: []string{"build", images[0], "-t", images[1], "--clear-cache", "--builder=gcr.io/buildpacks/builder:v1"},
-		},
-		{
-			name:   "multiple flags without builder",
-			flags:  []string{"--clear-cache", "--verbose"},
-			expect: []string{"build", images[0], "-t", images[1], "--clear-cache", "--verbose", "--builder=gcr.io/buildpacks/builder:v1"},
-		},
-		{
-			name:   "builder with --builder flag",
-			buildx: true,
-			flags:  []string{"--builder=heroku/buildpacks:20"},
-			expect: []string{"build", images[0], "-t", images[1], "--builder=heroku/buildpacks:20"},
-		},
-		{
-			name:   "builder with -B flag",
-			buildx: true,
-			flags:  []string{"-B=heroku/buildpacks:18"},
-			expect: []string{"build", images[0], "-t", images[1], "-B=heroku/buildpacks:18"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			imager := buildPackImager{}
-			require.Equal(t, tt.expect, imager.buildCommand(images, tt.flags))
-		})
-	}
-}
-
 func TestDescription(t *testing.T) {
 	require.NotEmpty(t, Pipe{}.String())
 }

--- a/www/docs/customization/docker.md
+++ b/www/docs/customization/docker.md
@@ -268,3 +268,16 @@ dockers:
     - "myuser/myimage"
     use: buildpacks
 ```
+
+Also, you can use a custom buildpack on `build_flag_templates` if you want. By default `gcr.io/buildpacks/builder:v1` will be use.
+
+```yaml
+# .goreleaser.yml
+dockers:
+  -
+    image_templates:
+    - "myuser/myimage"
+    use: buildpacks
+    build_flag_templates:
+    - "--builder=heroku/buildpacks:20"
+```

--- a/www/docs/customization/docker.md
+++ b/www/docs/customization/docker.md
@@ -269,7 +269,8 @@ dockers:
     use: buildpacks
 ```
 
-Also, you can use a custom buildpack on `build_flag_templates` if you want. By default `gcr.io/buildpacks/builder:v1` will be use.
+Also, you can use a custom buildpack on `build_flag_templates` if you want. 
+By default, `gcr.io/buildpacks/builder:v1` will be used.
 
 ```yaml
 # .goreleaser.yml

--- a/www/docs/customization/docker.md
+++ b/www/docs/customization/docker.md
@@ -86,7 +86,7 @@ dockers:
     dockerfile: Dockerfile
 
     # Set the "backend" for the Docker pipe.
-    # Valid options are: docker, buildx, podman
+    # Valid options are: docker, buildx, podman, buildpacks
     # podman is a GoReleaser Pro feature and is only available on Linux.
     # Defaults to docker.
     use: docker
@@ -255,3 +255,16 @@ Also worth noticing that currently Podman only works on Linux machines.
 
 !!! info
     The Podman backend is a [GoReleaser Pro feature](/pro/).
+
+## Buildpacks
+
+You can use [`buildpacks`](https://buildpacks.io) instead of `docker` by setting `use` to `buildpacks` on your config:
+
+```yaml
+# .goreleaser.yml
+dockers:
+  -
+    image_templates:
+    - "myuser/myimage"
+    use: buildpacks
+```


### PR DESCRIPTION
Greetings.

We (w/@developer-guy and @Dentrax ) are trying to add **buildpacks** support to **goreleaser**. With this feature, users won't have to use a Dockerfile to build and publish an image.

This gives us `Dockerfile`less usage of goreleaser. This PR fixes #2450 

- [Buildpacks](https://buildpacks.io/)
- [GCR Builder](https://github.com/GoogleCloudPlatform/buildpacks)

Notes:
- Buildpacks has several builder options but maybe we can use `gcr.io/buildpacks/builder:v1` if not any builder specified.

Todo
- [ ] More unit tests for **Buildpacks** 