### PR TITLE
feat: support templates for scm urls

### DIFF
--- a/internal/client/gitlab_test.go
+++ b/internal/client/gitlab_test.go
@@ -1,32 +1,229 @@
 package client
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
+	"text/template"
 
+	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGitLabReleaseURLTemplate(t *testing.T) {
-	ctx := context.New(config.Project{
-		GitLabURLs: config.GitLabURLs{
-			// default URL would otherwise be set via pipe/defaults
-			Download: DefaultGitLabDownloadURL,
+	tests := []struct {
+		name            string
+		downloadURL     string
+		wantDownloadURL string
+		wantErr         bool
+	}{
+		{
+			name:            "default_download_url",
+			downloadURL:     DefaultGitLabDownloadURL,
+			wantDownloadURL: "https://gitlab.com/owner/name/-/releases/{{ .Tag }}/downloads/{{ .ArtifactName }}",
 		},
-		Release: config.Release{
-			GitLab: config.Repo{
-				Owner: "owner",
-				Name:  "name",
+		{
+			name:            "download_url_template",
+			downloadURL:     "{{ .Env.GORELEASER_TEST_GITLAB_URLS_DOWNLOAD }}",
+			wantDownloadURL: "https://gitlab.mycompany.com/owner/name/-/releases/{{ .Tag }}/downloads/{{ .ArtifactName }}",
+		},
+		{
+			name:        "download_url_template_invalid_value",
+			downloadURL: "{{ .Env.GORELEASER_NOT_EXISTS }}",
+			wantErr:     true,
+		},
+		{
+			name:        "download_url_template_invalid",
+			downloadURL: "{{.dddddddddd",
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		ctx := context.New(config.Project{
+			Env: []string{
+				"GORELEASER_TEST_GITLAB_URLS_DOWNLOAD=https://gitlab.mycompany.com",
 			},
+			GitLabURLs: config.GitLabURLs{
+				Download: tt.downloadURL,
+			},
+			Release: config.Release{
+				GitLab: config.Repo{
+					Owner: "owner",
+					Name:  "name",
+				},
+			},
+		})
+		client, err := NewGitLab(ctx, ctx.Token)
+		require.NoError(t, err)
+
+		urlTpl, err := client.ReleaseURLTemplate(ctx)
+		if tt.wantErr {
+			require.Error(t, err)
+			return
+		}
+
+		require.NoError(t, err)
+		require.Equal(t, tt.wantDownloadURL, urlTpl)
+	}
+}
+
+func TestGitLabURLsAPITemplate(t *testing.T) {
+	tests := []struct {
+		name     string
+		apiURL   string
+		wantHost string
+	}{
+		{
+			name:     "default_values",
+			wantHost: "gitlab.com",
 		},
+		{
+			name:     "speicifed_api_env_key",
+			apiURL:   "https://gitlab.mycompany.com",
+			wantHost: "gitlab.mycompany.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envs := []string{}
+			gitlabURLs := config.GitLabURLs{}
+
+			if tt.apiURL != "" {
+				envs = append(envs, fmt.Sprintf("GORELEASER_TEST_GITLAB_URLS_API=%s", tt.apiURL))
+				gitlabURLs.API = "{{ .Env.GORELEASER_TEST_GITLAB_URLS_API }}"
+			}
+
+			ctx := context.New(config.Project{
+				Env:        envs,
+				GitLabURLs: gitlabURLs,
+			})
+
+			client, err := NewGitLab(ctx, ctx.Token)
+			require.NoError(t, err)
+
+			gitlabClient, ok := client.(*gitlabClient)
+			require.True(t, ok)
+
+			require.Equal(t, tt.wantHost, gitlabClient.client.BaseURL().Host)
+		})
+	}
+
+	t.Run("no_env_specified", func(t *testing.T) {
+		ctx := context.New(config.Project{
+			GitLabURLs: config.GitLabURLs{
+				API: "{{ .Env.GORELEASER_NOT_EXISTS }}",
+			},
+		})
+
+		_, err := NewGitLab(ctx, ctx.Token)
+		require.ErrorAs(t, err, &template.ExecError{})
 	})
-	client, err := NewGitLab(ctx, ctx.Token)
-	require.NoError(t, err)
 
-	urlTpl, err := client.ReleaseURLTemplate(ctx)
-	require.NoError(t, err)
+	t.Run("invalid_template", func(t *testing.T) {
+		ctx := context.New(config.Project{
+			GitLabURLs: config.GitLabURLs{
+				API: "{{.dddddddddd",
+			},
+		})
 
-	expectedURL := "https://gitlab.com/owner/name/-/releases/{{ .Tag }}/downloads/{{ .ArtifactName }}"
-	require.Equal(t, expectedURL, urlTpl)
+		_, err := NewGitLab(ctx, ctx.Token)
+		require.Error(t, err)
+	})
+}
+
+func TestGitLabURLsDownloadTemplate(t *testing.T) {
+	tests := []struct {
+		name        string
+		downloadURL string
+		wantURL     string
+		wantErr     bool
+	}{
+		{
+			name:    "empty_download_url",
+			wantURL: "/",
+		},
+		{
+			name:        "download_url_template",
+			downloadURL: "{{ .Env.GORELEASER_TEST_GITLAB_URLS_DOWNLOAD }}",
+			wantURL:     "https://gitlab.mycompany.com/",
+		},
+		{
+			name:        "download_url_template_invalid_value",
+			downloadURL: "{{ .Eenv.GORELEASER_NOT_EXISTS }}",
+			wantErr:     true,
+		},
+		{
+			name:        "download_url_template_invalid",
+			downloadURL: "{{.dddddddddd",
+			wantErr:     true,
+		},
+		{
+			name:        "download_url_string",
+			downloadURL: "https://gitlab.mycompany.com",
+			wantURL:     "https://gitlab.mycompany.com/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer fmt.Fprint(w, "{}")
+				defer w.WriteHeader(http.StatusOK)
+				defer r.Body.Close()
+
+				if !strings.Contains(r.URL.Path, "assets/links") {
+					_, _ = io.Copy(io.Discard, r.Body)
+					return
+				}
+
+				b, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+
+				reqBody := map[string]interface{}{}
+				err = json.Unmarshal(b, &reqBody)
+				require.NoError(t, err)
+
+				require.Equal(t, tt.wantURL, reqBody["url"])
+			}))
+			defer srv.Close()
+
+			ctx := context.New(config.Project{
+				Env: []string{
+					"GORELEASER_TEST_GITLAB_URLS_DOWNLOAD=https://gitlab.mycompany.com",
+				},
+				Release: config.Release{
+					GitLab: config.Repo{
+						Owner: "test",
+						Name:  "test",
+					},
+				},
+				GitLabURLs: config.GitLabURLs{
+					API:      srv.URL,
+					Download: tt.downloadURL,
+				},
+			})
+
+			tmpFile, err := os.CreateTemp(t.TempDir(), "")
+			require.NoError(t, err)
+
+			client, err := NewGitLab(ctx, ctx.Token)
+			require.NoError(t, err)
+
+			err = client.Upload(ctx, "1234", &artifact.Artifact{Name: "test", Path: "some-path"}, tmpFile)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }

--- a/internal/pipe/defaults/defaults.go
+++ b/internal/pipe/defaults/defaults.go
@@ -3,10 +3,12 @@
 package defaults
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/goreleaser/goreleaser/internal/client"
 	"github.com/goreleaser/goreleaser/internal/middleware"
+	"github.com/goreleaser/goreleaser/internal/tmpl"
 	"github.com/goreleaser/goreleaser/pkg/context"
 	"github.com/goreleaser/goreleaser/pkg/defaults"
 )
@@ -30,7 +32,12 @@ func (Pipe) Run(ctx *context.Context) error {
 		ctx.Config.GitLabURLs.Download = client.DefaultGitLabDownloadURL
 	}
 	if ctx.Config.GiteaURLs.Download == "" {
-		ctx.Config.GiteaURLs.Download = strings.ReplaceAll(ctx.Config.GiteaURLs.API, "/api/v1", "")
+		apiURL, err := tmpl.New(ctx).Apply(ctx.Config.GiteaURLs.API)
+		if err != nil {
+			return fmt.Errorf("templating Gitea API URL: %w", err)
+		}
+
+		ctx.Config.GiteaURLs.Download = strings.ReplaceAll(apiURL, "/api/v1", "")
 	}
 	for _, defaulter := range defaults.Defaulters {
 		if err := middleware.Logging(

--- a/www/docs/scm/gitea.md
+++ b/www/docs/scm/gitea.md
@@ -19,7 +19,7 @@ env_files:
 ## URLs
 
 You can use GoReleaser with Gitea by providing its URLs in
-the `.goreleaser.yml` configuration file:
+the `.goreleaser.yml` configuration file. This takes a normal string or a template value.
 
 ```yaml
 # .goreleaser.yml

--- a/www/docs/scm/github.md
+++ b/www/docs/scm/github.md
@@ -18,7 +18,9 @@ env_files:
 
 ## GitHub Enterprise
 
-You can use GoReleaser with GitHub Enterprise by providing its URLs in the `.goreleaser.yml` configuration file:
+You can use GoReleaser with GitHub Enterprise by providing its URLs in the
+`.goreleaser.yml` configuration file. This takes a normal string or a template
+value.
 
 ```yaml
 # .goreleaser.yml

--- a/www/docs/scm/gitlab.md
+++ b/www/docs/scm/gitlab.md
@@ -18,8 +18,8 @@ env_files:
 
 ## GitLab Enterprise or private hosted
 
-You can use GoReleaser with GitLab Enterprise by providing its URLs in
-the `.goreleaser.yml` configuration file:
+You can use GoReleaser with GitLab Enterprise by providing its URLs in the
+`.goreleaser.yml` configuration file. This takes a normal string or a template value.
 
 ```yaml
 # .goreleaser.yml


### PR DESCRIPTION
Thank you for this really well polished project and the hard work put into it 🙌 

Background
---
When a git repository is hosted in multiple GitLab instances the
`.goreleaser.yml` needs to take in consideration both APIs endpoints. At
the moment it defaults to GitLab.com and you can override it with
`gitlab_urls` however this forces you to only support 1 GitLab instance.

We need this for
https://gitlab.com/gitlab-com/gl-infra/infrastructure/-/issues/14122
where we have a tool that is developed on GitLab.com but then mirrored
to an internal GitLab instance since we need it to operate GitLab.com
even when it's down.

Solution
---
Support templates like `{{ .Env.CI_SERVER_URL }}` for the
`gitlab_urls`, `github_urls`  and `gitea_urls` so it can use environment
variables and the same `.goreleaser` file can be used in multiple SCM
instances.