### PR TITLE
fix: panic on gitlab create release

### DIFF
--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -213,7 +213,7 @@ func (c *gitlabClient) CreateRelease(ctx *context.Context, body string) (release
 	name := title
 	tagName := ctx.Git.CurrentTag
 	release, resp, err := c.client.Releases.GetRelease(projectID, tagName)
-	if err != nil && (resp != nil && resp.StatusCode != 403 && resp.StatusCode != 404) {
+	if err != nil && (resp == nil || (resp.StatusCode != 403 && resp.StatusCode != 404)) {
 		return "", err
 	}
 


### PR DESCRIPTION
Background
---
In 5bcfa9042d0efd419b660a3b63c815a13d919e30 the condition was changed to
that it can support the new status code returned by GitLab. However, the
condition is now checked `resp != nil` and not `resp == nil` which causes
the condition not to trigger when the resp is nil and only returns an
error. We can reproduce this issue by running
`TestGitLabCreateReleaseUknownHost` test added in this commit.

Solution
---
If we look at other error handling
https://github.com/goreleaser/goreleaser/blob/91a8abb2e6c5915d93866cb19be6b67db4a193f4/internal/client/gitlab.go#L106
we can see that we check if the `resp` is nil as well before continuing.

Added tests for the following use cases:
- When there is an error and no response was returned.
- When there is a 403 or 404 error so we expect to create a release first.
- When there is an unknown error (not 404, 403) we just bail.
