### PR TITLE
docs: fix environment variable to be COSIGN_PWD

### DIFF
--- a/www/docs/customization/docker_sign.md
+++ b/www/docs/customization/docker_sign.md
@@ -62,7 +62,7 @@ docker_signs:
 
     # Stdin data template to be given to the signature command as stdin.
     # Defaults to empty
-    stdin: '{{ .Env.GPG_PASSWORD }}'
+    stdin: '{{ .Env.COSIGN_PWD }}'
 
     # StdinFile file to be given to the signature command as stdin.
     # Defaults to empty


### PR DESCRIPTION
this is a small doc fix to update the documentation and use the  `COSIGN_PWD` instead of `GPG_PASSWORD` since it defaults to use `cosign`