### PR TITLE
update cosign installer action to 1.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - uses: sigstore/cosign-installer@v1.1.0
+      - uses: sigstore/cosign-installer@v1.2.0
       -
         name: Make Setup
         run: |


### PR DESCRIPTION
update cosign installer action to 1.2.0

Please hold until this is merged and we make a release: https://github.com/sigstore/cosign-installer/pull/25

/assing @caarlos0 
