### PR TITLE
feat(docker): install tini to handle Ctrl+C

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,10 @@ RUN apk add --no-cache bash \
 	git \
 	mercurial \
 	make \
-	build-base
+	build-base \
+	tini
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]
 CMD [ "-h" ]
 
 COPY scripts/entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
<!-- If applied, this commit will... -->
sometimes releasing may take a while. when running it in docker `Ctrl-C` is not passed properly to the goreleaser process.
<!-- Why is this change being made? -->
[why tini](https://github.com/krallin/tini/issues/8)