### PR TITLE
fix: brew/scoop panic

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -43,20 +43,11 @@ type Client interface {
 
 // New creates a new client depending on the token type.
 func New(ctx *context.Context) (Client, error) {
-	log.WithField("type", ctx.TokenType).Debug("token type")
-	if ctx.TokenType == context.TokenTypeGitHub {
-		return NewGitHub(ctx, ctx.Token)
-	}
-	if ctx.TokenType == context.TokenTypeGitLab {
-		return NewGitLab(ctx, ctx.Token)
-	}
-	if ctx.TokenType == context.TokenTypeGitea {
-		return NewGitea(ctx, ctx.Token)
-	}
-	return nil, nil
+	return newWithToken(ctx, ctx.Token)
 }
 
 func newWithToken(ctx *context.Context, token string) (Client, error) {
+	log.WithField("type", ctx.TokenType).Debug("token type")
 	if ctx.TokenType == context.TokenTypeGitHub {
 		return NewGitHub(ctx, token)
 	}
@@ -66,7 +57,7 @@ func newWithToken(ctx *context.Context, token string) (Client, error) {
 	if ctx.TokenType == context.TokenTypeGitea {
 		return NewGitea(ctx, token)
 	}
-	return nil, nil
+	return nil, fmt.Errorf("invalid client token type: %q", ctx.TokenType)
 }
 
 func NewIfToken(ctx *context.Context, cli Client, token string) (Client, error) {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -12,7 +12,7 @@ func TestClientEmpty(t *testing.T) {
 	ctx := &context.Context{}
 	client, err := New(ctx)
 	require.Nil(t, client)
-	require.NoError(t, err)
+	require.EqualError(t, err, `invalid client token type: ""`)
 }
 
 func TestClientNewGitea(t *testing.T) {
@@ -153,7 +153,7 @@ func TestNewWithToken(t *testing.T) {
 		}
 
 		cli, err := newWithToken(ctx, "{{ .Env.TK }}")
-		require.NoError(t, err)
+		require.EqualError(t, err, `invalid client token type: "nope"`)
 		require.Nil(t, cli)
 	})
 }

--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -83,11 +83,6 @@ func (Pipe) Run(ctx *context.Context) error {
 
 // Publish brew formula.
 func (Pipe) Publish(ctx *context.Context) error {
-	// we keep GitHub as default for now, in line with releases
-	if string(ctx.TokenType) == "" {
-		ctx.TokenType = context.TokenTypeGitHub
-	}
-
 	cli, err := client.New(ctx)
 	if err != nil {
 		return err

--- a/internal/pipe/env/env.go
+++ b/internal/pipe/env/env.go
@@ -83,12 +83,6 @@ func (Pipe) Run(ctx *context.Context) error {
 		return err
 	}
 
-	if githubToken != "" {
-		log.Debug("token type: github")
-		ctx.TokenType = context.TokenTypeGitHub
-		ctx.Token = githubToken
-	}
-
 	if gitlabToken != "" {
 		log.Debug("token type: gitlab")
 		ctx.TokenType = context.TokenTypeGitLab
@@ -99,6 +93,15 @@ func (Pipe) Run(ctx *context.Context) error {
 		log.Debug("token type: gitea")
 		ctx.TokenType = context.TokenTypeGitea
 		ctx.Token = giteaToken
+	}
+
+	if githubToken != "" {
+		log.Debug("token type: github")
+		ctx.Token = githubToken
+	}
+
+	if ctx.TokenType == "" {
+		ctx.TokenType = context.TokenTypeGitHub
 	}
 
 	return nil

--- a/internal/pipe/env/env_test.go
+++ b/internal/pipe/env/env_test.go
@@ -59,6 +59,12 @@ func TestSetDefaultTokenFiles(t *testing.T) {
 		})
 		require.EqualError(t, Pipe{}.Run(ctx), `template: tmpl:1: unexpected "}" in operand`)
 	})
+
+	t.Run("no token", func(t *testing.T) {
+		ctx := context.New(config.Project{})
+		require.NoError(t, Pipe{}.Run(ctx))
+		require.Equal(t, ctx.TokenType, context.TokenTypeGitHub)
+	})
 }
 
 func TestValidGithubEnv(t *testing.T) {


### PR DESCRIPTION
fixes  #2514

not really sure why it happens on some projects and not in others... but anyway, this should fix it...

the problem is that it might not have the `token type` set when running, which then was returning a nil client... this will now error and also always default to github token type if none was provided.

also some refactory to reuse some code on the client instantiation. 