### PR TITLE
fix: do not skip any defaults

### DIFF
--- a/internal/pipe/defaults/defaults.go
+++ b/internal/pipe/defaults/defaults.go
@@ -9,7 +9,6 @@ import (
 	"github.com/goreleaser/goreleaser/internal/client"
 	"github.com/goreleaser/goreleaser/internal/middleware/errhandler"
 	"github.com/goreleaser/goreleaser/internal/middleware/logging"
-	"github.com/goreleaser/goreleaser/internal/middleware/skip"
 	"github.com/goreleaser/goreleaser/internal/tmpl"
 	"github.com/goreleaser/goreleaser/pkg/context"
 	"github.com/goreleaser/goreleaser/pkg/defaults"
@@ -40,13 +39,10 @@ func (Pipe) Run(ctx *context.Context) error {
 		ctx.Config.GiteaURLs.Download = strings.ReplaceAll(apiURL, "/api/v1", "")
 	}
 	for _, defaulter := range defaults.Defaulters {
-		if err := skip.Maybe(
-			defaulter,
-			logging.Log(
-				defaulter.String(),
-				errhandler.Handle(defaulter.Default),
-				logging.ExtraPadding,
-			),
+		if err := logging.Log(
+			defaulter.String(),
+			errhandler.Handle(defaulter.Default),
+			logging.ExtraPadding,
 		)(ctx); err != nil {
 			return err
 		}


### PR DESCRIPTION
our defaults have many side effects... one example being the project name is inferred from the release config... 

until v0.179.0, the defaults ran anyway, but on 0.180 they wont in some cases, which may lead to errors.

until we figure this out, lets remove the conditional skipping from the defaults

closes #2520