### PR TITLE
fix: bug in handling gitlab-ci style urls

### DIFF
--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -30,7 +30,17 @@ func ExtractRepoFromURL(rawurl string) (config.Repo, error) {
 	// on HTTP and HTTPS URLs it will remove the http(s): prefix,
 	// which is ok. On SSH URLs the whole user@server will be removed,
 	// which is required.
-	s = s[strings.LastIndex(s, ":")+1:]
+
+	// If the url contains more than 1 ':' character, assume we are doing an
+	// http URL with a username/password in it, and normalize the URL.
+	// Gitlab-CI uses this type of URL
+	if strings.Count(s, ":") == 1 {
+		s = s[strings.LastIndex(s, ":")+1:]
+	} else {
+		// Handle Gitlab-ci funky URLs in the form of:
+		// "https://gitlab-ci-token:SOME_TOKEN@gitlab.yourcompany.com/yourgroup/yourproject.git"
+		s = "//" + s[strings.LastIndex(s, "@")+1:]
+	}
 
 	// now we can parse it with net/url
 	u, err := url.Parse(s)

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -37,6 +37,7 @@ func TestExtractRepoFromURL(t *testing.T) {
 		"git@custom:goreleaser/goreleaser.git",
 		"https://github.com/goreleaser/goreleaser.git",
 		"https://github.enterprise.com/goreleaser/goreleaser.git",
+		"https://gitlab-ci-token:SOME_TOKEN@gitlab.yourcompany.com/goreleaser/goreleaser.git",
 	} {
 		t.Run(url, func(t *testing.T) {
 			repo, err := git.ExtractRepoFromURL(url)


### PR DESCRIPTION
This PR will fix parsing of the git URL format that is used by gitlab-ci runners, for example:

```
https://gitlab-ci-token:SOME_TOKEN@gitlab.yourcompany.com/goreleaser/goreleaser.git
```

The URL style above works correctly in v0.179.0, but not v0.180.0, I believe because of the following PR:

https://github.com/goreleaser/goreleaser/pull/2474/files

Thanks, for the consideration, and for the awesome project in general!