### PR TITLE
docs: Fix invalid personal access token URL

### DIFF
--- a/www/docs/scm/gitlab.md
+++ b/www/docs/scm/gitlab.md
@@ -3,7 +3,7 @@
 ## API Token
 
 GoReleaser requires an API token with the `api` scope selected to deploy the artifacts to GitLab.
-You can create one [here](https://gitlab.com/profile/personal_access_tokens).
+You can create one [here](https://gitlab.com/-/profile/personal_access_tokens).
 
 This token should be added to the environment variables as `GITLAB_TOKEN`.
 


### PR DESCRIPTION
The url for the gitlab's CI integration seems to be outdated.

<img src="https://user-images.githubusercontent.com/6313452/135149130-b08038eb-9d26-41b3-bc24-187f5b07c611.png" alt="drawing" width="300"/>

