### PR TITLE
refactor: remove unused not impl error

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2,7 +2,6 @@
 package client
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
@@ -88,19 +87,4 @@ type RetriableError struct {
 
 func (e RetriableError) Error() string {
 	return e.Err.Error()
-}
-
-// NotImplementedError happens when trying to use something a client does not
-// implement.
-type NotImplementedError struct {
-	TokenType context.TokenType
-}
-
-func (e NotImplementedError) Error() string {
-	return fmt.Sprintf("not implemented for %s", e.TokenType)
-}
-
-// IsNotImplementedErr returns true if given error is a NotImplementedError.
-func IsNotImplementedErr(err error) bool {
-	return errors.As(err, &NotImplementedError{})
 }

--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -30,15 +30,6 @@ var ErrNoArchivesFound = errors.New("no linux/macos archives found")
 // for linux or windows.
 var ErrMultipleArchivesSameOS = errors.New("one tap can handle only archive of an OS/Arch combination. Consider using ids in the brew section")
 
-// ErrTokenTypeNotImplementedForBrew indicates that a new token type was not implemented for this pipe.
-type ErrTokenTypeNotImplementedForBrew struct {
-	TokenType context.TokenType
-}
-
-func (e ErrTokenTypeNotImplementedForBrew) Error() string {
-	return fmt.Sprintf("token type %q not implemented for brew pipe", e.TokenType)
-}
-
 // Pipe for brew deployment.
 type Pipe struct{}
 
@@ -293,9 +284,6 @@ func dataFor(ctx *context.Context, cfg config.Homebrew, cl client.Client, artifa
 		if cfg.URLTemplate == "" {
 			url, err := cl.ReleaseURLTemplate(ctx)
 			if err != nil {
-				if client.IsNotImplementedErr(err) {
-					return result, ErrTokenTypeNotImplementedForBrew{ctx.TokenType}
-				}
 				return result, err
 			}
 			cfg.URLTemplate = url

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -830,42 +830,6 @@ func TestRunEmptyTokenType(t *testing.T) {
 	require.NoError(t, runAll(ctx, client))
 }
 
-func TestRunTokenTypeNotImplementedForBrew(t *testing.T) {
-	folder := t.TempDir()
-	ctx := context.New(config.Project{
-		Dist:        folder,
-		ProjectName: "foo",
-		Release:     config.Release{},
-		Brews: []config.Homebrew{
-			{
-				Tap: config.RepoRef{
-					Owner: "test",
-					Name:  "test",
-				},
-			},
-		},
-	})
-	ctx.TokenType = context.TokenTypeGitea
-	ctx.Git = context.GitInfo{CurrentTag: "v1.0.1"}
-	path := filepath.Join(folder, "whatever.tar.gz")
-	f, err := os.Create(path)
-	require.NoError(t, err)
-	require.NoError(t, f.Close())
-	ctx.Artifacts.Add(&artifact.Artifact{
-		Name:   "bin",
-		Path:   path,
-		Goos:   "darwin",
-		Goarch: "amd64",
-		Type:   artifact.UploadableArchive,
-		Extra: map[string]interface{}{
-			"ID":     "foo",
-			"Format": "tar.gz",
-		},
-	})
-	client := &DummyClient{NotImplemented: true}
-	require.EqualError(t, runAll(ctx, client), `token type "gitea" not implemented for brew pipe`)
-}
-
 func TestDefault(t *testing.T) {
 	testlib.Mktmp(t)
 
@@ -912,9 +876,8 @@ func TestGHFolder(t *testing.T) {
 }
 
 type DummyClient struct {
-	CreatedFile    bool
-	Content        string
-	NotImplemented bool
+	CreatedFile bool
+	Content     string
 }
 
 func (dc *DummyClient) CloseMilestone(ctx *context.Context, repo client.Repo, title string) error {
@@ -926,10 +889,6 @@ func (dc *DummyClient) CreateRelease(ctx *context.Context, body string) (release
 }
 
 func (dc *DummyClient) ReleaseURLTemplate(ctx *context.Context) (string, error) {
-	if dc.NotImplemented {
-		return "", client.NotImplementedError{}
-	}
-
 	return "https://dummyhost/download/{{ .Tag }}/{{ .ArtifactName }}", nil
 }
 

--- a/internal/pipe/gofish/gofish.go
+++ b/internal/pipe/gofish/gofish.go
@@ -28,15 +28,6 @@ var ErrNoArchivesFound = errors.New("no linux/macos/windows archives found")
 
 var ErrMultipleArchivesSameOS = errors.New("one rig can handle only archive of an OS/Arch combination. Consider using ids in the gofish section")
 
-// ErrTokenTypeNotImplementedForGoFish indicates that a new token type was not implemented for this pipe.
-type ErrTokenTypeNotImplementedForGoFish struct {
-	TokenType context.TokenType
-}
-
-func (e ErrTokenTypeNotImplementedForGoFish) Error() string {
-	return fmt.Sprintf("token type %q not implemented for gofish pipe", e.TokenType)
-}
-
 // Pipe for goFish deployment.
 type Pipe struct{}
 
@@ -207,9 +198,6 @@ func dataFor(ctx *context.Context, cfg config.GoFish, cl client.Client, artifact
 		if cfg.URLTemplate == "" {
 			url, err := cl.ReleaseURLTemplate(ctx)
 			if err != nil {
-				if client.IsNotImplementedErr(err) {
-					return result, ErrTokenTypeNotImplementedForGoFish{ctx.TokenType}
-				}
 				return result, err
 			}
 			cfg.URLTemplate = url
@@ -245,8 +233,6 @@ func (Pipe) Publish(ctx *context.Context) error {
 }
 
 func publishAll(ctx *context.Context, cli client.Client) error {
-	// even if one of them skips, we run them all, and then show return the skips all at once.
-	// this is needed so we actually create the `dist/foo.lua` file, which is useful for debugging.
 	skips := pipe.SkipMemento{}
 	for _, rig := range ctx.Artifacts.Filter(artifact.ByType(artifact.GoFishRig)).List() {
 		err := doPublish(ctx, rig, cli)

--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -23,9 +23,6 @@ import (
 // ErrNoWindows when there is no build for windows (goos doesn't contain windows).
 var ErrNoWindows = errors.New("scoop requires a windows build")
 
-// ErrTokenTypeNotImplementedForScoop indicates that a new token type was not implemented for this pipe.
-var ErrTokenTypeNotImplementedForScoop = errors.New("token type not implemented for scoop pipe")
-
 const scoopConfigExtra = "ScoopConfig"
 
 // Pipe that builds and publishes scoop manifests.
@@ -209,9 +206,6 @@ func dataFor(ctx *context.Context, cl client.Client, artifacts []*artifact.Artif
 	if ctx.Config.Scoop.URLTemplate == "" {
 		url, err := cl.ReleaseURLTemplate(ctx)
 		if err != nil {
-			if client.IsNotImplementedErr(err) {
-				return manifest, ErrTokenTypeNotImplementedForScoop
-			}
 			return manifest, err
 		}
 		ctx.Config.Scoop.URLTemplate = url

--- a/internal/pipe/scoop/scoop_test.go
+++ b/internal/pipe/scoop/scoop_test.go
@@ -361,50 +361,6 @@ func Test_doRun(t *testing.T) {
 			noAssertions,
 		},
 		{
-			"token type not implemented for pipe",
-			args{
-				&context.Context{
-					Git: context.GitInfo{
-						CurrentTag: "v1.0.1",
-					},
-					Version:   "1.0.1",
-					Artifacts: artifact.New(),
-					Config: config.Project{
-						Builds: []config.Build{
-							{Binary: "test", Goarch: []string{"amd64"}, Goos: []string{"windows"}},
-						},
-						Dist:        ".",
-						ProjectName: "run-pipe",
-						Archives: []config.Archive{
-							{Format: "tar.gz"},
-						},
-						Release: config.Release{
-							GitHub: config.Repo{
-								Owner: "test",
-								Name:  "test",
-							},
-						},
-						Scoop: config.Scoop{
-							Bucket: config.RepoRef{
-								Owner: "test",
-								Name:  "test",
-							},
-							Description: "A run pipe test formula",
-							Homepage:    "https://github.com/goreleaser",
-						},
-					},
-				},
-				&DummyClient{NotImplemented: true},
-			},
-			[]*artifact.Artifact{
-				{Name: "foo_1.0.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64", Path: file},
-				{Name: "foo_1.0.1_windows_386.tar.gz", Goos: "windows", Goarch: "386", Path: file},
-			},
-			shouldErr(ErrTokenTypeNotImplementedForScoop.Error()),
-			shouldNotErr,
-			noAssertions,
-		},
-		{
 			"no windows build",
 			args{
 				&context.Context{
@@ -1081,10 +1037,9 @@ func TestSkip(t *testing.T) {
 }
 
 type DummyClient struct {
-	CreatedFile    bool
-	Content        string
-	Path           string
-	NotImplemented bool
+	CreatedFile bool
+	Content     string
+	Path        string
 }
 
 func (dc *DummyClient) CloseMilestone(ctx *context.Context, repo client.Repo, title string) error {
@@ -1096,9 +1051,6 @@ func (dc *DummyClient) CreateRelease(ctx *context.Context, body string) (release
 }
 
 func (dc *DummyClient) ReleaseURLTemplate(ctx *context.Context) (string, error) {
-	if dc.NotImplemented {
-		return "", client.NotImplementedError{}
-	}
 	return "", nil
 }
 


### PR DESCRIPTION
there's no client impl returning that error anymore, so we might as well remove it and the checks for it.