### PR TITLE
feat: add cosign tool in the goreleaser image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN apk add --no-cache bash \
 	build-base \
 	tini
 
+# install cosign
+COPY --from=gcr.io/projectsigstore/cosign:v1.3.1@sha256:3cd9b3a866579dc2e0cf2fdea547f4c9a27139276cc373165c26842bc594b8bd /bin/cosign /usr/local/bin/cosign
+
 ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]
 CMD [ "-h" ]
 


### PR DESCRIPTION
we are planning to use the goreleaser image in the release pipeline for some projects in `sigstore` but that image is lacking the `cosign` tool to sign the blobs and images.

Instead of download every time during the release process, it might be good to have that already present in the image 😄 
If this gets merged and when we release cosign v1.3.0 which will include the tool for arm65 then we update this to include for the arm64 image as well

If you do not agree feel free to close this PR.

thanks!
