### PR TITLE
fix: docs: Missing mattermost docs on website

### DIFF
--- a/www/htmltest.yml
+++ b/www/htmltest.yml
@@ -9,6 +9,7 @@ IgnoreURLs:
 - https://github.com/goreleaser/goreleaser/edit/
 - https://discord.com/
 - https://gofi.sh
+- https://docs.mattermost.com
 IgnoreDirs:
 - overrides
 IgnoreDirectoryMissingTrailingSlash: true

--- a/www/mkdocs.yml
+++ b/www/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
       - customization/announce/smtp.md
       - customization/announce/teams.md
       - customization/announce/twitter.md
+      - customization/announce/mattermost.md
 - Command Line Usage:
     - goreleaser: cmd/goreleaser.md
     - goreleaser init: cmd/goreleaser_init.md


### PR DESCRIPTION
Signed-off-by: Engin Diri <engin.diri@mail.schwarz>

Added the md file from mattermost announce feat (#253) to the website data.

FYI: @cpanato 
