### PR TITLE
feat: add template support for homebrew tap owner

### DIFF
--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -191,6 +191,12 @@ func doRun(ctx *context.Context, brew config.Homebrew, cl client.Client) error {
 	}
 	brew.Name = name
 
+	tapOwner, err := tmpl.New(ctx).Apply(brew.Tap.Owner)
+	if err != nil {
+		return err
+	}
+	brew.Tap.Owner = tapOwner
+
 	content, err := buildFormula(ctx, brew, cl, archives)
 	if err != nil {
 		return err


### PR DESCRIPTION
This is a minor fix to add support for templates in the Homebrew tap owner field.
Our use case for this was to get the owner field from environment variables

