### PR TITLE
docs: update CircleCI example

### DIFF
--- a/www/docs/ci/circle.md
+++ b/www/docs/ci/circle.md
@@ -18,8 +18,9 @@ workflows:
 jobs:
   release:
     docker:
-      - image: circleci/golang:1.17
+      - image: cimg/go:1.17
     steps:
       - checkout
       - run: curl -sL https://git.io/goreleaser | bash
+      - run: goreleaser
 ```


### PR DESCRIPTION
The Go image referenced in the example is a legacy image and will be deprecated. I've used instead our (CircleCI) next-gen Go image, which is what should be used going forward.