### PR TITLE
feat: Replace Make with Task

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           fetch-depth: 0
       -
+        name: Set up Task
+        uses: arduino/setup-task@v1
+      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       -
@@ -54,13 +57,13 @@ jobs:
             ${{ runner.os }}-go-
       - uses: sigstore/cosign-installer@v1.2.0
       -
-        name: Make Setup
+        name: Setup
         run: |
-          make setup
+          task setup
       -
-        name: Make CI
+        name: CI
         run: |
-          make ci
+          task ci
       -
         name: Upload coverage
         uses: codecov/codecov-action@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ conduct](/CODE_OF_CONDUCT.md).
 
 Prerequisites:
 
-- `make`
+- [Task](https://taskfile.dev/#/installation)
 - [Go 1.17+](https://golang.org/doc/install)
 - [snapcraft](https://snapcraft.io/)
 - [Docker](https://www.docker.com/)
@@ -24,13 +24,13 @@ git clone git@github.com:goreleaser/goreleaser.git
 `cd` into the directory and install the dependencies:
 
 ```sh
-make setup
+task setup
 ```
 
 A good way of making sure everything is all right is running the test suite:
 
 ```sh
-make test
+task test
 ```
 
 ## Test your change
@@ -38,13 +38,13 @@ make test
 You can create a branch for your changes and try to build from the source as you go:
 
 ```sh
-make build
+task build
 ```
 
 When you are satisfied with the changes, we suggest you run:
 
 ```sh
-make ci
+task ci
 ```
 
 ## Create a commit

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,79 @@
+# https://taskfile.dev
+
+version: '3'
+
+env:
+  GO111MODULE: on
+  GOPROXY: https://proxy.golang.org,direct
+
+vars:
+  DOCKER: '{{default "docker" .DOCKER}}'
+
+tasks:
+  dev:
+    desc: Setup pre-commit
+    cmds:
+      - cp -f scripts/pre-commit.sh .git/hooks/pre-commit
+
+  setup:
+    desc: Install dependencies
+    cmds:
+      - go mod tidy
+
+  build:
+    desc: Build the binary
+    cmds:
+      - go build
+
+  test:
+    desc: Run tests
+    env:
+      LC_ALL: C
+    vars:
+      TEST_OPTIONS: '{{default "" .TEST_OPTIONS}}'
+      SOURCE_FILES: '{{default "./..." .TEST_OPTIONS}}'
+      TEST_PATTERN: '{{default "." .TEST_PATTERN}}'
+    cmds:
+      - go test {{.TEST_OPTIONS}} -failfast -race -coverpkg=./... -covermode=atomic -coverprofile=coverage.txt {{.SOURCE_FILES}} -run {{.TEST_PATTERN}} -timeout=5m
+
+  cover:
+    desc: Run all the tests and opens the coverage report
+    cmds:
+      - go tool cover -html=coverage.txt
+
+  fmt:
+    desc: gofmt and goimports all go files
+    cmds:
+      - gofumpt -w -l -s .
+
+  ci:
+    desc: Run all the tests and code checks
+    deps: [build test]
+
+  imgs:
+    desc: Download and resize images
+    cmds:
+      - wget -O www/docs/static/logo.png https://github.com/goreleaser/artwork/raw/master/goreleaserfundo.png
+      - wget -O www/docs/static/card.png "https://og.caarlos0.dev/**GoReleaser**%20%7C%20Deliver%20Go%20binaries%20as%20fast%20and%20easily%20as%20possible.png?theme=light&md=1&fontSize=80px&images=https://github.com/goreleaser.png"
+      - wget -O www/docs/static/avatar.png https://github.com/goreleaser.png
+      - convert www/docs/static/avatar.png -define icon:auto-resize=64,48,32,16 docs/static/favicon.ico
+      - convert www/docs/static/avatar.png -resize x120 www/docs/static/apple-touch-icon.png
+
+  docs:serve:
+    desc: Start documentation server
+    cmds:
+      - '{{.DOCKER}} run --rm -it -p 8000:8000 -v ${PWD}/www:/docs docker.io/squidfunk/mkdocs-material'
+
+  docs:build:
+    desc: Build documentation
+    cmds:
+      - yum install -y jq
+      - pip install mkdocs-material mkdocs-minify-plugin lunr
+      - ./scripts/get-releases.sh
+      - (cd www && mkdocs build)
+
+  todo:
+    desc: Show to-do items per file
+    silent: true
+    cmds:
+      - grep --exclude-dir=vendor --exclude-dir=node_modules --exclude=Makefile --text --color -nRo -E ' TODO:.*|SkipNow' .


### PR DESCRIPTION
As discussed in private, this PR is a proposal to replace the Makefile with Task: https://taskfile.dev/

- Added a `Taskfile.yml`
- Changed CI to use it instead of Make
- Updated CONTRIBUTING documentation

I didn't delete the Makefile yet because some contributors may be used to it. It's your choice to delete it some day or not.

```bash
$ task --list
task: Available tasks for this project:
* build: 	Build the binary
* ci: 		Run all the tests and code checks
* cover: 	Run all the tests and opens the coverage report
* dev: 		Setup pre-commit
* docs:build: 	Build documentation
* docs:serve: 	Start documentation server
* fmt: 		gofmt and goimports all go files
* imgs: 	Download and resize images
* setup: 	Install dependencies
* test: 	Run tests
* todo: 	Show to-do items per file
```