### PR TITLE
chore(ci): cache go-build results on github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,14 +58,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       -
-        name: Cache Go modules
-        uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      -
         name: Setup Sigstore
         uses: sigstore/cosign-installer@v1.2.0
       -

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,16 @@ jobs:
         with:
           go-version: '1.17'
       -
+        name: Cache Go mod and build
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      -
         name: Cache Go modules
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
according to [this](https://github.com/mvdan/github-actions-golang), this seems like a good idea to speed up tests/builds a bit

wdyt?