### PR TITLE
fix: taskfile: rewerite task order of ci and add default taks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -52,10 +52,15 @@ tasks:
 
   ci:
     desc: Run all CI steps
-    deps:
-    - setup
-    - build
-    - test
+    cmds:
+      - task: setup
+      - task: build
+      - task: test
+
+  default:
+    desc: Runs the default tasks
+    cmds:
+      - task: ci
 
   docs:imgs:
     desc: Download and resize images


### PR DESCRIPTION
Signed-off-by: Engin Diri <engin.diri@mail.schwarz>

Hi,

i love `task` and I am happy to see #2557 is used in goreleaser.

This PR just changes the debs of the CI task because of:

```
Dependencies run in parallel, so dependencies of a task shouldn’t depend one another. If you want to force tasks to run serially take a look at the Calling Another Task section below.
```
https://taskfile.dev/#/usage?id=task-dependencies

and introduced the default task. So i can just call `task`

Hope its okay for you 😄 