### PR TITLE
feat: Allow release notes to be used in template strings

### DIFF
--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -46,6 +46,7 @@ const (
 	date            = "Date"
 	timestamp       = "Timestamp"
 	modulePath      = "ModulePath"
+	releaseNotes    = "ReleaseNotes"
 
 	// artifact-only keys.
 	osKey        = "Os"
@@ -90,6 +91,7 @@ func New(ctx *context.Context) *Template {
 			patch:           ctx.Semver.Patch,
 			prerelease:      ctx.Semver.Prerelease,
 			isSnapshot:      ctx.Snapshot,
+			releaseNotes:    ctx.ReleaseNotes,
 		},
 	}
 }

--- a/internal/tmpl/tmpl_test.go
+++ b/internal/tmpl/tmpl_test.go
@@ -32,6 +32,7 @@ func TestWithArtifact(t *testing.T) {
 	ctx.Git.Commit = "commit"
 	ctx.Git.FullCommit = "fullcommit"
 	ctx.Git.ShortCommit = "shortcommit"
+	ctx.ReleaseNotes = "test release notes"
 	for expect, tmpl := range map[string]string{
 		"bar":                              "{{.Env.FOO}}",
 		"Linux":                            "{{.Os}}",
@@ -54,6 +55,7 @@ func TestWithArtifact(t *testing.T) {
 		"1.3.0":                            "{{.Version | incminor }}",
 		"v1.2.4":                           "{{.Tag | incpatch }}",
 		"1.2.4":                            "{{.Version | incpatch }}",
+		"test release notes":               "{{ .ReleaseNotes }}",
 	} {
 		tmpl := tmpl
 		expect := expect

--- a/www/docs/customization/templates.md
+++ b/www/docs/customization/templates.md
@@ -28,6 +28,7 @@ On fields that support templating, these fields are always available:
 | `.Patch`            | the patch part of the version (assuming `Tag` is a valid semver, else `0`)                             |
 | `.Prerelease`       | the prerelease part of the version, e.g. `beta` (assuming `Tag` is a valid semver)                     |
 | `.RawVersion`       | Major.Minor.Patch (assuming `Tag` is a valid semver, else `0.0.0`)                                     |
+| `.ReleaseNotes`     | the generated release notes, available after the changelog step has been executed                      |
 | `.IsSnapshot`       | `true` if `--snapshot` is set, `false` otherwise                                                       |
 | `.IsNightly`        | `true` if `--nightly` is set, `false` otherwise                                                        |
 | `.Env`              | a map with system's environment variables                                                              |


### PR DESCRIPTION
This change allows you to use `{{ .ReleaseNotes }}` in any template string, after the changelog pipeline step has been executed.

Reason for this change: When using the announce feature, you might want to inform your users about the features and changes that this release brings. 