### PR TITLE
fix(archive): add extra fields to the archives

### DIFF
--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -92,13 +92,14 @@ func (t Type) String() string {
 }
 
 const (
-	ExtraID        = "ID"
-	ExtraBinary    = "Binary"
-	ExtraExt       = "Ext"
-	ExtraBuilds    = "Builds"
-	ExtraFormat    = "Format"
-	ExtraWrappedIn = "WrappedIn"
-	ExtraBinaries  = "Binaries"
+	ExtraID            = "ID"
+	ExtraBinary        = "Binary"
+	ExtraExt           = "Ext"
+	ExtraBuilds        = "Builds"
+	ExtraFormat        = "Format"
+	ExtraWrappedIn     = "WrappedIn"
+	ExtraBinaries      = "Binaries"
+	ExtraBinariesClean = "BinariesClean"
 )
 
 // Artifact represents an artifact and its relevant info.

--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -193,11 +193,12 @@ func create(ctx *context.Context, arch config.Archive, binaries []*artifact.Arti
 		Goarm:  binaries[0].Goarm,
 		Gomips: binaries[0].Gomips,
 		Extra: map[string]interface{}{
-			artifact.ExtraBuilds:    binaries,
-			artifact.ExtraID:        arch.ID,
-			artifact.ExtraFormat:    arch.Format,
-			artifact.ExtraWrappedIn: wrap,
-			artifact.ExtraBinaries:  bins,
+			artifact.ExtraBuilds:        binaries,
+			artifact.ExtraID:            arch.ID,
+			artifact.ExtraFormat:        arch.Format,
+			artifact.ExtraWrappedIn:     wrap,
+			artifact.ExtraBinaries:      bins,
+			artifact.ExtraBinariesClean: bins,
 		},
 	})
 	return nil
@@ -223,8 +224,7 @@ func skip(ctx *context.Context, archive config.Archive, binaries []*artifact.Art
 			return err
 		}
 		finalName := name + binary.ExtraOr(artifact.ExtraExt, "").(string)
-		log.
-			WithField("binary", binary.Name).
+		log.WithField("binary", binary.Name).
 			WithField("name", finalName).
 			Info("skip archiving")
 		ctx.Artifacts.Add(&artifact.Artifact{
@@ -236,10 +236,11 @@ func skip(ctx *context.Context, archive config.Archive, binaries []*artifact.Art
 			Goarm:  binary.Goarm,
 			Gomips: binary.Gomips,
 			Extra: map[string]interface{}{
-				artifact.ExtraBuilds:   []*artifact.Artifact{binary},
-				artifact.ExtraID:       archive.ID,
-				artifact.ExtraFormat:   archive.Format,
-				artifact.ExtraBinaries: []string{binary.Name},
+				artifact.ExtraBuilds:        []*artifact.Artifact{binary},
+				artifact.ExtraID:            archive.ID,
+				artifact.ExtraFormat:        archive.Format,
+				artifact.ExtraBinariesClean: []string{binary.Name},
+				artifact.ExtraBinaries:      []string{finalName},
 			},
 		})
 	}

--- a/internal/pipe/archive/archive_test.go
+++ b/internal/pipe/archive/archive_test.go
@@ -157,8 +157,13 @@ func TestRunPipe(t *testing.T) {
 			require.NoError(t, Pipe{}.Run(ctx))
 			archives := ctx.Artifacts.Filter(artifact.ByType(artifact.UploadableArchive)).List()
 			for _, arch := range archives {
+				expectBin := "bin/mybin"
+				if arch.Goos == "windows" {
+					expectBin += ".exe"
+				}
 				require.Equal(t, "myid", arch.ID(), "all archives must have the archive ID set")
 				require.Equal(t, []string{expectBin}, arch.ExtraOr(artifact.ExtraBinaries, []string{}).([]string))
+				require.Equal(t, []string{expectBin}, arch.ExtraOr(artifact.ExtraBinariesClean, []string{}).([]string))
 			}
 			require.Len(t, archives, 6)
 			// TODO: should verify the artifact fields here too
@@ -395,11 +400,14 @@ func TestRunPipeBinary(t *testing.T) {
 	)).List()[0]
 	windows := binaries.Filter(artifact.ByGoos("windows")).List()[0]
 	require.Equal(t, "mybin_0.0.1_darwin_amd64", darwinThin.Name)
-	require.Equal(t, darwinThin.ExtraOr("Binaries", []string{}), []string{"mybin_0.0.1_darwin_amd64"})
+	require.Equal(t, []string{"mybin_0.0.1_darwin_amd64"}, darwinThin.ExtraOr(artifact.ExtraBinaries, []string{}))
+	require.Equal(t, []string{"mybin"}, darwinThin.ExtraOr(artifact.ExtraBinariesClean, []string{}))
 	require.Equal(t, "myunibin_0.0.1_darwin_all", darwinUniversal.Name)
-	require.Equal(t, darwinUniversal.ExtraOr("Binaries", []string{}), []string{"myunibin_0.0.1_darwin_all"})
+	require.Equal(t, []string{"myunibin_0.0.1_darwin_all"}, darwinUniversal.ExtraOr(artifact.ExtraBinaries, []string{}))
+	require.Equal(t, []string{"myunibin"}, darwinUniversal.ExtraOr(artifact.ExtraBinariesClean, []string{}))
 	require.Equal(t, "mybin_0.0.1_windows_amd64.exe", windows.Name)
-	require.Equal(t, windows.ExtraOr("Binaries", []string{}), []string{"mybin_0.0.1_windows_amd64.exe"})
+	require.Equal(t, []string{"mybin_0.0.1_windows_amd64.exe"}, windows.ExtraOr(artifact.ExtraBinaries, []string{}))
+	require.Equal(t, []string{"mybin.exe"}, windows.ExtraOr(artifact.ExtraBinariesClean, []string{}))
 }
 
 func TestRunPipeDistRemoved(t *testing.T) {


### PR DESCRIPTION
we use the `Binaries` extra field in the gofish and brew pipes, and now, with #2576 and #2577, we need the binary to be the full name when format is `binary`.

This is the correct behavior, and should have been since the beginning. Wasn't a problem before because `UploadableBinaries` were not used in brew and gofish.

---

**EDIT**: end up adding a new field, `BinariesClean`, which is the "clean" binary name (e.g. `foo.exe`) - meanwhile there is still `Binaries` which is the full name (e.g. `foo_windows_amd64.exe`). This should make it easier to implement #2576 and #2577 better and more correctly (e.g. download `foo_windows_amd64.exe` and install it as `foo.exe`).