### PR TITLE
feat: release only specific build ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ www/docs/static/releases*.json
 completions/
 .vscode/
 .task/
+.idea/

--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -24,7 +24,7 @@ import (
 const brewConfigExtra = "BrewConfig"
 
 // ErrNoArchivesFound happens when 0 archives are found.
-var ErrNoArchivesFound = errors.New("no linux/macos archives found")
+var ErrNoArchivesFound = pipe.Skip("no linux/macos archives found")
 
 // ErrMultipleArchivesSameOS happens when the config yields multiple archives
 // for linux or windows.

--- a/internal/pipe/gofish/gofish.go
+++ b/internal/pipe/gofish/gofish.go
@@ -24,7 +24,7 @@ const goFishConfigExtra = "GoFishConfig"
 
 const foodFolder = "Food"
 
-var ErrNoArchivesFound = errors.New("no linux/macos/windows archives found")
+var ErrNoArchivesFound = pipe.Skip("no linux/macos/windows archives found")
 
 var ErrMultipleArchivesSameOS = errors.New("one rig can handle only archive of an OS/Arch combination. Consider using ids in the gofish section")
 

--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -4,7 +4,6 @@ package scoop
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -21,7 +20,7 @@ import (
 )
 
 // ErrNoWindows when there is no build for windows (goos doesn't contain windows).
-var ErrNoWindows = errors.New("scoop requires a windows build")
+var ErrNoWindows = pipe.Skip("scoop requires a windows build")
 
 const scoopConfigExtra = "ScoopConfig"
 


### PR DESCRIPTION
In order to allow releasing specific builds I added a new argument to release called 'only-build'. This argument allows one to select which build ids to build by using a regular expression. This is handy when you only want to release a specific build or test a specific build without having to wait for everything else to build as well.

Let me know what you think. If this seems like a feasible feature I will add some tests.