### PR TITLE
feat: improve build hooks to make it easier to create BOMs

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,6 +32,12 @@ builds:
     - -trimpath
   ldflags:
     - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{ .CommitDate }} -X main.builtBy=goreleaser
+  hooks:
+    post:
+      - cmd: "cyclonedx-gomod app -licenses -json -output {{.Env.artifact}}.bom.json"
+        custom_artifact:
+          path: "{{.Env.artifact}}.bom.json"
+          name: goreleaser.bom.json
 
 universal_binaries:
 - replace: true

--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -56,6 +56,8 @@ const (
 	GoFishRig
 	// ScoopManifest is an uploadable scoop manifest file.
 	ScoopManifest
+	// Custom file.
+	Custom
 )
 
 func (t Type) String() string {
@@ -86,6 +88,8 @@ func (t Type) String() string {
 		return "GoFish Rig"
 	case ScoopManifest:
 		return "Scoop Manifest"
+	case Custom:
+		return "Custom file"
 	default:
 		return "unknown"
 	}

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -28,6 +28,7 @@ func For(name string) Builder {
 
 // Options to be passed down to a builder.
 type Options struct {
+	ID     string
 	Name   string
 	Path   string
 	Ext    string

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -312,10 +312,17 @@ func (bhc BuildHooks) JSONSchemaType() *jsonschema.Type {
 	}
 }
 
+type CustomArtifact struct {
+	Path string `yaml:"path,omitempty"`
+	Name string `yaml:"name,omitempty"`
+}
+
 type BuildHook struct {
 	Dir string   `yaml:"dir,omitempty"`
 	Cmd string   `yaml:"cmd,omitempty"`
 	Env []string `yaml:"env,omitempty"`
+
+	CustomArtifact CustomArtifact `yaml:"custom_artifact,omitempty"`
 }
 
 // UnmarshalYAML is a custom unmarshaler that allows simplified declarations of commands as strings.


### PR DESCRIPTION
**THIS IS JUST A PoC FOR NOW**

refs #2617 #2597

the idea consists of:

- having an `artifact` env in the hooks
- allowing to add "custom artifacts" on hooks
- with that, one can easily wire things like `cyclonedx-gomod` to the pipeline
- the archive will have the related bom within it
  - not sure what should happen when using universal binaries as well
  - right now, the archive will not have any BOM in it
- this is also passing GOOS/GOARCH/etc to the hook commands
- this is not by any means a "final implementation" (or anything near that), just want to collect feedback on the API,  concerns, etc...