### PR TITLE
feat(source): add prefix_template option

### DIFF
--- a/internal/pipe/sourcearchive/source.go
+++ b/internal/pipe/sourcearchive/source.go
@@ -31,7 +31,19 @@ func (Pipe) Run(ctx *context.Context) (err error) {
 	filename := name + "." + ctx.Config.Source.Format
 	path := filepath.Join(ctx.Config.Dist, filename)
 	log.WithField("file", filename).Info("creating source archive")
-	out, err := git.Clean(git.Run("archive", "-o", path, ctx.Git.FullCommit))
+	args := []string{
+		"archive",
+		"-o", path,
+	}
+	if ctx.Config.Source.PrefixTemplate != "" {
+		prefix, err := tmpl.New(ctx).Apply(ctx.Config.Source.PrefixTemplate)
+		if err != nil {
+			return err
+		}
+		args = append(args, "--prefix", prefix)
+	}
+	args = append(args, ctx.Git.FullCommit)
+	out, err := git.Clean(git.Run(args...))
 	log.Debug(out)
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Type: artifact.UploadableSourceArchive,

--- a/internal/pipe/sourcearchive/source_test.go
+++ b/internal/pipe/sourcearchive/source_test.go
@@ -28,8 +28,9 @@ func TestArchive(t *testing.T) {
 				ProjectName: "foo",
 				Dist:        "dist",
 				Source: config.Source{
-					Format:  format,
-					Enabled: true,
+					Format:         format,
+					Enabled:        true,
+					PrefixTemplate: "{{ .ProjectName }}-{{ .Version }}/",
 				},
 			})
 			ctx.Git.FullCommit = "HEAD"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -756,9 +756,10 @@ type Publisher struct {
 
 // Source configuration.
 type Source struct {
-	NameTemplate string `yaml:"name_template,omitempty"`
-	Format       string `yaml:"format,omitempty"`
-	Enabled      bool   `yaml:"enabled,omitempty"`
+	NameTemplate   string `yaml:"name_template,omitempty"`
+	Format         string `yaml:"format,omitempty"`
+	Enabled        bool   `yaml:"enabled,omitempty"`
+	PrefixTemplate string `yaml:"prefix_template,omitempty"`
 }
 
 // Project includes all project configuration.

--- a/www/docs/customization/source.md
+++ b/www/docs/customization/source.md
@@ -18,6 +18,11 @@ source:
   # Any format git-archive supports, this supports too.
   # Defaults to `tar.gz`
   format: 'tar'
+
+  # Prefix template.
+  # String to prepend to each filename in the archive.
+  # Defaults to empty
+  prefix_template: '{{ .ProjectName }}-{{ .Version }}/'
 ```
 
 !!! tip


### PR DESCRIPTION
If applied, this change will add a `prefix_template` option to the source archive pipe. This allows the generated tarball to use a subdirectory for all files in the archive, as described in [`git-archive`](https://git-scm.com/docs/git-archive).

Currently, archives generated by the source archive step do not use a prefix, whereas traditionally the prefix of `{{ .ProjectName }}-{{ .Version }}/` is used. See https://github.com/twpayne/chezmoi/issues/1576.

The default prefix is none, to maintain compatibility for existing users.
