### PR TITLE
docs: Add Ministry of Justice UK to list of users

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -7,6 +7,7 @@ Currently, the following organizations are using GoReleaser:
 
 1. [Charm](https://charm.sh)
 1. [Hugo](https://gohugo.io/)
+1. [Ministry of Justice (UK)](https://mojdigital.blog.gov.uk/)
 1. [Numary](https://numary.com)
 1. [Schwarz IT](https://jobs.schwarz/)
 1. [TOTVS Labs](https://totvslabs.com)


### PR DESCRIPTION
Overview
---

This PR will add Ministry of Justice in the UK to the list of proud users of this tool. Using goreleaser dramatically  improves release time/velocity of our developers, which in turn improves the experience of the British public using digital justice tools and services.

Keep up the great work!   