### PR TITLE
feat: add message template support for git providers

### DIFF
--- a/internal/pipe/mattermost/mattermost.go
+++ b/internal/pipe/mattermost/mattermost.go
@@ -18,7 +18,7 @@ import (
 const (
 	defaultColor           = "#2D313E"
 	defaultUsername        = `GoReleaser`
-	defaultMessageTemplate = `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ trimsuffix .GitURL ".git" }}/releases/tag/{{ .Tag }}`
+	defaultMessageTemplate = `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}`
 	defaultMessageTitle    = `{{ .ProjectName }} {{ .Tag }} is out!`
 )
 
@@ -35,6 +35,7 @@ func (Pipe) Default(ctx *context.Context) error {
 	if ctx.Config.Announce.Mattermost.MessageTemplate == "" {
 		ctx.Config.Announce.Mattermost.MessageTemplate = defaultMessageTemplate
 	}
+
 	if ctx.Config.Announce.Mattermost.TitleTemplate == "" {
 		ctx.Config.Announce.Mattermost.TitleTemplate = defaultMessageTitle
 	}

--- a/internal/pipe/mattermost/mattermost_test.go
+++ b/internal/pipe/mattermost/mattermost_test.go
@@ -89,6 +89,7 @@ func TestPostWebhook(t *testing.T) {
 	})
 
 	ctx.Git.CurrentTag = "v1.0.0"
+	ctx.Git.ReleaseURL = "https://github.com/honk/honk/releases/tag/v1.0.0"
 	ctx.Git.URL = "https://github.com/honk/honk"
 
 	os.Setenv("MATTERMOST_WEBHOOK", ts.URL)

--- a/internal/pipe/reddit/reddit.go
+++ b/internal/pipe/reddit/reddit.go
@@ -11,9 +11,8 @@ import (
 )
 
 const (
-	defaultTitleTemplate     = `{{ .ProjectName }} {{ .Tag }} is out!`
-	defaultGitHubURLTemplate = `{{ trimsuffix .GitURL ".git" }}/releases/tag/{{ .Tag }}`
-	defaultGitLabURLTemplate = `{{ trimsuffix .GitURL ".git" }}/-/releases/{{ .Tag }}`
+	defaultTitleTemplate = `{{ .ProjectName }} {{ .Tag }} is out!`
+	defaultURLTemplate   = `{{ .ReleaseURL }}`
 )
 
 type Pipe struct{}
@@ -31,15 +30,8 @@ func (Pipe) Default(ctx *context.Context) error {
 		ctx.Config.Announce.Reddit.TitleTemplate = defaultTitleTemplate
 	}
 
-	switch ctx.TokenType {
-	case context.TokenTypeGitHub:
-		ctx.Config.Announce.Reddit.URLTemplate = defaultGitHubURLTemplate
-	case context.TokenTypeGitLab:
-		ctx.Config.Announce.Reddit.URLTemplate = defaultGitLabURLTemplate
-	case context.TokenTypeGitea:
-		ctx.Config.Announce.Reddit.URLTemplate = defaultGitHubURLTemplate
-	default:
-		return fmt.Errorf("invalid client token type: %q", ctx.TokenType)
+	if ctx.Config.Announce.Reddit.URLTemplate == "" {
+ 		ctx.Config.Announce.Reddit.URLTemplate = defaultURLTemplate
 	}
 
 	return nil

--- a/internal/pipe/reddit/reddit.go
+++ b/internal/pipe/reddit/reddit.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	defaultTitleTemplate = `{{ .ProjectName }} {{ .Tag }} is out!`
-	defaultURLTemplate   = `{{ trimsuffix .GitURL ".git" }}/releases/tag/{{ .Tag }}`
+	defaultTitleTemplate     = `{{ .ProjectName }} {{ .Tag }} is out!`
+	defaultGitHubURLTemplate = `{{ trimsuffix .GitURL ".git" }}/releases/tag/{{ .Tag }}`
+	defaultGitLabURLTemplate = `{{ trimsuffix .GitURL ".git" }}/-/releases/{{ .Tag }}`
 )
 
 type Pipe struct{}
@@ -30,8 +31,15 @@ func (Pipe) Default(ctx *context.Context) error {
 		ctx.Config.Announce.Reddit.TitleTemplate = defaultTitleTemplate
 	}
 
-	if ctx.Config.Announce.Reddit.URLTemplate == "" {
-		ctx.Config.Announce.Reddit.URLTemplate = defaultURLTemplate
+	switch ctx.TokenType {
+	case context.TokenTypeGitHub:
+		ctx.Config.Announce.Reddit.URLTemplate = defaultGitHubURLTemplate
+	case context.TokenTypeGitLab:
+		ctx.Config.Announce.Reddit.URLTemplate = defaultGitLabURLTemplate
+	case context.TokenTypeGitea:
+		ctx.Config.Announce.Reddit.URLTemplate = defaultGitHubURLTemplate
+	default:
+		return fmt.Errorf("invalid client token type: %q", ctx.TokenType)
 	}
 
 	return nil

--- a/internal/pipe/reddit/reddit_test.go
+++ b/internal/pipe/reddit/reddit_test.go
@@ -14,6 +14,7 @@ func TestStringer(t *testing.T) {
 
 func TestDefault(t *testing.T) {
 	ctx := context.New(config.Project{})
+	ctx.TokenType = context.TokenTypeGitHub
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, ctx.Config.Announce.Reddit.TitleTemplate, defaultTitleTemplate)
 }

--- a/internal/pipe/reddit/reddit_test.go
+++ b/internal/pipe/reddit/reddit_test.go
@@ -14,7 +14,6 @@ func TestStringer(t *testing.T) {
 
 func TestDefault(t *testing.T) {
 	ctx := context.New(config.Project{})
-	ctx.TokenType = context.TokenTypeGitHub
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, ctx.Config.Announce.Reddit.TitleTemplate, defaultTitleTemplate)
 }

--- a/internal/pipe/slack/slack.go
+++ b/internal/pipe/slack/slack.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	defaultUsername        = `GoReleaser`
-	defaultMessageTemplate = `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ trimsuffix .GitURL ".git" }}/releases/tag/{{ .Tag }}`
+	defaultMessageTemplate = `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}`
 )
 
 type Pipe struct{}

--- a/internal/pipe/smtp/smtp.go
+++ b/internal/pipe/smtp/smtp.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	defaultSubjectTemplate = `{{ .ProjectName }} {{ .Tag }} is out!`
-	defaultBodyTemplate    = `You can view details from: {{ trimsuffix .GitURL ".git" }}/releases/tag/{{ .Tag }}`
+	defaultBodyTemplate    = `You can view details from: {{ .ReleaseURL }}`
 )
 
 type Pipe struct{}
@@ -29,12 +29,12 @@ type Config struct {
 }
 
 func (Pipe) Default(ctx *context.Context) error {
-	if ctx.Config.Announce.SMTP.SubjectTemplate == "" {
-		ctx.Config.Announce.SMTP.SubjectTemplate = defaultSubjectTemplate
-	}
-
 	if ctx.Config.Announce.SMTP.BodyTemplate == "" {
 		ctx.Config.Announce.SMTP.BodyTemplate = defaultBodyTemplate
+	}
+
+	if ctx.Config.Announce.SMTP.SubjectTemplate == "" {
+		ctx.Config.Announce.SMTP.SubjectTemplate = defaultSubjectTemplate
 	}
 
 	return nil

--- a/internal/pipe/teams/teams.go
+++ b/internal/pipe/teams/teams.go
@@ -13,7 +13,7 @@ import (
 const (
 	defaultColor           = "#2D313E"
 	defaultIcon            = "https://goreleaser.com/static/avatar.png"
-	defaultMessageTemplate = `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ trimsuffix .GitURL ".git" }}/releases/tag/{{ .Tag }}`
+	defaultMessageTemplate = `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}`
 	defaultMessageTitle    = `{{ .ProjectName }} {{ .Tag }} is out!`
 )
 

--- a/internal/pipe/telegram/telegram.go
+++ b/internal/pipe/telegram/telegram.go
@@ -10,9 +10,7 @@ import (
 	"github.com/goreleaser/goreleaser/pkg/context"
 )
 
-const (
-	defaultMessageTemplate = `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}`
-)
+const defaultMessageTemplate = `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}`
 
 type Pipe struct{}
 

--- a/internal/pipe/telegram/telegram.go
+++ b/internal/pipe/telegram/telegram.go
@@ -10,7 +10,9 @@ import (
 	"github.com/goreleaser/goreleaser/pkg/context"
 )
 
-const defaultMessageTemplate = `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ trimsuffix .GitURL ".git" }}/releases/tag/{{ .Tag }}`
+const (
+	defaultMessageTemplate = `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}`
+)
 
 type Pipe struct{}
 

--- a/internal/pipe/twitter/twitter.go
+++ b/internal/pipe/twitter/twitter.go
@@ -11,7 +11,9 @@ import (
 	"github.com/goreleaser/goreleaser/pkg/context"
 )
 
-const defaultMessageTemplate = `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ trimsuffix .GitURL ".git" }}/releases/tag/{{ .Tag }}`
+const (
+	defaultMessageTemplate = `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}`
+)
 
 type Pipe struct{}
 

--- a/internal/pipe/twitter/twitter.go
+++ b/internal/pipe/twitter/twitter.go
@@ -11,9 +11,7 @@ import (
 	"github.com/goreleaser/goreleaser/pkg/context"
 )
 
-const (
-	defaultMessageTemplate = `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}`
-)
+const defaultMessageTemplate = `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}`
 
 type Pipe struct{}
 

--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/pkg/build"
 	"github.com/goreleaser/goreleaser/pkg/context"
@@ -37,6 +38,7 @@ const (
 	commitDate      = "CommitDate"
 	commitTimestamp = "CommitTimestamp"
 	gitURL          = "GitURL"
+	releaseURL      = "ReleaseURL"
 	major           = "Major"
 	minor           = "Minor"
 	patch           = "Patch"
@@ -83,6 +85,7 @@ func New(ctx *context.Context) *Template {
 			commitDate:      ctx.Git.CommitDate.UTC().Format(time.RFC3339),
 			commitTimestamp: ctx.Git.CommitDate.UTC().Unix(),
 			gitURL:          ctx.Git.URL,
+			releaseURL:      ctx.Git.ReleaseURL,
 			env:             ctx.Env,
 			date:            ctx.Date.UTC().Format(time.RFC3339),
 			timestamp:       ctx.Date.UTC().Unix(),

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -25,6 +25,7 @@ type GitInfo struct {
 	FullCommit  string
 	CommitDate  time.Time
 	URL         string
+	ReleaseURL  string
 }
 
 // Env is the environment variables.


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>
Co-authored-by: Furkan Türkal <furkan.turkal@trendyol.com>
Co-authored-by: Erkan Zileli <erkan.zileli@trendyol.com>

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

Fixes #2625 

<!-- Why is this change being made? -->

to support message templating while announcing for supported git providers such as GitHub, GitLab, Gitea

