### PR TITLE
chore: add iron security ref

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -7,6 +7,7 @@ Currently, the following organizations are using GoReleaser:
 
 1. [Charm](https://charm.sh)
 1. [Hugo](https://gohugo.io/)
+1. [IRON Security](https://iron.security)
 1. [Ministry of Justice (UK)](https://mojdigital.blog.gov.uk/)
 1. [Numary](https://numary.com)
 1. [Schwarz IT](https://jobs.schwarz/)


### PR DESCRIPTION
This adds a reference for [IRON](https://github.com/iron-security) which uses goreleaser for their Go projects.