### PR TITLE
feat: add sbom generation pipe (after signing)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ www/docs/static/releases*.json
 completions/
 .vscode/
 .task/
+.idea/

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -22,23 +22,24 @@ type releaseCmd struct {
 }
 
 type releaseOpts struct {
-	config            string
-	releaseNotesFile  string
-	releaseNotesTmpl  string
-	releaseHeaderFile string
-	releaseHeaderTmpl string
-	releaseFooterFile string
-	releaseFooterTmpl string
-	autoSnapshot      bool
-	snapshot          bool
-	skipPublish       bool
-	skipSign          bool
-	skipValidate      bool
-	skipAnnounce      bool
-	rmDist            bool
-	deprecated        bool
-	parallelism       int
-	timeout           time.Duration
+	config             string
+	releaseNotesFile   string
+	releaseNotesTmpl   string
+	releaseHeaderFile  string
+	releaseHeaderTmpl  string
+	releaseFooterFile  string
+	releaseFooterTmpl  string
+	autoSnapshot       bool
+	snapshot           bool
+	skipPublish        bool
+	skipSign           bool
+	skipValidate       bool
+	skipAnnounce       bool
+	skipSBOMCataloging bool
+	rmDist             bool
+	deprecated         bool
+	parallelism        int
+	timeout            time.Duration
 }
 
 func newReleaseCmd() *releaseCmd {
@@ -82,6 +83,7 @@ func newReleaseCmd() *releaseCmd {
 	cmd.Flags().BoolVar(&root.opts.skipPublish, "skip-publish", false, "Skips publishing artifacts")
 	cmd.Flags().BoolVar(&root.opts.skipAnnounce, "skip-announce", false, "Skips announcing releases (implies --skip-validate)")
 	cmd.Flags().BoolVar(&root.opts.skipSign, "skip-sign", false, "Skips signing artifacts")
+	cmd.Flags().BoolVar(&root.opts.skipSBOMCataloging, "skip-sbom", false, "Skips cataloging artifacts")
 	cmd.Flags().BoolVar(&root.opts.skipValidate, "skip-validate", false, "Skips git checks")
 	cmd.Flags().BoolVar(&root.opts.rmDist, "rm-dist", false, "Removes the dist folder")
 	cmd.Flags().IntVarP(&root.opts.parallelism, "parallelism", "p", 0, "Amount tasks to run concurrently (default: number of CPUs)")
@@ -139,6 +141,7 @@ func setupReleaseContext(ctx *context.Context, options releaseOpts) *context.Con
 	ctx.SkipAnnounce = ctx.Snapshot || options.skipPublish || options.skipAnnounce
 	ctx.SkipValidate = ctx.Snapshot || options.skipValidate
 	ctx.SkipSign = options.skipSign
+	ctx.SkipSBOMCataloging = options.skipSBOMCataloging
 	ctx.RmDist = options.rmDist
 
 	// test only

--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -42,6 +42,8 @@ const (
 	PublishableDockerImage
 	// DockerImage is a published Docker image.
 	DockerImage
+	// UnpublishableDockerImage is an unpublishable Docker image (output from docker build, but will not be pushed).
+	UnpublishableDockerImage
 	// DockerManifest is a published Docker manifest.
 	DockerManifest
 	// Checksum is a checksums file.
@@ -56,6 +58,8 @@ const (
 	GoFishRig
 	// ScoopManifest is an uploadable scoop manifest file.
 	ScoopManifest
+	// SBOM is a Software Bill of Materials file.
+	SBOM
 )
 
 func (t Type) String() string {

--- a/internal/pipe/pipe.go
+++ b/internal/pipe/pipe.go
@@ -25,6 +25,9 @@ var ErrSkipSignEnabled = Skip("artifact signing is disabled")
 // It means that the part of a Piper that validates some things was not run.
 var ErrSkipValidateEnabled = Skip("validation is disabled")
 
+// ErrSkipSBOMEnabled happens if --skip-sbom is set.
+var ErrSkipSBOMEnabled = Skip("artifact cataloging is disabled")
+
 // IsSkip returns true if the error is an ErrSkip.
 func IsSkip(err error) bool {
 	return errors.As(err, &ErrSkip{})

--- a/internal/pipe/sbom/sbom.go
+++ b/internal/pipe/sbom/sbom.go
@@ -1,0 +1,231 @@
+package sbom
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/apex/log"
+	"github.com/goreleaser/goreleaser/internal/artifact"
+	"github.com/goreleaser/goreleaser/internal/gio"
+	"github.com/goreleaser/goreleaser/internal/ids"
+	"github.com/goreleaser/goreleaser/internal/logext"
+	"github.com/goreleaser/goreleaser/internal/semerrgroup"
+	"github.com/goreleaser/goreleaser/internal/tmpl"
+	"github.com/goreleaser/goreleaser/pkg/config"
+	"github.com/goreleaser/goreleaser/pkg/context"
+)
+
+// Pipe that catalogs common artifacts as an SBOM.
+type Pipe struct{}
+
+func (Pipe) String() string                 { return "cataloging artifacts" }
+func (Pipe) Skip(ctx *context.Context) bool { return len(ctx.Config.SBOMs) == 0 }
+
+// Default sets the Pipes defaults.
+func (Pipe) Default(ctx *context.Context) error {
+	ids := ids.New("sboms")
+	for i := range ctx.Config.SBOMs {
+		cfg := &ctx.Config.SBOMs[i]
+		if cfg.Cmd == "" {
+			cfg.Cmd = "syft"
+			//return errors.New("cataloging artifacts failed: no command specified")
+		}
+		if len(cfg.SBOMs) == 0 {
+			var sbom string
+			switch cfg.Artifacts {
+			case "container":
+				sbom = `{{ replace .ArtifactName "/" "-" }}.sbom`
+			case "binary":
+				sbom = "{{ .ArtifactName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}.sbom"
+			default:
+				sbom = "{{ .ArtifactName }}.sbom"
+			}
+			cfg.SBOMs = []string{sbom}
+		}
+		if len(cfg.Args) == 0 {
+			cfg.Args = []string{"--file", "{{ .Dist }}/$sbom0", "--output", "spdx-json", "$artifact"}
+		}
+		if cfg.Artifacts == "" {
+			cfg.Artifacts = "none"
+		}
+		if cfg.ID == "" {
+			cfg.ID = "default"
+		}
+		ids.Inc(cfg.ID)
+	}
+	return ids.Validate()
+}
+
+// Run executes the Pipe.
+func (Pipe) Run(ctx *context.Context) error {
+	g := semerrgroup.New(ctx.Parallelism)
+	for _, cfg := range ctx.Config.SBOMs {
+		g.Go(catalogTask(ctx, cfg))
+	}
+	return g.Wait()
+}
+
+func catalogTask(ctx *context.Context, cfg config.SBOM) func() error {
+	return func() error {
+		var filters []artifact.Filter
+		switch cfg.Artifacts {
+		case "all":
+			filters = append(filters, artifact.Or(
+				artifact.ByType(artifact.UploadableArchive),
+				artifact.ByType(artifact.Binary),
+				artifact.ByType(artifact.UploadableSourceArchive),
+				artifact.ByType(artifact.Checksum),
+				artifact.ByType(artifact.LinuxPackage),
+				artifact.ByType(artifact.PublishableDockerImage),
+				artifact.ByType(artifact.UnpublishableDockerImage),
+			))
+		case "source":
+			filters = append(filters, artifact.ByType(artifact.UploadableSourceArchive))
+			if len(cfg.IDs) > 0 {
+				log.Warn("when artifacts is `source`, `ids` has no effect. ignoring")
+			}
+		case "archive":
+			filters = append(filters, artifact.ByType(artifact.UploadableArchive))
+		case "binary":
+			filters = append(filters, artifact.ByType(artifact.Binary))
+		case "package":
+			filters = append(filters, artifact.ByType(artifact.LinuxPackage))
+		case "container":
+			filters = append(filters, artifact.Or(
+				artifact.ByType(artifact.PublishableDockerImage),
+				artifact.ByType(artifact.UnpublishableDockerImage),
+			))
+		case "none":
+			newArtifacts, err := catalogArtifact(ctx, cfg, nil)
+			if err != nil {
+				return err
+			}
+			for _, newArtifact := range newArtifacts {
+				ctx.Artifacts.Add(newArtifact)
+			}
+			return nil
+		default:
+			return fmt.Errorf("invalid list of artifacts to catalog: %s", cfg.Artifacts)
+		}
+
+		if len(cfg.IDs) > 0 {
+			filters = append(filters, artifact.ByIDs(cfg.IDs...))
+		}
+		artifacts := ctx.Artifacts.Filter(artifact.And(filters...)).List()
+		return catalog(ctx, cfg, artifacts)
+	}
+}
+
+func catalog(ctx *context.Context, cfg config.SBOM, artifacts []*artifact.Artifact) error {
+	for _, a := range artifacts {
+		newArtifacts, err := catalogArtifact(ctx, cfg, a)
+		if err != nil {
+			return err
+		}
+		for _, newArtifact := range newArtifacts {
+			ctx.Artifacts.Add(newArtifact)
+		}
+	}
+	return nil
+}
+
+func catalogArtifact(ctx *context.Context, cfg config.SBOM, a *artifact.Artifact) ([]*artifact.Artifact, error) {
+	env := ctx.Env.Copy()
+	var fields log.Fields
+	templater := tmpl.New(ctx).WithEnv(env)
+	if a != nil {
+		env["artifact"] = a.Path
+		env["artifactID"] = a.ID()
+
+		templater = templater.WithArtifact(a, nil)
+
+		var names []string
+		for idx, sbom := range cfg.SBOMs {
+			name, err := templater.Apply(expand(sbom, env))
+			if err != nil {
+				return nil, fmt.Errorf("cataloging artifacts failed: %s: invalid template: %w", a, err)
+			}
+
+			env[fmt.Sprintf("sbom%d", idx)] = name
+			names = append(names, name)
+		}
+
+		fields = log.Fields{"cmd": cfg.Cmd, "artifact": a.Path, "sboms": strings.Join(names, ", ")}
+	} else {
+		fields = log.Fields{"cmd": cfg.Cmd, "artifact": "(manual)", "sboms": strings.Join(cfg.SBOMs, ", ")}
+	}
+
+	// nolint:prealloc
+	var args []string
+	for _, arg := range cfg.Args {
+		arg, err := templater.Apply(expand(arg, env))
+		if err != nil {
+			return nil, fmt.Errorf("cataloging artifacts failed: %s: invalid template: %w", arg, err)
+		}
+		args = append(args, arg)
+	}
+
+	// The GoASTScanner flags this as a security risk.
+	// However, this works as intended. The nosec annotation
+	// tells the scanner to ignore this.
+	// #nosec
+	cmd := exec.CommandContext(ctx, cfg.Cmd, args...)
+	var b bytes.Buffer
+	w := gio.Safe(&b)
+	cmd.Stderr = io.MultiWriter(logext.NewWriter(fields, logext.Error), w)
+	cmd.Stdout = io.MultiWriter(logext.NewWriter(fields, logext.Info), w)
+
+	log.WithFields(fields).Info("cataloging")
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("cataloging artifacts: %s failed: %w: %s", cfg.Cmd, err, b.String())
+	}
+
+	if len(cfg.SBOMs) == 0 {
+		return nil, nil
+	}
+
+	var artifacts []*artifact.Artifact
+
+	for _, sbom := range cfg.SBOMs {
+		templater = tmpl.New(ctx).WithEnv(env)
+		if a != nil {
+			env["artifact"] = a.Name
+			templater = templater.WithArtifact(a, nil)
+		}
+
+		name, err := templater.Apply(expand(sbom, env))
+		if err != nil {
+			return nil, fmt.Errorf("cataloging artifacts failed: %s: invalid template: %w", a, err)
+		}
+
+		search := filepath.Join(ctx.Config.Dist, name)
+		matches, err := filepath.Glob(search)
+		if err != nil {
+			return nil, fmt.Errorf("cataloging artifacts: failed to find SBOM artifact %q: %w", search, err)
+		}
+		for _, match := range matches {
+			artifacts = append(artifacts, &artifact.Artifact{
+				Type: artifact.SBOM,
+				Name: name,
+				Path: match,
+				Extra: map[string]interface{}{
+					artifact.ExtraID: cfg.ID,
+				},
+			})
+		}
+
+	}
+
+	return artifacts, nil
+}
+
+func expand(s string, env map[string]string) string {
+	return os.Expand(s, func(key string) string {
+		return env[key]
+	})
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -4,6 +4,8 @@ package pipeline
 import (
 	"fmt"
 
+	"github.com/goreleaser/goreleaser/internal/pipe/sbom"
+
 	"github.com/goreleaser/goreleaser/internal/pipe/announce"
 	"github.com/goreleaser/goreleaser/internal/pipe/archive"
 	"github.com/goreleaser/goreleaser/internal/pipe/before"
@@ -71,6 +73,7 @@ var Pipeline = append(
 	checksums.Pipe{},     // checksums of the files
 	sign.Pipe{},          // sign artifacts
 	docker.Pipe{},        // create and push docker images
+	sbom.Pipe{},          // create SBOMs of artifacts
 	publish.Pipe{},       // publishes artifacts
 	announce.Pipe{},      // announce releases
 )

--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -27,6 +27,7 @@ type Fields map[string]interface{}
 const (
 	// general keys.
 	projectName     = "ProjectName"
+	dist            = "Dist"
 	version         = "Version"
 	rawVersion      = "RawVersion"
 	tag             = "Tag"
@@ -72,6 +73,7 @@ func New(ctx *context.Context) *Template {
 	return &Template{
 		fields: Fields{
 			projectName:     ctx.Config.ProjectName,
+			dist:            ctx.Config.Dist,
 			modulePath:      ctx.ModulePath,
 			version:         ctx.Version,
 			rawVersion:      rawVersionV,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -587,6 +587,16 @@ type NFPMOverridables struct {
 	APK              NFPMAPK           `yaml:"apk,omitempty"`
 }
 
+// SBOM config.
+type SBOM struct {
+	ID        string   `yaml:"id,omitempty"`
+	Cmd       string   `yaml:"cmd,omitempty"`
+	Args      []string `yaml:"args,omitempty"`
+	SBOMs     []string `yaml:"sboms,omitempty"`
+	Artifacts string   `yaml:"artifacts,omitempty"`
+	IDs       []string `yaml:"ids,omitempty"`
+}
+
 // Sign config.
 type Sign struct {
 	ID        string   `yaml:"id,omitempty"`
@@ -792,6 +802,7 @@ type Project struct {
 	Source          Source           `yaml:"source,omitempty"`
 	GoMod           GoMod            `yaml:"gomod,omitempty"`
 	Announce        Announce         `yaml:"announce,omitempty"`
+	SBOMs           []SBOM           `yaml:"sboms,omitempty"`
 
 	UniversalBinaries []UniversalBinary `yaml:"universal_binaries,omitempty"`
 

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -87,6 +87,7 @@ type Context struct {
 	SkipAnnounce       bool
 	SkipSign           bool
 	SkipValidate       bool
+	SkipSBOMCataloging bool
 	RmDist             bool
 	PreRelease         bool
 	Deprecated         bool

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -5,6 +5,8 @@ package defaults
 import (
 	"fmt"
 
+	"github.com/goreleaser/goreleaser/internal/pipe/sbom"
+
 	"github.com/goreleaser/goreleaser/internal/pipe/archive"
 	"github.com/goreleaser/goreleaser/internal/pipe/artifactory"
 	"github.com/goreleaser/goreleaser/internal/pipe/blob"
@@ -60,6 +62,7 @@ var Defaulters = []Defaulter{
 	checksums.Pipe{},
 	sign.Pipe{},
 	sign.DockerPipe{},
+	sbom.Pipe{},
 	docker.Pipe{},
 	docker.ManifestPipe{},
 	artifactory.Pipe{},


### PR DESCRIPTION
**This is a PoC only not intended for merging**

This is a follow up from https://github.com/goreleaser/goreleaser/issues/2597#issuecomment-957842629 .

This is also an alternative to https://github.com/goreleaser/goreleaser/pull/2648 , where the SBOM generation process takes place after artifact signing. This is to allow for cataloging of container artifacts:

```
  -
    id: container-sbom
    artifacts: container
    ids:
      - primary-image
```

The downside to this approach is that SBOMs cannot be captured in the `checksum` and `signs` sections directly.

This additionally required changing the `docker.Pipe` object to always output an artifact even if publishing is being skipped. 