### PR TITLE
feat: CHANGELOG categories

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -713,10 +713,18 @@ type Filters struct {
 
 // Changelog Config.
 type Changelog struct {
-	Filters Filters `yaml:"filters,omitempty"`
-	Sort    string  `yaml:"sort,omitempty"`
-	Skip    bool    `yaml:"skip,omitempty"` // TODO(caarlos0): rename to Disable to match other pipes
-	Use     string  `yaml:"use,omitempty"`
+	Filters Filters          `yaml:"filters,omitempty"`
+	Sort    string           `yaml:"sort,omitempty"`
+	Skip    bool             `yaml:"skip,omitempty"` // TODO(caarlos0): rename to Disable to match other pipes
+	Use     string           `yaml:"use,omitempty"`
+	Groups  []ChangeLogGroup `yaml:"groups,omitempty"`
+}
+
+// ChangeLogGroup holds the grouping criteria for the changelog.
+type ChangeLogGroup struct {
+	Title  string `yaml:"title,omitempty"`
+	Regexp string `yaml:"regexp,omitempty"`
+	Order  int    `yaml:"order,omitempty"`
 }
 
 // EnvFiles holds paths to files that contains environment variables

--- a/www/docs/customization/changelog.md
+++ b/www/docs/customization/changelog.md
@@ -25,6 +25,20 @@ changelog:
   # Default is empty
   sort: asc
 
+  # Group commits messages by given regex and title.
+  # Order value defines the order of the groups.
+  # Proving no regex means all commits will be grouped under the default group.
+  # Default is no groups.
+  groups:
+    - title: Features
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 0
+    - title: 'Bug fixes'
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 1
+    - title: Others
+      order: 999
+
   filters:
     # Commit messages matching the regexp listed here will be removed from
     # the changelog


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->
Fixes #2669 request from @blacktop

The implementation could look like this:

![image](https://user-images.githubusercontent.com/38325136/141848751-409fe318-8794-415b-b737-f98737586a91.png)

The example is in a test repo, with no commits so dont wonder in looks blant. And the `use` is set to `git` so no userids. You can change this if you want. So it looks like this:

![image](https://user-images.githubusercontent.com/38325136/141850020-8e4b04c3-33b7-49c9-8952-8ec11f50a3e6.png)

I tried to follow the [guidance](https://www.conventionalcommits.org/en/v1.0.0/) from @aalmiray and sorted the commits in features, Bug fixes and Others. 

You need to follow the conventional commits rules `<type>[optional scope]: <description>` to end in the right group. `feat:` goes to `Features`, `fix:` goes to `Bug Fixes`, etc.

You can activate the grouping feature via the flag `group: true` in the `changlog` block of the goreleaser config.

Looking for your feedback!

