### PR TITLE
fix: apk add --no-cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ COPY scripts/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 COPY goreleaser_*.apk /tmp/
-RUN apk add --allow-untrusted /tmp/goreleaser_*.apk
+RUN apk add --no-cache --allow-untrusted /tmp/goreleaser_*.apk


### PR DESCRIPTION
prevents apk cache

noticed it while playing with https://contains.dev/goreleaser/goreleaser/latest/layers :D 