### PR TITLE
refactor: use os and io packages instead of io/ioutil

### DIFF
--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -2,7 +2,6 @@ package artifact
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -245,7 +244,7 @@ func TestChecksumFileDoesntExist(t *testing.T) {
 }
 
 func TestInvalidAlgorithm(t *testing.T) {
-	f, err := ioutil.TempFile(t.TempDir(), "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 	artifact := Artifact{

--- a/internal/client/gitea_test.go
+++ b/internal/client/gitea_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -433,7 +432,7 @@ func (s *GiteaUploadSuite) SetupTest() {
 	t := s.T()
 	s.GiteaReleasesTestSuite.SetupTest()
 	s.artifact = &artifact.Artifact{Name: "ArtifactName"}
-	file, err := ioutil.TempFile(t.TempDir(), "gitea_test_tempfile")
+	file, err := os.CreateTemp(t.TempDir(), "gitea_test_tempfile")
 	require.NoError(t, err)
 	require.NotNil(t, file)
 	t.Cleanup(func() {

--- a/internal/gio/copy_test.go
+++ b/internal/gio/copy_test.go
@@ -1,7 +1,6 @@
 package gio
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -73,7 +72,7 @@ func TestCopyErrors(t *testing.T) {
 
 func TestCopyFile(t *testing.T) {
 	dir := t.TempDir()
-	src, err := ioutil.TempFile(dir, "src")
+	src, err := os.CreateTemp(dir, "src")
 	require.NoError(t, err)
 	require.NoError(t, src.Close())
 	dst := filepath.Join(dir, "dst")

--- a/internal/pipe/archive/archive_test.go
+++ b/internal/pipe/archive/archive_test.go
@@ -6,7 +6,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -861,13 +860,13 @@ func TestRunPipeSameArchiveFilename(t *testing.T) {
 func TestDuplicateFilesInsideArchive(t *testing.T) {
 	folder := t.TempDir()
 
-	f, err := ioutil.TempFile(folder, "")
+	f, err := os.CreateTemp(folder, "")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, f.Close())
 	})
 
-	ff, err := ioutil.TempFile(folder, "")
+	ff, err := os.CreateTemp(folder, "")
 	require.NoError(t, err)
 	require.NoError(t, ff.Close())
 
@@ -1046,7 +1045,7 @@ func TestFindFiles(t *testing.T) {
 func TestArchive_globbing(t *testing.T) {
 	assertGlob := func(t *testing.T, files []config.File, expected []string) {
 		t.Helper()
-		bin, err := ioutil.TempFile(t.TempDir(), "binary")
+		bin, err := os.CreateTemp(t.TempDir(), "binary")
 		require.NoError(t, err)
 		dist := t.TempDir()
 		ctx := context.New(config.Project{

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -2,7 +2,6 @@ package brew
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -637,7 +636,7 @@ func TestRunPipeMultipleArchivesSameOsBuild(t *testing.T) {
 	)
 
 	ctx.TokenType = context.TokenTypeGitHub
-	f, err := ioutil.TempFile(t.TempDir(), "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, f.Close())

--- a/internal/pipe/checksums/checksums_test.go
+++ b/internal/pipe/checksums/checksums_test.go
@@ -1,7 +1,6 @@
 package checksums
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -123,7 +122,7 @@ func TestPipeFileNotExist(t *testing.T) {
 }
 
 func TestPipeInvalidNameTemplate(t *testing.T) {
-	binFile, err := ioutil.TempFile(t.TempDir(), "goreleasertest-bin")
+	binFile, err := os.CreateTemp(t.TempDir(), "goreleasertest-bin")
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, binFile.Close()) })
 	_, err = binFile.WriteString("fake artifact")
@@ -160,7 +159,7 @@ func TestPipeInvalidNameTemplate(t *testing.T) {
 
 func TestPipeCouldNotOpenChecksumsTxt(t *testing.T) {
 	folder := t.TempDir()
-	binFile, err := ioutil.TempFile(folder, "goreleasertest-bin")
+	binFile, err := os.CreateTemp(folder, "goreleasertest-bin")
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, binFile.Close()) })
 	_, err = binFile.WriteString("fake artifact")

--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -2,7 +2,6 @@ package docker
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -126,7 +125,7 @@ func (Pipe) Run(ctx *context.Context) error {
 }
 
 func process(ctx *context.Context, docker config.Docker, artifacts []*artifact.Artifact) error {
-	tmp, err := ioutil.TempDir(ctx.Config.Dist, "goreleaserdocker")
+	tmp, err := os.MkdirTemp(ctx.Config.Dist, "goreleaserdocker")
 	if err != nil {
 		return fmt.Errorf("failed to create temporary dir: %w", err)
 	}

--- a/internal/pipe/env/env_test.go
+++ b/internal/pipe/env/env_test.go
@@ -2,7 +2,6 @@ package env
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -154,7 +153,7 @@ func TestEmptyGiteaFileEnv(t *testing.T) {
 
 func TestEmptyGithubEnvFile(t *testing.T) {
 	require.NoError(t, os.Unsetenv("GITHUB_TOKEN"))
-	f, err := ioutil.TempFile(t.TempDir(), "token")
+	f, err := os.CreateTemp(t.TempDir(), "token")
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 	require.NoError(t, os.Chmod(f.Name(), 0o377))
@@ -170,7 +169,7 @@ func TestEmptyGithubEnvFile(t *testing.T) {
 
 func TestEmptyGitlabEnvFile(t *testing.T) {
 	require.NoError(t, os.Unsetenv("GITLAB_TOKEN"))
-	f, err := ioutil.TempFile(t.TempDir(), "token")
+	f, err := os.CreateTemp(t.TempDir(), "token")
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 	require.NoError(t, os.Chmod(f.Name(), 0o377))
@@ -186,7 +185,7 @@ func TestEmptyGitlabEnvFile(t *testing.T) {
 
 func TestEmptyGiteaEnvFile(t *testing.T) {
 	require.NoError(t, os.Unsetenv("GITEA_TOKEN"))
-	f, err := ioutil.TempFile(t.TempDir(), "token")
+	f, err := os.CreateTemp(t.TempDir(), "token")
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 	require.NoError(t, os.Chmod(f.Name(), 0o377))
@@ -232,7 +231,7 @@ func TestLoadEnv(t *testing.T) {
 	t.Run("env file exists", func(t *testing.T) {
 		env := "SUPER_SECRET_ENV_NOPE"
 		require.NoError(t, os.Unsetenv(env))
-		f, err := ioutil.TempFile(t.TempDir(), "token")
+		f, err := os.CreateTemp(t.TempDir(), "token")
 		require.NoError(t, err)
 		fmt.Fprintf(f, "123")
 		require.NoError(t, f.Close())
@@ -243,7 +242,7 @@ func TestLoadEnv(t *testing.T) {
 	t.Run("env file with an empty line at the end", func(t *testing.T) {
 		env := "SUPER_SECRET_ENV_NOPE"
 		require.NoError(t, os.Unsetenv(env))
-		f, err := ioutil.TempFile(t.TempDir(), "token")
+		f, err := os.CreateTemp(t.TempDir(), "token")
 		require.NoError(t, err)
 		fmt.Fprintf(f, "123\n")
 		require.NoError(t, f.Close())
@@ -254,7 +253,7 @@ func TestLoadEnv(t *testing.T) {
 	t.Run("env file is not readable", func(t *testing.T) {
 		env := "SUPER_SECRET_ENV_NOPE"
 		require.NoError(t, os.Unsetenv(env))
-		f, err := ioutil.TempFile(t.TempDir(), "token")
+		f, err := os.CreateTemp(t.TempDir(), "token")
 		require.NoError(t, err)
 		fmt.Fprintf(f, "123")
 		require.NoError(t, f.Close())

--- a/internal/pipe/mattermost/mattermost.go
+++ b/internal/pipe/mattermost/mattermost.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/apex/log"
@@ -112,7 +111,7 @@ func postWebhook(ctx *context.Context, url string, msg *incomingWebhookRequest) 
 
 func closeBody(r *http.Response) {
 	if r.Body != nil {
-		_, _ = io.Copy(ioutil.Discard, r.Body)
+		_, _ = io.Copy(io.Discard, r.Body)
 		_ = r.Body.Close()
 	}
 }

--- a/internal/pipe/mattermost/mattermost_test.go
+++ b/internal/pipe/mattermost/mattermost_test.go
@@ -2,7 +2,7 @@ package mattermost
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -66,7 +66,7 @@ func TestPostWebhook(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rc := &incomingWebhookRequest{}
 
-		body, _ := ioutil.ReadAll(r.Body)
+		body, _ := io.ReadAll(r.Body)
 		err := json.Unmarshal(body, rc)
 		require.NoError(t, err)
 		require.Equal(t, defaultColor, rc.Attachments[0].Color)

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -1,7 +1,6 @@
 package nfpm
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1055,7 +1054,7 @@ func TestMeta(t *testing.T) {
 }
 
 func TestSkipSign(t *testing.T) {
-	folder, err := ioutil.TempDir("", "archivetest")
+	folder, err := os.MkdirTemp("", "archivetest")
 	require.NoError(t, err)
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -46,7 +46,7 @@ func TestLoadBadReader(t *testing.T) {
 }
 
 func TestFile(t *testing.T) {
-	f, err := ioutil.TempFile(t.TempDir(), "config")
+	f, err := os.CreateTemp(t.TempDir(), "config")
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 	_, err = Load(filepath.Join(f.Name()))


### PR DESCRIPTION
`io/ioutil` is deprecated so i replaced it according to https://golang.org/doc/go1.16#ioutil