### PR TITLE
fix: ensure certificate is always within dist

### DIFF
--- a/internal/pipe/sign/sign.go
+++ b/internal/pipe/sign/sign.go
@@ -191,14 +191,8 @@ func signone(ctx *context.Context, cfg config.Sign, art *artifact.Artifact) ([]*
 
 	// re-execute template results, using artifact name as artifact so they eval to the actual needed file name.
 	env["artifact"] = art.Name
-	name, err = tmpl.New(ctx).WithEnv(env).Apply(expand(cfg.Signature, env))
-	if err != nil {
-		return nil, fmt.Errorf("sign failed: %s: invalid template: %w", art.Name, err)
-	}
-	cert, err = tmpl.New(ctx).WithEnv(env).Apply(expand(cfg.Certificate, env))
-	if err != nil {
-		return nil, fmt.Errorf("sign failed: %s: invalid template: %w", art.Name, err)
-	}
+	name, _ = tmpl.New(ctx).WithEnv(env).Apply(expand(cfg.Signature, env))   // could never error as it passed the previous check
+	cert, _ = tmpl.New(ctx).WithEnv(env).Apply(expand(cfg.Certificate, env)) // could never error as it passed the previous check
 
 	result := []*artifact.Artifact{
 		{

--- a/internal/pipe/sign/sign.go
+++ b/internal/pipe/sign/sign.go
@@ -137,6 +137,9 @@ func signone(ctx *context.Context, cfg config.Sign, art *artifact.Artifact) ([]*
 	if err != nil {
 		return nil, fmt.Errorf("sign failed: %s: %w", art.Name, err)
 	}
+	if cert != "" && filepath.Dir(cert) == "." {
+		cert = filepath.Join(ctx.Config.Dist, cert)
+	}
 	env["certificate"] = cert
 
 	// nolint:prealloc
@@ -210,10 +213,11 @@ func signone(ctx *context.Context, cfg config.Sign, art *artifact.Artifact) ([]*
 	}
 
 	if cert != "" {
+		certFilename := filepath.Base(cert)
 		result = append(result, &artifact.Artifact{
 			Type: artifact.Certificate,
-			Name: cert,
-			Path: filepath.Join(artifactPathBase, cert),
+			Name: certFilename,
+			Path: cert,
 			Extra: map[string]interface{}{
 				artifact.ExtraID: cfg.ID,
 			},

--- a/internal/pipe/sign/sign_test.go
+++ b/internal/pipe/sign/sign_test.go
@@ -522,7 +522,7 @@ func TestSignArtifacts(t *testing.T) {
 				config.Project{
 					Signs: []config.Sign{
 						{
-							Certificate: "${artifactName}.pem",
+							Certificate: "${artifact}.pem",
 							Artifacts:   "checksum",
 						},
 					},
@@ -669,6 +669,7 @@ func testSign(tb testing.TB, ctx *context.Context, certificateNames, signaturePa
 	certNames := []string{}
 	for _, cert := range certificates {
 		certNames = append(certNames, cert.Name)
+		require.True(tb, strings.HasPrefix(cert.Path, ctx.Config.Dist))
 	}
 	sort.Strings(certificateNames)
 	sort.Strings(certNames)

--- a/internal/pipe/sign/sign_test.go
+++ b/internal/pipe/sign/sign_test.go
@@ -539,7 +539,7 @@ func TestSignArtifacts(t *testing.T) {
 					Signs: []config.Sign{
 						{
 							Env:         []string{"NOT_HONK=honk", "HONK={{ .Env.NOT_HONK }}"},
-							Certificate: `{{ trimsuffix (trimsuffix .Env.artifactName ".tar.gz") ".deb" }}_${HONK}.pem`,
+							Certificate: `{{ trimsuffix (trimsuffix .Env.artifact ".tar.gz") ".deb" }}_${HONK}.pem`,
 							Artifacts:   "all",
 						},
 					},

--- a/www/docs/customization/docker_sign.md
+++ b/www/docs/customization/docker_sign.md
@@ -19,12 +19,6 @@ docker_signs:
     # Defaults to "default".
     id: foo
 
-    # Name/template of the signature file.
-    # Note that with cosign you don't need to use this.
-    #
-    # Defaults to empty.
-    signature: "${artifact}_sig"
-
     # Path to the signature command
     #
     # Defaults to `cosign`
@@ -61,14 +55,6 @@ docker_signs:
     # Defaults to empty
     stdin_file: ./.password
 
-    # Sets a certificate name that your signing command should write to.
-    # You can later use `${certificate}` or `.Env.certificate` in the `args` section.
-    # This is particularly useful for keyless signing (for instance, with cosign).
-    # Note that this should be a name, not a path.
-    #
-    # Defaults to empty.
-    certificate: '{{ trimsuffix .Env.artifactName ".tar.gz" }}.pem'
-
     # List of environment variables that will be passed to the signing command as well as the templates.
     #
     # Defaults to empty
@@ -84,7 +70,6 @@ These environment variables might be available in the fields that are templateab
 - `${artifact}`: the path to the artifact that will be signed [^1]
 - `${artifactID}`: the ID of the artifact that will be signed
 - `${certificate}`: the certificate filename, if provided
-- `${artifactName}`: the name of the artifact [^1]
 
 [^1]: notice that the this might contain `/` characters, which depending on how you use it migth evaluate to actual paths within the filesystem. Use with care.
 

--- a/www/docs/customization/sign.md
+++ b/www/docs/customization/sign.md
@@ -107,9 +107,6 @@ These environment variables might be available in the fields that are templateab
 - `${artifactID}`: the ID of the artifact that will be signed
 - `${certificate}`: the certificate filename, if provided
 - `${signature}`: the signature filename
-- `${artifactName}`: the name of the artifact [^1]
-
-[^1]: notice that the name won't have the `dist` prefix, so if you are using it to build filepaths, be sure to prefix them properly. Prefer using `${artifact}` instead.
 
 ## Signing with cosign
 


### PR DESCRIPTION
Previously, `artifactName` would give you a path in the root of the repository, and `artifact` would lead to double-dist (`dist/dist/foo.pem`).

This PR ensures that filename and path are always correct.

This also removes from docs some sections that are not useful and/or should not be used.

refs  #2662