### PR TITLE
feat: allow to use .PreviousTag on templates

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,6 +48,7 @@ changelog:
     - '^test:'
     - '^chore'
     - Merge pull request
+    - Merge remote-tracking branch
     - Merge branch
     - go mod tidy
   groups:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,7 +60,6 @@ changelog:
     - title: Other work
       order: 999
 
-
 dockers:
 - image_templates:
   - 'goreleaser/goreleaser:{{ .Tag }}-amd64'
@@ -226,6 +225,8 @@ release:
   extra_files:
     - glob: ./cosign.pub
   footer: |
+    **Full Changelog**: https://github.com/goreleaser/goreleaser/{{ .PreviousTag }}...{{ .Tag }}
+
     ## What to do next?
 
     - Check out the [GoReleaser Pro](https://goreleaser.com/pro) distribution;

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -78,6 +78,7 @@ func TestChangelog(t *testing.T) {
 			},
 		},
 	})
+	ctx.Git.PreviousTag = "v0.0.1"
 	ctx.Git.CurrentTag = "v0.0.2"
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Contains(t, ctx.ReleaseNotes, "## Changelog")
@@ -92,32 +93,6 @@ func TestChangelog(t *testing.T) {
 	bts, err := os.ReadFile(filepath.Join(folder, "CHANGELOG.md"))
 	require.NoError(t, err)
 	require.NotEmpty(t, string(bts))
-}
-
-func TestChangelogPreviousTagEnv(t *testing.T) {
-	folder := testlib.Mktmp(t)
-	testlib.GitInit(t)
-	testlib.GitCommit(t, "first")
-	testlib.GitTag(t, "v0.0.1")
-	testlib.GitCommit(t, "second")
-	testlib.GitTag(t, "v0.0.2")
-	testlib.GitCommit(t, "third")
-	testlib.GitTag(t, "v0.0.3")
-	ctx := context.New(config.Project{
-		Dist: folder,
-		Changelog: config.Changelog{
-			Use:     "git",
-			Filters: config.Filters{},
-		},
-	})
-	ctx.Git.CurrentTag = "v0.0.3"
-	require.NoError(t, os.Setenv("GORELEASER_PREVIOUS_TAG", "v0.0.1"))
-	require.NoError(t, Pipe{}.Run(ctx))
-	require.NoError(t, os.Setenv("GORELEASER_PREVIOUS_TAG", ""))
-	require.Contains(t, ctx.ReleaseNotes, "## Changelog")
-	require.NotContains(t, ctx.ReleaseNotes, "first")
-	require.Contains(t, ctx.ReleaseNotes, "second")
-	require.Contains(t, ctx.ReleaseNotes, "third")
 }
 
 func TestChangelogForGitlab(t *testing.T) {
@@ -149,6 +124,7 @@ func TestChangelogForGitlab(t *testing.T) {
 	})
 	ctx.TokenType = context.TokenTypeGitLab
 	ctx.Git.CurrentTag = "v0.0.2"
+	ctx.Git.PreviousTag = "v0.0.1"
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Contains(t, ctx.ReleaseNotes, "## Changelog")
 	require.NotContains(t, ctx.ReleaseNotes, "first")
@@ -176,6 +152,7 @@ func TestChangelogSort(t *testing.T) {
 	ctx := context.New(config.Project{
 		Changelog: config.Changelog{},
 	})
+	ctx.Git.PreviousTag = "v0.9.9"
 	ctx.Git.CurrentTag = "v1.0.0"
 
 	for _, cfg := range []struct {
@@ -245,6 +222,7 @@ func TestChangelogOfFirstRelease(t *testing.T) {
 	testlib.GitTag(t, "v0.0.1")
 	ctx := context.New(config.Project{})
 	ctx.Git.CurrentTag = "v0.0.1"
+	ctx.Git.PreviousTag = "v0.0.1"
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Contains(t, ctx.ReleaseNotes, "## Changelog")
 	for _, msg := range msgs {

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -123,8 +123,8 @@ func TestChangelogForGitlab(t *testing.T) {
 		},
 	})
 	ctx.TokenType = context.TokenTypeGitLab
-	ctx.Git.CurrentTag = "v0.0.2"
 	ctx.Git.PreviousTag = "v0.0.1"
+	ctx.Git.CurrentTag = "v0.0.2"
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Contains(t, ctx.ReleaseNotes, "## Changelog")
 	require.NotContains(t, ctx.ReleaseNotes, "first")
@@ -222,7 +222,6 @@ func TestChangelogOfFirstRelease(t *testing.T) {
 	testlib.GitTag(t, "v0.0.1")
 	ctx := context.New(config.Project{})
 	ctx.Git.CurrentTag = "v0.0.1"
-	ctx.Git.PreviousTag = "v0.0.1"
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Contains(t, ctx.ReleaseNotes, "## Changelog")
 	for _, msg := range msgs {
@@ -246,6 +245,7 @@ func TestChangelogFilterInvalidRegex(t *testing.T) {
 			},
 		},
 	})
+	ctx.Git.PreviousTag = "v0.0.3"
 	ctx.Git.CurrentTag = "v0.0.4"
 	require.EqualError(t, Pipe{}.Run(ctx), "error parsing regexp: invalid or unsupported Perl syntax: `(?ia`")
 }

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -289,7 +289,7 @@ func TestNoPreviousTag(t *testing.T) {
 	}
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Equal(t, "v0.0.1", ctx.Git.CurrentTag)
-	require.NotEmpty(t, ctx.Git.PreviousTag, "should be a commit sha256")
+	require.Empty(t, ctx.Git.PreviousTag, "should be empty")
 }
 
 func TestPreviousTagFromCI(t *testing.T) {
@@ -343,6 +343,6 @@ func TestCommitDate(t *testing.T) {
 	}
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Equal(t, "v0.0.1", ctx.Git.CurrentTag)
-	require.NotEmpty(t, ctx.Git.PreviousTag)
+	require.Empty(t, ctx.Git.PreviousTag)
 	require.True(t, commitDate.Equal(ctx.Git.CommitDate), "commit date does not match expected")
 }

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -201,6 +201,7 @@ func TestSnapshotNoTags(t *testing.T) {
 	ctx.Snapshot = true
 	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
 	require.Equal(t, fakeInfo.CurrentTag, ctx.Git.CurrentTag)
+	require.Empty(t, ctx.Git.PreviousTag)
 }
 
 func TestSnapshotNoCommits(t *testing.T) {
@@ -277,6 +278,57 @@ func TestTagFromCI(t *testing.T) {
 	}
 }
 
+func TestNoPreviousTag(t *testing.T) {
+	testlib.Mktmp(t)
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
+	testlib.GitCommit(t, "commit1")
+	testlib.GitTag(t, "v0.0.1")
+	ctx := &context.Context{
+		Config: config.Project{},
+	}
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, "v0.0.1", ctx.Git.CurrentTag)
+	require.NotEmpty(t, ctx.Git.PreviousTag, "should be a commit sha256")
+}
+
+func TestPreviousTagFromCI(t *testing.T) {
+	testlib.Mktmp(t)
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
+	testlib.GitCommit(t, "commit1")
+	testlib.GitTag(t, "v0.0.1")
+	testlib.GitCommit(t, "commit2")
+	testlib.GitTag(t, "v0.0.2")
+
+	for _, tc := range []struct {
+		envs     map[string]string
+		expected string
+	}{
+		{expected: "v0.0.1"},
+		{
+			envs:     map[string]string{"GORELEASER_PREVIOUS_TAG": "v0.0.2"},
+			expected: "v0.0.2",
+		},
+	} {
+		t.Run(tc.expected, func(t *testing.T) {
+			for name, value := range tc.envs {
+				require.NoError(t, os.Setenv(name, value))
+			}
+
+			ctx := &context.Context{
+				Config: config.Project{},
+			}
+			require.NoError(t, Pipe{}.Run(ctx))
+			require.Equal(t, tc.expected, ctx.Git.PreviousTag)
+
+			for name := range tc.envs {
+				require.NoError(t, os.Setenv(name, ""))
+			}
+		})
+	}
+}
+
 func TestCommitDate(t *testing.T) {
 	// round to seconds since this is expressed in a Unix timestamp
 	commitDate := time.Now().AddDate(-1, 0, 0).Round(1 * time.Second)
@@ -291,5 +343,6 @@ func TestCommitDate(t *testing.T) {
 	}
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Equal(t, "v0.0.1", ctx.Git.CurrentTag)
+	require.NotEmpty(t, ctx.Git.PreviousTag)
 	require.True(t, commitDate.Equal(ctx.Git.CommitDate), "commit date does not match expected")
 }

--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -31,6 +31,7 @@ const (
 	version         = "Version"
 	rawVersion      = "RawVersion"
 	tag             = "Tag"
+	previousTag     = "PreviousTag"
 	branch          = "Branch"
 	commit          = "Commit"
 	shortCommit     = "ShortCommit"
@@ -78,6 +79,7 @@ func New(ctx *context.Context) *Template {
 			version:         ctx.Version,
 			rawVersion:      rawVersionV,
 			tag:             ctx.Git.CurrentTag,
+			previousTag:     ctx.Git.PreviousTag,
 			branch:          ctx.Git.Branch,
 			commit:          ctx.Git.Commit,
 			shortCommit:     ctx.Git.ShortCommit,

--- a/internal/tmpl/tmpl_test.go
+++ b/internal/tmpl/tmpl_test.go
@@ -22,6 +22,7 @@ func TestWithArtifact(t *testing.T) {
 		"FOO": "bar",
 	}
 	ctx.Version = "1.2.3"
+	ctx.Git.PreviousTag = "v1.2.2"
 	ctx.Git.CurrentTag = "v1.2.3"
 	ctx.Semver = context.Semver{
 		Major: 1,
@@ -56,6 +57,7 @@ func TestWithArtifact(t *testing.T) {
 		"v1.2.4":                           "{{.Tag | incpatch }}",
 		"1.2.4":                            "{{.Version | incpatch }}",
 		"test release notes":               "{{ .ReleaseNotes }}",
+		"v1.2.2":                           "{{ .PreviousTag }}",
 	} {
 		tmpl := tmpl
 		expect := expect

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -20,6 +20,7 @@ import (
 type GitInfo struct {
 	Branch      string
 	CurrentTag  string
+	PreviousTag string
 	Commit      string
 	ShortCommit string
 	FullCommit  string

--- a/www/docs/customization/templates.md
+++ b/www/docs/customization/templates.md
@@ -17,6 +17,7 @@ On fields that support templating, these fields are always available:
 | `.Branch`           | the current git branch                                                                                 |
 | `.PrefixedTag`      | the current git tag prefixed with the monorepo config tag prefix (if any)                              |
 | `.Tag`              | the current git tag                                                                                    |
+| `.PreviousTag`      | the previous git tag, or empty if no previous tags                                                     |
 | `.ShortCommit`      | the git commit short hash                                                                              |
 | `.FullCommit`       | the git commit full hash                                                                               |
 | `.Commit`           | the git commit hash (deprecated)                                                                       |


### PR DESCRIPTION
Previous tag will be available as a template field. It will be empty if there are no previous tag (e.g. first ever release of a repo).

Changelog still works by using the first commit on those cases (as it already does today).