### PR TITLE
chore: update strings when using a custom distribution directory

### DIFF
--- a/internal/pipe/dist/dist.go
+++ b/internal/pipe/dist/dist.go
@@ -14,14 +14,14 @@ import (
 type Pipe struct{}
 
 func (Pipe) String() string {
-	return "checking ./dist"
+	return "checking distribution directory"
 }
 
 // Run the pipe.
 func (Pipe) Run(ctx *context.Context) (err error) {
 	_, err = os.Stat(ctx.Config.Dist)
 	if os.IsNotExist(err) {
-		log.Debug("./dist doesn't exist, creating empty folder")
+		log.Debugf("%s doesn't exist, creating empty folder", ctx.Config.Dist)
 		return mkdir(ctx)
 	}
 	if ctx.RmDist {
@@ -37,13 +37,13 @@ func (Pipe) Run(ctx *context.Context) (err error) {
 		return
 	}
 	if len(files) != 0 {
-		log.Debugf("there are %d files on ./dist", len(files))
+		log.Debugf("there are %d files on %s", len(files), ctx.Config.Dist)
 		return fmt.Errorf(
 			"%s is not empty, remove it before running goreleaser or use the --rm-dist flag",
 			ctx.Config.Dist,
 		)
 	}
-	log.Debug("./dist is empty")
+	log.Debugf("%s is empty", ctx.Config.Dist)
 	return mkdir(ctx)
 }
 


### PR DESCRIPTION
When using a custom distribution directory goreleaser outputs the commands/information using the default distribution directory `./dist`

This PR updates the strings to use the custom name if that is set, to avoid any confusion for the user when reading the logs

