### PR TITLE
chore: avoid task error on fmt

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -48,7 +48,7 @@ tasks:
   fmt:
     desc: gofumpt all code
     cmds:
-      - gofumpt -w -l -s .
+      - gofumpt -w -l .
 
   lint:
     desc: Lint the code with golangci-lint


### PR DESCRIPTION
removing the `-s` flag since it's been removed in [`gofumpt v0.2.0`](https://github.com/mvdan/gofumpt/blob/master/CHANGELOG.md#020---2021-11-10)