### PR TITLE
feat: add git summary support (aka git describe --dirty --tags --always)

### DIFF
--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -45,6 +45,7 @@ var fakeInfo = context.GitInfo{
 	Commit:      "none",
 	ShortCommit: "none",
 	FullCommit:  "none",
+	Summary:     "none",
 }
 
 func getInfo(ctx *context.Context) (context.GitInfo, error) {
@@ -83,6 +84,10 @@ func getGitInfo() (context.GitInfo, error) {
 	if err != nil {
 		return context.GitInfo{}, fmt.Errorf("couldn't get commit date: %w", err)
 	}
+	summary, err := getSummary()
+	if err != nil {
+		return context.GitInfo{}, fmt.Errorf("couldn't get summary: %w", err)
+	}
 	gitURL, err := getURL()
 	if err != nil {
 		return context.GitInfo{}, fmt.Errorf("couldn't get remote URL: %w", err)
@@ -107,6 +112,7 @@ func getGitInfo() (context.GitInfo, error) {
 			CommitDate:  date,
 			URL:         gitURL,
 			CurrentTag:  "v0.0.0",
+			Summary:     summary,
 		}, ErrNoTag
 	}
 
@@ -125,6 +131,7 @@ func getGitInfo() (context.GitInfo, error) {
 		ShortCommit: short,
 		CommitDate:  date,
 		URL:         gitURL,
+		Summary:     summary,
 	}, nil
 }
 
@@ -186,6 +193,10 @@ func getShortCommit() (string, error) {
 
 func getFullCommit() (string, error) {
 	return git.Clean(git.Run("show", "--format='%H'", "HEAD", "--quiet"))
+}
+
+func getSummary() (string, error) {
+	return git.Clean(git.Run("describe", "--always", "--dirty", "--tags"))
 }
 
 func getTag() (string, error) {

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -37,6 +37,7 @@ func TestSingleCommit(t *testing.T) {
 	}
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Equal(t, "v0.0.1", ctx.Git.CurrentTag)
+	require.Equal(t, "v0.0.1", ctx.Git.Summary)
 }
 
 func TestBranch(t *testing.T) {
@@ -51,6 +52,7 @@ func TestBranch(t *testing.T) {
 	}
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Equal(t, "test-branch", ctx.Git.Branch)
+	require.Equal(t, "test-branch-tag", ctx.Git.Summary)
 }
 
 func TestNoRemote(t *testing.T) {
@@ -172,9 +174,13 @@ func TestTagIsNotLastCommit(t *testing.T) {
 	testlib.GitCommit(t, "commit3")
 	testlib.GitTag(t, "v0.0.1")
 	testlib.GitCommit(t, "commit4")
-	err := Pipe{}.Run(context.New(config.Project{}))
+	ctx := &context.Context{
+		Config: config.Project{},
+	}
+	err := Pipe{}.Run(ctx)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "git tag v0.0.1 was not made against commit")
+	require.Contains(t, ctx.Git.Summary, "v0.0.1-1-g") // commit not represented because it changes every test
 }
 
 func TestValidState(t *testing.T) {
@@ -233,6 +239,7 @@ func TestSnapshotDirty(t *testing.T) {
 	ctx := context.New(config.Project{})
 	ctx.Snapshot = true
 	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
+	require.Equal(t, "v0.0.1", ctx.Git.Summary)
 }
 
 func TestGitNotInPath(t *testing.T) {

--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -39,6 +39,7 @@ const (
 	commitDate      = "CommitDate"
 	commitTimestamp = "CommitTimestamp"
 	gitURL          = "GitURL"
+	summary         = "Summary"
 	releaseURL      = "ReleaseURL"
 	major           = "Major"
 	minor           = "Minor"
@@ -87,6 +88,7 @@ func New(ctx *context.Context) *Template {
 			commitDate:      ctx.Git.CommitDate.UTC().Format(time.RFC3339),
 			commitTimestamp: ctx.Git.CommitDate.UTC().Unix(),
 			gitURL:          ctx.Git.URL,
+			summary:         ctx.Git.Summary,
 			releaseURL:      ctx.ReleaseURL,
 			env:             ctx.Env,
 			date:            ctx.Date.UTC().Format(time.RFC3339),

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -26,6 +26,7 @@ type GitInfo struct {
 	FullCommit  string
 	CommitDate  time.Time
 	URL         string
+	Summary     string
 }
 
 // Env is the environment variables.

--- a/www/docs/customization/templates.md
+++ b/www/docs/customization/templates.md
@@ -24,6 +24,7 @@ On fields that support templating, these fields are always available:
 | `.CommitDate`       | the UTC commit date in RFC 3339 format                                                                 |
 | `.CommitTimestamp`  | the UTC commit date in Unix format                                                                     |
 | `.GitURL`           | the git remote url                                                                                     |
+| `.Summary`          | the git summary (git describe --dirty --always --tags) Format: `TAG-N-COMMIT` (eg 1.0.0-10-g34f56g3)   |
 | `.Major`            | the major part of the version[^2]                                                                      |
 | `.Minor`            | the minor part of the version[^2]                                                                      |
 | `.Patch`            | the patch part of the version[^2]                                                                      |


### PR DESCRIPTION
If applied, this commit will make `git describe --dirty --tags --always` available under the `context.GitInfo` as `Summary` and ultimately available in template replacements as `.Summary`

This change is being made because the above commands output is very useful as an alternative for build outputs.

This command when run on a tagged commit will return just the tag, when run on any other commit, it will provide `TAG-N-COMMIT` where N is the number of commits since last tag, and commit is the short commit id.

I would be happy to rename this to any other field that makes more sense, I prefer the `TAG-N-COMMIT` vs `TAG-SNAPSHOT-COMMIT` format, this just allows options. With further search and replace, you can change the `-` to `.` or `+`, depending on your semver desires.

## Examples

Simple

```yaml
snapshot:
  name_template: '{{ .Summary }}'
```

Advanced, if you want to replace `-` with `.`

```yaml
snapshot:
  name_template: '{{ replace .Summary "-" "." }}'
```

