### PR TITLE
feat: allow a --output flag on goreleaser build

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"time"
 
@@ -119,7 +120,7 @@ func buildProject(options buildOpts) (*context.Context, error) {
 }
 
 func setupPipeline(ctx *context.Context, options buildOpts) []pipeline.Piper {
-	if options.singleTarget && options.output != "" && (options.id != "" || len(ctx.Config.Builds) == 1) {
+	if options.singleTarget && (options.id != "" || len(ctx.Config.Builds) == 1) {
 		return append(pipeline.BuildPipeline, withOutputPipe{options.output})
 	}
 	return pipeline.BuildPipeline
@@ -205,5 +206,9 @@ func (w withOutputPipe) String() string {
 
 func (w withOutputPipe) Run(ctx *context.Context) error {
 	path := ctx.Artifacts.Filter(artifact.ByType(artifact.Binary)).List()[0].Path
-	return gio.Copy(path, w.output)
+	out := w.output
+	if out == "" {
+		out = filepath.Base(path)
+	}
+	return gio.Copy(path, out)
 }

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -53,14 +53,14 @@ func TestSetupPipeline(t *testing.T) {
 	})
 
 	t.Run("single-target and id", func(t *testing.T) {
-		require.Equal(t, pipeline.BuildPipeline, setupPipeline(context.New(config.Project{}), buildOpts{
+		require.Equal(t, append(pipeline.BuildPipeline, withOutputPipe{""}), setupPipeline(context.New(config.Project{}), buildOpts{
 			singleTarget: true,
 			id:           "foo",
 		}))
 	})
 
 	t.Run("single-target and single build on config", func(t *testing.T) {
-		require.Equal(t, pipeline.BuildPipeline, setupPipeline(context.New(config.Project{
+		require.Equal(t, append(pipeline.BuildPipeline, withOutputPipe{""}), setupPipeline(context.New(config.Project{
 			Builds: []config.Build{{}},
 		}), buildOpts{
 			singleTarget: true,


### PR DESCRIPTION
closes #2685

This would add similar behavior as `go build`, a `-o` flag.

so, when you `goreleaser build --single-target -o foo`, it will save the binary as `foo` (if you have only one build config, otherwise this also needs the `--id` flag).

Hopefully this helps replacing some build tasks on makefiles :) 