### PR TITLE
fix: git url with port

### DIFF
--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -38,10 +38,6 @@ func ExtractRepoFromURL(rawurl string) (config.Repo, error) {
 	// Gitlab-CI uses this type of URL
 	if strings.Count(s, ":") == 1 {
 		s = s[strings.LastIndex(s, ":")+1:]
-	} else {
-		// Handle Gitlab-ci funky URLs in the form of:
-		// "https://gitlab-ci-token:SOME_TOKEN@gitlab.yourcompany.com/yourgroup/yourproject.git"
-		s = "//" + s[strings.LastIndex(s, "@")+1:]
 	}
 
 	// now we can parse it with net/url

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -8,6 +8,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNotARepo(t *testing.T) {
+	testlib.Mktmp(t)
+	_, err := git.ExtractRepoFromConfig()
+	require.EqualError(t, err, `current folder is not a git repository`)
+}
+
+func TestNoRemote(t *testing.T) {
+	testlib.Mktmp(t)
+	testlib.GitInit(t)
+	_, err := git.ExtractRepoFromConfig()
+	require.EqualError(t, err, `no remote configured to list refs from`)
+}
+
 func TestRepoName(t *testing.T) {
 	testlib.Mktmp(t)
 	testlib.GitInit(t)
@@ -37,6 +50,7 @@ func TestExtractRepoFromURL(t *testing.T) {
 		"git@custom:goreleaser/goreleaser.git",
 		"https://foo@github.com/goreleaser/goreleaser",
 		"https://github.com/goreleaser/goreleaser.git",
+		"https://something.with.port:8080/goreleaser/goreleaser.git",
 		"https://github.enterprise.com/goreleaser/goreleaser.git",
 		"https://gitlab-ci-token:SOME_TOKEN@gitlab.yourcompany.com/goreleaser/goreleaser.git",
 	} {


### PR DESCRIPTION
closes #2704

there's a test covering the exact example commented in this else branch, and it still passes after it is removed.

Also added more tests to increase test coverage a bit.