### PR TITLE
docs(quickstart): minimum github_token perms

### DIFF
--- a/www/docs/quick-start.md
+++ b/www/docs/quick-start.md
@@ -44,7 +44,8 @@ In order to release to GitHub, you'll need to export a `GITHUB_TOKEN` environmen
 It will be used to deploy releases to your GitHub repository.
 You can create a new github token [here](https://github.com/settings/tokens/new).
 
-the minimum permissions the `GITHUB_TOKEN` should have to run this are `write:packages`
+!!! info
+    The minimum permissions the `GITHUB_TOKEN` should have to run this are `write:packages`
 
 ```sh
 export GITHUB_TOKEN="YOUR_GH_TOKEN"

--- a/www/docs/quick-start.md
+++ b/www/docs/quick-start.md
@@ -44,6 +44,8 @@ In order to release to GitHub, you'll need to export a `GITHUB_TOKEN` environmen
 It will be used to deploy releases to your GitHub repository.
 You can create a new github token [here](https://github.com/settings/tokens/new).
 
+the minimum permissions the `GITHUB_TOKEN` should have to run this are `write:packages`
+
 ```sh
 export GITHUB_TOKEN="YOUR_GH_TOKEN"
 ```


### PR DESCRIPTION
# Commit Message
after testing, this is what I found

not sure this is the exact way we should write this but it's a start

# If applied, this commit will... 

add additional test to the quickstart docs

# Why is this change being made?

as I am a security minded person, and the goreleaser doesn't state what permissions are required, I thought it would be wise to write in the quickstart docs

