### PR TITLE
feat: get annotated tag message

### DIFF
--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -116,6 +116,11 @@ func getGitInfo() (context.GitInfo, error) {
 		}, ErrNoTag
 	}
 
+	subject, err := getTagSubject(tag)
+	if err != nil {
+		return context.GitInfo{}, fmt.Errorf("couldn't get tag subject: %w", err)
+	}
+
 	previous, err := getPreviousTag(tag)
 	if err != nil {
 		// shouldn't error, will only affect templates
@@ -132,6 +137,7 @@ func getGitInfo() (context.GitInfo, error) {
 		CommitDate:  date,
 		URL:         gitURL,
 		Summary:     summary,
+		Subject:     subject,
 	}, nil
 }
 
@@ -197,6 +203,10 @@ func getFullCommit() (string, error) {
 
 func getSummary() (string, error) {
 	return git.Clean(git.Run("describe", "--always", "--dirty", "--tags"))
+}
+
+func getTagSubject(tag string) (string, error) {
+	return git.Clean(git.Run("tag", "-l", "--format='%(contents:subject)'", tag))
 }
 
 func getTag() (string, error) {

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -37,6 +37,22 @@ func TestSingleCommit(t *testing.T) {
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Equal(t, "v0.0.1", ctx.Git.CurrentTag)
 	require.Equal(t, "v0.0.1", ctx.Git.Summary)
+	require.Equal(t, "commit1", ctx.Git.Subject)
+}
+
+func TestAnnotatedTags(t *testing.T) {
+	testlib.Mktmp(t)
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
+	testlib.GitCommit(t, "commit1")
+	testlib.GitAnnotatedTag(t, "v0.0.1", "first version")
+	ctx := &context.Context{
+		Config: config.Project{},
+	}
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, "v0.0.1", ctx.Git.CurrentTag)
+	require.Equal(t, "first version", ctx.Git.Subject)
+	require.Equal(t, "v0.0.1", ctx.Git.Summary)
 }
 
 func TestBranch(t *testing.T) {

--- a/internal/testlib/git.go
+++ b/internal/testlib/git.go
@@ -50,6 +50,14 @@ func GitTag(tb testing.TB, tag string) {
 	require.Empty(tb, out)
 }
 
+// GitAnnotatedTag creates an annotated tag.
+func GitAnnotatedTag(tb testing.TB, tag, subject string) {
+	tb.Helper()
+	out, err := fakeGit("tag", "-a", tag, "-m", subject)
+	require.NoError(tb, err)
+	require.Empty(tb, out)
+}
+
 // GitBranch creates a git branch.
 func GitBranch(tb testing.TB, branch string) {
 	tb.Helper()

--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/pkg/build"
 	"github.com/goreleaser/goreleaser/pkg/context"
@@ -40,6 +39,7 @@ const (
 	commitTimestamp = "CommitTimestamp"
 	gitURL          = "GitURL"
 	summary         = "Summary"
+	subject         = "Subject"
 	releaseURL      = "ReleaseURL"
 	major           = "Major"
 	minor           = "Minor"
@@ -89,6 +89,7 @@ func New(ctx *context.Context) *Template {
 			commitTimestamp: ctx.Git.CommitDate.UTC().Unix(),
 			gitURL:          ctx.Git.URL,
 			summary:         ctx.Git.Summary,
+			subject:         ctx.Git.Subject,
 			releaseURL:      ctx.ReleaseURL,
 			env:             ctx.Env,
 			date:            ctx.Date.UTC().Format(time.RFC3339),

--- a/internal/tmpl/tmpl_test.go
+++ b/internal/tmpl/tmpl_test.go
@@ -33,6 +33,7 @@ func TestWithArtifact(t *testing.T) {
 	ctx.Git.Commit = "commit"
 	ctx.Git.FullCommit = "fullcommit"
 	ctx.Git.ShortCommit = "shortcommit"
+	ctx.Git.Subject = "awesome release"
 	ctx.ReleaseNotes = "test release notes"
 	for expect, tmpl := range map[string]string{
 		"bar":                              "{{.Env.FOO}}",
@@ -58,6 +59,7 @@ func TestWithArtifact(t *testing.T) {
 		"1.2.4":                            "{{.Version | incpatch }}",
 		"test release notes":               "{{ .ReleaseNotes }}",
 		"v1.2.2":                           "{{ .PreviousTag }}",
+		"awesome release":                  "{{ .Subject }}",
 	} {
 		tmpl := tmpl
 		expect := expect

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -27,6 +27,7 @@ type GitInfo struct {
 	CommitDate  time.Time
 	URL         string
 	Summary     string
+	Subject     string
 }
 
 // Env is the environment variables.

--- a/www/docs/customization/templates.md
+++ b/www/docs/customization/templates.md
@@ -43,6 +43,7 @@ On fields that support templating, these fields are always available:
 | `.ReleaseURL`          | the current release download url[^4]                                                                   |
 | `.Summary`             | the git summary, e.g. `v1.0.0-10-g34f56g3`[^5]                                                         |
 | `.PrefixedSummary`     | the git summary prefixed with the monorepo config tag prefix (if any)                                  |
+| `.Subject`             | the annotated tag message, or the message of the commit it points out to                               |
 
 [^1]: The `v` prefix is stripped and it might be changed in `snapshot` and `nightly` builds.
 [^2]: Assuming `Tag` is a valid a SemVer, otherwise empty/zeroed.


### PR DESCRIPTION
this adds a new template field, `.Subject`, which will contain the annotated tag message if tag is annotated, or the message of the commit it points to.

This can be used on `release.name_template`, for example 🤘

closes #2726