### PR TITLE
feat: allow to always log signing output

### DIFF
--- a/internal/logext/writer.go
+++ b/internal/logext/writer.go
@@ -22,7 +22,12 @@ const (
 
 // NewWriter creates a new log writer.
 func NewWriter(fields log.Fields, out Output) io.Writer {
-	if isDebug() {
+	return NewConditionalWriter(fields, out, IsDebug())
+}
+
+// NewConditionalWriter creates a new log writer that only writes when the given condition is met.
+func NewConditionalWriter(fields log.Fields, out Output, condition bool) io.Writer {
+	if condition {
 		return logWriter{
 			ctx: newLogger(fields),
 			out: out,
@@ -56,7 +61,8 @@ func newLogger(fields log.Fields) *log.Entry {
 	return logger
 }
 
-func isDebug() bool {
+// IsDebug returns true if the current log level is debug.
+func IsDebug() bool {
 	return logLevel() == log.DebugLevel
 }
 

--- a/internal/logext/writer.go
+++ b/internal/logext/writer.go
@@ -22,12 +22,12 @@ const (
 
 // NewWriter creates a new log writer.
 func NewWriter(fields log.Fields, out Output) io.Writer {
-	return NewConditionalWriter(fields, out, IsDebug())
+	return NewConditionalWriter(fields, out, false)
 }
 
-// NewConditionalWriter creates a new log writer that only writes when the given condition is met.
+// NewConditionalWriter creates a new log writer that only writes when the given condition is met or debug is enabled.
 func NewConditionalWriter(fields log.Fields, out Output, condition bool) io.Writer {
-	if condition {
+	if condition || isDebug() {
 		return logWriter{
 			ctx: newLogger(fields),
 			out: out,
@@ -61,8 +61,7 @@ func newLogger(fields log.Fields) *log.Entry {
 	return logger
 }
 
-// IsDebug returns true if the current log level is debug.
-func IsDebug() bool {
+func isDebug() bool {
 	return logLevel() == log.DebugLevel
 }
 

--- a/internal/pipe/sign/sign.go
+++ b/internal/pipe/sign/sign.go
@@ -174,8 +174,8 @@ func signone(ctx *context.Context, cfg config.Sign, art *artifact.Artifact) ([]*
 	cmd := exec.CommandContext(ctx, cfg.Cmd, args...)
 	var b bytes.Buffer
 	w := gio.Safe(&b)
-	cmd.Stderr = io.MultiWriter(logext.NewWriter(fields, logext.Error), w)
-	cmd.Stdout = io.MultiWriter(logext.NewWriter(fields, logext.Info), w)
+	cmd.Stderr = io.MultiWriter(logext.NewConditionalWriter(fields, logext.Error, cfg.AlwaysOutput || logext.IsDebug()), w)
+	cmd.Stdout = io.MultiWriter(logext.NewConditionalWriter(fields, logext.Info, cfg.AlwaysOutput || logext.IsDebug()), w)
 	if stdin != nil {
 		cmd.Stdin = stdin
 	}

--- a/internal/pipe/sign/sign.go
+++ b/internal/pipe/sign/sign.go
@@ -185,8 +185,8 @@ func signone(ctx *context.Context, cfg config.Sign, art *artifact.Artifact) ([]*
 	cmd := exec.CommandContext(ctx, cfg.Cmd, args...)
 	var b bytes.Buffer
 	w := gio.Safe(&b)
-	cmd.Stderr = io.MultiWriter(logext.NewConditionalWriter(fields, logext.Error, cfg.AlwaysOutput || logext.IsDebug()), w)
-	cmd.Stdout = io.MultiWriter(logext.NewConditionalWriter(fields, logext.Info, cfg.AlwaysOutput || logext.IsDebug()), w)
+	cmd.Stderr = io.MultiWriter(logext.NewConditionalWriter(fields, logext.Error, cfg.Output), w)
+	cmd.Stdout = io.MultiWriter(logext.NewConditionalWriter(fields, logext.Info, cfg.Output), w)
 	if stdin != nil {
 		cmd.Stdin = stdin
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -621,16 +621,17 @@ type NFPMOverridables struct {
 
 // Sign config.
 type Sign struct {
-	ID          string   `yaml:"id,omitempty"`
-	Cmd         string   `yaml:"cmd,omitempty"`
-	Args        []string `yaml:"args,omitempty"`
-	Signature   string   `yaml:"signature,omitempty"`
-	Artifacts   string   `yaml:"artifacts,omitempty"`
-	IDs         []string `yaml:"ids,omitempty"`
-	Stdin       *string  `yaml:"stdin,omitempty"`
-	StdinFile   string   `yaml:"stdin_file,omitempty"`
-	Env         []string `yaml:"env,omitempty"`
-	Certificate string   `yaml:"certificate,omitempty"`
+	ID           string   `yaml:"id,omitempty"`
+	Cmd          string   `yaml:"cmd,omitempty"`
+	Args         []string `yaml:"args,omitempty"`
+	Signature    string   `yaml:"signature,omitempty"`
+	Artifacts    string   `yaml:"artifacts,omitempty"`
+	IDs          []string `yaml:"ids,omitempty"`
+	Stdin        *string  `yaml:"stdin,omitempty"`
+	StdinFile    string   `yaml:"stdin_file,omitempty"`
+	Env          []string `yaml:"env,omitempty"`
+	Certificate  string   `yaml:"certificate,omitempty"`
+	AlwaysOutput bool     `yaml:"always_output,omitempty"`
 }
 
 // SnapcraftAppMetadata for the binaries that will be in the snap package.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -621,17 +621,17 @@ type NFPMOverridables struct {
 
 // Sign config.
 type Sign struct {
-	ID           string   `yaml:"id,omitempty"`
-	Cmd          string   `yaml:"cmd,omitempty"`
-	Args         []string `yaml:"args,omitempty"`
-	Signature    string   `yaml:"signature,omitempty"`
-	Artifacts    string   `yaml:"artifacts,omitempty"`
-	IDs          []string `yaml:"ids,omitempty"`
-	Stdin        *string  `yaml:"stdin,omitempty"`
-	StdinFile    string   `yaml:"stdin_file,omitempty"`
-	Env          []string `yaml:"env,omitempty"`
-	Certificate  string   `yaml:"certificate,omitempty"`
-	AlwaysOutput bool     `yaml:"always_output,omitempty"`
+	ID          string   `yaml:"id,omitempty"`
+	Cmd         string   `yaml:"cmd,omitempty"`
+	Args        []string `yaml:"args,omitempty"`
+	Signature   string   `yaml:"signature,omitempty"`
+	Artifacts   string   `yaml:"artifacts,omitempty"`
+	IDs         []string `yaml:"ids,omitempty"`
+	Stdin       *string  `yaml:"stdin,omitempty"`
+	StdinFile   string   `yaml:"stdin_file,omitempty"`
+	Env         []string `yaml:"env,omitempty"`
+	Certificate string   `yaml:"certificate,omitempty"`
+	Output      bool     `yaml:"output,omitempty"`
 }
 
 // SnapcraftAppMetadata for the binaries that will be in the snap package.

--- a/www/docs/customization/docker_sign.md
+++ b/www/docs/customization/docker_sign.md
@@ -62,11 +62,11 @@ docker_signs:
     - FOO=bar
     - HONK=honkhonk
 
-    # By default, the stdout and stderr of the signing cmd are discarded.
-    # If you want them to be shown, set this to true.
+    # By default, the stdout and stderr of the signing cmd are discarded unless GoReleaser is running with `--debug` set.
+    # You can set this to true if you want them to be displayed regardless.
     #
     # Defaults to false
-    always_output: true
+    output: true
 ```
 
 ### Available variable names

--- a/www/docs/customization/docker_sign.md
+++ b/www/docs/customization/docker_sign.md
@@ -61,6 +61,12 @@ docker_signs:
     env:
     - FOO=bar
     - HONK=honkhonk
+
+    # By default, the stdout and stderr of the signing cmd are discarded.
+    # If you want them to be shown, set this to true.
+    #
+    # Defaults to false
+    always_output: true
 ```
 
 ### Available variable names

--- a/www/docs/customization/sign.md
+++ b/www/docs/customization/sign.md
@@ -97,6 +97,12 @@ signs:
     env:
     - FOO=bar
     - HONK=honkhonk
+
+    # By default, the stdout and stderr of the signing cmd are discarded.
+    # If you want them to be shown, set this to true.
+    #
+    # Defaults to false
+    always_output: true
 ```
 
 ### Available variable names

--- a/www/docs/customization/sign.md
+++ b/www/docs/customization/sign.md
@@ -98,11 +98,11 @@ signs:
     - FOO=bar
     - HONK=honkhonk
 
-    # By default, the stdout and stderr of the signing cmd are discarded.
-    # If you want them to be shown, set this to true.
+    # By default, the stdout and stderr of the signing cmd are discarded unless GoReleaser is running with `--debug` set.
+    # You can set this to true if you want them to be displayed regardless.
     #
     # Defaults to false
-    always_output: true
+    output: true
 ```
 
 ### Available variable names


### PR DESCRIPTION
by default, when signing, output is only shown when goreleaser is running in debug mode.

this adds a config that allows to always log the output... so if you use, say, cosign with their oidc (which will print an URL you'll need to visit to auth), you won't need to run with `--debug` anymore.