### PR TITLE
Fix JSON schema for ReleaseNotesMode

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -477,7 +477,7 @@ type Release struct {
 	Header                 string      `yaml:"header,omitempty"`
 	Footer                 string      `yaml:"footer,omitempty"`
 
-	ReleaseNotesMode ReleaseNotesMode `yaml:"mode,omitempty" jsonschema:"title=enum=keep-existing,enum=append,enum=prepend,enum=replace,default=keep-existing"`
+	ReleaseNotesMode ReleaseNotesMode `yaml:"mode,omitempty" jsonschema:"enum=keep-existing,enum=append,enum=prepend,enum=replace,default=keep-existing"`
 }
 
 // Milestone config used for VCS milestone.

--- a/www/docs/static/schema.json
+++ b/www/docs/static/schema.json
@@ -1715,6 +1715,7 @@
 					},
 					"mode": {
 						"enum": [
+							"keep-existing",
 							"append",
 							"prepend",
 							"replace"


### PR DESCRIPTION
In the JSON schema, the `keep-existing` value [was missing](https://github.com/goreleaser/goreleaser/blob/167d95e67fe0266fd75bc5dffc949f5db550dc73/www/docs/static/schema.json#L1716) for `ReleaseNotesMode`.
```
					"mode": {
						"enum": [
							"append",
							"prepend",
							"replace"
						],
						"type": "string",
						"default": "keep-existing"
					}
```


I fixed a typo in the struct tags and rebuilt the schema (`task schema:generate`). This adds `keep-existing` in the enum.

Note: [`schema-pro.json`](https://github.com/goreleaser/goreleaser/blob/167d95e67fe0266fd75bc5dffc949f5db550dc73/www/docs/static/schema-pro.json#L1884) is also affected, but I don't know how it is generated.