### PR TITLE
feat: add support for GitLab Generic Packages

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,9 +25,10 @@ type GitHubURLs struct {
 
 // GitLabURLs holds the URLs to be used when using gitlab ce/enterprise.
 type GitLabURLs struct {
-	API           string `yaml:"api,omitempty"`
-	Download      string `yaml:"download,omitempty"`
-	SkipTLSVerify bool   `yaml:"skip_tls_verify,omitempty"`
+	API                string `yaml:"api,omitempty"`
+	Download           string `yaml:"download,omitempty"`
+	SkipTLSVerify      bool   `yaml:"skip_tls_verify,omitempty"`
+	UsePackageRegistry bool   `yaml:"use_package_registry,omitempty"`
 }
 
 // GiteaURLs holds the URLs to be used when using gitea.

--- a/www/docs/scm/gitlab.md
+++ b/www/docs/scm/gitlab.md
@@ -28,6 +28,9 @@ gitlab_urls:
   download: https://gitlab.company.com
   # set to true if you use a self-signed certificate
   skip_tls_verify: false
+  # set to true if you want to upload to the Package Registry rather than attachments
+  # Only works with GitLab 13.5+
+  use_package_registry: false
 ```
 
 If none are set, they default to GitLab's public URLs.
@@ -37,6 +40,19 @@ If none are set, they default to GitLab's public URLs.
     on [release](https://docs.gitlab.com/ee/user/project/releases/index.html) functionality
     and [direct asset linking](https://docs.gitlab.com/ee/user/project/releases/index.html#permanent-links-to-release-assets).
 
+## Generic Package Registry
+
+GitLab introduced the [Generic Package Registry](https://docs.gitlab.com/ee/user/packages/package_registry/index.html) in Gitlab 13.5.
+
+Normally, `goreleaser` uploads release files as "attachments", which may have [administrative limits](https://docs.gitlab.com/ee/user/admin_area/settings/account_and_limit_settings.html).  Notably, hosted gitlab.com instances have a 10MB attachment limit which cannot be changed.
+
+Uploading to the Generic Package Registry does not have this restriction.  To use it instead, set `use_package_registry` to `true`.
+
+```yaml
+# .goreleaser.yml
+gitlab_urls:
+  use_package_registry: true
+```
 
 ## Example release
 


### PR DESCRIPTION
GitLab's Generic Package Repository allows uploading files
to GitLab, as an alternative to attachments.

Added the flag `use_package_registry` to the `gitlab_urls` config.
When false, the default, it will behave as before.
When true, it will publish the file to the Generic Package Registry.
Either way, the URL is bound to the release the same

Updated `go-gitlab` to version 0.52.2 which has the new
`GenericPackages.PublishPackageFile` function.

----
Fixes #2006.  

I tried to run local tests on it and it was not working (failures with `internal/pipe` and weird assembly output);  however, I think that is unrelated to this PR as I've tested this many times before without issue.  My apologies if this is not the case and the CI fails.