### PR TITLE
fix: artifacts.json when type is archive

### DIFF
--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -24,7 +24,7 @@ type Type int
 
 const (
 	// UploadableArchive a tar.gz/zip archive to be uploaded.
-	UploadableArchive Type = iota
+	UploadableArchive Type = iota + 1
 	// UploadableBinary is a binary file to be uploaded.
 	UploadableBinary
 	// UploadableFile is any file that can be uploaded.

--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -503,6 +503,13 @@ func TestMarshalJSON(t *testing.T) {
 	})
 	artifacts.Add(&Artifact{
 		Name: "foo",
+		Type: UploadableArchive,
+		Extra: map[string]interface{}{
+			ExtraID: "adsad",
+		},
+	})
+	artifacts.Add(&Artifact{
+		Name: "foo",
 		Type: Checksum,
 		Extra: map[string]interface{}{
 			ExtraRefresh: func() error { return nil },

--- a/internal/artifact/testdata/TestMarshalJSON.json.golden
+++ b/internal/artifact/testdata/TestMarshalJSON.json.golden
@@ -1,1 +1,1 @@
-[{"name":"foo","type":"Binary","extra":{"ID":"adsad"}},{"name":"foo","type":"Checksum","extra":{"Refresh":"func() error"}}]
+[{"name":"foo","type":"Binary","extra":{"ID":"adsad"}},{"name":"foo","type":"Archive","extra":{"ID":"adsad"}},{"name":"foo","type":"Checksum","extra":{"Refresh":"func() error"}}]

--- a/internal/pipe/scoop/scoop_test.go
+++ b/internal/pipe/scoop/scoop_test.go
@@ -624,6 +624,7 @@ func Test_doRun(t *testing.T) {
 			ctx := tt.args.ctx
 			ctx.Artifacts = artifact.New()
 			for _, a := range tt.artifacts {
+				a.Type = artifact.UploadableArchive
 				ctx.Artifacts.Add(&a)
 			}
 			require.NoError(t, Pipe{}.Default(ctx))


### PR DESCRIPTION
since type is an int, 0 is ignored, so we need to start at 1