### PR TITLE
fix: sign with cert only

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -203,17 +203,13 @@ snapcrafts:
 
 signs:
 - cmd: cosign
-  output: true
-  env: ['COSIGN_EXPERIMENTAL=1']
-  certificate: checksums.pem
-  args: ["sign-blob", "--output-signature=${signature}", "--output-certificate=${certificate}", "${artifact}"]
+  stdin: '{{ .Env.COSIGN_PWD }}'
+  args: ["sign-blob", "-key=cosign.key", "-output=${signature}", "${artifact}"]
   artifacts: checksum
 
 docker_signs:
 - artifacts: manifests
-  env: ['COSIGN_EXPERIMENTAL=1']
-  certificate: docker.pem
-  args: ["sign", "--output-signature=${signature}", "--output-certificate=${certificate}", "${artifact}"]
+  stdin: '{{ .Env.COSIGN_PWD }}'
 
 publishers:
   - name: fury.io

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -203,13 +203,17 @@ snapcrafts:
 
 signs:
 - cmd: cosign
-  stdin: '{{ .Env.COSIGN_PWD }}'
-  args: ["sign-blob", "-key=cosign.key", "-output=${signature}", "${artifact}"]
+  output: true
+  env: ['COSIGN_EXPERIMENTAL=1']
+  certificate: checksums.pem
+  args: ["sign-blob", "--output-signature=${signature}", "--output-certificate=${certificate}", "${artifact}"]
   artifacts: checksum
 
 docker_signs:
 - artifacts: manifests
-  stdin: '{{ .Env.COSIGN_PWD }}'
+  env: ['COSIGN_EXPERIMENTAL=1']
+  certificate: docker.pem
+  args: ["sign", "--output-signature=${signature}", "--output-certificate=${certificate}", "${artifact}"]
 
 publishers:
   - name: fury.io

--- a/internal/pipe/sign/sign.go
+++ b/internal/pipe/sign/sign.go
@@ -196,24 +196,22 @@ func signone(ctx *context.Context, cfg config.Sign, art *artifact.Artifact) ([]*
 		return nil, fmt.Errorf("sign: %s failed: %w: %s", cfg.Cmd, err, b.String())
 	}
 
-	if cfg.Signature == "" {
-		return nil, nil
-	}
+	var result []*artifact.Artifact
 
 	// re-execute template results, using artifact name as artifact so they eval to the actual needed file name.
 	env["artifact"] = art.Name
 	name, _ = tmpl.New(ctx).WithEnv(env).Apply(expand(cfg.Signature, env))   // could never error as it passed the previous check
 	cert, _ = tmpl.New(ctx).WithEnv(env).Apply(expand(cfg.Certificate, env)) // could never error as it passed the previous check
 
-	result := []*artifact.Artifact{
-		{
+	if cfg.Signature != "" {
+		result = append(result, &artifact.Artifact{
 			Type: artifact.Signature,
 			Name: name,
 			Path: env["signature"],
 			Extra: map[string]interface{}{
 				artifact.ExtraID: cfg.ID,
 			},
-		},
+		})
 	}
 
 	if cert != "" {

--- a/internal/pipe/sign/sign.go
+++ b/internal/pipe/sign/sign.go
@@ -200,11 +200,12 @@ func signone(ctx *context.Context, cfg config.Sign, art *artifact.Artifact) ([]*
 		stdin = f
 	}
 
-	fields := log.Fields{
-		"cmd":         cfg.Cmd,
-		"artifact":    art.Name,
-		"signature":   name,
-		"certificate": cert,
+	fields := log.Fields{"cmd": cfg.Cmd, "artifact": art.Name}
+	if name != "" {
+		fields["signature"] = name
+	}
+	if cert != "" {
+		fields["certificate"] = cert
 	}
 
 	// The GoASTScanner flags this as a security risk.

--- a/internal/pipe/sign/sign.go
+++ b/internal/pipe/sign/sign.go
@@ -132,10 +132,10 @@ func relativeToDist(dist, f string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if !strings.HasPrefix(af, df) {
-		return filepath.Join(dist, f), nil
+	if strings.HasPrefix(af, df) {
+		return f, nil
 	}
-	return f, nil
+	return filepath.Join(dist, f), nil
 }
 
 func tmplPath(ctx *context.Context, env map[string]string, s string) (string, error) {

--- a/internal/pipe/sign/sign.go
+++ b/internal/pipe/sign/sign.go
@@ -140,7 +140,7 @@ func relativeToDist(dist, f string) (string, error) {
 
 func tmplPath(ctx *context.Context, env map[string]string, s string) (string, error) {
 	result, err := tmpl.New(ctx).WithEnv(env).Apply(expand(s, env))
-	if err != nil {
+	if err != nil || result == "" {
 		return "", err
 	}
 	return relativeToDist(ctx.Config.Dist, result)
@@ -200,7 +200,12 @@ func signone(ctx *context.Context, cfg config.Sign, art *artifact.Artifact) ([]*
 		stdin = f
 	}
 
-	fields := log.Fields{"cmd": cfg.Cmd, "artifact": art.Name}
+	fields := log.Fields{
+		"cmd":         cfg.Cmd,
+		"artifact":    art.Name,
+		"signature":   name,
+		"certificate": cert,
+	}
 
 	// The GoASTScanner flags this as a security risk.
 	// However, this works as intended. The nosec annotation

--- a/internal/pipe/sign/sign_docker_test.go
+++ b/internal/pipe/sign/sign_docker_test.go
@@ -2,9 +2,12 @@ package sign
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/internal/artifact"
+	"github.com/goreleaser/goreleaser/internal/gio"
 	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
@@ -49,9 +52,9 @@ func TestDockerSignInvalidArtifacts(t *testing.T) {
 
 func TestDockerSignArtifacts(t *testing.T) {
 	testlib.CheckPath(t, "cosign")
-	key := "testdata/cosign/cosign.key"
+	key := "cosign.key"
 	cmd := "sh"
-	args := []string{"-c", "echo ${artifact} > ${signature} && cosign sign -key=" + key + " -upload=false ${artifact} > ${signature}"}
+	args := []string{"-c", "echo ${artifact} > ${signature} && cosign sign --key=" + key + " --upload=false ${artifact} > ${signature}"}
 	password := "password"
 
 	img1 := "ghcr.io/caarlos0/goreleaser-docker-manifest-actions-example:1.2.1-amd64"
@@ -69,34 +72,50 @@ func TestDockerSignArtifacts(t *testing.T) {
 					Artifacts: "all",
 					Stdin:     &password,
 					Cmd:       "cosign",
-					Args:      []string{"sign", "--key=" + key, "-upload=false", "${artifact}"},
+					Args:      []string{"sign", "--key=" + key, "--upload=false", "${artifact}"},
+				},
+			},
+		},
+		"only certificate": {
+			Expected: []string{
+				"ghcrio-caarlos0-goreleaser-docker-manifest-actions-example-121-amd64.pem",
+				"ghcrio-caarlos0-goreleaser-docker-manifest-actions-example-121-arm64v8.pem",
+				"ghcrio-caarlos0-goreleaser-docker-manifest-actions-example-121.pem",
+			},
+			Signs: []config.Sign{
+				{
+					Artifacts:   "all",
+					Stdin:       &password,
+					Cmd:         "cosign",
+					Certificate: `{{ replace (replace (replace .Env.artifact "/" "-") ":" "-") "." "" }}.pem`,
+					Args:        []string{"sign", "--output-certificate=${certificate}", "--key=" + key, "--upload=false", "${artifact}"},
 				},
 			},
 		},
 		"sign all": {
 			Expected: []string{
-				"testdata/cosign/all_img1.sig",
-				"testdata/cosign/all_img2.sig",
-				"testdata/cosign/all_man1.sig",
+				"all_img1.sig",
+				"all_img2.sig",
+				"all_man1.sig",
 			},
 			Signs: []config.Sign{
 				{
 					Artifacts: "all",
 					Stdin:     &password,
-					Signature: `testdata/cosign/all_${artifactID}.sig`,
+					Signature: `all_${artifactID}.sig`,
 					Cmd:       cmd,
 					Args:      args,
 				},
 			},
 		},
 		"sign all filtering id": {
-			Expected: []string{"testdata/cosign/all_filter_by_id_img2.sig"},
+			Expected: []string{"all_filter_by_id_img2.sig"},
 			Signs: []config.Sign{
 				{
 					Artifacts: "all",
 					IDs:       []string{"img2"},
 					Stdin:     &password,
-					Signature: "testdata/cosign/all_filter_by_id_${artifactID}.sig",
+					Signature: "all_filter_by_id_${artifactID}.sig",
 					Cmd:       cmd,
 					Args:      args,
 				},
@@ -104,26 +123,26 @@ func TestDockerSignArtifacts(t *testing.T) {
 		},
 		"sign images only": {
 			Expected: []string{
-				"testdata/cosign/images_img1.sig",
-				"testdata/cosign/images_img2.sig",
+				"images_img1.sig",
+				"images_img2.sig",
 			},
 			Signs: []config.Sign{
 				{
 					Artifacts: "images",
 					Stdin:     &password,
-					Signature: "testdata/cosign/images_${artifactID}.sig",
+					Signature: "images_${artifactID}.sig",
 					Cmd:       cmd,
 					Args:      args,
 				},
 			},
 		},
 		"sign manifests only": {
-			Expected: []string{"testdata/cosign/manifests_man1.sig"},
+			Expected: []string{"manifests_man1.sig"},
 			Signs: []config.Sign{
 				{
 					Artifacts: "manifests",
 					Stdin:     &password,
-					Signature: "testdata/cosign/manifests_${artifactID}.sig",
+					Signature: "manifests_${artifactID}.sig",
 					Cmd:       cmd,
 					Args:      args,
 				},
@@ -134,12 +153,12 @@ func TestDockerSignArtifacts(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.New(config.Project{})
 			ctx.Config.DockerSigns = cfg.Signs
-
-			t.Cleanup(func() {
-				for _, f := range cfg.Expected {
-					require.NoError(t, os.Remove(f))
-				}
-			})
+			wd, err := os.Getwd()
+			require.NoError(t, err)
+			tmp := testlib.Mktmp(t)
+			require.NoError(t, gio.Copy(filepath.Join(wd, "testdata/cosign/"), tmp))
+			ctx.Config.Dist = "dist"
+			require.NoError(t, os.Mkdir("dist", 0755))
 
 			ctx.Artifacts.Add(&artifact.Artifact{
 				Name: img1,
@@ -169,8 +188,14 @@ func TestDockerSignArtifacts(t *testing.T) {
 			require.NoError(t, DockerPipe{}.Default(ctx))
 			require.NoError(t, DockerPipe{}.Publish(ctx))
 			var sigs []string
-			for _, sig := range ctx.Artifacts.Filter(artifact.ByType(artifact.Signature)).List() {
+			for _, sig := range ctx.Artifacts.Filter(
+				artifact.Or(
+					artifact.ByType(artifact.Signature),
+					artifact.ByType(artifact.Certificate),
+				),
+			).List() {
 				sigs = append(sigs, sig.Name)
+				require.Truef(t, strings.HasPrefix(sig.Path, ctx.Config.Dist), "signature %q is not in dist dir %q", sig.Path, ctx.Config.Dist)
 			}
 			require.Equal(t, cfg.Expected, sigs)
 		})

--- a/internal/pipe/sign/sign_docker_test.go
+++ b/internal/pipe/sign/sign_docker_test.go
@@ -158,7 +158,7 @@ func TestDockerSignArtifacts(t *testing.T) {
 			tmp := testlib.Mktmp(t)
 			require.NoError(t, gio.Copy(filepath.Join(wd, "testdata/cosign/"), tmp))
 			ctx.Config.Dist = "dist"
-			require.NoError(t, os.Mkdir("dist", 0755))
+			require.NoError(t, os.Mkdir("dist", 0o755))
 
 			ctx.Artifacts.Add(&artifact.Artifact{
 				Name: img1,


### PR DESCRIPTION
sign may emit a certificate but not a signature, currently if there is no signature it also ignores the certificate options.

Also fixed so all certificates and signatures are always stored within `dist`.