### PR TITLE
fix: logext shouldnt mess with default logger

### DIFF
--- a/internal/logext/writer.go
+++ b/internal/logext/writer.go
@@ -56,9 +56,10 @@ func (w logWriter) Write(p []byte) (int, error) {
 func newLogger(fields log.Fields) *log.Entry {
 	handler := cli.New(cli.Default.Writer)
 	handler.Padding = cli.Default.Padding + 3
-	logger := log.WithFields(fields)
-	logger.Logger.Handler = handler
-	return logger
+	return (&log.Logger{
+		Handler: handler,
+		Level:   log.InfoLevel,
+	}).WithFields(fields)
 }
 
 func isDebug() bool {


### PR DESCRIPTION
we are actually changing the padding of the default logger... this should improve log output a bit.