### PR TITLE
Introduce extrafiles pipe and top-level extra_files configuration, support extra_files in publishers

### DIFF
--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -203,6 +203,59 @@ func TestExecute(t *testing.T) {
 			nil,
 		},
 		{
+			"extra files",
+			[]config.Publisher{
+				{
+					Name: "test",
+					Cmd:  MockCmd + " {{ .ArtifactName }}",
+					Env: []string{
+						MarshalMockEnv(&MockData{
+							AnyOf: []MockCall{
+								{ExpectedArgs: []string{"a.deb"}, ExitCode: 0, ExpectedEnv: osEnv()},
+								{ExpectedArgs: []string{"a.ubi"}, ExitCode: 0, ExpectedEnv: osEnv()},
+								{ExpectedArgs: []string{"a.tar"}, ExitCode: 0, ExpectedEnv: osEnv()},
+								{ExpectedArgs: []string{"a.txt"}, ExitCode: 0, ExpectedEnv: osEnv()},
+								{ExpectedArgs: []string{"foo/bar"}, ExitCode: 0, ExpectedEnv: osEnv()},
+								{ExpectedArgs: []string{"foo/bar:amd64"}, ExitCode: 0, ExpectedEnv: osEnv()},
+							},
+						}),
+					},
+					ExtraFiles: []config.ExtraFile{
+						{Glob: filepath.Join("testdata", "*.txt")},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"extra files with rename",
+			[]config.Publisher{
+				{
+					Name: "test",
+					Cmd:  MockCmd + " {{ .ArtifactName }}",
+					Env: []string{
+						MarshalMockEnv(&MockData{
+							AnyOf: []MockCall{
+								{ExpectedArgs: []string{"a.deb"}, ExitCode: 0, ExpectedEnv: osEnv()},
+								{ExpectedArgs: []string{"a.ubi"}, ExitCode: 0, ExpectedEnv: osEnv()},
+								{ExpectedArgs: []string{"a.tar"}, ExitCode: 0, ExpectedEnv: osEnv()},
+								{ExpectedArgs: []string{"b.txt"}, ExitCode: 0, ExpectedEnv: osEnv()},
+								{ExpectedArgs: []string{"foo/bar"}, ExitCode: 0, ExpectedEnv: osEnv()},
+								{ExpectedArgs: []string{"foo/bar:amd64"}, ExitCode: 0, ExpectedEnv: osEnv()},
+							},
+						}),
+					},
+					ExtraFiles: []config.ExtraFile{
+						{
+							Glob:         filepath.Join("testdata", "*.txt"),
+							NameTemplate: "b.txt",
+						},
+					},
+				},
+			},
+			nil,
+		},
+		{
 			"try dir templating",
 			[]config.Publisher{
 				{

--- a/internal/exec/testdata/a.txt
+++ b/internal/exec/testdata/a.txt
@@ -1,0 +1,1 @@
+lorem ipsum

--- a/internal/pipe/checksums/checksums.go
+++ b/internal/pipe/checksums/checksums.go
@@ -68,6 +68,7 @@ func refresh(ctx *context.Context, filepath string) error {
 	filter := artifact.Or(
 		artifact.ByType(artifact.UploadableArchive),
 		artifact.ByType(artifact.UploadableBinary),
+		artifact.ByType(artifact.UploadableFile),
 		artifact.ByType(artifact.UploadableSourceArchive),
 		artifact.ByType(artifact.LinuxPackage),
 		artifact.ByType(artifact.SBOM),

--- a/internal/pipe/extrafiles/extrafiles.go
+++ b/internal/pipe/extrafiles/extrafiles.go
@@ -1,0 +1,40 @@
+// Package extrafiles provides a Pipe that adds extra pre-existing files
+package extrafiles
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/goreleaser/goreleaser/internal/artifact"
+	intextrafiles "github.com/goreleaser/goreleaser/internal/extrafiles"
+	"github.com/goreleaser/goreleaser/pkg/context"
+)
+
+// Pipe for extra files.
+type Pipe struct{}
+
+// String returns the description of the pipe.
+func (Pipe) String() string                 { return "extra files" }
+func (Pipe) Skip(ctx *context.Context) bool { return len(ctx.Config.ExtraFiles) == 0 }
+
+// Add extra file artifacts.
+func (Pipe) Run(ctx *context.Context) error {
+	extraFiles, err := intextrafiles.Find(ctx, ctx.Config.ExtraFiles)
+	if err != nil {
+		return err
+	}
+
+	for name, path := range extraFiles {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return fmt.Errorf("failed to add extra file %s: %w", name, err)
+		}
+
+		ctx.Artifacts.Add(&artifact.Artifact{
+			Name: name,
+			Path: path,
+			Type: artifact.UploadableFile,
+		})
+	}
+
+	return nil
+}

--- a/internal/pipe/extrafiles/extrafiles_test.go
+++ b/internal/pipe/extrafiles/extrafiles_test.go
@@ -1,0 +1,39 @@
+package extrafiles
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/goreleaser/goreleaser/pkg/config"
+	"github.com/goreleaser/goreleaser/pkg/context"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescription(t *testing.T) {
+	require.NotEmpty(t, Pipe{}.String())
+}
+
+func TestSkip(t *testing.T) {
+	t.Run("skip", func(t *testing.T) {
+		require.True(t, Pipe{}.Skip(context.New(config.Project{})))
+	})
+
+	t.Run("dont skip", func(t *testing.T) {
+		ctx := context.New(config.Project{
+			ExtraFiles: []config.ExtraFile{
+				{},
+			},
+		})
+		require.False(t, Pipe{}.Skip(ctx))
+	})
+}
+
+func TestRun(t *testing.T) {
+	require.NoError(t, Pipe{}.Run(context.New(config.Project{
+		ExtraFiles: []config.ExtraFile{
+			{
+				Glob: filepath.Join("testdata", "*.txt"),
+			},
+		},
+	})))
+}

--- a/internal/pipe/extrafiles/testdata/a.txt
+++ b/internal/pipe/extrafiles/testdata/a.txt
@@ -1,0 +1,1 @@
+lorem ipsum

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -17,6 +17,7 @@ import (
 	"github.com/goreleaser/goreleaser/internal/pipe/docker"
 	"github.com/goreleaser/goreleaser/internal/pipe/effectiveconfig"
 	"github.com/goreleaser/goreleaser/internal/pipe/env"
+	"github.com/goreleaser/goreleaser/internal/pipe/extrafiles"
 	"github.com/goreleaser/goreleaser/internal/pipe/git"
 	"github.com/goreleaser/goreleaser/internal/pipe/gofish"
 	"github.com/goreleaser/goreleaser/internal/pipe/gomod"
@@ -76,6 +77,7 @@ var Pipeline = append(
 	gofish.Pipe{},        // create gofish rig
 	krew.Pipe{},          // krew plugins
 	scoop.Pipe{},         // create scoop buckets
+	extrafiles.Pipe{},    // add extra file artifacts
 	sbom.Pipe{},          // create SBOMs of artifacts
 	checksums.Pipe{},     // checksums of the files
 	sign.Pipe{},          // sign artifacts

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -799,13 +799,14 @@ type Upload struct {
 
 // Publisher configuration.
 type Publisher struct {
-	Name      string   `yaml:"name,omitempty"`
-	IDs       []string `yaml:"ids,omitempty"`
-	Checksum  bool     `yaml:"checksum,omitempty"`
-	Signature bool     `yaml:"signature,omitempty"`
-	Dir       string   `yaml:"dir,omitempty"`
-	Cmd       string   `yaml:"cmd,omitempty"`
-	Env       []string `yaml:"env,omitempty"`
+	Name       string      `yaml:"name,omitempty"`
+	IDs        []string    `yaml:"ids,omitempty"`
+	Checksum   bool        `yaml:"checksum,omitempty"`
+	Signature  bool        `yaml:"signature,omitempty"`
+	Dir        string      `yaml:"dir,omitempty"`
+	Cmd        string      `yaml:"cmd,omitempty"`
+	Env        []string    `yaml:"env,omitempty"`
+	ExtraFiles []ExtraFile `yaml:"extra_files,omitempty"`
 }
 
 // Source configuration.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -821,6 +821,7 @@ type Source struct {
 type Project struct {
 	ProjectName     string           `yaml:"project_name,omitempty"`
 	Env             []string         `yaml:"env,omitempty"`
+	ExtraFiles      []ExtraFile      `yaml:"extra_files,omitempty"`
 	Release         Release          `yaml:"release,omitempty"`
 	Milestones      []Milestone      `yaml:"milestones,omitempty"`
 	Brews           []Homebrew       `yaml:"brews,omitempty"`

--- a/www/docs/customization/checksum.md
+++ b/www/docs/customization/checksum.md
@@ -30,6 +30,7 @@ checksum:
   disable: true
 
   # You can add extra pre-existing files to the checksums file.
+  # These extra files are in addition to any top-level extra_files configuration.
   # The filename on the checksum will be the last part of the path (base).
   # If another file with the same name exists, the last one found will be used.
   # These globs can also include templates.

--- a/www/docs/customization/extra_files.md
+++ b/www/docs/customization/extra_files.md
@@ -1,0 +1,32 @@
+# Extra Files
+
+GoReleaser supports including extra pre-existing files in the following (each also supporting individual configuration):
+
+- [blobs](/customization/blob/)
+- [checksum](/customization/checksum/)
+- [publishers](/customization/publishers/)
+- [release](/customization/release/)
+
+```yaml
+# .goreleaser.yml
+extra_files:
+  # Multiple extra file configurations can be added.
+  # Defaults to empty.
+  -
+    # Glob pattern to match file(s). Supports templates.
+    # The filename will be the last part of the path (base).
+    glob: ./path/to/file.txt
+
+    # Replacement filename. Supports templates.
+    # Glob must match single file for name replacement.
+    name_template: newname.txt
+```
+
+If another file with the same name exists across globs, the last one found will be used.
+
+```yaml
+# .goreleaser.yml
+extra_files:
+  - glob: ./glob/**/to/**/file/**/*
+  - glob: ./glob/foo/to/bar/file/foobar/override_from_previous
+```

--- a/www/docs/customization/publishers.md
+++ b/www/docs/customization/publishers.md
@@ -114,6 +114,19 @@ publishers:
     # Environment variables
     env:
       - API_TOKEN=secret-token
+
+    # You can publish extra pre-existing files.
+    # The filename published will be the last part of the path (base).
+    # If another file with the same name exists, the last one found will be used.
+    # These globs can also include templates.
+    #
+    # Defaults to empty.
+    extra_files:
+      - glob: ./path/to/file.txt
+      - glob: ./glob/**/to/**/file/**/*
+      - glob: ./glob/foo/to/bar/file/foobar/override_from_previous
+      - glob: ./single_file.txt
+        name_template: file.txt # note that this only works if glob matches 1 file only
 ```
 
 These settings should allow you to push your artifacts to any number of endpoints

--- a/www/docs/customization/publishers.md
+++ b/www/docs/customization/publishers.md
@@ -116,6 +116,7 @@ publishers:
       - API_TOKEN=secret-token
 
     # You can publish extra pre-existing files.
+    # These extra files are in addition to any top-level extra_files configuration.
     # The filename published will be the last part of the path (base).
     # If another file with the same name exists, the last one found will be used.
     # These globs can also include templates.

--- a/www/docs/customization/release.md
+++ b/www/docs/customization/release.md
@@ -75,6 +75,7 @@ release:
   disable: true
 
   # You can add extra pre-existing files to the release.
+  # These extra files are in addition to any top-level extra_files configuration.
   # The filename on the release will be the last part of the path (base).
   # If another file with the same name exists, the last one found will be used.
   # These globs can also include templates.

--- a/www/docs/static/schema-pro.json
+++ b/www/docs/static/schema-pro.json
@@ -1559,6 +1559,13 @@
 						},
 						"type": "array"
 					},
+					"extra_files": {
+						"items": {
+							"$schema": "http://json-schema.org/draft-04/schema#",
+							"$ref": "#/definitions/ExtraFile"
+						},
+						"type": "array"
+					},
 					"release": {
 						"$schema": "http://json-schema.org/draft-04/schema#",
 						"$ref": "#/definitions/Release"
@@ -1805,6 +1812,13 @@
 					"env": {
 						"items": {
 							"type": "string"
+						},
+						"type": "array"
+					},
+					"extra_files": {
+						"items": {
+							"$schema": "http://json-schema.org/draft-04/schema#",
+							"$ref": "#/definitions/ExtraFile"
 						},
 						"type": "array"
 					}

--- a/www/docs/static/schema.json
+++ b/www/docs/static/schema.json
@@ -1431,6 +1431,13 @@
 						},
 						"type": "array"
 					},
+					"extra_files": {
+						"items": {
+							"$schema": "http://json-schema.org/draft-04/schema#",
+							"$ref": "#/definitions/ExtraFile"
+						},
+						"type": "array"
+					},
 					"release": {
 						"$schema": "http://json-schema.org/draft-04/schema#",
 						"$ref": "#/definitions/Release"
@@ -1643,6 +1650,13 @@
 					"env": {
 						"items": {
 							"type": "string"
+						},
+						"type": "array"
+					},
+					"extra_files": {
+						"items": {
+							"$schema": "http://json-schema.org/draft-04/schema#",
+							"$ref": "#/definitions/ExtraFile"
 						},
 						"type": "array"
 					}

--- a/www/mkdocs.yml
+++ b/www/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
     - customization/hooks.md
     - customization/dist.md
     - customization/project.md
+    - customization/extra_files.md
   - Build:
     - customization/build.md
     - customization/gomod.md


### PR DESCRIPTION
Closes #2768
Supersedes #2770

Additional support for `id` filtering should theoretically be possible as well with some modification of `extrafiles.Find()` to return artifacts instead of the simple map, but that felt outside the scope of this initial support.