### PR TITLE
docs(ci): fix circle config example

### DIFF
--- a/www/docs/ci/circle.md
+++ b/www/docs/ci/circle.md
@@ -22,5 +22,4 @@ jobs:
     steps:
       - checkout
       - run: curl -sL https://git.io/goreleaser | bash
-      - run: goreleaser
 ```


### PR DESCRIPTION
Hello! First of all thanks for the great tool 👍 It's really helps to deliver binaries as fast and easily as possible! Yesterday I have faced with slight inaccuracy in the CircleCI example config. It causes to failed build. The last command in config produces an error and seems like unnecessary:

```
/bin/bash: goreleaser: command not found
Exited with code exit status 127
```

[CircleCI failed build](https://app.circleci.com/pipelines/github/mocktools/go-smtp-mock/222/workflows/afee5f9c-d1b8-4c21-bdaa-a866a9087cb2/jobs/423)

<img width="1155" alt="Screenshot 2021-12-17 at 15 07 04" src="https://user-images.githubusercontent.com/14002692/146549178-7c7aeb70-7e64-4f7b-96b6-06009769c7b6.png">

So, this commit will fix this issue.