### PR TITLE
feat: do not release goreleaser for arm6

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,7 +25,6 @@ builds:
     - arm
     - arm64
   goarm:
-    - "6"
     - "7"
   mod_timestamp: '{{ .CommitTimestamp }}'
   flags:
@@ -133,6 +132,7 @@ brews:
       owner: goreleaser
       name: homebrew-tap
     folder: Formula
+    goarm: "7"
     homepage:  https://goreleaser.com
     description: Deliver Go binaries as fast and easily as possible
     license: MIT

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -152,11 +152,6 @@ tasks:
           Cmd: '{{.rpm}} goreleaser-*.aarch64.rpm'
       - task: goreleaser:test:pkg
         vars:
-          Platform: 'arm/6'
-          Image: fedora
-          Cmd: '{{.rpm}} goreleaser-*.armv6hl.rpm'
-      - task: goreleaser:test:pkg
-        vars:
           Platform: 'arm/7'
           Image: fedora
           Cmd: '{{.rpm}} goreleaser-*.armv7hl.rpm'
@@ -176,11 +171,6 @@ tasks:
           Platform: 'arm64'
           Image: ubuntu
           Cmd: '{{.dpkg}} goreleaser*_arm64.deb'
-      - task: goreleaser:test:pkg
-        vars:
-          Platform: 'arm/6'
-          Image: debian
-          Cmd: '{{.dpkg}} goreleaser*_armel.deb'
       - task: goreleaser:test:pkg
         vars:
           Platform: 'arm/7'
@@ -207,11 +197,6 @@ tasks:
           Platform: 'arm64'
           Image: alpine
           Cmd: '{{.apk}} goreleaser*_aarch64.apk'
-      - task: goreleaser:test:pkg
-        vars:
-          Platform: 'arm/6'
-          Image: alpine
-          Cmd: '{{.apk}} goreleaser*_armhf.apk'
       - task: goreleaser:test:pkg
         vars:
           Platform: 'arm/7'


### PR DESCRIPTION
has virtually no downloads, and was never really tested...

I think we can have fewer targets, only the most common ones. Should speed up the release a bit and also lower the number of files in the release


wdyt?