### PR TITLE
fix: logext STDERR use warn instead of error

### DIFF
--- a/internal/logext/testdata/TestWriter/debug/1.txt.golden
+++ b/internal/logext/testdata/TestWriter/debug/1.txt.golden
@@ -1,2 +1,2 @@
-      ⨯ foo                       foo=bar
-      ⨯ bar                       foo=bar
+      • foo                       foo=bar
+      • bar                       foo=bar

--- a/internal/logext/writer.go
+++ b/internal/logext/writer.go
@@ -47,7 +47,7 @@ func (w logWriter) Write(p []byte) (int, error) {
 		case Info:
 			w.ctx.Info(line)
 		case Error:
-			w.ctx.Error(line)
+			w.ctx.Warn(line)
 		}
 	}
 	return len(p), nil


### PR DESCRIPTION
its common for CLIs to log to STDERR, showing those as errors seems a bit too much, changing them to warn for now. We can then evaluate and maybe change all to info if needed