### PR TITLE
fix: sbom binary filter

### DIFF
--- a/internal/pipe/sbom/sbom.go
+++ b/internal/pipe/sbom/sbom.go
@@ -96,11 +96,7 @@ func catalogTask(ctx *context.Context, cfg config.SBOM) func() error {
 		case "archive":
 			filters = append(filters, artifact.ByType(artifact.UploadableArchive))
 		case "binary":
-			filters = append(filters, artifact.Or(
-				artifact.ByType(artifact.Binary),
-				artifact.ByType(artifact.UploadableBinary),
-				artifact.ByType(artifact.UniversalBinary),
-			))
+			filters = append(filters, artifact.ByType(artifact.UploadableBinary))
 		case "package":
 			filters = append(filters, artifact.ByType(artifact.LinuxPackage))
 		case "any":


### PR DESCRIPTION
When using the `sbom` config with `binary` artifact it was generating a duplicate list of binaries to generate the sbom and that generate the `artifacts.json` with duplicate entries and that will fail in the release step when trying to upload the files to the GitHub, for example, it tries to push duplicate files and that fail in the GitHub side.

applying this change the list is correct.