### PR TITLE
fix: don't format github-native changelog

### DIFF
--- a/internal/pipe/changelog/changelog.go
+++ b/internal/pipe/changelog/changelog.go
@@ -72,7 +72,9 @@ func (Pipe) Run(ctx *context.Context) error {
 		"## Changelog",
 	}
 
-	if shouldGroup(ctx.Config.Changelog) {
+	if ctx.Config.Changelog.Use == "github-native" {
+		changelogElements = []string{strings.Join(entries, changelogStringJoiner)}
+	} else if shouldGroup(ctx.Config.Changelog) {
 		log.Debug("grouping entries")
 		groups := ctx.Config.Changelog.Groups
 


### PR DESCRIPTION
Thank you for building goreleaser! While setting it up on https://github.com/pelletier/go-toml/tree/v2, I've noticed that when using the `github-native` changelog setting and publishing releases to GitHub, the resulting release had an odd formatting issue (see below).

The Github changelog generation API returns a pre-formatted changelog. The current implementation prefixes every line of that log with "* ". This operation breaks the formatting.

This change makes goreleaser treat github-native changelog as-is, without trying to modify it.

I tried to write a unit test for this, but couldn't find a good way to both mock the `githubNativeChangeloger` and evaluate the execution of `Pipe.Run`.

Would love to hear your thoughts on that change!

---

Formatting:

![image](https://user-images.githubusercontent.com/172804/147883061-a6dd91c1-d6a6-43da-bd2f-cb5a10d481bf.png)
