### PR TITLE
feat: allow multiple ids on universal binaries

### DIFF
--- a/internal/pipe/universalbinary/universalbinary.go
+++ b/internal/pipe/universalbinary/universalbinary.go
@@ -34,6 +34,9 @@ func (Pipe) Default(ctx *context.Context) error {
 		if unibin.ID == "" {
 			unibin.ID = ctx.Config.ProjectName
 		}
+		if len(unibin.IDs) == 0 {
+			unibin.IDs = []string{unibin.ID}
+		}
 		if unibin.NameTemplate == "" {
 			unibin.NameTemplate = "{{ .ProjectName }}"
 		}
@@ -228,6 +231,6 @@ func filterFor(unibin config.UniversalBinary) artifact.Filter {
 	return artifact.And(
 		artifact.ByType(artifact.Binary),
 		artifact.ByGoos("darwin"),
-		artifact.ByIDs(unibin.ID),
+		artifact.ByIDs(unibin.IDs...),
 	)
 }

--- a/internal/pipe/universalbinary/universalbinary_test.go
+++ b/internal/pipe/universalbinary/universalbinary_test.go
@@ -32,6 +32,24 @@ func TestDefault(t *testing.T) {
 		require.NoError(t, Pipe{}.Default(ctx))
 		require.Equal(t, config.UniversalBinary{
 			ID:           "proj",
+			IDs:          []string{"proj"},
+			NameTemplate: "{{ .ProjectName }}",
+		}, ctx.Config.UniversalBinaries[0])
+	})
+
+	t.Run("given ids", func(t *testing.T) {
+		ctx := &context.Context{
+			Config: config.Project{
+				ProjectName: "proj",
+				UniversalBinaries: []config.UniversalBinary{
+					{IDs: []string{"foo"}},
+				},
+			},
+		}
+		require.NoError(t, Pipe{}.Default(ctx))
+		require.Equal(t, config.UniversalBinary{
+			ID:           "proj",
+			IDs:          []string{"foo"},
 			NameTemplate: "{{ .ProjectName }}",
 		}, ctx.Config.UniversalBinaries[0])
 	})
@@ -48,6 +66,7 @@ func TestDefault(t *testing.T) {
 		require.NoError(t, Pipe{}.Default(ctx))
 		require.Equal(t, config.UniversalBinary{
 			ID:           "foo",
+			IDs:          []string{"foo"},
 			NameTemplate: "{{ .ProjectName }}",
 		}, ctx.Config.UniversalBinaries[0])
 	})
@@ -64,6 +83,7 @@ func TestDefault(t *testing.T) {
 		require.NoError(t, Pipe{}.Default(ctx))
 		require.Equal(t, config.UniversalBinary{
 			ID:           "proj",
+			IDs:          []string{"proj"},
 			NameTemplate: "foo",
 		}, ctx.Config.UniversalBinaries[0])
 	})
@@ -111,6 +131,7 @@ func TestRun(t *testing.T) {
 		UniversalBinaries: []config.UniversalBinary{
 			{
 				ID:           "foo",
+				IDs:          []string{"foo"},
 				NameTemplate: "foo",
 				Replace:      true,
 			},
@@ -123,6 +144,7 @@ func TestRun(t *testing.T) {
 		UniversalBinaries: []config.UniversalBinary{
 			{
 				ID:           "foo",
+				IDs:          []string{"foo"},
 				NameTemplate: "foo",
 			},
 		},
@@ -133,6 +155,7 @@ func TestRun(t *testing.T) {
 		UniversalBinaries: []config.UniversalBinary{
 			{
 				ID:           "notfoo",
+				IDs:          []string{"notfoo"},
 				NameTemplate: "notfoo",
 			},
 		},
@@ -143,6 +166,7 @@ func TestRun(t *testing.T) {
 		UniversalBinaries: []config.UniversalBinary{
 			{
 				ID:           "foo",
+				IDs:          []string{"foo"},
 				NameTemplate: "foo",
 			},
 		},
@@ -153,6 +177,7 @@ func TestRun(t *testing.T) {
 		UniversalBinaries: []config.UniversalBinary{
 			{
 				ID:           "foo",
+				IDs:          []string{"foo"},
 				NameTemplate: "foo",
 				Hooks: config.BuildHookConfig{
 					Pre: []config.Hook{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -435,7 +435,8 @@ func (f File) JSONSchemaType() *jsonschema.Type {
 
 // UniversalBinary setups macos universal binaries.
 type UniversalBinary struct {
-	ID           string          `yaml:"id,omitempty"`
+	ID           string          `yaml:"id,omitempty"` // deprecated
+	IDs          []string        `yaml:"ids,omitempty"`
 	NameTemplate string          `yaml:"name_template,omitempty"`
 	Replace      bool            `yaml:"replace,omitempty"`
 	Hooks        BuildHookConfig `yaml:"hooks,omitempty"`

--- a/www/docs/customization/universalbinaries.md
+++ b/www/docs/customization/universalbinaries.md
@@ -9,10 +9,17 @@ Here's how to use it:
 # .goreleaser.yaml
 universal_binaries:
 -
-  # ID of the source build
+  # ID of resulting universal binary.
   #
   # Defaults to the project name.
   id: foo
+
+  # IDs to use to filter the built binaries.
+  #
+  # Defaults to the `id` field.
+  ids:
+  - build1
+  - build2
 
   # Universal binary name template.
   #


### PR DESCRIPTION
fixes #2759

* behavior still the same if no `ids` is provided
* if `ids` is provided, it will be used to filter, and the resulting universal binary will have the ID set in the `id` field

since before it was not possible to set multiple ids, and the previous behavior will remain, this is not a breaking change IMO