### PR TITLE
feat: allow to template commit author

### DIFF
--- a/internal/commitauthor/author.go
+++ b/internal/commitauthor/author.go
@@ -7,8 +7,10 @@ import (
 	"github.com/goreleaser/goreleaser/pkg/context"
 )
 
-const defaultName = "goreleaserbot"
-const defaultEmail = "goreleaser@carlosbecker.com"
+const (
+	defaultName  = "goreleaserbot"
+	defaultEmail = "goreleaser@carlosbecker.com"
+)
 
 // Get templates the commit author and returns the filled fields.
 func Get(ctx *context.Context, og config.CommitAuthor) (config.CommitAuthor, error) {

--- a/internal/commitauthor/author.go
+++ b/internal/commitauthor/author.go
@@ -1,0 +1,35 @@
+// Package commitauthor provides common commit author functionality.
+package commitauthor
+
+import (
+	"github.com/goreleaser/goreleaser/internal/tmpl"
+	"github.com/goreleaser/goreleaser/pkg/config"
+	"github.com/goreleaser/goreleaser/pkg/context"
+)
+
+const defaultName = "goreleaserbot"
+const defaultEmail = "goreleaser@carlosbecker.com"
+
+// Get templates the commit author and returns the filled fields.
+func Get(ctx *context.Context, og config.CommitAuthor) (config.CommitAuthor, error) {
+	var author config.CommitAuthor
+	var err error
+
+	author.Name, err = tmpl.New(ctx).Apply(og.Name)
+	if err != nil {
+		return author, err
+	}
+	author.Email, err = tmpl.New(ctx).Apply(og.Email)
+	return author, err
+}
+
+// Default sets the default commit author name and email.
+func Default(og config.CommitAuthor) config.CommitAuthor {
+	if og.Name == "" {
+		og.Name = defaultName
+	}
+	if og.Email == "" {
+		og.Email = defaultEmail
+	}
+	return og
+}

--- a/internal/commitauthor/author_test.go
+++ b/internal/commitauthor/author_test.go
@@ -1,0 +1,72 @@
+package commitauthor
+
+import (
+	"testing"
+
+	"github.com/goreleaser/goreleaser/pkg/config"
+	"github.com/goreleaser/goreleaser/pkg/context"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGet(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		author, err := Get(context.New(config.Project{
+			Env: []string{"NAME=foo", "MAIL=foo@bar"},
+		}), config.CommitAuthor{
+			Name:  "{{.Env.NAME}}",
+			Email: "{{.Env.MAIL}}",
+		})
+		require.NoError(t, err)
+		require.Equal(t, config.CommitAuthor{
+			Name:  "foo",
+			Email: "foo@bar",
+		}, author)
+	})
+
+	t.Run("invalid name tmpl", func(t *testing.T) {
+		_, err := Get(
+			context.New(config.Project{}),
+			config.CommitAuthor{
+				Name:  "{{.Env.NOPE}}",
+				Email: "a",
+			})
+		require.Error(t, err)
+	})
+
+	t.Run("invalid email tmpl", func(t *testing.T) {
+		_, err := Get(
+			context.New(config.Project{}),
+			config.CommitAuthor{
+				Name:  "a",
+				Email: "{{.Env.NOPE}}",
+			})
+		require.Error(t, err)
+	})
+}
+
+func TestDefault(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		require.Equal(t, Default(config.CommitAuthor{}), config.CommitAuthor{
+			Name:  defaultName,
+			Email: defaultEmail,
+		})
+	})
+
+	t.Run("no name", func(t *testing.T) {
+		require.Equal(t, Default(config.CommitAuthor{
+			Email: "a",
+		}), config.CommitAuthor{
+			Name:  defaultName,
+			Email: "a",
+		})
+	})
+
+	t.Run("no email", func(t *testing.T) {
+		require.Equal(t, Default(config.CommitAuthor{
+			Name: "a",
+		}), config.CommitAuthor{
+			Name:  "a",
+			Email: defaultEmail,
+		})
+	})
+}


### PR DESCRIPTION
closes #2761

allow to template commit author everywhere:

- brew
- gofish
- krew
- scoop

created a "central" `commitauthor` package to hold the code for the defaults and templates.