### PR TITLE
chore: remove stale trigger paths

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,11 +5,9 @@ on:
     branches:
       - 'main'
     paths:
-      - '.github/workflows/htmltest.yml'
       - 'www/*'
   pull_request:
     paths:
-      - '.github/workflows/htmltest.yml'
       - 'www/*'
 
 jobs:


### PR DESCRIPTION
If applied, this commit will tidy up some stale paths in the GitHub Actions `docs` workflow.

`.github/workflows/htmltest.yml` no longer exists, and the `www/*` path catches changes to `www/htmltest.yml`.
