### PR TITLE
fix: dedupliate cataloging binary artifacts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/muesli/coral v1.0.0
 	github.com/muesli/mango-coral v1.0.1
 	github.com/muesli/roff v0.1.0
+	github.com/scylladb/go-set v1.0.2
 	github.com/slack-go/slack v0.10.2
 	github.com/stretchr/testify v1.7.0
 	github.com/ulikunitz/xz v0.5.10

--- a/go.sum
+++ b/go.sum
@@ -322,6 +322,8 @@ github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
+github.com/fatih/set v0.2.1 h1:nn2CaJyknWE/6txyUDGwysr3G5QC6xWB/PtVjPBbeaA=
+github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
@@ -674,6 +676,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/scylladb/go-set v1.0.2 h1:SkvlMCKhP0wyyct6j+0IHJkBkSZL+TDzZ4E7f7BCcRE=
+github.com/scylladb/go-set v1.0.2/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=


### PR DESCRIPTION
This PR makes the following adjustments:
- primarily restores the capability to reference binary artifacts when `sbom[].artifact == binary`
- adds the ability to have templates within `sbom[].env` values
- only prepends `dist` config value to paths that relative paths (takes no action on absolute paths)
- decomposes templating code further for the SBOM pipe and surround with more testing

Why make this change? primarily to unlock more workflows when generating SBOMs.

Not all tooling can work with encapsulations of go binaries (zip/tar) and instead need access to the binary directly. Since goreleaser manages creating the binary it is possible to expose the original binary to SBOM tooling even though it may be an encapsulation that is attached to a release (e.g. a zip or tar.gz)

Take for example using `cyclonedx-gomod app`:

```
#.goreleaser.yaml

archives:
  - format: tar.gz

sboms:
  - documents:
      - "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}.cdx.sbom"
    artifacts: binary
    cmd: cyclonedx-gomod
    env: 
      - GOOS={{ .Os }}
      - GOARCH={{ .Arch }}
    args: ["app",  "-json", "-output", "$document", "$PWD"]

```

With `artifacts: binary` the SBOM tool gets access to the unarchived binary even though `archives[0].format = tar.gz` and there is **_no_** `archives[].format = binary` set. Additionally this uses goreleaser-sourced variables to seed the correct go-specific environment variables that the tool keys in on.

Relevant links:
- Support additional SBOM files based on CycloneDX: https://github.com/goreleaser/goreleaser/issues/2808
- Removal of binary from the SBOM pipe artifact filter: https://github.com/goreleaser/goreleaser/pull/2798