### PR TITLE
fix: improve deprecate logs

### DIFF
--- a/internal/deprecate/deprecate.go
+++ b/internal/deprecate/deprecate.go
@@ -43,10 +43,14 @@ func Notice(ctx *context.Context, property string) {
 // NoticeCustom warns the user about the deprecation of the given property.
 func NoticeCustom(ctx *context.Context, property, tmpl string) {
 	ctx.Deprecated = true
-	cli.Default.Padding += 3
-	defer func() {
-		cli.Default.Padding -= 3
-	}()
+	// XXX: this is very ugly!
+	w := log.Log.(*log.Logger).Handler.(*cli.Handler).Writer
+	handler := cli.New(w)
+	handler.Padding = cli.Default.Padding + 3
+	log := &log.Logger{
+		Handler: handler,
+		Level:   log.InfoLevel,
+	}
 	// replaces . and _ with -
 	url := baseURL + strings.NewReplacer(
 		".", "",

--- a/internal/deprecate/testdata/TestNotice.txt.golden
+++ b/internal/deprecate/testdata/TestNotice.txt.golden
@@ -1,3 +1,3 @@
    • first                    
-   • DEPRECATED: `foo.bar.whatever` should not be used anymore, check https://goreleaser.com/deprecations#foobarwhatever for more info
+      • DEPRECATED: `foo.bar.whatever` should not be used anymore, check https://goreleaser.com/deprecations#foobarwhatever for more info
    • last                     

--- a/internal/deprecate/testdata/TestNoticeCustom.txt.golden
+++ b/internal/deprecate/testdata/TestNoticeCustom.txt.golden
@@ -1,3 +1,3 @@
    • first                    
-   • DEPRECATED: some custom template with a url https://goreleaser.com/deprecations#something-else
+      • DEPRECATED: some custom template with a url https://goreleaser.com/deprecations#something-else
    • last                     


### PR DESCRIPTION
this should prevent concurrent logs from getting the wrong padding, as we wont be messing with the global logger padding anymore

brain dump: maybe worth copying what we actually use from that log library and tune it so we can avoid these kinds of hacks?