### PR TITLE
fix: pre-commit hook

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 FILES=$(git diff --cached --name-only --diff-filter=ACMR)
 
-gofumpt -s -l -w .
+gofumpt -l -w .
 golangci-lint run --new --fix
 
 git add $FILES


### PR DESCRIPTION
`-s` is now implicit, so it actually generates a warning. we can drop that option.