### PR TITLE
docs(cookbooks): Add documentation for how to publish to JFrog artifa…

### DIFF
--- a/www/docs/cookbooks/publish-to-artifactory.md
+++ b/www/docs/cookbooks/publish-to-artifactory.md
@@ -1,0 +1,42 @@
+# Publish to Artifactory
+
+## Publish to Artifactory using curl
+
+Example of a [publishers](/customization/publishers/) section pushing files to a Artifactory instance using curl:
+
+```yaml
+publishers:
+- name: artifactory
+  cmd: >-
+    curl -k -H "X-JFrog-Art-API: {{ .Env.ARTIFACTORY_API_KEY }}"
+      -X PUT
+      -H "Accept: application/json"
+      -H "Content-Type: multipart/form-data"
+      "https://artifactory.somehost.com/artifactory/my-repository/{{ tolower .Env.PROJECT_KEY }}/{{ tolower .ProjectName }}/{{ .Version }}/{{ .ArtifactName }}
+      -T @{{ .ArtifactName }}
+  dir: "{{ dir .ArtifactPath }}"
+```
+
+## Publish to Artifactory using jfrog cli
+
+This assumes you have the [jfrog cli](https://jfrog.com/getcli/) downloaded and in your path, and configured with an API key
+
+Example of a [publishers](/customization/publishers/) section pushing files to a Artifactory instance using jfrog cli with api key in config file:
+
+```yaml
+publishers:
+- name: artifactory
+  cmd: >-
+    jfrog rt u "{{ .ArtifactName }}" "my-repository/{{ tolower .Env.PROJECT_KEY }}/{{ tolower .ProjectName }}/{{ .Version }}/"
+  dir: "{{ dir .ArtifactPath }}"
+```
+
+Example of a [publishers](/customization/publishers/) section pushing files to a Artifactory instance using jfrog cli with api key in environment
+
+```yaml
+publishers:
+- name: artifactory
+  cmd: >-
+    jfrog rt u "{{ .ArtifactName }}" "my-repository/{{ tolower .Env.PROJECT_KEY }}/{{ tolower .ProjectName }}/{{ .Version }}/" --api-key "{{ .Env.ARTIFACTORY_API_KEY }}"
+  dir: "{{ dir .ArtifactPath }}"
+```

--- a/www/mkdocs.yml
+++ b/www/mkdocs.yml
@@ -146,6 +146,7 @@ nav:
   - cookbooks/cgo-and-crosscompiling.md
   - cookbooks/debconf-templates.md
   - cookbooks/publish-to-nexus.md
+  - cookbooks/publish-to-artifactory.md
   - cookbooks/release-a-library.md
   - cookbooks/semantic-release.md
   - cookbooks/set-a-custom-git-tag.md


### PR DESCRIPTION
…ctory.

This commit adds a new cookbook that covers how to upload to JFrog Artifactory: https://jfrog.com/artifactory/ using the REST API: https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API
or the jfrog cli: https://jfrog.com/getcli/

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

...

<!-- Why is this change being made? -->

...

<!-- # Provide links to any relevant tickets, URLs or other resources -->

...
