### PR TITLE
feat: add goreleaser image to ArtifactHub

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -71,7 +71,7 @@ dockers:
   use: buildx
   build_flag_templates:
   - "--pull"
-  - "--label=io.artifacthub.package.readme-url={{.ENV.README_URL}}"
+  - "--label=io.artifacthub.package.readme-url={{.Env.README_URL}}"
   - "--label=org.opencontainers.image.description={{.Env.DESCRIPTION}}"
   - "--label=org.opencontainers.image.created={{.Date}}"
   - "--label=org.opencontainers.image.name={{.ProjectName}}"
@@ -88,7 +88,7 @@ dockers:
   use: buildx
   build_flag_templates:
   - "--pull"
-  - "--label=io.artifacthub.package.readme-url={{.ENV.README_URL}}"
+  - "--label=io.artifacthub.package.readme-url={{.Env.README_URL}}"
   - "--label=org.opencontainers.image.description={{.Env.DESCRIPTION}}"
   - "--label=org.opencontainers.image.created={{.Date}}"
   - "--label=org.opencontainers.image.name={{.ProjectName}}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,7 @@
 env:
   - GO111MODULE=on
+  - DESCRIPTION="Deliver Go binaries as fast and easily as possible"
+  - README_URL="https://raw.githubusercontent.com/goreleaser/goreleaser/main/README.md"
 
 before:
   hooks:
@@ -69,6 +71,8 @@ dockers:
   use: buildx
   build_flag_templates:
   - "--pull"
+  - "--label=io.artifacthub.package.readme-url={{.ENV.README_URL}}"
+  - "--label=org.opencontainers.image.description={{.Env.DESCRIPTION}}"
   - "--label=org.opencontainers.image.created={{.Date}}"
   - "--label=org.opencontainers.image.name={{.ProjectName}}"
   - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -84,6 +88,8 @@ dockers:
   use: buildx
   build_flag_templates:
   - "--pull"
+  - "--label=io.artifacthub.package.readme-url={{.ENV.README_URL}}"
+  - "--label=org.opencontainers.image.description={{.Env.DESCRIPTION}}"
   - "--label=org.opencontainers.image.created={{.Date}}"
   - "--label=org.opencontainers.image.name={{.ProjectName}}"
   - "--label=org.opencontainers.image.revision={{.FullCommit}}"


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->

Adding the GoReleaser Image to the new ArtifactHub function https://artifacthub.io/docs/topics/repositories/#container-images-repositories

So far so good, It's just miss two properites:

![image](https://user-images.githubusercontent.com/38325136/151679675-03418b51-a1e8-46cb-8ec7-ad4f029767ba.png)

This PR will add them.


<!-- If applied, this commit will... -->

Fixes: #2830 

