### PR TITLE
feat: expose runtime goos and goarch on templates and metadata

### DIFF
--- a/internal/pipe/metadata/metadata.go
+++ b/internal/pipe/metadata/metadata.go
@@ -33,6 +33,10 @@ func writeMetadata(ctx *context.Context) error {
 		Version:     ctx.Version,
 		Commit:      ctx.Git.Commit,
 		Date:        ctx.Date,
+		Runtime: metaRuntime{
+			Goos:   ctx.Runtime.Goos,
+			Goarch: ctx.Runtime.Goarch,
+		},
 	}, "metadata.json")
 }
 
@@ -51,10 +55,16 @@ func writeJSON(ctx *context.Context, j interface{}, name string) error {
 }
 
 type metadata struct {
-	ProjectName string    `json:"project_name"`
-	Tag         string    `json:"tag"`
-	PreviousTag string    `json:"previous_tag"`
-	Version     string    `json:"version"`
-	Commit      string    `json:"commit"`
-	Date        time.Time `json:"date"`
+	ProjectName string      `json:"project_name"`
+	Tag         string      `json:"tag"`
+	PreviousTag string      `json:"previous_tag"`
+	Version     string      `json:"version"`
+	Commit      string      `json:"commit"`
+	Date        time.Time   `json:"date"`
+	Runtime     metaRuntime `json:"runtime"`
+}
+
+type metaRuntime struct {
+	Goos   string `json:"goos"`
+	Goarch string `json:"goarch"`
 }

--- a/internal/pipe/metadata/metadata_test.go
+++ b/internal/pipe/metadata/metadata_test.go
@@ -27,6 +27,10 @@ func TestRun(t *testing.T) {
 		Dist:        tmp,
 		ProjectName: "name",
 	})
+	ctx.Runtime = context.Runtime{
+		Goos:   "fakeos",
+		Goarch: "fakearch",
+	}
 	ctx.Version = "1.2.3"
 	ctx.Git = context.GitInfo{
 		CurrentTag:  "v1.2.3",

--- a/internal/pipe/metadata/testdata/TestRun/metadata.json.golden
+++ b/internal/pipe/metadata/testdata/TestRun/metadata.json.golden
@@ -1,1 +1,1 @@
-{"project_name":"name","tag":"v1.2.3","previous_tag":"v1.2.2","version":"1.2.3","commit":"aef34a","date":"2022-01-22T10:12:13Z"}
+{"project_name":"name","tag":"v1.2.3","previous_tag":"v1.2.2","version":"1.2.3","commit":"aef34a","date":"2022-01-22T10:12:13Z","runtime":{"goos":"fakeos","goarch":"fakearch"}}

--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -52,6 +52,7 @@ const (
 	timestamp       = "Timestamp"
 	modulePath      = "ModulePath"
 	releaseNotes    = "ReleaseNotes"
+	runtimeK        = "Runtime"
 
 	// artifact-only keys.
 	osKey        = "Os"
@@ -102,6 +103,7 @@ func New(ctx *context.Context) *Template {
 			prerelease:      ctx.Semver.Prerelease,
 			isSnapshot:      ctx.Snapshot,
 			releaseNotes:    ctx.ReleaseNotes,
+			runtimeK:        ctx.Runtime,
 		},
 	}
 }

--- a/internal/tmpl/tmpl_test.go
+++ b/internal/tmpl/tmpl_test.go
@@ -63,8 +63,8 @@ func TestWithArtifact(t *testing.T) {
 		"v1.2.2":                           "{{ .PreviousTag }}",
 		"awesome release":                  "{{ .TagSubject }}",
 		"awesome release\n\nanother line":  "{{ .TagContents }}",
-		runtime.GOOS:                       "{{ .Runtime.Goos }}",
-		runtime.GOARCH:                     "{{ .Runtime.Goarch }}",
+		"runtime: " + runtime.GOOS:         "runtime: {{ .Runtime.Goos }}",
+		"runtime: " + runtime.GOARCH:       "runtime: {{ .Runtime.Goarch }}",
 	} {
 		tmpl := tmpl
 		expect := expect

--- a/internal/tmpl/tmpl_test.go
+++ b/internal/tmpl/tmpl_test.go
@@ -3,6 +3,7 @@ package tmpl
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"text/template"
 
@@ -62,6 +63,8 @@ func TestWithArtifact(t *testing.T) {
 		"v1.2.2":                           "{{ .PreviousTag }}",
 		"awesome release":                  "{{ .TagSubject }}",
 		"awesome release\n\nanother line":  "{{ .TagContents }}",
+		runtime.GOOS:                       "{{ .Runtime.Goos }}",
+		runtime.GOARCH:                     "{{ .Runtime.Goarch }}",
 	} {
 		tmpl := tmpl
 		expect := expect

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -9,6 +9,7 @@ package context
 import (
 	ctx "context"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -98,6 +99,12 @@ type Context struct {
 	Deprecated         bool
 	Parallelism        int
 	Semver             Semver
+	Runtime            Runtime
+}
+
+type Runtime struct {
+	Goos   string
+	Goarch string
 }
 
 // Semver represents a semantic version.
@@ -129,6 +136,10 @@ func Wrap(ctx ctx.Context, config config.Project) *Context {
 		Parallelism: 4,
 		Artifacts:   artifact.New(),
 		Date:        time.Now(),
+		Runtime: Runtime{
+			Goos:   runtime.GOOS,
+			Goarch: runtime.GOARCH,
+		},
 	}
 }
 

--- a/pkg/context/context_test.go
+++ b/pkg/context/context_test.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -20,6 +21,8 @@ func TestNew(t *testing.T) {
 	require.Equal(t, "BAR", ctx.Env["FOO"])
 	require.Equal(t, "1", ctx.Env["BAR"])
 	require.Equal(t, 4, ctx.Parallelism)
+	require.Equal(t, runtime.GOOS, ctx.Runtime.Goos)
+	require.Equal(t, runtime.GOARCH, ctx.Runtime.Goarch)
 }
 
 func TestNewWithTimeout(t *testing.T) {

--- a/www/docs/customization/templates.md
+++ b/www/docs/customization/templates.md
@@ -45,6 +45,8 @@ On fields that support templating, these fields are always available:
 | `.PrefixedSummary`     | the git summary prefixed with the monorepo config tag prefix (if any)                                  |
 | `.TagSubject`          | the annotated tag message subject, or the message subject of the commit it points out[^6]              |
 | `.TagContents`         | the annotated tag message, or the message of the commit it points out[^7]                              |
+| `.Runtime.Goos`        | equivalent to `runtime.GOOS`                                                                           |
+| `.Runtime.Goarch`      | equivalent to `runtime.GOARCH`                                                                         |
 
 [^1]: The `v` prefix is stripped and it might be changed in `snapshot` and `nightly` builds.
 [^2]: Assuming `Tag` is a valid a SemVer, otherwise empty/zeroed.


### PR DESCRIPTION
Expose `{{ .Runtime.Goos }}` and `{{ .Runtime.Goarch }}`

refs  #2829