### PR TITLE
chore: bump mango and adapt to changed API

### DIFF
--- a/cmd/man.go
+++ b/cmd/man.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/muesli/mango/mcobra"
+	mcobra "github.com/muesli/mango-cobra"
 	"github.com/muesli/roff"
 	"github.com/spf13/cobra"
 )

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/imdario/mergo v0.3.12
 	github.com/jarcoal/httpmock v1.1.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/muesli/mango v0.0.0-20220118122812-f367188b892e
+	github.com/muesli/mango-cobra v0.0.0-20220201011537-57e8ea90d84d
 	github.com/muesli/roff v0.1.0
 	github.com/slack-go/slack v0.10.1
 	github.com/spf13/cobra v1.3.0
@@ -123,6 +123,8 @@ require (
 	github.com/mikesmitty/edkey v0.0.0-20170222072505-3356ea4e686a // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/muesli/mango v0.0.0-20220201014152-f7df5a1c5b4b // indirect
+	github.com/muesli/mango-pflag v0.0.0-20220201005230-61491fbf5067 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -668,8 +668,14 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/muesli/mango v0.0.0-20220118122812-f367188b892e h1:ykZ/Hqqvqm2lmZ1YoruxTWaOb90IKlkMuT0Io9baO+A=
 github.com/muesli/mango v0.0.0-20220118122812-f367188b892e/go.mod h1:r40g5Hx6ZzbjDW0GZhCpSX2Wyt9SPSDRoQGaODqxSz4=
+github.com/muesli/mango v0.0.0-20220201004148-738bbf77ebc7/go.mod h1:q8VakJrokLG9eyXL/eKXdCWoiysU67gvmmLOZ9BVVm8=
+github.com/muesli/mango v0.0.0-20220201014152-f7df5a1c5b4b h1:kGcKjlZqUNbpUjBMdIq5/RbA2gN9ypH0Tv+MNBtCgK4=
+github.com/muesli/mango v0.0.0-20220201014152-f7df5a1c5b4b/go.mod h1:5XFpbC8jY5UUv89YQciiXNlbi+iJgt29VDC5xbzrLL4=
+github.com/muesli/mango-cobra v0.0.0-20220201011537-57e8ea90d84d h1:y9wFb79xE6eVS8ZgZMXjn2UQeWOG7fhAX1vvgXhJvwc=
+github.com/muesli/mango-cobra v0.0.0-20220201011537-57e8ea90d84d/go.mod h1:Bo5JdUxA1zYbNIzUK5YxAemYZz88tXpwBqiYkSQDpTY=
+github.com/muesli/mango-pflag v0.0.0-20220201005230-61491fbf5067 h1:7FPaDhKrGIao4vT+DgDRoTRyS+vS7RyPCSZkfD7QjGE=
+github.com/muesli/mango-pflag v0.0.0-20220201005230-61491fbf5067/go.mod h1:RsCECu56gEckjyi4fLJQsQTCIBYFfSEW24AuOEpD+sM=
 github.com/muesli/roff v0.1.0 h1:YD0lalCotmYuF5HhZliKWlIx7IEhiXeSfq7hNjFqGF8=
 github.com/muesli/roff v0.1.0/go.mod h1:pjAHQM9hdUUwm/krAfrLGgJkXJ+YuhtsfZ42kieB2Ig=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=


### PR DESCRIPTION
mango's API has changed, and the mango-cobra adapter has been moved into a separate repository. This change bumps mango and adapts goreleaser's code to this API change.

See: https://github.com/muesli/mango/pull/5