### PR TITLE
fix: nfpm binaries should have 755 instead of 775 perms

### DIFF
--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -197,6 +197,9 @@ func create(ctx *context.Context, fpm config.NFPM, format string, binaries []*ar
 			contents = append(contents, &files.Content{
 				Source:      filepath.ToSlash(src),
 				Destination: filepath.ToSlash(dst),
+				FileInfo: &files.ContentFileInfo{
+					Mode: 0o755,
+				},
 			})
 		}
 	}


### PR DESCRIPTION
this makes lintian a bit happier


refs https://github.com/goreleaser/nfpm/issues/439