### PR TITLE
fix: make --release-notes flags more deterministic

### DIFF
--- a/internal/pipe/changelog/changelog.go
+++ b/internal/pipe/changelog/changelog.go
@@ -49,7 +49,7 @@ func (Pipe) Run(ctx *context.Context) error {
 	}
 	ctx.ReleaseNotes = notes
 
-	if ctx.ReleaseNotes != "" {
+	if ctx.ReleaseNotesFile != "" || ctx.ReleaseNotesTmpl != "" {
 		return nil
 	}
 

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -25,13 +25,26 @@ func TestChangelogProvidedViaFlag(t *testing.T) {
 	require.Equal(t, "c0ff33 coffeee\n", ctx.ReleaseNotes)
 }
 
-func TestChangelogProvidedViaFlagIsAnWhitespaceOnlyFile(t *testing.T) {
+func TestChangelogProvidedViaFlagIsAWhitespaceOnlyFile(t *testing.T) {
 	ctx := context.New(config.Project{})
 	ctx.ReleaseNotesFile = "testdata/changes-empty.md"
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Equal(t, "\n", ctx.ReleaseNotes)
 }
 
+func TestChangelogProvidedViaFlagIsReallyEmpty(t *testing.T) {
+	ctx := context.New(config.Project{})
+	ctx.ReleaseNotesFile = "testdata/changes-really-empty.md"
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, "", ctx.ReleaseNotes)
+}
+
+func TestChangelogTmplProvidedViaFlagIsReallyEmpty(t *testing.T) {
+	ctx := context.New(config.Project{})
+	ctx.ReleaseNotesTmpl = "testdata/changes-really-empty.md"
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, "", ctx.ReleaseNotes)
+}
 func TestTemplatedChangelogProvidedViaFlag(t *testing.T) {
 	ctx := context.New(config.Project{})
 	ctx.ReleaseNotesFile = "testdata/changes.md"

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -45,6 +45,7 @@ func TestChangelogTmplProvidedViaFlagIsReallyEmpty(t *testing.T) {
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Equal(t, "", ctx.ReleaseNotes)
 }
+
 func TestTemplatedChangelogProvidedViaFlag(t *testing.T) {
 	ctx := context.New(config.Project{})
 	ctx.ReleaseNotesFile = "testdata/changes.md"


### PR DESCRIPTION
if the a file is given, but is empty, leave the changelog empty (although it will be warned).

this makes whitespace-only and empty files have the same behavior.