### PR TITLE
feat: allow to use .Path and .Name on universal binary post hooks

### DIFF
--- a/internal/pipe/universalbinary/universalbinary.go
+++ b/internal/pipe/universalbinary/universalbinary.go
@@ -52,7 +52,11 @@ func (Pipe) Run(ctx *context.Context) error {
 	for _, unibin := range ctx.Config.UniversalBinaries {
 		unibin := unibin
 		g.Go(func() error {
-			opts := build.Options{}
+			opts := build.Options{
+				Target: "darwin_all",
+				Goos:   "darwin",
+				Goarch: "all",
+			}
 			if err := runHook(ctx, &opts, unibin.Hooks.Pre); err != nil {
 				return fmt.Errorf("pre hook failed: %w", err)
 			}

--- a/internal/pipe/universalbinary/universalbinary_test.go
+++ b/internal/pipe/universalbinary/universalbinary_test.go
@@ -185,7 +185,7 @@ func TestRun(t *testing.T) {
 					},
 					Post: []config.Hook{
 						{Cmd: "touch " + post},
-						{Cmd: `sh -c 'echo "{{ .Name }}" > {{ .Path }}.post'`, Output: true},
+						{Cmd: `sh -c 'echo "{{ .Name }} {{ .Os }} {{ .Arch }} {{ .Arm }} {{ .Target }} {{ .Ext }}" > {{ .Path }}.post'`, Output: true},
 					},
 				},
 			},
@@ -273,7 +273,7 @@ func TestRun(t *testing.T) {
 		require.FileExists(t, post)
 		bts, err := os.ReadFile(post)
 		require.NoError(t, err)
-		require.Equal(t, "foo\n", string(bts))
+		require.Equal(t, "foo darwin all  darwin_all \n", string(bts))
 	})
 
 	t.Run("failing pre-hook", func(t *testing.T) {

--- a/internal/pipe/universalbinary/universalbinary_test.go
+++ b/internal/pipe/universalbinary/universalbinary_test.go
@@ -185,6 +185,7 @@ func TestRun(t *testing.T) {
 					},
 					Post: []config.Hook{
 						{Cmd: "touch " + post},
+						{Cmd: `sh -c 'echo "{{ .Name }}" > {{ .Path }}.post'`, Output: true},
 					},
 				},
 			},
@@ -268,6 +269,11 @@ func TestRun(t *testing.T) {
 		require.NoError(t, Pipe{}.Run(ctx5))
 		require.FileExists(t, pre)
 		require.FileExists(t, post)
+		post := filepath.Join(dist, "foo_darwin_all/foo.post")
+		require.FileExists(t, post)
+		bts, err := os.ReadFile(post)
+		require.NoError(t, err)
+		require.Equal(t, "foo\n", string(bts))
 	})
 
 	t.Run("failing pre-hook", func(t *testing.T) {

--- a/www/docs/customization/universalbinaries.md
+++ b/www/docs/customization/universalbinaries.md
@@ -37,6 +37,7 @@ universal_binaries:
   # Hooks can be used to customize the final binary,
   # for example, to run generators.
   # Those fields allow templates.
+  #
   # Default is both hooks empty.
   hooks:
     pre: rice embed-go
@@ -73,3 +74,8 @@ You can use the Go template engine to remove it if you'd like.
     - id: bar
       name_template: bin2
     ```
+## Hooks templates
+
+Both the `pre` and `post` hooks allow the regular template variables.
+The `post` hook also allows the usage of `{{ .Path }}` and `{{ .Name }}`,
+denoting the path to the universal binary and its name, respectively.

--- a/www/docs/customization/universalbinaries.md
+++ b/www/docs/customization/universalbinaries.md
@@ -74,8 +74,22 @@ You can use the Go template engine to remove it if you'd like.
     - id: bar
       name_template: bin2
     ```
-## Hooks templates
 
-Both the `pre` and `post` hooks allow the regular template variables.
-The `post` hook also allows the usage of `{{ .Path }}` and `{{ .Name }}`,
-denoting the path to the universal binary and its name, respectively.
+## Naming templates
+
+Most fields that support [templating](/customization/templates/) will also
+support the following build details:
+
+| Key     | Description                       |
+|---------|-----------------------------------|
+| .Os     | `GOOS`, always `darwin`           |
+| .Arch   | `GOARCH`, always `all`            |
+| .Arm    | `GOARM`, always empty             |
+| .Ext    | Extension, always empty           |
+| .Target | Build target, always `darwin_all` |
+| .Path   | The binary path                   |
+| .Name   | The binary name                   |
+
+!!! tip
+    Notice that `.Path` and `.Name` will only be available after they are
+    evaluated, so they are mostly only useful in the `post` hooks.


### PR DESCRIPTION
This allows the usage of `{{ .Path }}` and `{{ .Name }}` on post templates.  Closes #2890  