### PR TITLE
docs: adds Conduit to USERS.md

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -9,6 +9,7 @@ Here's a running list of some organizations using GoReleaser[^1]:
 1. [Charm](https://charm.sh)
 1. [Comcast](https://comcast.github.io)
 1. [Compose Generator](https://www.compose-generator.com)
+1. [Conduit](https://www.conduit.io/)
 1. [CrowdStrike](https://www.crowdstrike.com)
 1. [DeepSource](https://deepsource.io)
 1. [EVCC](https://evcc.io)


### PR DESCRIPTION
If applied, this commit will update the USERS.md document to add the Conduit website in its correct alphabetical place.