### PR TITLE
feat: change default nfpm bindir

### DIFF
--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -46,7 +46,7 @@ func (Pipe) Default(ctx *context.Context) error {
 			fpm.ID = "default"
 		}
 		if fpm.Bindir == "" {
-			fpm.Bindir = "/usr/local/bin"
+			fpm.Bindir = "/usr/bin"
 		}
 		if fpm.PackageName == "" {
 			fpm.PackageName = ctx.Config.ProjectName

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -363,8 +363,8 @@ func TestInvalidTemplate(t *testing.T) {
 
 	t.Run("bindir", func(t *testing.T) {
 		ctx := makeCtx()
-		ctx.Config.NFPMs[0].Bindir = "/usr/local/{{ .NOPE }}"
-		require.Contains(t, Pipe{}.Run(ctx).Error(), `template: tmpl:1:14: executing "tmpl" at <.NOPE>: map has no entry for key "NOPE"`)
+		ctx.Config.NFPMs[0].Bindir = "/usr/{{ .NOPE }}"
+		require.Contains(t, Pipe{}.Run(ctx).Error(), `template: tmpl:1:8: executing "tmpl" at <.NOPE>: map has no entry for key "NOPE"`)
 	})
 }
 
@@ -511,7 +511,7 @@ func TestDefault(t *testing.T) {
 		},
 	}
 	require.NoError(t, Pipe{}.Default(ctx))
-	require.Equal(t, "/usr/local/bin", ctx.Config.NFPMs[0].Bindir)
+	require.Equal(t, "/usr/bin", ctx.Config.NFPMs[0].Bindir)
 	require.Equal(t, []string{"foo", "bar"}, ctx.Config.NFPMs[0].Builds)
 	require.Equal(t, defaultNameTemplate, ctx.Config.NFPMs[0].FileNameTemplate)
 	require.Equal(t, ctx.Config.ProjectName, ctx.Config.NFPMs[0].PackageName)

--- a/www/docs/customization/nfpm.md
+++ b/www/docs/customization/nfpm.md
@@ -92,7 +92,7 @@ nfpms:
       - fish
 
     # Template to the path that the binaries should be installed.
-    # Defaults to `/usr/local/bin`.
+    # Defaults to `/usr/bin`.
     bindir: /usr/bin
 
     # Version Epoch.


### PR DESCRIPTION
`/usr/local/bin` is intended for binaries compiled locally, which is never the case for goreleaser.  

This PR changes the default to `/usr/bin` instead.  

closes #2909  