### PR TITLE
feat: annotated tag body

### DIFF
--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -116,17 +116,17 @@ func getGitInfo() (context.GitInfo, error) {
 		}, ErrNoTag
 	}
 
-	subject, err := getTagSubject(tag)
+	subject, err := getTagWithFormat(tag, "contents:subject")
 	if err != nil {
 		return context.GitInfo{}, fmt.Errorf("couldn't get tag subject: %w", err)
 	}
 
-	contents, err := getTagContents(tag, "")
+	contents, err := getTagWithFormat(tag, "contents")
 	if err != nil {
 		return context.GitInfo{}, fmt.Errorf("couldn't get tag contents: %w", err)
 	}
 
-	body, err := getTagContents(tag, ":body")
+	body, err := getTagWithFormat(tag, "contents:body")
 	if err != nil {
 		return context.GitInfo{}, fmt.Errorf("couldn't get tag content body: %w", err)
 	}
@@ -217,12 +217,8 @@ func getSummary() (string, error) {
 	return git.Clean(git.Run("describe", "--always", "--dirty", "--tags"))
 }
 
-func getTagSubject(tag string) (string, error) {
-	return git.Clean(git.Run("tag", "-l", "--format='%(contents:subject)'", tag))
-}
-
-func getTagContents(tag, format string) (string, error) {
-	out, err := git.Run("tag", "-l", "--format='%(contents"+format+")'", tag)
+func getTagWithFormat(tag, format string) (string, error) {
+	out, err := git.Run("tag", "-l", "--format='%("+format+")'", tag)
 	return strings.TrimSpace(strings.TrimSuffix(strings.ReplaceAll(out, "'", ""), "\n\n")), err
 }
 

--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -121,9 +121,14 @@ func getGitInfo() (context.GitInfo, error) {
 		return context.GitInfo{}, fmt.Errorf("couldn't get tag subject: %w", err)
 	}
 
-	contents, err := getTagContents(tag)
+	contents, err := getTagContents(tag, "")
 	if err != nil {
 		return context.GitInfo{}, fmt.Errorf("couldn't get tag contents: %w", err)
+	}
+
+	body, err := getTagContents(tag, ":body")
+	if err != nil {
+		return context.GitInfo{}, fmt.Errorf("couldn't get tag content body: %w", err)
 	}
 
 	previous, err := getPreviousTag(tag)
@@ -144,6 +149,7 @@ func getGitInfo() (context.GitInfo, error) {
 		Summary:     summary,
 		TagSubject:  subject,
 		TagContents: contents,
+		TagBody:     body,
 	}, nil
 }
 
@@ -215,9 +221,9 @@ func getTagSubject(tag string) (string, error) {
 	return git.Clean(git.Run("tag", "-l", "--format='%(contents:subject)'", tag))
 }
 
-func getTagContents(tag string) (string, error) {
-	out, err := git.Run("tag", "-l", "--format='%(contents)'", tag)
-	return strings.TrimSuffix(strings.ReplaceAll(out, "'", ""), "\n\n"), err
+func getTagContents(tag, format string) (string, error) {
+	out, err := git.Run("tag", "-l", "--format='%(contents"+format+")'", tag)
+	return strings.TrimSpace(strings.TrimSuffix(strings.ReplaceAll(out, "'", ""), "\n\n")), err
 }
 
 func getTag() (string, error) {

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -53,6 +53,7 @@ func TestAnnotatedTags(t *testing.T) {
 	require.Equal(t, "v0.0.1", ctx.Git.CurrentTag)
 	require.Equal(t, "first version", ctx.Git.TagSubject)
 	require.Equal(t, "first version\n\nlalalla\nlalal\nlah", ctx.Git.TagContents)
+	require.Equal(t, "lalalla\nlalal\nlah", ctx.Git.TagBody)
 	require.Equal(t, "v0.0.1", ctx.Git.Summary)
 }
 

--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -41,6 +41,7 @@ const (
 	summary         = "Summary"
 	tagSubject      = "TagSubject"
 	tagContents     = "TagContents"
+	tagBody         = "TagBody"
 	releaseURL      = "ReleaseURL"
 	major           = "Major"
 	minor           = "Minor"
@@ -93,6 +94,7 @@ func New(ctx *context.Context) *Template {
 			summary:         ctx.Git.Summary,
 			tagSubject:      ctx.Git.TagSubject,
 			tagContents:     ctx.Git.TagContents,
+			tagBody:         ctx.Git.TagBody,
 			releaseURL:      ctx.ReleaseURL,
 			env:             ctx.Env,
 			date:            ctx.Date.UTC().Format(time.RFC3339),

--- a/internal/tmpl/tmpl_test.go
+++ b/internal/tmpl/tmpl_test.go
@@ -36,6 +36,7 @@ func TestWithArtifact(t *testing.T) {
 	ctx.Git.ShortCommit = "shortcommit"
 	ctx.Git.TagSubject = "awesome release"
 	ctx.Git.TagContents = "awesome release\n\nanother line"
+	ctx.Git.TagBody = "another line"
 	ctx.ReleaseNotes = "test release notes"
 	for expect, tmpl := range map[string]string{
 		"bar":                              "{{.Env.FOO}}",
@@ -63,6 +64,7 @@ func TestWithArtifact(t *testing.T) {
 		"v1.2.2":                           "{{ .PreviousTag }}",
 		"awesome release":                  "{{ .TagSubject }}",
 		"awesome release\n\nanother line":  "{{ .TagContents }}",
+		"another line":                     "{{ .TagBody }}",
 		"runtime: " + runtime.GOOS:         "runtime: {{ .Runtime.Goos }}",
 		"runtime: " + runtime.GOARCH:       "runtime: {{ .Runtime.Goarch }}",
 	} {

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -30,6 +30,7 @@ type GitInfo struct {
 	Summary     string
 	TagSubject  string
 	TagContents string
+	TagBody     string
 }
 
 // Env is the environment variables.

--- a/www/docs/customization/templates.md
+++ b/www/docs/customization/templates.md
@@ -45,6 +45,7 @@ On fields that support templating, these fields are always available:
 | `.PrefixedSummary`     | the git summary prefixed with the monorepo config tag prefix (if any)                                  |
 | `.TagSubject`          | the annotated tag message subject, or the message subject of the commit it points out[^6]              |
 | `.TagContents`         | the annotated tag message, or the message of the commit it points out[^7]                              |
+| `.TagBody`             | the annotated tag message's body, or the message's body of the commit it points out[^7]                |
 | `.Runtime.Goos`        | equivalent to `runtime.GOOS`                                                                           |
 | `.Runtime.Goarch`      | equivalent to `runtime.GOARCH`                                                                         |
 


### PR DESCRIPTION
this adds another template variable, `TagBody`, with the body of the annotated tag/commit message only.  

closes #2920