### PR TITLE
fix: trim spaces from aur private key

### DIFF
--- a/internal/pipe/aur/aur.go
+++ b/internal/pipe/aur/aur.go
@@ -361,7 +361,7 @@ func doPublish(ctx *context.Context, pkgs []*artifact.Artifact) error {
 		return err
 	}
 
-	key, err = keyPath(key)
+	key, err = keyPath(strings.TrimSpace(key))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I had this issue on a repo, and it seems at least one more person had it too: ssh/git complaining that the key is invalid.  

My guess is that gh secret set from a file is now appending a new line - as it worked with the exact same key before, for me at least.  

anyway, if thats it, this pr should fix it. 

 closes https://github.com/goreleaser/goreleaser-action/issues/326  