### PR TITLE
docs: Add a new cookbook that covers using the jfrog-cli as an alternative to the artifactory publisher to publish to artifactory.

### DIFF
--- a/www/docs/cookbooks/using-jfrog-cli-to-publish-to-artifactory.md
+++ b/www/docs/cookbooks/using-jfrog-cli-to-publish-to-artifactory.md
@@ -1,0 +1,24 @@
+# Publish to Artifactory using jfrog cli
+This cookbook is an example of a [publishers](/customization/publishers/) section that uses the [jfrog cli](https://jfrog.com/getcli/) to upload files to Artifactory.  It is an alternative to using the [Artifactory Publisher](/customization/artifactory.md) to upload to artifactory.
+
+The benefit of this method is that it uses the jfrog cli configuration instead of environment variables for configuration.
+
+This assumes you have the [jfrog cli](https://jfrog.com/getcli/) downloaded and in your path, and [configured](https://www.jfrog.com/confluence/display/CLI/JFrog+CLI#JFrogCLI-JFrogPlatformConfiguration) with an API key.
+
+```yaml
+publishers:
+- name: artifactory
+ cmd: >-
+   jfrog rt u "{{ .ArtifactName }}" "my-repository/{{ tolower .Env.PROJECT_KEY }}/{{ tolower .ProjectName }}/{{ .Version }}/"
+ dir: "{{ dir .ArtifactPath }}"
+```
+
+Example of a [publishers](/customization/publishers/) section pushing files to a Artifactory instance using jfrog cli with api key in environment
+
+```yaml
+publishers:
+- name: artifactory
+ cmd: >-
+   jfrog rt u "{{ .ArtifactName }}" "my-repository/{{ tolower .Env.PROJECT_KEY }}/{{ tolower .ProjectName }}/{{ .Version }}/" --api-key "{{ .Env.ARTIFACTORY_API_KEY }}"
+ dir: "{{ dir .ArtifactPath }}"
+```

--- a/www/mkdocs.yml
+++ b/www/mkdocs.yml
@@ -146,6 +146,7 @@ nav:
   - cookbooks//build-go-modules.md
   - cookbooks/cgo-and-crosscompiling.md
   - cookbooks/debconf-templates.md
+  - cookbooks/using-jfrog-cli-to-publish-to-artifactory.md
   - cookbooks/publish-to-nexus.md
   - cookbooks/release-a-library.md
   - cookbooks/semantic-release.md


### PR DESCRIPTION
The jfrog cli allows storing the artifactory configuration in a configuration file rather than directly in the environment.

This is a refactor of the previous PR I had and closed here:  https://github.com/goreleaser/goreleaser/pull/2854

I have found it easier to configure the jfrog cli to contain my artifactory credentials.
