### PR TITLE
fix: build breaking on windows 386

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/muesli/coral v1.0.0
 	github.com/muesli/mango-coral v1.0.1
 	github.com/muesli/roff v0.1.0
-	github.com/scylladb/go-set v1.0.2
 	github.com/slack-go/slack v0.10.2
 	github.com/stretchr/testify v1.7.0
 	github.com/ulikunitz/xz v0.5.10

--- a/go.sum
+++ b/go.sum
@@ -322,8 +322,6 @@ github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
-github.com/fatih/set v0.2.1 h1:nn2CaJyknWE/6txyUDGwysr3G5QC6xWB/PtVjPBbeaA=
-github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
@@ -676,8 +674,6 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
-github.com/scylladb/go-set v1.0.2 h1:SkvlMCKhP0wyyct6j+0IHJkBkSZL+TDzZ4E7f7BCcRE=
-github.com/scylladb/go-set v1.0.2/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -17,7 +17,6 @@ import (
 	"sync"
 
 	"github.com/apex/log"
-	"github.com/scylladb/go-set/strset"
 )
 
 // Type defines the type of an artifact.
@@ -387,9 +386,9 @@ func ByIDs(ids ...string) Filter {
 func ByBinaryLikeArtifacts(arts Artifacts) Filter {
 	// find all of the paths for any uploadable binary artifacts
 	uploadableBins := arts.Filter(ByType(UploadableBinary)).List()
-	uploadableBinPaths := strset.New()
+	uploadableBinPaths := map[string]struct{}{}
 	for _, a := range uploadableBins {
-		uploadableBinPaths.Add(a.Path)
+		uploadableBinPaths[a.Path] = struct{}{}
 	}
 
 	// we want to keep any matching artifact that is not a binary that already has a path accounted for
@@ -398,7 +397,8 @@ func ByBinaryLikeArtifacts(arts Artifacts) Filter {
 		if a.Type == UploadableBinary {
 			return true
 		}
-		return !uploadableBinPaths.Has(a.Path)
+		_, ok := uploadableBinPaths[a.Path]
+		return !ok
 	}
 
 	return And(


### PR DESCRIPTION
For some reason the set lib was trowing an int overflow  error on snapshot when there are no binary artifacts to sign. 

This list is small, we don't need to worry about allocations et al, so I just switched it for a `map` for now, which seems to fix the issue...

cc @wagoodman 

Refs  #2839 
See https://github.com/goreleaser/goreleaser/runs/5334854323?check_suite_focus=true#step:21:50  