### PR TITLE
improvement(pipe/brew): install amd64 binaries when no arm64 binaries present

### DIFF
--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -374,6 +374,10 @@ func dataFor(ctx *context.Context, cfg config.Homebrew, cl client.Client, artifa
 		}
 	}
 
+	if len(result.MacOSPackages) == 1 && result.MacOSPackages[0].Arch == "amd64" {
+		result.HasOnlyAmd64MacOsPkg = true
+	}
+
 	sort.Slice(result.LinuxPackages, lessFnFor(result.LinuxPackages))
 	sort.Slice(result.MacOSPackages, lessFnFor(result.MacOSPackages))
 	return result, nil

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -81,9 +81,10 @@ var defaultTemplateData = templateData{
 			Install:     []string{`bin.install "test"`},
 		},
 	},
-	Name:    "Test",
-	Version: "0.1.3",
-	Caveats: []string{},
+	Name:                 "Test",
+	Version:              "0.1.3",
+	Caveats:              []string{},
+	HasOnlyAmd64MacOsPkg: false,
 }
 
 func assertDefaultTemplateData(t *testing.T, formulae string) {

--- a/internal/pipe/brew/testdata/TestFullPipe/custom_block.rb.golden
+++ b/internal/pipe/brew/testdata/TestFullPipe/custom_block.rb.golden
@@ -9,12 +9,20 @@ class CustomBlock < Formula
   depends_on :macos
 
   on_macos do
-    if Hardware::CPU.intel?
-      url "https://dummyhost/download/v1.0.1/bin.tar.gz"
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    url "https://dummyhost/download/v1.0.1/bin.tar.gz"
+    sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
-      def install
-        bin.install "custom_block"
+    def install
+      bin.install "custom_block"
+    end
+
+    if Hardware::CPU.arm?
+      def caveats
+        <<~EOS
+          The darwin_arm64 architecture is not supported for the CustomBlock
+          formula at this time. The darwin_amd64 binary may work in compatibility
+          mode, but it might not be fully supported.
+        EOS
       end
     end
   end

--- a/internal/pipe/brew/testdata/TestFullPipe/custom_download_strategy.rb.golden
+++ b/internal/pipe/brew/testdata/TestFullPipe/custom_download_strategy.rb.golden
@@ -9,12 +9,20 @@ class CustomDownloadStrategy < Formula
   depends_on :macos
 
   on_macos do
-    if Hardware::CPU.intel?
-      url "https://dummyhost/download/v1.0.1/bin.tar.gz", :using => GitHubPrivateRepositoryReleaseDownloadStrategy
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    url "https://dummyhost/download/v1.0.1/bin.tar.gz", :using => GitHubPrivateRepositoryReleaseDownloadStrategy
+    sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
-      def install
-        bin.install "custom_download_strategy"
+    def install
+      bin.install "custom_download_strategy"
+    end
+
+    if Hardware::CPU.arm?
+      def caveats
+        <<~EOS
+          The darwin_arm64 architecture is not supported for the CustomDownloadStrategy
+          formula at this time. The darwin_amd64 binary may work in compatibility
+          mode, but it might not be fully supported.
+        EOS
       end
     end
   end

--- a/internal/pipe/brew/testdata/TestFullPipe/custom_require.rb.golden
+++ b/internal/pipe/brew/testdata/TestFullPipe/custom_require.rb.golden
@@ -10,12 +10,20 @@ class CustomRequire < Formula
   depends_on :macos
 
   on_macos do
-    if Hardware::CPU.intel?
-      url "https://dummyhost/download/v1.0.1/bin.tar.gz", :using => CustomDownloadStrategy
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    url "https://dummyhost/download/v1.0.1/bin.tar.gz", :using => CustomDownloadStrategy
+    sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
-      def install
-        bin.install "custom_require"
+    def install
+      bin.install "custom_require"
+    end
+
+    if Hardware::CPU.arm?
+      def caveats
+        <<~EOS
+          The darwin_arm64 architecture is not supported for the CustomRequire
+          formula at this time. The darwin_amd64 binary may work in compatibility
+          mode, but it might not be fully supported.
+        EOS
       end
     end
   end

--- a/internal/pipe/brew/testdata/TestFullPipe/default.rb.golden
+++ b/internal/pipe/brew/testdata/TestFullPipe/default.rb.golden
@@ -9,12 +9,20 @@ class Default < Formula
   depends_on :macos
 
   on_macos do
-    if Hardware::CPU.intel?
-      url "https://dummyhost/download/v1.0.1/bin.tar.gz"
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    url "https://dummyhost/download/v1.0.1/bin.tar.gz"
+    sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
-      def install
-        bin.install "default"
+    def install
+      bin.install "default"
+    end
+
+    if Hardware::CPU.arm?
+      def caveats
+        <<~EOS
+          The darwin_arm64 architecture is not supported for the Default
+          formula at this time. The darwin_amd64 binary may work in compatibility
+          mode, but it might not be fully supported.
+        EOS
       end
     end
   end

--- a/internal/pipe/brew/testdata/TestFullPipe/default_gitlab.rb.golden
+++ b/internal/pipe/brew/testdata/TestFullPipe/default_gitlab.rb.golden
@@ -9,12 +9,20 @@ class DefaultGitlab < Formula
   depends_on :macos
 
   on_macos do
-    if Hardware::CPU.intel?
-      url "https://dummyhost/download/v1.0.1/bin.tar.gz"
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    url "https://dummyhost/download/v1.0.1/bin.tar.gz"
+    sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
-      def install
-        bin.install "default_gitlab"
+    def install
+      bin.install "default_gitlab"
+    end
+
+    if Hardware::CPU.arm?
+      def caveats
+        <<~EOS
+          The darwin_arm64 architecture is not supported for the DefaultGitlab
+          formula at this time. The darwin_amd64 binary may work in compatibility
+          mode, but it might not be fully supported.
+        EOS
       end
     end
   end

--- a/internal/pipe/brew/testdata/TestFullPipe/valid_tap_templates.rb.golden
+++ b/internal/pipe/brew/testdata/TestFullPipe/valid_tap_templates.rb.golden
@@ -9,12 +9,20 @@ class ValidTapTemplates < Formula
   depends_on :macos
 
   on_macos do
-    if Hardware::CPU.intel?
-      url "https://dummyhost/download/v1.0.1/bin.tar.gz"
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    url "https://dummyhost/download/v1.0.1/bin.tar.gz"
+    sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
-      def install
-        bin.install "valid_tap_templates"
+    def install
+      bin.install "valid_tap_templates"
+    end
+
+    if Hardware::CPU.arm?
+      def caveats
+        <<~EOS
+          The darwin_arm64 architecture is not supported for the ValidTapTemplates
+          formula at this time. The darwin_amd64 binary may work in compatibility
+          mode, but it might not be fully supported.
+        EOS
       end
     end
   end

--- a/internal/pipe/brew/testdata/TestRunPipeForMultipleArmVersions/multiple_armv5.rb.golden
+++ b/internal/pipe/brew/testdata/TestRunPipeForMultipleArmVersions/multiple_armv5.rb.golden
@@ -8,12 +8,20 @@ class MultipleArmv5 < Formula
   version "1.0.1"
 
   on_macos do
-    if Hardware::CPU.intel?
-      url "https://dummyhost/download/v1.0.1/bin.tar.gz"
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    url "https://dummyhost/download/v1.0.1/bin.tar.gz"
+    sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
-      def install
-        bin.install "multiple_armv5"
+    def install
+      bin.install "multiple_armv5"
+    end
+
+    if Hardware::CPU.arm?
+      def caveats
+        <<~EOS
+          The darwin_arm64 architecture is not supported for the MultipleArmv5
+          formula at this time. The darwin_amd64 binary may work in compatibility
+          mode, but it might not be fully supported.
+        EOS
       end
     end
   end

--- a/internal/pipe/brew/testdata/TestRunPipeForMultipleArmVersions/multiple_armv6.rb.golden
+++ b/internal/pipe/brew/testdata/TestRunPipeForMultipleArmVersions/multiple_armv6.rb.golden
@@ -8,12 +8,20 @@ class MultipleArmv6 < Formula
   version "1.0.1"
 
   on_macos do
-    if Hardware::CPU.intel?
-      url "https://dummyhost/download/v1.0.1/bin.tar.gz"
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    url "https://dummyhost/download/v1.0.1/bin.tar.gz"
+    sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
-      def install
-        bin.install "multiple_armv6"
+    def install
+      bin.install "multiple_armv6"
+    end
+
+    if Hardware::CPU.arm?
+      def caveats
+        <<~EOS
+          The darwin_arm64 architecture is not supported for the MultipleArmv6
+          formula at this time. The darwin_amd64 binary may work in compatibility
+          mode, but it might not be fully supported.
+        EOS
       end
     end
   end

--- a/internal/pipe/brew/testdata/TestRunPipeForMultipleArmVersions/multiple_armv7.rb.golden
+++ b/internal/pipe/brew/testdata/TestRunPipeForMultipleArmVersions/multiple_armv7.rb.golden
@@ -8,12 +8,20 @@ class MultipleArmv7 < Formula
   version "1.0.1"
 
   on_macos do
-    if Hardware::CPU.intel?
-      url "https://dummyhost/download/v1.0.1/bin.tar.gz"
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    url "https://dummyhost/download/v1.0.1/bin.tar.gz"
+    sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
-      def install
-        bin.install "multiple_armv7"
+    def install
+      bin.install "multiple_armv7"
+    end
+
+    if Hardware::CPU.arm?
+      def caveats
+        <<~EOS
+          The darwin_arm64 architecture is not supported for the MultipleArmv7
+          formula at this time. The darwin_amd64 binary may work in compatibility
+          mode, but it might not be fully supported.
+        EOS
       end
     end
   end

--- a/internal/pipe/brew/testdata/TestRunPipeNameTemplate.rb.golden
+++ b/internal/pipe/brew/testdata/TestRunPipeNameTemplate.rb.golden
@@ -9,11 +9,19 @@ class FooIsBar < Formula
   depends_on :macos
 
   on_macos do
-    if Hardware::CPU.intel?
-      url "https://dummyhost/download/v1.0.1/bin.tar.gz"
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    url "https://dummyhost/download/v1.0.1/bin.tar.gz"
+    sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
-      def install
+    def install
+    end
+
+    if Hardware::CPU.arm?
+      def caveats
+        <<~EOS
+          The darwin_arm64 architecture is not supported for the FooIsBar
+          formula at this time. The darwin_amd64 binary may work in compatibility
+          mode, but it might not be fully supported.
+        EOS
       end
     end
   end


### PR DESCRIPTION
Currently on a M1 macbook when adding a tap with formulas that only support `amd64` it fails to add the tap. With errors similar to the below. Which prevents new `arm64` users from using the tap.

```
brew tap --force-auto-update cdx/brewtest https://github.com/ryancurrah/brewtest
==> Tapping ryancurrah/brewtest
Cloning into '/opt/homebrew/Library/Taps/ryancurrah/homebrew-brewtest'...
remote: Enumerating objects: 15, done.
remote: Counting objects: 100% (15/15), done.
remote: Compressing objects: 100% (11/11), done.
remote: Total 15 (delta 2), reused 0 (delta 0), pack-reused 0
Receiving objects: 100% (15/15), done.
Resolving deltas: 100% (2/2), done.
Error: Invalid formula: /opt/homebrew/Library/Taps/ryancurrah/homebrew-brewtest/Formula/rcurrahtest.rb
formulae require at least a URL
Error: Cannot tap ryancurrah/brewtest: invalid syntax in tap!
```

This pull request attempts to resolve the issue by allowing M1 macbook users to install an `amd64` binary if no `arm64` binary is available and allows them to install the tap without error as well.

Users can try using Rosetta to run the `amd64` binary with their M1 macbook.

Apple support article showing how to install Rosetta https://support.apple.com/en-us/HT211861.

closes https://github.com/goreleaser/goreleaser/pull/2917
refs https://github.com/goreleaser/goreleaser/pull/2278
refs https://github.com/goreleaser/goreleaser/issues/2159
