### PR TITLE
fix: nfpm globbing multiple times

### DIFF
--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -319,10 +319,6 @@ func create(ctx *context.Context, fpm config.NFPM, format string, binaries []*ar
 		info.Deb.Signature = nfpm.DebSignature{}
 	}
 
-	if err = nfpm.Validate(info); err != nil {
-		return fmt.Errorf("invalid nfpm config: %w", err)
-	}
-
 	packager, err := nfpm.Get(format)
 	if err != nil {
 		return err
@@ -346,6 +342,7 @@ func create(ctx *context.Context, fpm config.NFPM, format string, binaries []*ar
 		return err
 	}
 	defer w.Close()
+
 	if err := packager.Package(info, w); err != nil {
 		return fmt.Errorf("nfpm failed: %w", err)
 	}

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -140,6 +140,10 @@ func TestRunPipe(t *testing.T) {
 							Source:      "./testdata/testfile-{{ .Arch }}.txt",
 							Destination: "/etc/nope3_{{ .ProjectName }}.conf",
 						},
+						{
+							Source:      "./testdata/folder",
+							Destination: "/etc/folder",
+						},
 					},
 					Replacements: map[string]string{
 						"linux": "Tux",
@@ -177,6 +181,7 @@ func TestRunPipe(t *testing.T) {
 			"./testdata/testfile.txt",
 			"./testdata/testfile.txt",
 			"/etc/nope.conf",
+			"./testdata/folder",
 			"./testdata/testfile-" + pkg.Goarch + ".txt",
 			binPath,
 		}, sources(pkg.ExtraOr(extraFiles, files.Contents{}).(files.Contents)))
@@ -187,10 +192,11 @@ func TestRunPipe(t *testing.T) {
 			"/etc/nope-rpm.conf",
 			"/etc/nope2.conf",
 			"/etc/nope3_mybin.conf",
+			"/etc/folder",
 			"/usr/bin/subdir/mybin",
 		}, destinations(pkg.ExtraOr(extraFiles, files.Contents{}).(files.Contents)))
 	}
-	require.Len(t, ctx.Config.NFPMs[0].Contents, 6, "should not modify the config file list")
+	require.Len(t, ctx.Config.NFPMs[0].Contents, 7, "should not modify the config file list")
 }
 
 func TestRunPipeConventionalNameTemplate(t *testing.T) {
@@ -494,7 +500,7 @@ func TestInvalidConfig(t *testing.T) {
 			artifact.ExtraID: "default",
 		},
 	})
-	require.Contains(t, Pipe{}.Run(ctx).Error(), `invalid nfpm config: package name must be provided`)
+	require.Contains(t, Pipe{}.Run(ctx).Error(), `nfpm failed: package name must be provided`)
 }
 
 func TestDefault(t *testing.T) {


### PR DESCRIPTION
The nfpm pipe was globbing the input list, and then globbing its result
as well. If you add a folder that had a file with, say `[]`, in it, it
would later fail the release upon trying to evaluate that as a glob.

This is probably some faulty nFPM update in which I should have removed
that but didn't.

Either way, this should fix it.

closes #2946
