### PR TITLE
feat: set -mod on gomod pipe

### DIFF
--- a/internal/pipe/gomod/gomod.go
+++ b/internal/pipe/gomod/gomod.go
@@ -29,7 +29,11 @@ func (Pipe) Default(ctx *context.Context) error {
 
 // Run the pipe.
 func (Pipe) Run(ctx *context.Context) error {
-	out, err := exec.CommandContext(ctx, ctx.Config.GoMod.GoBinary, "list", "-m").CombinedOutput()
+	flags := []string{"list", "-m"}
+	if ctx.Config.GoMod.Mod != "" {
+		flags = append(flags, "-mod="+ctx.Config.GoMod.Mod)
+	}
+	out, err := exec.CommandContext(ctx, ctx.Config.GoMod.GoBinary, flags...).CombinedOutput()
 	result := strings.TrimSpace(string(out))
 	if result == go115NotAGoModuleError || result == go116NotAGoModuleError {
 		return pipe.Skip("not a go module")

--- a/internal/pipe/gomod/gomod_test.go
+++ b/internal/pipe/gomod/gomod_test.go
@@ -18,6 +18,17 @@ func TestRun(t *testing.T) {
 	require.Equal(t, "github.com/goreleaser/goreleaser", ctx.ModulePath)
 }
 
+func TestRunCustomMod(t *testing.T) {
+	ctx := context.New(config.Project{
+		GoMod: config.GoMod{
+			Mod: "readonly",
+		},
+	})
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, "github.com/goreleaser/goreleaser", ctx.ModulePath)
+}
+
 func TestRunOutsideGoModule(t *testing.T) {
 	dir := testlib.Mktmp(t)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\nfunc main() {println(0)}"), 0o666))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -938,6 +938,7 @@ type GoMod struct {
 	Proxy    bool     `yaml:"proxy,omitempty"`
 	Env      []string `yaml:"env,omitempty"`
 	GoBinary string   `yaml:"gobinary,omitempty"`
+	Mod      string   `yaml:"mod,omitempty"`
 }
 
 type Announce struct {

--- a/www/docs/customization/gomod.md
+++ b/www/docs/customization/gomod.md
@@ -25,6 +25,10 @@ gomod:
     - GOSUMDB=sum.golang.org
     - GOPRIVATE=example.com/blah
 
+  # Sets the `-mod` flag value.
+  # Defaults to empty.
+  mod: mod
+
   # Which Go binary to use.
   # Defaults to `go`.
   gobinary: go1.15


### PR DESCRIPTION
this allows to set the -mod flag on the command used to grab the module root package, in case its needed to ignore the vendor folder, force readonly, etc...  


closes #2975