### PR TITLE
feat: remove some deprecated code, go 1.15 support

### DIFF
--- a/internal/builders/buildtarget/targets.go
+++ b/internal/builders/buildtarget/targets.go
@@ -55,13 +55,6 @@ func matrix(build config.Build, version []byte) ([]string, error) {
 		if target.mips != "" && !contains(target.mips, validGomips) {
 			return result, fmt.Errorf("invalid gomips: %s", target.mips)
 		}
-		if target.os == "darwin" && target.arch == "arm64" && !go116re.Match(version) {
-			log.Warn(color.New(color.Bold, color.FgHiYellow).Sprintf(
-				"DEPRECATED: skipped darwin/arm64 build on Go < 1.16 for compatibility, check %s for more info.",
-				"https://goreleaser.com/deprecations/#builds-for-darwinarm64",
-			))
-			continue
-		}
 		if target.os == "windows" && target.arch == "arm64" && !go117re.Match(version) {
 			log.Warn(color.New(color.Bold, color.FgHiYellow).Sprintf(
 				"DEPRECATED: skipped windows/arm64 build on Go < 1.17 for compatibility, check %s for more info.",
@@ -138,10 +131,7 @@ func ignored(build config.Build, target target) bool {
 	return false
 }
 
-var (
-	go116re = regexp.MustCompile(`go version go1.1[6-9]`)
-	go117re = regexp.MustCompile(`go version go1.1[7-9]`)
-)
+var go117re = regexp.MustCompile(`go version go1.1[7-9]`)
 
 func goVersion(build config.Build) ([]byte, error) {
 	cmd := exec.Command(build.GoBinary, "version")

--- a/internal/builders/buildtarget/targets_test.go
+++ b/internal/builders/buildtarget/targets_test.go
@@ -57,38 +57,6 @@ func TestAllBuildTargets(t *testing.T) {
 		},
 	}
 
-	t.Run("go 1.15", func(t *testing.T) {
-		result, err := matrix(build, []byte("go version go1.15.0"))
-		require.NoError(t, err)
-		require.Equal(t, []string{
-			"linux_386",
-			"linux_amd64",
-			"linux_arm_6",
-			"linux_arm64",
-			"linux_mips_hardfloat",
-			"linux_mips_softfloat",
-			"linux_mips64_softfloat",
-			"linux_mipsle_hardfloat",
-			"linux_mipsle_softfloat",
-			"linux_mips64le_hardfloat",
-			"linux_riscv64",
-			"darwin_amd64",
-			"freebsd_386",
-			"freebsd_amd64",
-			"freebsd_arm_6",
-			"freebsd_arm_7",
-			"freebsd_arm64",
-			"openbsd_386",
-			"openbsd_amd64",
-			"openbsd_arm64",
-			"windows_386",
-			"windows_amd64",
-			"windows_arm_6",
-			"windows_arm_7",
-			"js_wasm",
-		}, result)
-	})
-
 	t.Run("go 1.16", func(t *testing.T) {
 		result, err := matrix(build, []byte("go version go1.16.2"))
 		require.NoError(t, err)

--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/apex/log"
 	"github.com/goreleaser/goreleaser/internal/artifact"
-	"github.com/goreleaser/goreleaser/internal/deprecate"
 	"github.com/goreleaser/goreleaser/internal/gio"
 	"github.com/goreleaser/goreleaser/internal/ids"
 	"github.com/goreleaser/goreleaser/internal/pipe"
@@ -50,12 +49,6 @@ func (Pipe) Default(ctx *context.Context) error {
 		}
 		if docker.Dockerfile == "" {
 			docker.Dockerfile = "Dockerfile"
-		}
-		if docker.Buildx {
-			deprecate.Notice(ctx, "docker.use_buildx")
-			if docker.Use == "" {
-				docker.Use = useBuildx
-			}
 		}
 		if docker.Use == "" {
 			docker.Use = useDocker

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -787,7 +787,6 @@ type Docker struct {
 	Files              []string `yaml:"extra_files,omitempty"`
 	BuildFlagTemplates []string `yaml:"build_flag_templates,omitempty"`
 	PushFlags          []string `yaml:"push_flags,omitempty"`
-	Buildx             bool     `yaml:"use_buildx,omitempty"` // deprecated: use Use instead
 	Use                string   `yaml:"use,omitempty"`
 }
 

--- a/www/docs/customization/gomod.md
+++ b/www/docs/customization/gomod.md
@@ -27,7 +27,7 @@ gomod:
 
   # Which Go binary to use.
   # Defaults to `go`.
-  gobinary: go1.15
+  gobinary: go1.17
 ```
 
 !!! tip

--- a/www/docs/deprecations.md
+++ b/www/docs/deprecations.md
@@ -107,9 +107,14 @@ ignore:
 
 If you try to use new versions of GoReleaser with Go 1.16 or older, it will warn about it until this deprecation warning expires, after that your build will likely fail.
 
-### docker.use_buildx
 
-> since 2021-06-26 (v0.172.0)
+## Expired deprecation notices
+
+The following options were deprecated in the past and were already removed.
+
+### dockers.use_buildx
+
+> since 2021-06-26 (v0.172.0), removed 2022-03-16 (v1.7.0)
 
 `use_buildx` is deprecated in favor of the more generalist `use`, since now it also allow other options in the future:
 
@@ -131,7 +136,7 @@ Change this:
 
 ### builds for darwin/arm64
 
-> since 2021-02-17 (v0.157.0)
+> since 2021-02-17 (v0.157.0), removed 2022-03-16 (v1.7.0)
 
 Since Go 1.16, `darwin/arm64` is macOS on Apple Silicon instead of `iOS`.
 
@@ -147,10 +152,6 @@ ignore:
 ```
 
 If you try to use new versions of GoReleaser with Go 1.15 or older, it will warn about it until this deprecation warning expires, after that your build will likely fail.
-
-## Expired deprecation notices
-
-The following options were deprecated in the past and were already removed.
 
 ### Skipping SemVer Validations
 


### PR DESCRIPTION
- auto ignore darwin/arm64 on go <1.15, check https://goreleaser.com/deprecations/#builds-for-darwinarm64
- `dockers.use_buildx` (do not mix with `dockers.use: buildx`), check https://goreleaser.com/deprecations/#dockersuse_buildx
