### PR TITLE
fix(ci): golangci-lint on go 1.18

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,5 @@
+run:
+  go: 1.18
 linters:
   enable:
     - thelper


### PR DESCRIPTION
Make golangci-link work again since the go 1.18 upgrade

refs https://github.com/golangci/golangci-lint/issues/2649#issuecomment-1072732099