### PR TITLE
fix: sign before brew et al

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -75,14 +75,14 @@ var Pipeline = append(
 	sourcearchive.Pipe{}, // archive the source code using git-archive
 	nfpm.Pipe{},          // archive via fpm (deb, rpm) using "native" go impl
 	snapcraft.Pipe{},     // archive via snapcraft (snap)
+	sbom.Pipe{},          // create SBOMs of artifacts
+	checksums.Pipe{},     // checksums of the files
+	sign.Pipe{},          // sign artifacts
 	aur.Pipe{},           // create arch linux aur pkgbuild
 	brew.Pipe{},          // create brew tap
 	gofish.Pipe{},        // create gofish rig
 	krew.Pipe{},          // krew plugins
 	scoop.Pipe{},         // create scoop buckets
-	sbom.Pipe{},          // create SBOMs of artifacts
-	checksums.Pipe{},     // checksums of the files
-	sign.Pipe{},          // sign artifacts
 	docker.Pipe{},        // create and push docker images
 	metadata.Pipe{},      // creates a metadata.json and an artifacts.json files in the dist folder
 	publish.Pipe{},       // publishes artifacts


### PR DESCRIPTION
Signing might change a file (e.g. gon), so, if sign after we built the brew tap, the checksums won't match.  Moving this around a bit should have no negative side-effects (that I'm aware of, that is), and should fix that issue.  closes #3010  