### PR TITLE
Update GitHub action docs, change secret to GH_TOKEN instead of GITHUB_TOKEN

### DIFF
--- a/www/docs/ci/actions.md
+++ b/www/docs/ci/actions.md
@@ -48,7 +48,7 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
           # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 ```


### PR DESCRIPTION
In actions it is not allowed to have a secret in your repository which starts with GITHUB
