### PR TITLE
fix: nfpm lintian concurrency issue

### DIFF
--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -191,7 +191,7 @@ func create(ctx *context.Context, fpm config.NFPM, format string, binaries []*ar
 		for _, ov := range fpm.Deb.Lintian {
 			lines = append(lines, fmt.Sprintf("%s: %s", fpm.PackageName, ov))
 		}
-		lintianPath := filepath.Join(ctx.Config.Dist, "deb", fpm.PackageName, ".lintian")
+		lintianPath := filepath.Join(ctx.Config.Dist, "deb", fpm.PackageName+"_"+arch, ".lintian")
 		if err := os.MkdirAll(filepath.Dir(lintianPath), 0o755); err != nil {
 			return fmt.Errorf("failed to write lintian file: %w", err)
 		}
@@ -199,7 +199,7 @@ func create(ctx *context.Context, fpm config.NFPM, format string, binaries []*ar
 			return fmt.Errorf("failed to write lintian file: %w", err)
 		}
 
-		log.Infof("creating %q", lintianPath)
+		log.Debugf("creating %q", lintianPath)
 		contents = append(contents, &files.Content{
 			Source:      lintianPath,
 			Destination: filepath.Join("./usr/share/lintian/overrides", fpm.PackageName),

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -628,6 +628,7 @@ func TestOverrides(t *testing.T) {
 
 func TestDebSpecificConfig(t *testing.T) {
 	setupContext := func(tb testing.TB) *context.Context {
+		tb.Helper()
 		folder := t.TempDir()
 		dist := filepath.Join(folder, "dist")
 		require.NoError(t, os.Mkdir(dist, 0o755))

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -627,84 +627,100 @@ func TestOverrides(t *testing.T) {
 }
 
 func TestDebSpecificConfig(t *testing.T) {
-	folder := t.TempDir()
-	dist := filepath.Join(folder, "dist")
-	require.NoError(t, os.Mkdir(dist, 0o755))
-	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0o755))
-	binPath := filepath.Join(dist, "mybin", "mybin")
-	f, err := os.Create(binPath)
-	require.NoError(t, err)
-	require.NoError(t, f.Close())
-	ctx := context.New(config.Project{
-		ProjectName: "mybin",
-		Dist:        dist,
-		NFPMs: []config.NFPM{
-			{
-				ID:      "someid",
-				Builds:  []string{"default"},
-				Formats: []string{"deb"},
-				NFPMOverridables: config.NFPMOverridables{
-					PackageName: "foo",
-					Contents: []*files.Content{
-						{
-							Source:      "testdata/testfile.txt",
-							Destination: "/usr/share/testfile.txt",
+	setupContext := func(tb testing.TB) *context.Context {
+		folder := t.TempDir()
+		dist := filepath.Join(folder, "dist")
+		require.NoError(t, os.Mkdir(dist, 0o755))
+		require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0o755))
+		binPath := filepath.Join(dist, "mybin", "mybin")
+		f, err := os.Create(binPath)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+		ctx := context.New(config.Project{
+			ProjectName: "mybin",
+			Dist:        dist,
+			NFPMs: []config.NFPM{
+				{
+					ID:         "someid",
+					Builds:     []string{"default"},
+					Formats:    []string{"deb"},
+					Maintainer: "foo",
+					NFPMOverridables: config.NFPMOverridables{
+						PackageName: "foo",
+						Contents: []*files.Content{
+							{
+								Source:      "testdata/testfile.txt",
+								Destination: "/usr/share/testfile.txt",
+							},
 						},
-					},
-					Deb: config.NFPMDeb{
-						Signature: config.NFPMDebSignature{
-							KeyFile: "./testdata/privkey.gpg",
-						},
-						Lintian: []string{
-							"statically-linked-binary",
-							"changelog-file-missing-in-native-package",
+						Deb: config.NFPMDeb{
+							Signature: config.NFPMDebSignature{
+								KeyFile: "./testdata/privkey.gpg",
+							},
 						},
 					},
 				},
 			},
-		},
-	})
-	ctx.Version = "1.0.0"
-	ctx.Git = context.GitInfo{CurrentTag: "v1.0.0"}
-	for _, goos := range []string{"linux", "darwin"} {
-		for _, goarch := range []string{"amd64", "386"} {
-			ctx.Artifacts.Add(&artifact.Artifact{
-				Name:   "mybin",
-				Path:   binPath,
-				Goarch: goarch,
-				Goos:   goos,
-				Type:   artifact.Binary,
-				Extra: map[string]interface{}{
-					artifact.ExtraID: "default",
-				},
-			})
+		})
+		ctx.Version = "1.0.0"
+		ctx.Git = context.GitInfo{CurrentTag: "v1.0.0"}
+		for _, goos := range []string{"linux", "darwin"} {
+			for _, goarch := range []string{"amd64", "386"} {
+				ctx.Artifacts.Add(&artifact.Artifact{
+					Name:   "mybin",
+					Path:   binPath,
+					Goarch: goarch,
+					Goos:   goos,
+					Type:   artifact.Binary,
+					Extra: map[string]interface{}{
+						artifact.ExtraID: "default",
+					},
+				})
+			}
 		}
+		return ctx
 	}
 
 	t.Run("no passphrase set", func(t *testing.T) {
 		require.Contains(
 			t,
-			Pipe{}.Run(ctx).Error(),
+			Pipe{}.Run(setupContext(t)).Error(),
 			`key is encrypted but no passphrase was provided`,
 		)
 	})
 
 	t.Run("general passphrase set", func(t *testing.T) {
+		ctx := setupContext(t)
 		ctx.Env = map[string]string{
 			"NFPM_SOMEID_PASSPHRASE": "hunter2",
 		}
 		require.NoError(t, Pipe{}.Run(ctx))
-
-		bts, err := os.ReadFile(filepath.Join(dist, "deb/foo/.lintian"))
-		require.NoError(t, err)
-		require.Equal(t, "foo: statically-linked-binary\nfoo: changelog-file-missing-in-native-package", string(bts))
 	})
 
 	t.Run("packager specific passphrase set", func(t *testing.T) {
+		ctx := setupContext(t)
 		ctx.Env = map[string]string{
 			"NFPM_SOMEID_DEB_PASSPHRASE": "hunter2",
 		}
 		require.NoError(t, Pipe{}.Run(ctx))
+	})
+
+	t.Run("lintian", func(t *testing.T) {
+		ctx := setupContext(t)
+		ctx.Env = map[string]string{
+			"NFPM_SOMEID_DEB_PASSPHRASE": "hunter2",
+		}
+		ctx.Config.NFPMs[0].NFPMOverridables.Deb.Lintian = []string{
+			"statically-linked-binary",
+			"changelog-file-missing-in-native-package",
+		}
+		require.NoError(t, Pipe{}.Run(ctx))
+
+		for _, goarch := range []string{"amd64", "386"} {
+			bts, err := os.ReadFile(filepath.Join(ctx.Config.Dist, "deb/foo_"+goarch+"/.lintian"))
+			require.NoError(t, err)
+			require.Equal(t, "foo: statically-linked-binary\nfoo: changelog-file-missing-in-native-package", string(bts))
+		}
 	})
 }
 


### PR DESCRIPTION
Several goroutines might touch the lintian file inside dist at the same time, which might cause weird errors, namely `archive/tar: write too long`.  

This PR fixes it by namespacing the file to the package name + arch, so one goroutine won't touch the work of the other. 

 It also improves some logs and tests.  