### PR TITLE
WIP: feat: Support build using Kaniko on Docker

### DIFF
--- a/internal/pipe/docker/api.go
+++ b/internal/pipe/docker/api.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"bytes"
 	"fmt"
+	"github.com/goreleaser/goreleaser/pkg/config"
 	"io"
 	"os/exec"
 	"sync"
@@ -33,7 +34,7 @@ func registerImager(use string, impl imager) {
 
 // imager is something that can build and push docker images.
 type imager interface {
-	Build(ctx *context.Context, root string, images, flags []string) error
+	Build(ctx *context.Context, docker config.Docker, root string, images, flags []string) error
 	Push(ctx *context.Context, image string, flags []string) error
 }
 

--- a/internal/pipe/docker/api_buildpack.go
+++ b/internal/pipe/docker/api_buildpack.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"fmt"
+	"github.com/goreleaser/goreleaser/pkg/config"
 	"strings"
 
 	"github.com/goreleaser/goreleaser/pkg/context"
@@ -14,7 +15,7 @@ func (i buildPackImager) Push(ctx *context.Context, image string, flags []string
 	return dockerImager{}.Push(ctx, image, flags)
 }
 
-func (i buildPackImager) Build(ctx *context.Context, root string, images, flags []string) error {
+func (i buildPackImager) Build(ctx *context.Context, _ config.Docker, root string, images, flags []string) error {
 	if err := runCommand(ctx, "", "pack", i.buildCommand(images, flags)...); err != nil {
 		return fmt.Errorf("failed to build %s: %w", images[0], err)
 	}

--- a/internal/pipe/docker/api_docker.go
+++ b/internal/pipe/docker/api_docker.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"fmt"
+	"github.com/goreleaser/goreleaser/pkg/config"
 
 	"github.com/goreleaser/goreleaser/pkg/context"
 )
@@ -51,7 +52,7 @@ func (i dockerImager) Push(ctx *context.Context, image string, flags []string) e
 	return nil
 }
 
-func (i dockerImager) Build(ctx *context.Context, root string, images, flags []string) error {
+func (i dockerImager) Build(ctx *context.Context, _ config.Docker, root string, images, flags []string) error {
 	if err := runCommand(ctx, root, "docker", i.buildCommand(images, flags)...); err != nil {
 		return fmt.Errorf("failed to build %s: %w", images[0], err)
 	}

--- a/internal/pipe/docker/api_kaniko.go
+++ b/internal/pipe/docker/api_kaniko.go
@@ -1,0 +1,82 @@
+package docker
+
+import (
+	"fmt"
+	"github.com/goreleaser/goreleaser/pkg/config"
+	"os"
+
+	"github.com/goreleaser/goreleaser/pkg/context"
+)
+
+func init() {
+	registerImager(useKaniko, kanikoImager{})
+}
+
+const (
+	kanikoExecutorImage = "gcr.io/kaniko-project/executor:latest"
+	kanikoWorkspace     = "/workspace"
+)
+
+type kanikoImager struct{}
+
+// Push is a no-op and it returns nil because kaniko performs build and push in a single step.
+// https://github.com/GoogleContainerTools/kaniko#how-does-kaniko-work
+func (i kanikoImager) Push(_ *context.Context, _ string, _ []string) error {
+	return nil
+}
+
+func (i kanikoImager) Build(ctx *context.Context, docker config.Docker, root string, images, flags []string) error {
+	if err := runCommand(ctx, root, "docker", i.buildCommand(docker, images, flags)...); err != nil {
+		return fmt.Errorf("failed to build %s: %w", images[0], err)
+	}
+	return nil
+}
+
+func (i kanikoImager) buildCommand(docker config.Docker, images, flags []string) []string {
+	base := []string{"run"}
+
+	base = i.appendWorkspaceVolumeMount(base)
+	base = i.appendKanikoExectorImage(base)
+	base = i.appendContext(base)
+	base = i.appendDockerfile(base, docker.Dockerfile)
+	base = i.appendDestinations(base, images)
+	base = i.appendNoPush(base, docker.SkipPush == "true")
+	base = i.appendFlags(base, flags)
+
+	return base
+}
+
+func (i kanikoImager) appendWorkspaceVolumeMount(base []string) []string {
+	cwd, _ := os.Getwd()
+	return append(base, "-v", fmt.Sprintf("%s:%s", cwd, kanikoWorkspace))
+}
+
+func (i kanikoImager) appendKanikoExectorImage(base []string) []string {
+	return append(base, kanikoExecutorImage)
+}
+
+func (i kanikoImager) appendContext(base []string) []string {
+	return append(base, "--context", fmt.Sprintf("dir://%s", kanikoWorkspace))
+}
+
+func (i kanikoImager) appendDockerfile(base []string, dockerfile string) []string {
+	return append(base, "--dockerfile", fmt.Sprintf("%s/%s", kanikoWorkspace, dockerfile))
+}
+
+func (i kanikoImager) appendDestinations(base, images []string) []string {
+	for _, image := range images {
+		base = append(base, "--destination", image)
+	}
+	return base
+}
+
+func (i kanikoImager) appendNoPush(base []string, skipPush bool) []string {
+	if skipPush {
+		base = append(base, "--no-push")
+	}
+	return base
+}
+
+func (i kanikoImager) appendFlags(base []string, flags []string) []string {
+	return append(base, flags...)
+}

--- a/internal/pipe/docker/api_kaniko_test.go
+++ b/internal/pipe/docker/api_kaniko_test.go
@@ -1,0 +1,43 @@
+package docker
+
+import (
+	"fmt"
+	"github.com/goreleaser/goreleaser/pkg/config"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKanikoImagerBuildCommand(t *testing.T) {
+	images := []string{"goreleaser/test_build_flag", "goreleaser/test_multiple_tags"}
+	cwd, _ := os.Getwd()
+	tests := []struct {
+		name       string
+		flags      []string
+		dockerfile string
+		skipPush   string
+		expect     []string
+	}{
+		{
+			name:       "kaniko build on docker",
+			flags:      []string{"--label=foo=bar", "--build-arg=bar=baz"},
+			dockerfile: "Dockerfile",
+			expect:     []string{"run", "-v", fmt.Sprintf("%s:/workspace", cwd), kanikoExecutorImage, "--context", "dir:///workspace", "--dockerfile", "/workspace/Dockerfile", "--destination", images[0], "--destination", images[1], "--label=foo=bar", "--build-arg=bar=baz"},
+		},
+		{
+			name:       "kaniko build with skip push",
+			dockerfile: "test/Dockerfile",
+			skipPush:   "true",
+			expect:     []string{"run", "-v", fmt.Sprintf("%s:/workspace", cwd), kanikoExecutorImage, "--context", "dir:///workspace", "--dockerfile", "/workspace/test/Dockerfile", "--destination", images[0], "--destination", images[1], "--no-push"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			imager := kanikoImager{}
+			docker := config.Docker{Dockerfile: tt.dockerfile, SkipPush: tt.skipPush}
+			require.Equal(t, tt.expect, imager.buildCommand(docker, images, tt.flags))
+		})
+	}
+}

--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -24,6 +24,7 @@ const (
 
 	useBuildx     = "buildx"
 	useDocker     = "docker"
+	useKaniko     = "kaniko"
 	useBuildPacks = "buildpacks" // deprecated: should not be used anymore
 )
 
@@ -177,7 +178,7 @@ func process(ctx *context.Context, docker config.Docker, artifacts []*artifact.A
 	}
 
 	log.Info("building docker image")
-	if err := imagers[docker.Use].Build(ctx, tmp, images, buildFlags); err != nil {
+	if err := imagers[docker.Use].Build(ctx, docker, tmp, images, buildFlags); err != nil {
 		return err
 	}
 


### PR DESCRIPTION

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

This commit will add a feature to build Docker image using Kaniko running on Docker.

The implementation adds a new kaniko api that implements `imager` interface. 

As kaniko builds and pushes in the same command, the `Push` method is a no-op. A no-push option is available within Kaniko through a CLI flag `--no-push`. So Goreleaser's `--skip_push` is translated into Kaniko's `--no-push`.

<!-- Why is this change being made? -->

...

<!-- # Provide links to any relevant tickets, URLs or other resources -->

#2322
