### PR TITLE
fix: custom targets if missing goamd64, goarm, gomips

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -69,6 +69,21 @@ func (*Builder) WithDefaults(build config.Build) (config.Build, error) {
 		if err != nil {
 			return build, err
 		}
+	} else {
+		for i, target := range build.Targets {
+			if strings.HasSuffix(target, "_amd64") {
+				build.Targets[i] = target + "_v1"
+			}
+			if strings.HasSuffix(target, "_arm") {
+				build.Targets[i] = target + "_6"
+			}
+			if strings.HasSuffix(target, "_mips") ||
+				strings.HasSuffix(target, "_mips64") ||
+				strings.HasSuffix(target, "_mipsle") ||
+				strings.HasSuffix(target, "_mips64le") {
+				build.Targets[i] = target + "_hardfloat"
+			}
+		}
 	}
 	return build, nil
 }

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -95,6 +95,66 @@ func TestWithDefaults(t *testing.T) {
 			},
 			goBinary: "go",
 		},
+		"custom targets no amd64": {
+			build: config.Build{
+				ID:     "foo3",
+				Binary: "foo",
+				Targets: []string{
+					"linux_386",
+					"darwin_amd64",
+				},
+			},
+			targets: []string{
+				"linux_386",
+				"darwin_amd64_v1",
+			},
+			goBinary: "go",
+		},
+		"custom targets no arm": {
+			build: config.Build{
+				ID:      "foo3",
+				Binary:  "foo",
+				Targets: []string{"linux_arm"},
+			},
+			targets:  []string{"linux_arm_6"},
+			goBinary: "go",
+		},
+		"custom targets no mips": {
+			build: config.Build{
+				ID:      "foo3",
+				Binary:  "foo",
+				Targets: []string{"linux_mips"},
+			},
+			targets:  []string{"linux_mips_hardfloat"},
+			goBinary: "go",
+		},
+		"custom targets no mipsle": {
+			build: config.Build{
+				ID:      "foo3",
+				Binary:  "foo",
+				Targets: []string{"linux_mipsle"},
+			},
+			targets:  []string{"linux_mipsle_hardfloat"},
+			goBinary: "go",
+		},
+		"custom targets no mips64": {
+			build: config.Build{
+				ID:      "foo3",
+				Binary:  "foo",
+				Targets: []string{"linux_mips64"},
+			},
+			targets:  []string{"linux_mips64_hardfloat"},
+			goBinary: "go",
+		},
+		"custom targets no mips64le": {
+			build: config.Build{
+				ID:      "foo3",
+				Binary:  "foo",
+				Targets: []string{"linux_mips64le"},
+			},
+			targets:  []string{"linux_mips64le_hardfloat"},
+			goBinary: "go",
+		},
 		"empty with custom dir": {
 			build: config.Build{
 				ID:     "foo2",


### PR DESCRIPTION
if the user provide custom targets without the goamd64, goarm or gomips bit, things may go awry at some point.  this prevents issues by suffixing them with the default when its missing.  closes https://github.com/goreleaser/goreleaser/issues/3055  