### PR TITLE
fix: fixed #3058 issue

### DIFF
--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -50,8 +50,8 @@ func ExtractRepoFromURL(rawurl string) (config.Repo, error) {
 	// split the parsed url path by /, the last parts should be the owner and name
 	ss := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
 
-	// if less than 2 parts, its likely not a valid repository
-	if len(ss) < 2 {
+	// if path doesn't contain any item, its likely not a valid repository
+	if len(ss) == 0 {
 		return config.Repo{}, fmt.Errorf("unsupported repository URL: %s", rawurl)
 	}
 	repo := config.Repo{

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -50,6 +50,7 @@ func TestExtractRepoFromURL(t *testing.T) {
 	for _, url := range []string{
 		"git@github.com:goreleaser/goreleaser.git",
 		"git@custom:goreleaser/goreleaser.git",
+		"ssh://username@git.example.com/goreleaser",
 		"https://foo@github.com/goreleaser/goreleaser",
 		"https://github.com/goreleaser/goreleaser.git",
 		"https://something.with.port:8080/goreleaser/goreleaser.git",
@@ -78,8 +79,8 @@ func TestExtractRepoFromURL(t *testing.T) {
 
 	// invalid urls
 	for _, url := range []string{
-		"git@gist.github.com:someid.git",
-		"https://gist.github.com/someid.git",
+		"git@gist.github.com:",
+		"https://gist.github.com/",
 	} {
 		t.Run(url, func(t *testing.T) {
 			repo, err := git.ExtractRepoFromURL(url)


### PR DESCRIPTION
This commit is a fix for #3058 issue, when goreleaser thinks that in git remote url any path with less than 2 items is an invalid url.

 **Why is this change being made:** To support exotic git engines like [Gerrit](https://www.gerritcodereview.com/), since git is not providing any limitations to repository url.

No any additional tests needed, it's just a fix to minimum value