### PR TITLE
fix: prevent folder collisions in builds and universal binaries

### DIFF
--- a/internal/pipe/build/build.go
+++ b/internal/pipe/build/build.go
@@ -73,7 +73,7 @@ func buildWithDefaults(ctx *context.Context, build config.Build) (config.Build, 
 		build.Binary = ctx.Config.ProjectName
 	}
 	if build.ID == "" {
-		build.ID = ctx.Config.ProjectName
+		build.ID = build.Binary
 	}
 	for k, v := range build.Env {
 		build.Env[k] = os.ExpandEnv(v)

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -288,6 +288,7 @@ func TestDefaultBuildID(t *testing.T) {
 			Builds: []config.Build{
 				{
 					Binary: "{{.Env.FOO}}",
+					ID:     "bar",
 				},
 				{
 					Binary: "bar",
@@ -295,9 +296,11 @@ func TestDefaultBuildID(t *testing.T) {
 			},
 		},
 	}
-	require.EqualError(t, Pipe{}.Default(ctx), "found 2 builds with the ID 'foo', please fix your config")
-	build := ctx.Config.Builds[0]
-	require.Equal(t, ctx.Config.ProjectName, build.ID)
+	require.EqualError(t, Pipe{}.Default(ctx), "found 2 builds with the ID 'bar', please fix your config")
+	build1 := ctx.Config.Builds[0].ID
+	build2 := ctx.Config.Builds[1].ID
+	require.Equal(t, build1, build2)
+	require.Equal(t, "bar", build2)
 }
 
 func TestSeveralBuildsWithTheSameID(t *testing.T) {

--- a/internal/pipe/universalbinary/universalbinary.go
+++ b/internal/pipe/universalbinary/universalbinary.go
@@ -140,7 +140,7 @@ func makeUniversalBinary(ctx *context.Context, opts *build.Options, unibin confi
 	}
 	opts.Name = name
 
-	path := filepath.Join(ctx.Config.Dist, name+"_darwin_all", name)
+	path := filepath.Join(ctx.Config.Dist, unibin.ID+"_darwin_all", name)
 	opts.Path = path
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
@@ -151,7 +151,9 @@ func makeUniversalBinary(ctx *context.Context, opts *build.Options, unibin confi
 		return pipe.Skip(fmt.Sprintf("no darwin binaries found with id %q", unibin.ID))
 	}
 
-	log.WithField("binary", path).Infof("creating from %d binaries", len(binaries))
+	log.WithField("id", unibin.ID).
+		WithField("binary", path).
+		Infof("creating from %d binaries", len(binaries))
 
 	var inputs []input
 	offset := int64(align)

--- a/internal/pipe/universalbinary/universalbinary_test.go
+++ b/internal/pipe/universalbinary/universalbinary_test.go
@@ -353,7 +353,7 @@ func TestRun(t *testing.T) {
 func checkUniversalBinary(tb testing.TB, unibin *artifact.Artifact) {
 	tb.Helper()
 
-	require.True(tb, strings.HasSuffix(unibin.Path, "foo_darwin_all/foo"))
+	require.True(tb, strings.HasSuffix(unibin.Path, unibin.ID()+"_darwin_all/foo"))
 	f, err := macho.OpenFat(unibin.Path)
 	require.NoError(tb, err)
 	require.Len(tb, f.Arches, 2)

--- a/www/docs/customization/build.md
+++ b/www/docs/customization/build.md
@@ -13,7 +13,7 @@ builds:
   # You can have multiple builds defined as a yaml list
   -
     # ID of the build.
-    # Defaults to the project name.
+    # Defaults to the binary name.
     id: "my-build"
 
     # Path to project's (sub)directory containing Go code.


### PR DESCRIPTION
- on universal binaries, use the build id instead of the binary name to
   create the folder in the dist folder 
- on builds, default the id the to the binary name instead of project
   name. The binary name already defaults to the project id if empty, so
   this should only prevent having to specify the id + binary name in
   some cases.  

closes #3061  