### PR TITLE
Update scoop.md

### DIFF
--- a/www/docs/customization/scoop.md
+++ b/www/docs/customization/scoop.md
@@ -25,7 +25,7 @@ scoop:
     branch: main
 
     # Optionally a token can be provided, if it differs from the token provided to GoReleaser
-    token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    token: "{{ .Env.SCOOP_TAP_GITHUB_TOKEN }}"
 
   # Folder inside the repository to put the scoop.
   # Default is the root folder.


### PR DESCRIPTION
Probably a typo in the docs.

It refers to homebrew instead of scoop 
https://goreleaser.com/customization/scoop/?h=scoop 