### PR TITLE
feat: allow git remote urls from non-scm sources

### DIFF
--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -60,6 +60,8 @@ func TestExtractRepoFromURL(t *testing.T) {
 			repo, err := git.ExtractRepoFromURL(url)
 			require.NoError(t, err)
 			require.Equal(t, "goreleaser/goreleaser", repo.String())
+			require.NoError(t, repo.CheckSCM())
+			require.Equal(t, url, repo.RawURL)
 		})
 	}
 
@@ -73,18 +75,35 @@ func TestExtractRepoFromURL(t *testing.T) {
 			repo, err := git.ExtractRepoFromURL(url)
 			require.NoError(t, err)
 			require.Equal(t, "group/nested/goreleaser/goreleaser", repo.String())
+			require.NoError(t, repo.CheckSCM())
+			require.Equal(t, url, repo.RawURL)
 		})
 	}
 
-	// invalid urls
 	for _, url := range []string{
 		"git@gist.github.com:someid.git",
 		"https://gist.github.com/someid.git",
 	} {
 		t.Run(url, func(t *testing.T) {
 			repo, err := git.ExtractRepoFromURL(url)
+			require.NoError(t, err)
+			require.Equal(t, "someid", repo.String())
+			require.Error(t, repo.CheckSCM())
+			require.Equal(t, url, repo.RawURL)
+		})
+	}
+
+	// invalid urls
+	for _, url := range []string{
+		"git@gist.github.com:",
+		"https://gist.github.com/",
+	} {
+		t.Run(url, func(t *testing.T) {
+			repo, err := git.ExtractRepoFromURL(url)
 			require.EqualError(t, err, "unsupported repository URL: "+url)
 			require.Equal(t, "", repo.String())
+			require.Error(t, repo.CheckSCM())
+			require.Equal(t, url, repo.RawURL)
 		})
 	}
 }

--- a/internal/pipe/changelog/changelog.go
+++ b/internal/pipe/changelog/changelog.go
@@ -287,6 +287,9 @@ func newGithubChangeloger(ctx *context.Context) (changeloger, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := repo.CheckSCM(); err != nil {
+		return nil, err
+	}
 	return &githubNativeChangeloger{
 		client: cli,
 		repo: client.Repo{
@@ -303,6 +306,9 @@ func newSCMChangeloger(ctx *context.Context) (changeloger, error) {
 	}
 	repo, err := git.ExtractRepoFromConfig(ctx)
 	if err != nil {
+		return nil, err
+	}
+	if err := repo.CheckSCM(); err != nil {
 		return nil, err
 	}
 	return &scmChangeloger{

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -536,6 +536,21 @@ func TestGetChangeloger(t *testing.T) {
 		require.IsType(t, c, &githubNativeChangeloger{})
 	})
 
+	t.Run(useGitHubNative+"-invalid-repo", func(t *testing.T) {
+		testlib.Mktmp(t)
+		testlib.GitInit(t)
+		testlib.GitRemoteAdd(t, "https://gist.github.com/")
+		ctx := context.New(config.Project{
+			Changelog: config.Changelog{
+				Use: useGitHubNative,
+			},
+		})
+		ctx.TokenType = context.TokenTypeGitHub
+		c, err := getChangeloger(ctx)
+		require.EqualError(t, err, "unsupported repository URL: https://gist.github.com/")
+		require.Nil(t, c)
+	})
+
 	t.Run(useGitLab, func(t *testing.T) {
 		ctx := context.New(config.Project{
 			Changelog: config.Changelog{
@@ -546,6 +561,21 @@ func TestGetChangeloger(t *testing.T) {
 		c, err := getChangeloger(ctx)
 		require.NoError(t, err)
 		require.IsType(t, c, &scmChangeloger{})
+	})
+
+	t.Run(useGitHub+"-invalid-repo", func(t *testing.T) {
+		testlib.Mktmp(t)
+		testlib.GitInit(t)
+		testlib.GitRemoteAdd(t, "https://gist.github.com/")
+		ctx := context.New(config.Project{
+			Changelog: config.Changelog{
+				Use: useGitHub,
+			},
+		})
+		ctx.TokenType = context.TokenTypeGitHub
+		c, err := getChangeloger(ctx)
+		require.EqualError(t, err, "unsupported repository URL: https://gist.github.com/")
+		require.Nil(t, c)
 	})
 
 	t.Run("invalid", func(t *testing.T) {

--- a/internal/pipe/milestone/milestone.go
+++ b/internal/pipe/milestone/milestone.go
@@ -29,8 +29,10 @@ func (Pipe) Default(ctx *context.Context) error {
 
 		if milestone.Repo.Name == "" {
 			repo, err := git.ExtractRepoFromConfig(ctx)
-
 			if err != nil && !ctx.Snapshot {
+				return err
+			}
+			if err := repo.CheckSCM(); err != nil && !ctx.Snapshot {
 				return err
 			}
 

--- a/internal/pipe/milestone/milestone_test.go
+++ b/internal/pipe/milestone/milestone_test.go
@@ -31,6 +31,18 @@ func TestDefaultWithRepoConfig(t *testing.T) {
 	require.Equal(t, "configowner", ctx.Config.Milestones[0].Repo.Owner)
 }
 
+func TestDefaultWithInvalidRemote(t *testing.T) {
+	testlib.Mktmp(t)
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:githubowner.git")
+
+	ctx := context.New(config.Project{
+		Milestones: []config.Milestone{{}},
+	})
+	ctx.TokenType = context.TokenTypeGitHub
+	require.Error(t, Pipe{}.Default(ctx))
+}
+
 func TestDefaultWithRepoRemote(t *testing.T) {
 	testlib.Mktmp(t)
 	testlib.GitInit(t)

--- a/internal/pipe/release/release_test.go
+++ b/internal/pipe/release/release_test.go
@@ -354,6 +354,18 @@ func TestDefault(t *testing.T) {
 	require.Equal(t, "https://github.com/goreleaser/goreleaser/releases/tag/v1.0.0", ctx.ReleaseURL)
 }
 
+func TestDefaultInvalidURL(t *testing.T) {
+	testlib.Mktmp(t)
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:goreleaser.git")
+
+	ctx := context.New(config.Project{})
+	ctx.TokenType = context.TokenTypeGitHub
+	ctx.Config.GitHubURLs.Download = "https://github.com"
+	ctx.Git.CurrentTag = "v1.0.0"
+	require.Error(t, Pipe{}.Default(ctx))
+}
+
 func TestDefaultWithGitlab(t *testing.T) {
 	testlib.Mktmp(t)
 	testlib.GitInit(t)
@@ -369,6 +381,18 @@ func TestDefaultWithGitlab(t *testing.T) {
 	require.Equal(t, "https://gitlab.com/gitlabowner/gitlabrepo/-/releases/v1.0.0", ctx.ReleaseURL)
 }
 
+func TestDefaultWithGitlabInvalidURL(t *testing.T) {
+	testlib.Mktmp(t)
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@gitlab.com:gitlabrepo.git")
+
+	ctx := context.New(config.Project{})
+	ctx.TokenType = context.TokenTypeGitLab
+	ctx.Config.GitLabURLs.Download = "https://gitlab.com"
+	ctx.Git.CurrentTag = "v1.0.0"
+	require.Error(t, Pipe{}.Default(ctx))
+}
+
 func TestDefaultWithGitea(t *testing.T) {
 	testlib.Mktmp(t)
 	testlib.GitInit(t)
@@ -382,6 +406,18 @@ func TestDefaultWithGitea(t *testing.T) {
 	require.Equal(t, "gitearepo", ctx.Config.Release.Gitea.Name)
 	require.Equal(t, "giteaowner", ctx.Config.Release.Gitea.Owner)
 	require.Equal(t, "https://git.honk.com/giteaowner/gitearepo/releases/tag/v1.0.0", ctx.ReleaseURL)
+}
+
+func TestDefaultWithGiteaInvalidURL(t *testing.T) {
+	testlib.Mktmp(t)
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@gitea.example.com:gitearepo.git")
+
+	ctx := context.New(config.Project{})
+	ctx.TokenType = context.TokenTypeGitea
+	ctx.Config.GiteaURLs.Download = "https://git.honk.com"
+	ctx.Git.CurrentTag = "v1.0.0"
+	require.Error(t, Pipe{}.Default(ctx))
 }
 
 func TestDefaultPreRelease(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -42,16 +43,30 @@ type GiteaURLs struct {
 // Repo represents any kind of repo (github, gitlab, etc).
 // to upload releases into.
 type Repo struct {
-	Owner string `yaml:"owner,omitempty"`
-	Name  string `yaml:"name,omitempty"`
+	Owner  string `yaml:"owner,omitempty"`
+	Name   string `yaml:"name,omitempty"`
+	RawURL string `yaml:"-"`
 }
 
 // String of the repo, e.g. owner/name.
 func (r Repo) String() string {
-	if r.Owner == "" && r.Name == "" {
-		return ""
+	if r.isSCM() {
+		return r.Owner + "/" + r.Name
 	}
-	return r.Owner + "/" + r.Name
+	return r.Owner
+}
+
+// CheckSCM returns an error if the given url is not a valid scm url.
+func (r Repo) CheckSCM() error {
+	if r.isSCM() {
+		return nil
+	}
+	return fmt.Errorf("invalid scm url: %s", r.RawURL)
+}
+
+// isSCM returns true if the repo has both an owner and name.
+func (r Repo) isSCM() bool {
+	return r.Owner != "" && r.Name != ""
 }
 
 // RepoRef represents any kind of repo which may differ


### PR DESCRIPTION
basically allows to use goreleaser against a repo with a git url without both owner and repo name.

closes #3060
closes #3058
