### PR TITLE
docs: add example for semantic-release

### DIFF
--- a/www/docs/cookbooks/semantic-release.md
+++ b/www/docs/cookbooks/semantic-release.md
@@ -3,10 +3,33 @@
 GoReleaser does not create any tags, it just runs on what is already there.
 
 You can, though, leverage other tools to do the work for you, like for example
-[svu](https://github.com/caarlos0/svu):
+[svu](https://github.com/caarlos0/svu) or [semantic-release](https://github.com/semantic-release/semantic-release).
+
+## Example: svu
 
 ```bash
 git tag "$(svu next)"
 git push --tags
 goreleaser --rm-dist
+```
+
+## Example: semantic-release
+
+.releaserc.yml
+
+```yaml
+preset: angular
+plugins:
+  - "@semantic-release/commit-analyzer"
+  - "@semantic-release/release-notes-generator"
+  - "@semantic-release/changelog"
+  - "@semantic-release/git"
+  - - "@semantic-release/exec"
+    - publishCmd: |
+        echo "${nextRelease.notes}" > /tmp/release-notes.md
+        goreleaser release --release-notes /tmp/release-notes.md --rm-dist
+```
+
+```bash
+npx -p @semantic-release/changelog -p @semantic-release/exec -p @semantic-release/git semantic-release
 ```


### PR DESCRIPTION
The commit will add an example of the use of sematic-release in the documentation (https://github.com/semantic-release/semantic-release).

The solution in the issue https://github.com/goreleaser/goreleaser/issues/910 was not documented.