### PR TITLE
refactor: improve archive pipe

### DIFF
--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -164,8 +164,11 @@ func doCreate(ctx *context.Context, arch config.Archive, binaries []*artifact.Ar
 	if err != nil {
 		return err
 	}
-
-	a := NewEnhancedArchive(archive.New(archiveFile), wrap)
+	a, err := archive.New(archiveFile, format)
+	if err != nil {
+		return err
+	}
+	a = NewEnhancedArchive(a, wrap)
 	defer a.Close()
 
 	files, err := findFiles(template, arch.Files)

--- a/internal/pipe/archive/archive_test.go
+++ b/internal/pipe/archive/archive_test.go
@@ -901,8 +901,9 @@ func TestDuplicateFilesInsideArchive(t *testing.T) {
 	ff, err := os.CreateTemp(folder, "")
 	require.NoError(t, err)
 	require.NoError(t, ff.Close())
-
-	a := NewEnhancedArchive(archive.New(f), "")
+	a, err := archive.New(f, "tar.gz")
+	require.NoError(t, err)
+	a = NewEnhancedArchive(a, "")
 	t.Cleanup(func() {
 		require.NoError(t, a.Close())
 	})
@@ -1155,4 +1156,19 @@ func TestArchive_globbing(t *testing.T) {
 			"var/yada/d.txt",
 		})
 	})
+}
+
+func TestInvalidFormat(t *testing.T) {
+	ctx := context.New(config.Project{
+		Dist: t.TempDir(),
+		Archives: []config.Archive{
+			{
+				ID:           "foo",
+				NameTemplate: "foo",
+				Meta:         true,
+				Format:       "7z",
+			},
+		},
+	})
+	require.EqualError(t, Pipe{}.Run(ctx), "invalid archive format: 7z")
 }

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -2,8 +2,8 @@
 package archive
 
 import (
-	"os"
-	"strings"
+	"fmt"
+	"io"
 
 	"github.com/goreleaser/goreleaser/pkg/archive/gzip"
 	"github.com/goreleaser/goreleaser/pkg/archive/tar"
@@ -20,21 +20,18 @@ type Archive interface {
 }
 
 // New archive.
-func New(file *os.File) Archive {
-	if strings.HasSuffix(file.Name(), ".tar.gz") {
-		return targz.New(file)
+func New(w io.Writer, format string) (Archive, error) {
+	switch format {
+	case "tar.gz":
+		return targz.New(w), nil
+	case "tar":
+		return tar.New(w), nil
+	case "gz":
+		return gzip.New(w), nil
+	case "tar.xz":
+		return tarxz.New(w), nil
+	case "zip":
+		return zip.New(w), nil
 	}
-	if strings.HasSuffix(file.Name(), ".gz") {
-		return gzip.New(file)
-	}
-	if strings.HasSuffix(file.Name(), ".tar.xz") {
-		return tarxz.New(file)
-	}
-	if strings.HasSuffix(file.Name(), ".zip") {
-		return zip.New(file)
-	}
-	if strings.HasSuffix(file.Name(), ".tar") {
-		return tar.New(file)
-	}
-	return targz.New(file)
+	return nil, fmt.Errorf("invalid archive format: %s", format)
 }

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -1,6 +1,7 @@
 package archive
 
 import (
+	"io"
 	"os"
 	"testing"
 
@@ -15,15 +16,13 @@ func TestArchive(t *testing.T) {
 	require.NoError(t, empty.Close())
 	require.NoError(t, os.Mkdir(folder+"/folder-inside", 0o755))
 
-	for _, format := range []string{"tar.gz", "zip", "gz", "tar.xz", "tar", "willbeatargzanyway"} {
+	for _, format := range []string{"tar.gz", "zip", "gz", "tar.xz", "tar"} {
 		format := format
 		t.Run(format, func(t *testing.T) {
-			file, err := os.Create(folder + "/folder." + format)
+			archive, err := New(io.Discard, format)
 			require.NoError(t, err)
-			archive := New(file)
 			t.Cleanup(func() {
 				require.NoError(t, archive.Close())
-				require.NoError(t, file.Close())
 			})
 			require.NoError(t, archive.Add(config.File{
 				Source:      empty.Name(),
@@ -35,4 +34,9 @@ func TestArchive(t *testing.T) {
 			}))
 		})
 	}
+
+	t.Run("7z", func(t *testing.T) {
+		_, err := New(io.Discard, "7z")
+		require.EqualError(t, err, "invalid archive format: 7z")
+	})
 }


### PR DESCRIPTION
Defaulting to tar.gz is probably not a good idea, better error instead.