### PR TITLE
fix: archive should not actually verify links

### DIFF
--- a/pkg/archive/tar/tar.go
+++ b/pkg/archive/tar/tar.go
@@ -28,11 +28,6 @@ func (a Archive) Close() error {
 
 // Add file to the archive.
 func (a Archive) Add(f config.File) error {
-	file, err := os.Open(f.Source) // #nosec
-	if err != nil {
-		return err
-	}
-	defer file.Close()
 	info, err := os.Lstat(f.Source) // #nosec
 	if err != nil {
 		return err
@@ -69,6 +64,11 @@ func (a Archive) Add(f config.File) error {
 	if info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 		return nil
 	}
+	file, err := os.Open(f.Source) // #nosec
+	if err != nil {
+		return err
+	}
+	defer file.Close()
 	_, err = io.Copy(a.tw, file)
 	return err
 }

--- a/pkg/archive/tar/tar_test.go
+++ b/pkg/archive/tar/tar_test.go
@@ -151,15 +151,11 @@ func TestTarFileInfo(t *testing.T) {
 }
 
 func TestTarInvalidLink(t *testing.T) {
-	tmp := t.TempDir()
-	f, err := os.Create(filepath.Join(tmp, "test.tar"))
-	require.NoError(t, err)
-	defer f.Close() // nolint: errcheck
-	archive := New(f)
+	archive := New(io.Discard)
 	defer archive.Close() // nolint: errcheck
 
-	require.EqualError(t, archive.Add(config.File{
+	require.NoError(t, archive.Add(config.File{
 		Source:      "../testdata/badlink.txt",
 		Destination: "badlink.txt",
-	}), "open ../testdata/badlink.txt: no such file or directory")
+	}))
 }

--- a/pkg/archive/zip/zip.go
+++ b/pkg/archive/zip/zip.go
@@ -34,11 +34,6 @@ func (a Archive) Close() error {
 
 // Add a file to the zip archive.
 func (a Archive) Add(f config.File) error {
-	file, err := os.Open(f.Source) // #nosec
-	if err != nil {
-		return err
-	}
-	defer file.Close()
 	info, err := os.Lstat(f.Source) // #nosec
 	if err != nil {
 		return err
@@ -62,6 +57,14 @@ func (a Archive) Add(f config.File) error {
 	if err != nil {
 		return err
 	}
+	if info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return nil
+	}
+	file, err := os.Open(f.Source) // #nosec
+	if err != nil {
+		return err
+	}
+	defer file.Close()
 	_, err = io.Copy(w, file)
 	return err
 }

--- a/pkg/archive/zip/zip_test.go
+++ b/pkg/archive/zip/zip_test.go
@@ -2,6 +2,7 @@ package zip
 
 import (
 	"archive/zip"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -135,4 +136,14 @@ func TestZipFileInfo(t *testing.T) {
 		require.Equal(t, now.Unix(), next.Modified.Unix())
 		require.Equal(t, fs.FileMode(0o755), next.FileInfo().Mode())
 	}
+}
+
+func TestTarInvalidLink(t *testing.T) {
+	archive := New(io.Discard)
+	defer archive.Close() // nolint: errcheck
+
+	require.NoError(t, archive.Add(config.File{
+		Source:      "../testdata/badlink.txt",
+		Destination: "badlink.txt",
+	}))
 }


### PR DESCRIPTION
This seems to be the way `tar` et al works... if you give it a folder with a symlink pointing to nowhere, it will archive that symbolic link no question asked.

we should probably do the same, specially given #3102

IMHO not a breaking change, as someone with bad links wont be able to archive things in the current version of goreleaser.