### PR TITLE
fix: better handle docker skip errors

### DIFF
--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -128,6 +128,9 @@ func (Pipe) Run(ctx *context.Context) error {
 		})
 	}
 	if err := g.Wait(); err != nil {
+		if pipe.IsSkip(err) {
+			return err
+		}
 		return fmt.Errorf("docker build failed: %w\nLearn more at https://goreleaser.com/errors/docker-build\n", err) // nolint:revive
 	}
 	return nil


### PR DESCRIPTION
Otherwise it'll advise the link when its actually just skipping the run...