### PR TITLE
fix: brew formula class generation when using dots

### DIFF
--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -408,7 +408,7 @@ func split(s string) []string {
 func formulaNameFor(name string) string {
 	name = strings.ReplaceAll(name, "-", " ")
 	name = strings.ReplaceAll(name, "_", " ")
-	name = strings.ReplaceAll(name, ".", "_")
+	name = strings.ReplaceAll(name, ".", "")
 	name = strings.ReplaceAll(name, "@", "AT")
 	return strings.ReplaceAll(strings.Title(name), " ", "") // nolint:staticcheck
 }

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -28,7 +28,7 @@ func TestNameWithUnderline(t *testing.T) {
 }
 
 func TestNameWithDots(t *testing.T) {
-	require.Equal(t, formulaNameFor("binaryv0.0.0"), "Binaryv0_0_0")
+	require.Equal(t, formulaNameFor("binaryv0.0.0"), "Binaryv000")
 }
 
 func TestNameWithAT(t *testing.T) {


### PR DESCRIPTION
Resolves: #3116

Change homebrew class generation to match what homebrew expects based on [Homebrew's code](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/formulary.rb#L150-L156) for generating class names.

