### PR TITLE
fix: duplicate draft release in GitHub

### DIFF
--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -245,7 +245,7 @@ func (c *githubClient) CreateRelease(ctx *context.Context, body string) (string,
 			opt.Page = resp.NextPage
 		}
 	} else {
-		release, _, err = c.client.Repositories.GetReleaseByTag(
+		release, _, _ = c.client.Repositories.GetReleaseByTag(
 			ctx,
 			ctx.Config.Release.GitHub.Owner,
 			ctx.Config.Release.GitHub.Name,


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

For draft releases in GitHub, treat other draft releases with the same name as the same release.

<!-- Why is this change being made? -->


<!-- # Provide links to any relevant tickets, URLs or other resources -->

Fix #3148
