### PR TITLE
fix: allow wrap_in_directory in JSON Schema to be boolean

### DIFF
--- a/www/docs/static/schema-pro.json
+++ b/www/docs/static/schema-pro.json
@@ -196,7 +196,14 @@
 						"type": "array"
 					},
 					"wrap_in_directory": {
-						"type": "string"
+						"oneOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "boolean"
+							}
+						]
 					},
 					"files": {
 						"items": {

--- a/www/docs/static/schema.json
+++ b/www/docs/static/schema.json
@@ -175,7 +175,14 @@
 						"type": "array"
 					},
 					"wrap_in_directory": {
-						"type": "string"
+						"oneOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "boolean"
+							}
+						]
 					},
 					"files": {
 						"items": {


### PR DESCRIPTION
This PR changes JSON schema of `.archives.wrap_directory`.
The current schema allows string only, but boolean should be also allowed.

VSCode's [YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) seems to uses this schema and reports incorrect warning to user.
<img width="591" alt="image" src="https://user-images.githubusercontent.com/7571111/173213457-32551ee8-4ddf-42b4-a1f9-d1095fcca1ba.png">

The document about of archives is [here](https://goreleaser.com/customization/archive/).
