### PR TITLE
feat: removed deprecated windows arm handling on go 1.16

### DIFF
--- a/internal/builders/buildtarget/targets.go
+++ b/internal/builders/buildtarget/targets.go
@@ -6,11 +6,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"regexp"
 	"strings"
 
 	"github.com/apex/log"
-	"github.com/fatih/color"
 	"github.com/goreleaser/goreleaser/pkg/config"
 )
 
@@ -54,13 +52,6 @@ func matrix(build config.Build, version []byte) ([]string, error) {
 		}
 		if target.amd64 != "" && !contains(target.amd64, validGoamd64) {
 			return result, fmt.Errorf("invalid goamd64: %s", target.amd64)
-		}
-		if target.os == "windows" && target.arch == "arm64" && !go117re.Match(version) {
-			log.Warn(color.New(color.Bold, color.FgHiYellow).Sprintf(
-				"DEPRECATED: skipped windows/arm64 build on Go < 1.17 for compatibility, check %s for more info.",
-				"https://goreleaser.com/deprecations/#builds-for-windowsarm64",
-			))
-			continue
 		}
 		if !valid(target) {
 			log.WithField("target", target).Debug("skipped invalid build")
@@ -143,8 +134,6 @@ func ignored(build config.Build, target target) bool {
 	}
 	return false
 }
-
-var go117re = regexp.MustCompile(`go version go1.1[7-9]`)
 
 func goVersion(build config.Build) ([]byte, error) {
 	cmd := exec.Command(build.GoBinary, "version")

--- a/internal/builders/buildtarget/targets_test.go
+++ b/internal/builders/buildtarget/targets_test.go
@@ -66,49 +66,6 @@ func TestAllBuildTargets(t *testing.T) {
 		},
 	}
 
-	t.Run("go 1.16", func(t *testing.T) {
-		result, err := matrix(build, []byte("go version go1.16.2"))
-		require.NoError(t, err)
-		require.Equal(t, []string{
-			"linux_386",
-			"linux_amd64_v1",
-			"linux_amd64_v2",
-			"linux_amd64_v4",
-			"linux_arm_6",
-			"linux_arm64",
-			"linux_mips_hardfloat",
-			"linux_mips_softfloat",
-			"linux_mips64_softfloat",
-			"linux_mipsle_hardfloat",
-			"linux_mipsle_softfloat",
-			"linux_mips64le_hardfloat",
-			"linux_riscv64",
-			"darwin_amd64_v1",
-			"darwin_amd64_v2",
-			"darwin_amd64_v4",
-			"darwin_arm64",
-			"freebsd_386",
-			"freebsd_amd64_v1",
-			"freebsd_amd64_v2",
-			"freebsd_amd64_v4",
-			"freebsd_arm_6",
-			"freebsd_arm_7",
-			"freebsd_arm64",
-			"openbsd_386",
-			"openbsd_amd64_v1",
-			"openbsd_amd64_v2",
-			"openbsd_amd64_v4",
-			"openbsd_arm64",
-			"windows_386",
-			"windows_amd64_v1",
-			"windows_amd64_v2",
-			"windows_amd64_v4",
-			"windows_arm_6",
-			"windows_arm_7",
-			"js_wasm",
-		}, result)
-	})
-
 	t.Run("go 1.18", func(t *testing.T) {
 		result, err := matrix(build, []byte("go version go1.18.0"))
 		require.NoError(t, err)

--- a/www/docs/deprecations.md
+++ b/www/docs/deprecations.md
@@ -115,9 +115,13 @@ nFPM empty folders is now deprecated in favor of a `dir` content type:
         type: dir
     ```
 
+## Expired deprecation notices
+
+The following options were deprecated in the past and were already removed.
+
 ### builds for windows/arm64
 
-> since 2021-08-16 (v0.175.0)
+> since 2021-08-16 (v0.175.0), removed 2022-06-12 (v1.10.0)
 
 Since Go 1.17, `windows/arm64` is a valid target.
 
@@ -133,10 +137,6 @@ ignore:
 ```
 
 If you try to use new versions of GoReleaser with Go 1.16 or older, it will warn about it until this deprecation warning expires, after that your build will likely fail.
-
-## Expired deprecation notices
-
-The following options were deprecated in the past and were already removed.
 
 ### godownloader
 


### PR DESCRIPTION
has been deprecated for almost 1y, fully removing it now.