### PR TITLE
docs: adds Koordinator to USERS.md

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -24,6 +24,7 @@ Here's a running list of some organizations using GoReleaser[^1]:
 1. [Helm](https://helm.sh)
 1. [Hugo](https://gohugo.io)
 1. [IRON Security](https://iron.security)
+1. [Koordinator](https://koordinator.sh)
 1. [Microsoft](https://microsoft.com)
 1. [Minio](https://min.io)
 1. [Ministry of Justice (UK)](https://mojdigital.blog.gov.uk)


### PR DESCRIPTION
[Koordinator](https://koordinator.sh/) is a QoS based scheduling system for hybrid orchestration workloads on Kubernetes, bringing workloads the best layout and status. We uses GoReleaser to release containers, packages, and binaries.

So this PR would like to add Koordinator to USERS.md, thanks.