### PR TITLE
feat: add --skip-docker

### DIFF
--- a/cmd/release.go
+++ b/cmd/release.go
@@ -36,6 +36,7 @@ type releaseOpts struct {
 	skipValidate       bool
 	skipAnnounce       bool
 	skipSBOMCataloging bool
+	skipDocker         bool
 	rmDist             bool
 	deprecated         bool
 	parallelism        int
@@ -84,6 +85,7 @@ func newReleaseCmd() *releaseCmd {
 	cmd.Flags().BoolVar(&root.opts.skipAnnounce, "skip-announce", false, "Skips announcing releases (implies --skip-validate)")
 	cmd.Flags().BoolVar(&root.opts.skipSign, "skip-sign", false, "Skips signing artifacts")
 	cmd.Flags().BoolVar(&root.opts.skipSBOMCataloging, "skip-sbom", false, "Skips cataloging artifacts")
+	cmd.Flags().BoolVar(&root.opts.skipDocker, "skip-docker", false, "Skips Docker Images/Manifests builds")
 	cmd.Flags().BoolVar(&root.opts.skipValidate, "skip-validate", false, "Skips git checks")
 	cmd.Flags().BoolVar(&root.opts.rmDist, "rm-dist", false, "Removes the dist folder")
 	cmd.Flags().IntVarP(&root.opts.parallelism, "parallelism", "p", 0, "Amount tasks to run concurrently (default: number of CPUs)")
@@ -141,6 +143,7 @@ func setupReleaseContext(ctx *context.Context, options releaseOpts) *context.Con
 	ctx.SkipValidate = ctx.Snapshot || options.skipValidate
 	ctx.SkipSign = options.skipSign
 	ctx.SkipSBOMCataloging = options.skipSBOMCataloging
+	ctx.SkipDocker = options.skipDocker
 	ctx.RmDist = options.rmDist
 
 	// test only

--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -31,7 +31,7 @@ const (
 type Pipe struct{}
 
 func (Pipe) String() string                 { return "docker images" }
-func (Pipe) Skip(ctx *context.Context) bool { return len(ctx.Config.Dockers) == 0 }
+func (Pipe) Skip(ctx *context.Context) bool { return len(ctx.Config.Dockers) == 0 || ctx.SkipDocker }
 
 // Default sets the pipe defaults.
 func (Pipe) Default(ctx *context.Context) error {

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -1372,6 +1372,12 @@ func TestSkip(t *testing.T) {
 			require.True(t, Pipe{}.Skip(context.New(config.Project{})))
 		})
 
+		t.Run("skip docker", func(t *testing.T) {
+			ctx := context.New(config.Project{})
+			ctx.SkipDocker = true
+			require.True(t, Pipe{}.Skip(ctx))
+		})
+
 		t.Run("dont skip", func(t *testing.T) {
 			ctx := context.New(config.Project{
 				Dockers: []config.Docker{{}},
@@ -1383,6 +1389,12 @@ func TestSkip(t *testing.T) {
 	t.Run("manifest", func(t *testing.T) {
 		t.Run("skip", func(t *testing.T) {
 			require.True(t, ManifestPipe{}.Skip(context.New(config.Project{})))
+		})
+
+		t.Run("skip docker", func(t *testing.T) {
+			ctx := context.New(config.Project{})
+			ctx.SkipDocker = true
+			require.True(t, ManifestPipe{}.Skip(ctx))
 		})
 
 		t.Run("dont skip", func(t *testing.T) {

--- a/internal/pipe/docker/manifest.go
+++ b/internal/pipe/docker/manifest.go
@@ -19,8 +19,10 @@ import (
 // allowing to publish multi-arch docker images.
 type ManifestPipe struct{}
 
-func (ManifestPipe) String() string                 { return "docker manifests" }
-func (ManifestPipe) Skip(ctx *context.Context) bool { return len(ctx.Config.DockerManifests) == 0 }
+func (ManifestPipe) String() string { return "docker manifests" }
+func (ManifestPipe) Skip(ctx *context.Context) bool {
+	return len(ctx.Config.DockerManifests) == 0 || ctx.SkipDocker
+}
 
 // Default sets the pipe defaults.
 func (ManifestPipe) Default(ctx *context.Context) error {

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -95,6 +95,7 @@ type Context struct {
 	SkipSign           bool
 	SkipValidate       bool
 	SkipSBOMCataloging bool
+	SkipDocker         bool
 	RmDist             bool
 	PreRelease         bool
 	Deprecated         bool


### PR DESCRIPTION
Allow to skip the entire docker images and manifests builds.

Might be useful for faster local builds et al.

closes #3144
