### PR TITLE
docs: no-main error if running outside project root

### DIFF
--- a/www/docs/errors/no-main.md
+++ b/www/docs/errors/no-main.md
@@ -31,3 +31,7 @@ builds:
 ```
 
 For more info, check the [builds documentation](/customization/build/).
+
+## If you ran goreleaser outside the root of the project
+
+Run goreleaser in the root of the project.


### PR DESCRIPTION
Minor fix; if you run goreleaser outside the root of the project you'll see the no-main error.

This may be a bug instead, maybe should be done that way.