### PR TITLE
fix: run defaults pipe before before pipe

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -50,8 +50,8 @@ var BuildPipeline = []Piper{
 	env.Pipe{},             // load and validate environment variables
 	git.Pipe{},             // get and validate git repo state
 	semver.Pipe{},          // parse current tag to a semver
-	before.Pipe{},          // run global hooks before build
 	defaults.Pipe{},        // load default configs
+	before.Pipe{},          // run global hooks before build
 	snapshot.Pipe{},        // snapshot version handling
 	dist.Pipe{},            // ensure ./dist is clean
 	gomod.Pipe{},           // setup gomod-related stuff


### PR DESCRIPTION
otherwise, before might not have some template variables, for example,
the project name.

not sure if this will have adverse side effects though, need to think a
bit more about it.

fixes #3196
