### PR TITLE
fix: use default builder with buildx

### DIFF
--- a/internal/pipe/docker/api_docker.go
+++ b/internal/pipe/docker/api_docker.go
@@ -61,7 +61,7 @@ func (i dockerImager) Build(ctx *context.Context, root string, images, flags []s
 func (i dockerImager) buildCommand(images, flags []string) []string {
 	base := []string{"build", "."}
 	if i.buildx {
-		base = []string{"buildx", "build", ".", "--load"}
+		base = []string{"buildx", "--builder", "default", "build", ".", "--load"}
 	}
 	for _, image := range images {
 		base = append(base, "-t", image)

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -1122,7 +1122,7 @@ func TestBuildCommand(t *testing.T) {
 			name:   "buildx",
 			buildx: true,
 			flags:  []string{"--label=foo", "--build-arg=bar=baz"},
-			expect: []string{"buildx", "build", ".", "--load", "-t", images[0], "-t", images[1], "--label=foo", "--build-arg=bar=baz"},
+			expect: []string{"buildx", "--builder", "default", "build", ".", "--load", "-t", images[0], "-t", images[1], "--label=foo", "--build-arg=bar=baz"},
 		},
 	}
 	for _, tt := range tests {

--- a/www/docs/customization/docker.md
+++ b/www/docs/customization/docker.md
@@ -240,6 +240,27 @@ docker build -t myuser/myimage . \
 !!! tip
     Learn more about the [name template engine](/customization/templates/).
 
+## Use a specific builder with Docker buildx
+
+If `buildx` is enabled, the `default` context builder will be used when building
+the image. This builder is always available and backed by BuildKit in the
+Docker engine. If you want to use a different builder, you can specify it using
+the `build_flag_templates` field:
+
+```yaml
+# .goreleaser.yaml
+dockers:
+  -
+    image_templates:
+    - "myuser/myimage"
+    use: buildx
+    build_flag_templates:
+    - "--builder=mybuilder"
+```
+
+!!! tip
+    Learn more about the [buildx builder instances](https://docs.docker.com/buildx/working-with-buildx/#work-with-builder-instances).
+
 ## Podman
 
 !!! success "GoReleaser Pro"


### PR DESCRIPTION
fixes #3187 

Set the buildx builder for building Docker images to the `default` context builder that is backed by BuildKit in the Docker engine. This builder is always available when using buildx through the Docker CLI so should not be an issue for anyone.

Also adds a new section in the documentation in case some users want to use a specific builder.

In a follow-up we could also create a specific builder before building the image that is attached to the project and could be named `goreleaser_buildx_builer_{{.ProjectName}}` for example. This way users could benefit from advanced features not available with the default builder like cache exporters.