### PR TITLE
feat: changelog group improvements

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,17 +52,21 @@ changelog:
     - Merge branch
     - go mod tidy
   groups:
-    - title: 'New Features and updates'
+    - title: Dependency updates
+      regexp: "^.*feat\\(deps\\)*:+.*$"
+      order: 300
+    - title: 'New Features'
       regexp: "^.*feat[(\\w)]*:+.*$"
-      order: 0
+      order: 100
     - title: 'Bug fixes'
       regexp: "^.*fix[(\\w)]*:+.*$"
-      order: 10
+      order: 200
     - title: 'Documentation updates'
       regexp: "^.*docs[(\\w)]*:+.*$"
-      order: 20
+      order: 400
     - title: Other work
-      order: 999
+      order: 9999
+
 
 
 dockers:

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -619,6 +619,7 @@ func TestGroup(t *testing.T) {
 	testlib.GitCommit(t, "added feature 1")
 	testlib.GitCommit(t, "fixed bug 2")
 	testlib.GitCommit(t, "ignored: whatever")
+	testlib.GitCommit(t, "feat(deps): update foobar [bot]")
 	testlib.GitCommit(t, "fix: whatever")
 	testlib.GitCommit(t, "docs: whatever")
 	testlib.GitCommit(t, "chore: something about cArs we dont need")
@@ -630,6 +631,11 @@ func TestGroup(t *testing.T) {
 		Dist: folder,
 		Changelog: config.Changelog{
 			Groups: []config.ChangeLogGroup{
+				{
+					Title:  "Bots",
+					Regexp: ".*bot.*",
+					Order:  900,
+				},
 				{
 					Title:  "Features",
 					Regexp: "^.*feat[(\\w)]*:+.*$",
@@ -655,6 +661,7 @@ func TestGroup(t *testing.T) {
 	ctx.Git.CurrentTag = "v0.0.2"
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Contains(t, ctx.ReleaseNotes, "## Changelog")
+	require.Contains(t, ctx.ReleaseNotes, "### Bots")
 	require.Contains(t, ctx.ReleaseNotes, "### Features")
 	require.Contains(t, ctx.ReleaseNotes, "### Bug Fixes")
 	require.NotContains(t, ctx.ReleaseNotes, "### Catch nothing")


### PR DESCRIPTION
This changes the changelog grouping feature a bit: it evaluates the
groups in the order they are declared in the config file, but renders
them following their `order` attribute.

This allows to have better filters, for instance, you might want to have
dependabot commits in another section, which does not need a high
priority in the changelog output, but does when evaluating, as it might
share the words with other groups: in goreleaser's case, the `feat`
prefix.

Giving that Go's regex seems to don't allow negative look-aheads (which
would help in this particular case), this seems like a good quality of
life improvement.
