### PR TITLE
feat: allow to template release.repo

### DIFF
--- a/internal/pipe/release/release.go
+++ b/internal/pipe/release/release.go
@@ -48,51 +48,18 @@ func (Pipe) Default(ctx *context.Context) error {
 
 	switch ctx.TokenType {
 	case context.TokenTypeGitLab:
-		if ctx.Config.Release.GitLab.Name == "" {
-			repo, err := getRepository(ctx)
-			if err != nil {
-				return err
-			}
-			ctx.Config.Release.GitLab = repo
+		if err := setupGitLab(ctx); err != nil {
+			return err
 		}
-		ctx.ReleaseURL = fmt.Sprintf(
-			"%s/%s/%s/-/releases/%s",
-			ctx.Config.GitLabURLs.Download,
-			ctx.Config.Release.GitLab.Owner,
-			ctx.Config.Release.GitLab.Name,
-			ctx.Git.CurrentTag,
-		)
 	case context.TokenTypeGitea:
-		if ctx.Config.Release.Gitea.Name == "" {
-			repo, err := getRepository(ctx)
-			if err != nil {
-				return err
-			}
-			ctx.Config.Release.Gitea = repo
+		if err := setupGitea(ctx); err != nil {
+			return err
 		}
-		ctx.ReleaseURL = fmt.Sprintf(
-			"%s/%s/%s/releases/tag/%s",
-			ctx.Config.GiteaURLs.Download,
-			ctx.Config.Release.Gitea.Owner,
-			ctx.Config.Release.Gitea.Name,
-			ctx.Git.CurrentTag,
-		)
 	default:
 		// We keep github as default for now
-		if ctx.Config.Release.GitHub.Name == "" {
-			repo, err := getRepository(ctx)
-			if err != nil && !ctx.Snapshot {
-				return err
-			}
-			ctx.Config.Release.GitHub = repo
+		if err := setupGitHub(ctx); err != nil {
+			return err
 		}
-		ctx.ReleaseURL = fmt.Sprintf(
-			"%s/%s/%s/releases/tag/%s",
-			ctx.Config.GitHubURLs.Download,
-			ctx.Config.Release.GitHub.Owner,
-			ctx.Config.Release.GitHub.Name,
-			ctx.Git.CurrentTag,
-		)
 	}
 
 	// Check if we have to check the git tag for an indicator to mark as pre release

--- a/internal/pipe/release/scm.go
+++ b/internal/pipe/release/scm.go
@@ -1,0 +1,104 @@
+package release
+
+import (
+	"fmt"
+
+	"github.com/goreleaser/goreleaser/internal/tmpl"
+	"github.com/goreleaser/goreleaser/pkg/context"
+)
+
+func setupGitHub(ctx *context.Context) error {
+	if ctx.Config.Release.GitHub.Name == "" {
+		repo, err := getRepository(ctx)
+		if err != nil && !ctx.Snapshot {
+			return err
+		}
+		ctx.Config.Release.GitHub = repo
+	}
+
+	owner, err := tmpl.New(ctx).Apply(ctx.Config.Release.GitHub.Owner)
+	if err != nil {
+		return err
+	}
+	ctx.Config.Release.GitHub.Owner = owner
+
+	name, err := tmpl.New(ctx).Apply(ctx.Config.Release.GitHub.Name)
+	if err != nil {
+		return err
+	}
+	ctx.Config.Release.GitHub.Name = name
+
+	ctx.ReleaseURL = fmt.Sprintf(
+		"%s/%s/%s/releases/tag/%s",
+		ctx.Config.GitHubURLs.Download,
+		ctx.Config.Release.GitHub.Owner,
+		ctx.Config.Release.GitHub.Name,
+		ctx.Git.CurrentTag,
+	)
+
+	return nil
+}
+
+func setupGitLab(ctx *context.Context) error {
+	if ctx.Config.Release.GitLab.Name == "" {
+		repo, err := getRepository(ctx)
+		if err != nil {
+			return err
+		}
+		ctx.Config.Release.GitLab = repo
+	}
+
+	owner, err := tmpl.New(ctx).Apply(ctx.Config.Release.GitLab.Owner)
+	if err != nil {
+		return err
+	}
+	ctx.Config.Release.GitLab.Owner = owner
+
+	name, err := tmpl.New(ctx).Apply(ctx.Config.Release.GitLab.Name)
+	if err != nil {
+		return err
+	}
+	ctx.Config.Release.GitLab.Name = name
+
+	ctx.ReleaseURL = fmt.Sprintf(
+		"%s/%s/%s/-/releases/%s",
+		ctx.Config.GitLabURLs.Download,
+		ctx.Config.Release.GitLab.Owner,
+		ctx.Config.Release.GitLab.Name,
+		ctx.Git.CurrentTag,
+	)
+
+	return nil
+}
+
+func setupGitea(ctx *context.Context) error {
+	if ctx.Config.Release.Gitea.Name == "" {
+		repo, err := getRepository(ctx)
+		if err != nil {
+			return err
+		}
+		ctx.Config.Release.Gitea = repo
+	}
+
+	owner, err := tmpl.New(ctx).Apply(ctx.Config.Release.Gitea.Owner)
+	if err != nil {
+		return err
+	}
+	ctx.Config.Release.Gitea.Owner = owner
+
+	name, err := tmpl.New(ctx).Apply(ctx.Config.Release.Gitea.Name)
+	if err != nil {
+		return err
+	}
+	ctx.Config.Release.Gitea.Name = name
+
+	ctx.ReleaseURL = fmt.Sprintf(
+		"%s/%s/%s/releases/tag/%s",
+		ctx.Config.GiteaURLs.Download,
+		ctx.Config.Release.Gitea.Owner,
+		ctx.Config.Release.Gitea.Name,
+		ctx.Git.CurrentTag,
+	)
+
+	return nil
+}

--- a/internal/pipe/release/scm_test.go
+++ b/internal/pipe/release/scm_test.go
@@ -1,0 +1,168 @@
+package release
+
+import (
+	"testing"
+
+	"github.com/goreleaser/goreleaser/pkg/config"
+	"github.com/goreleaser/goreleaser/pkg/context"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupGitLab(t *testing.T) {
+	t.Run("no repo", func(t *testing.T) {
+		ctx := context.New(config.Project{})
+
+		require.NoError(t, setupGitLab(ctx))
+		require.Equal(t, "goreleaser", ctx.Config.Release.GitLab.Owner)
+		require.Equal(t, "goreleaser", ctx.Config.Release.GitLab.Name)
+	})
+
+	t.Run("with templates", func(t *testing.T) {
+		ctx := context.New(config.Project{
+			Env: []string{"NAME=foo", "OWNER=bar"},
+			Release: config.Release{
+				GitLab: config.Repo{
+					Owner: "{{.Env.OWNER}}",
+					Name:  "{{.Env.NAME}}",
+				},
+			},
+		})
+
+		require.NoError(t, setupGitLab(ctx))
+		require.Equal(t, "bar", ctx.Config.Release.GitLab.Owner)
+		require.Equal(t, "foo", ctx.Config.Release.GitLab.Name)
+	})
+
+	t.Run("with invalid templates", func(t *testing.T) {
+		t.Run("owner", func(t *testing.T) {
+			ctx := context.New(config.Project{
+				Release: config.Release{
+					GitLab: config.Repo{
+						Name:  "foo",
+						Owner: "{{.Env.NOPE}}",
+					},
+				},
+			})
+
+			require.Error(t, setupGitLab(ctx))
+		})
+
+		t.Run("name", func(t *testing.T) {
+			ctx := context.New(config.Project{
+				Release: config.Release{
+					GitLab: config.Repo{
+						Name: "{{.Env.NOPE}}",
+					},
+				},
+			})
+
+			require.Error(t, setupGitLab(ctx))
+		})
+	})
+}
+
+func TestSetupGitea(t *testing.T) {
+	t.Run("no repo", func(t *testing.T) {
+		ctx := context.New(config.Project{})
+
+		require.NoError(t, setupGitea(ctx))
+		require.Equal(t, "goreleaser", ctx.Config.Release.Gitea.Owner)
+		require.Equal(t, "goreleaser", ctx.Config.Release.Gitea.Name)
+	})
+
+	t.Run("with templates", func(t *testing.T) {
+		ctx := context.New(config.Project{
+			Env: []string{"NAME=foo", "OWNER=bar"},
+			Release: config.Release{
+				Gitea: config.Repo{
+					Owner: "{{.Env.OWNER}}",
+					Name:  "{{.Env.NAME}}",
+				},
+			},
+		})
+
+		require.NoError(t, setupGitea(ctx))
+		require.Equal(t, "bar", ctx.Config.Release.Gitea.Owner)
+		require.Equal(t, "foo", ctx.Config.Release.Gitea.Name)
+	})
+
+	t.Run("with invalid templates", func(t *testing.T) {
+		t.Run("owner", func(t *testing.T) {
+			ctx := context.New(config.Project{
+				Release: config.Release{
+					Gitea: config.Repo{
+						Name:  "foo",
+						Owner: "{{.Env.NOPE}}",
+					},
+				},
+			})
+
+			require.Error(t, setupGitea(ctx))
+		})
+
+		t.Run("name", func(t *testing.T) {
+			ctx := context.New(config.Project{
+				Release: config.Release{
+					Gitea: config.Repo{
+						Name: "{{.Env.NOPE}}",
+					},
+				},
+			})
+
+			require.Error(t, setupGitea(ctx))
+		})
+	})
+}
+
+func TestSetupGitHub(t *testing.T) {
+	t.Run("no repo", func(t *testing.T) {
+		ctx := context.New(config.Project{})
+
+		require.NoError(t, setupGitHub(ctx))
+		require.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Owner)
+		require.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Name)
+	})
+
+	t.Run("with templates", func(t *testing.T) {
+		ctx := context.New(config.Project{
+			Env: []string{"NAME=foo", "OWNER=bar"},
+			Release: config.Release{
+				GitHub: config.Repo{
+					Owner: "{{.Env.OWNER}}",
+					Name:  "{{.Env.NAME}}",
+				},
+			},
+		})
+
+		require.NoError(t, setupGitHub(ctx))
+		require.Equal(t, "bar", ctx.Config.Release.GitHub.Owner)
+		require.Equal(t, "foo", ctx.Config.Release.GitHub.Name)
+	})
+
+	t.Run("with invalid templates", func(t *testing.T) {
+		t.Run("owner", func(t *testing.T) {
+			ctx := context.New(config.Project{
+				Release: config.Release{
+					GitHub: config.Repo{
+						Name:  "foo",
+						Owner: "{{.Env.NOPE}}",
+					},
+				},
+			})
+
+			require.Error(t, setupGitHub(ctx))
+		})
+
+		t.Run("name", func(t *testing.T) {
+			ctx := context.New(config.Project{
+				Release: config.Release{
+					GitHub: config.Repo{
+						Name: "{{.Env.NOPE}}",
+					},
+				},
+			})
+
+			require.Error(t, setupGitHub(ctx))
+		})
+	})
+}


### PR DESCRIPTION
this will allow to use templates in the release.github/gitea/gitlab owner and name fields.

closes https://github.com/goreleaser/goreleaser/issues/3202