### PR TITLE
fix(ci): less logs in the test output

### DIFF
--- a/internal/testlib/log.go
+++ b/internal/testlib/log.go
@@ -1,0 +1,11 @@
+package testlib
+
+import (
+	"io"
+
+	"github.com/caarlos0/log"
+)
+
+func init() {
+	log.Log = log.New(io.Discard)
+}


### PR DESCRIPTION
Test output is too verbose, this should help by disabling the default logger when testing.

Most tests import testlib, so this might just be enough for all of them.