### PR TITLE
feat: allow multiple ids to be passed to build

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -77,7 +77,7 @@ When using ` + "`--single-target`" + `, the ` + "`GOOS`" + ` and ` + "`GOARCH`" 
 	cmd.Flags().IntVarP(&root.opts.parallelism, "parallelism", "p", 0, "Amount tasks to run concurrently (default: number of CPUs)")
 	cmd.Flags().DurationVar(&root.opts.timeout, "timeout", 30*time.Minute, "Timeout to the entire build process")
 	cmd.Flags().BoolVar(&root.opts.singleTarget, "single-target", false, "Builds only for current GOOS and GOARCH")
-	cmd.Flags().StringArrayVar(&root.opts.id, "id", nil, "Builds only the specified build id(s)")
+	cmd.Flags().StringArrayVar(&root.opts.id, "id", nil, "Builds only the specified build ids")
 	cmd.Flags().BoolVar(&root.opts.deprecated, "deprecated", false, "Force print the deprecation message - tests only")
 	cmd.Flags().StringVarP(&root.opts.output, "output", "o", "", "Copy the binary to the path after the build. Only taken into account when using --single-target and a single id (either with --id or if config only has one build)")
 	_ = cmd.Flags().MarkHidden("deprecated")
@@ -184,7 +184,7 @@ func setupBuildID(ctx *context.Context, ids []string) error {
 	}
 
 	if len(keep) == 0 {
-		return fmt.Errorf("no builds with id(s) '%s'", ids)
+		return fmt.Errorf("no builds with ids '%s'", ids)
 	}
 
 	ctx.Config.Builds = keep

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -66,7 +66,7 @@ func TestSetupPipeline(t *testing.T) {
 			pipeline.BuildCmdPipeline,
 			setupPipeline(context.New(config.Project{}), buildOpts{
 				singleTarget: true,
-				id:           "foo",
+				id:           []string{"foo"},
 			}),
 		)
 	})
@@ -77,7 +77,7 @@ func TestSetupPipeline(t *testing.T) {
 			append(pipeline.BuildCmdPipeline, withOutputPipe{"foobar"}),
 			setupPipeline(context.New(config.Project{}), buildOpts{
 				singleTarget: true,
-				id:           "foo",
+				id:           []string{"foo"},
 				output:       ".",
 			}),
 		)
@@ -106,7 +106,7 @@ func TestSetupPipeline(t *testing.T) {
 				context.New(config.Project{}),
 				buildOpts{
 					singleTarget: true,
-					id:           "foo",
+					id:           []string{"foo"},
 					output:       "foobar",
 				},
 			),
@@ -205,7 +205,7 @@ func TestBuildFlags(t *testing.T) {
 				},
 			})
 			require.NoError(t, setupBuildContext(ctx, buildOpts{
-				id: "foo",
+				id: []string{"foo"},
 			}))
 		})
 
@@ -221,14 +221,14 @@ func TestBuildFlags(t *testing.T) {
 				},
 			})
 			require.EqualError(t, setupBuildContext(ctx, buildOpts{
-				id: "bar",
-			}), "no builds with id 'bar'")
+				id: []string{"bar"},
+			}), "no builds with id(s) '[bar]'")
 		})
 
 		t.Run("default config", func(t *testing.T) {
 			ctx := context.New(config.Project{})
 			require.NoError(t, setupBuildContext(ctx, buildOpts{
-				id: "aaa",
+				id: []string{"aaa"},
 			}))
 		})
 
@@ -241,7 +241,7 @@ func TestBuildFlags(t *testing.T) {
 				},
 			})
 			require.NoError(t, setupBuildContext(ctx, buildOpts{
-				id: "not foo but doesnt matter",
+				id: []string{"not foo but doesnt matter"},
 			}))
 		})
 	})

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -209,6 +209,38 @@ func TestBuildFlags(t *testing.T) {
 			}))
 		})
 
+		t.Run("match-multiple", func(t *testing.T) {
+			ctx := context.New(config.Project{
+				Builds: []config.Build{
+					{
+						ID: "default",
+					},
+					{
+						ID: "foo",
+					},
+				},
+			})
+			require.NoError(t, setupBuildContext(ctx, buildOpts{
+				id: []string{"foo", "default"},
+			}))
+		})
+
+		t.Run("match-partial", func(t *testing.T) {
+			ctx := context.New(config.Project{
+				Builds: []config.Build{
+					{
+						ID: "default",
+					},
+					{
+						ID: "foo",
+					},
+				},
+			})
+			require.NoError(t, setupBuildContext(ctx, buildOpts{
+				id: []string{"foo", "notdefault"},
+			}))
+		})
+
 		t.Run("dont match", func(t *testing.T) {
 			ctx := context.New(config.Project{
 				Builds: []config.Build{


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->
This should be valid and build both build1 and build2 but no other
`goreleaser build --id build1 --id build2`

<!-- Why is this change being made? -->

Because it's annoying that this feature is missing.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

...
