### PR TITLE
Not failing if there's the pre-built field in builds

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -307,6 +307,12 @@ func (a FlagArray) JSONSchema() *jsonschema.Schema {
 	}
 }
 
+// PreBuilt holds the data for prebuild binary specification. Currently a feature of goreleaser-pro, but back porting
+// this field to support yamls made for goreleaser-pro.
+type PreBuilt struct {
+	Path string `yaml:"path,omitempty"`
+}
+
 // Build contains the build configuration section.
 type Build struct {
 	ID              string          `yaml:"id,omitempty"`
@@ -330,6 +336,7 @@ type Build struct {
 	NoMainCheck     bool            `yaml:"no_main_check,omitempty"`
 	UnproxiedMain   string          `yaml:"-"` // used by gomod.proxy
 	UnproxiedDir    string          `yaml:"-"` // used by gomod.proxy
+	PreBuilt        PreBuilt        `yaml:"prebuilt,omitempty"`
 
 	BuildDetails          `yaml:",inline"`       // nolint: tagliatelle
 	BuildDetailsOverrides []BuildDetailsOverride `yaml:"overrides,omitempty"`


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->

Right now, goreleaser-pro adds the ability to specify the location of pre-built binaries, which is really cool: https://goreleaser.com/customization/build/#import-pre-built-binaries

The catch is that if you add them, then you can't use your yaml with regular goreleaser, like for the build step as it'll come up as incorrect schema. So I made this pr to accept the prebuilt field and just ignore it

<!-- If applied, this commit will... -->

...

<!-- Why is this change being made? -->

...

<!-- # Provide links to any relevant tickets, URLs or other resources -->

...
