### PR TITLE
docs: use `--output-signature` with cosign sign

### DIFF
--- a/www/docs/customization/sign.md
+++ b/www/docs/customization/sign.md
@@ -50,7 +50,6 @@ signs:
     # Defaults to `["--output", "${signature}", "--detach-sign", "${artifact}"]`
     args: ["--output", "${signature}", "${artifact}", "{{ .ProjectName }}"]
 
-
     # Which artifacts to sign
     #
     #   all:      all artifacts
@@ -126,7 +125,7 @@ Assuming you have a `cosign.key` in the repository root and a `COSIGN_PWD` envir
 signs:
 - cmd: cosign
   stdin: '{{ .Env.COSIGN_PWD }}'
-  args: ["sign-blob", "--key=cosign.key", "--output=${signature}", "${artifact}"]
+  args: ["sign-blob", "--key=cosign.key", "--output-signature=${signature}", "${artifact}"]
   artifacts: all
 ```
 
@@ -209,7 +208,7 @@ but you'll need to manually add the `.sig` files to the release and/or archive:
 builds:
 - hooks:
     post:
-      - sh -c "COSIGN_PASSWORD=$COSIGN_PWD cosign sign-blob --key cosign.key --output dist/{{ .ProjectName }}_{{ .Version }}_{{ .Target }}.sig {{ .Path }}"
+      - sh -c "COSIGN_PASSWORD=$COSIGN_PWD cosign sign-blob --key cosign.key --output-signature dist/{{ .ProjectName }}_{{ .Version }}_{{ .Target }}.sig {{ .Path }}"
 
 # add to the release directly:
 release:


### PR DESCRIPTION
`cosign sign` complains with the following error when using `--output`
⨯ release failed after 14.73s error=sign: cosign failed: exit status 1: WARNING: the '--output' flag is deprecated and will be removed in the future. Use '--output-signature'

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

...

<!-- Why is this change being made? -->

...

<!-- # Provide links to any relevant tickets, URLs or other resources -->

...
