### PR TITLE
fix: improve output on github actions

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,23 +3,17 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/caarlos0/log"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/goreleaser/goreleaser/pkg/context"
-	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
 )
 
 var boldStyle = lipgloss.NewStyle().Bold(true)
 
 func Execute(version string, exit func(int), args []string) {
-	// enable colored output on travis
-	if os.Getenv("CI") != "" {
-		lipgloss.SetColorProfile(termenv.ANSI256)
-	}
 	newRootCmd(version, exit).Execute(args)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,9 @@ require (
 	github.com/caarlos0/env/v6 v6.9.3
 	github.com/caarlos0/go-reddit/v3 v3.0.1
 	github.com/caarlos0/go-shellwords v1.0.12
-	github.com/caarlos0/log v0.1.0
+	github.com/caarlos0/log v0.1.1
 	github.com/charmbracelet/keygen v0.3.0
-	github.com/charmbracelet/lipgloss v0.5.1-0.20220604171933-77aae4ab0bf5
+	github.com/charmbracelet/lipgloss v0.5.1-0.20220615005615-2e17a8a06096
 	github.com/dghubble/go-twitter v0.0.0-20211115160449-93a8679adecb
 	github.com/dghubble/oauth1 v0.7.1
 	github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible
@@ -28,7 +28,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/muesli/mango-cobra v1.2.0
 	github.com/muesli/roff v0.1.0
-	github.com/muesli/termenv v0.12.1-0.20220606102431-9500d1649068
+	github.com/muesli/termenv v0.12.1-0.20220615005108-4e9068de9898
 	github.com/slack-go/slack v0.11.0
 	github.com/spf13/cobra v1.5.0
 	github.com/stretchr/testify v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/caarlos0/go-reddit/v3 v3.0.1/go.mod h1:QlwgmG5SAqxMeQvg/A2dD1x9cIZCO5
 github.com/caarlos0/go-rpmutils v0.2.1-0.20211112020245-2cd62ff89b11 h1:IRrDwVlWQr6kS1U8/EtyA1+EHcc4yl8pndcqXWrEamg=
 github.com/caarlos0/go-shellwords v1.0.12 h1:HWrUnu6lGbWfrDcFiHcZiwOLzHWjjrPVehULaTFgPp8=
 github.com/caarlos0/go-shellwords v1.0.12/go.mod h1:bYeeX1GrTLPl5cAMYEzdm272qdsQAZiaHgeF0KTk1Gw=
-github.com/caarlos0/log v0.1.0 h1:Y0QiCN6KiJ1N9Aa6OnWJI9A4Xa7Fv88Wd1J04G74wfE=
-github.com/caarlos0/log v0.1.0/go.mod h1:tnVRnjHtFPOMNYk6qiJA6tRC47MTXI+BEly06yVgcP4=
+github.com/caarlos0/log v0.1.1 h1:eVk0VPVXKB3nk18Gpj+LUZq81ojOamVQebt9wlf2VY4=
+github.com/caarlos0/log v0.1.1/go.mod h1:lYxaBNu0NYLm5tdxBysIb2LNhNUUFqNAzSHNu737Loo=
 github.com/caarlos0/sshmarshal v0.0.0-20220308164159-9ddb9f83c6b3 h1:w2ANoiT4ubmh4Nssa3/QW1M7lj3FZkma8f8V5aBDxXM=
 github.com/caarlos0/sshmarshal v0.0.0-20220308164159-9ddb9f83c6b3/go.mod h1:7Pd/0mmq9x/JCzKauogNjSQEhivBclCQHfr9dlpDIyA=
 github.com/caarlos0/testfs v0.4.4 h1:3PHvzHi5Lt+g332CiShwS8ogTgS3HjrmzZxCm6JCDr8=
@@ -219,8 +219,8 @@ github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/charmbracelet/keygen v0.3.0 h1:mXpsQcH7DDlST5TddmXNXjS0L7ECk4/kLQYyBcsan2Y=
 github.com/charmbracelet/keygen v0.3.0/go.mod h1:1ukgO8806O25lUZ5s0IrNur+RlwTBERlezdgW71F5rM=
-github.com/charmbracelet/lipgloss v0.5.1-0.20220604171933-77aae4ab0bf5 h1:FHeFmaVqTDMJSzaIYT8Dk4MjY8idNhO/+RWq5eITRFU=
-github.com/charmbracelet/lipgloss v0.5.1-0.20220604171933-77aae4ab0bf5/go.mod h1:zVjS7jlggirpJYwsdaMKFhT+0Y1pFdQGS9x7GIz9ov4=
+github.com/charmbracelet/lipgloss v0.5.1-0.20220615005615-2e17a8a06096 h1:ai19sA3Zyg3DARevWCbdLOWt+MfWiE3e8voBqzFOgP8=
+github.com/charmbracelet/lipgloss v0.5.1-0.20220615005615-2e17a8a06096/go.mod h1:D7uPgcyfB9T1Ug2mfJOnES17o47nz5oqIzSSVrpcviU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -569,9 +569,8 @@ github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68 h1:y1p/ycavWjGT9Fn
 github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68/go.mod h1:Xk+z4oIWdQqJzsxyjgl3P22oYZnHdZ8FFTHAQQt5BMQ=
 github.com/muesli/roff v0.1.0 h1:YD0lalCotmYuF5HhZliKWlIx7IEhiXeSfq7hNjFqGF8=
 github.com/muesli/roff v0.1.0/go.mod h1:pjAHQM9hdUUwm/krAfrLGgJkXJ+YuhtsfZ42kieB2Ig=
-github.com/muesli/termenv v0.12.1-0.20220604163637-eddc39a244f4/go.mod h1:bN6sPNtkiahdhHv2Xm6RGU16LSCxfbIZvMfqjOCfrR4=
-github.com/muesli/termenv v0.12.1-0.20220606102431-9500d1649068 h1:Tg+qMMarOW1WJTM6xh8GweXRIvByM4Mtj6QTO6SB7EI=
-github.com/muesli/termenv v0.12.1-0.20220606102431-9500d1649068/go.mod h1:bN6sPNtkiahdhHv2Xm6RGU16LSCxfbIZvMfqjOCfrR4=
+github.com/muesli/termenv v0.12.1-0.20220615005108-4e9068de9898 h1:0j+cbZdhLgpNxjg0nWCasHUA82fgWOXxxGgWNVOLS1I=
+github.com/muesli/termenv v0.12.1-0.20220615005108-4e9068de9898/go.mod h1:bN6sPNtkiahdhHv2Xm6RGU16LSCxfbIZvMfqjOCfrR4=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=

--- a/internal/logext/testdata/TestWriter/debug/0.txt.golden
+++ b/internal/logext/testdata/TestWriter/debug/0.txt.golden
@@ -1,2 +1,2 @@
-    • foo                           foo=bar
-    • bar                           foo=bar
+    • foo                                            foo=bar
+    • bar                                            foo=bar

--- a/internal/logext/testdata/TestWriter/debug/1.txt.golden
+++ b/internal/logext/testdata/TestWriter/debug/1.txt.golden
@@ -1,2 +1,2 @@
-    • foo                           foo=bar
-    • bar                           foo=bar
+    • foo                                            foo=bar
+    • bar                                            foo=bar

--- a/internal/logext/writer_test.go
+++ b/internal/logext/writer_test.go
@@ -7,11 +7,15 @@ import (
 	"testing"
 
 	"github.com/caarlos0/log"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/goreleaser/goreleaser/internal/golden"
+	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/require"
 )
 
 func TestWriter(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.Ascii)
+
 	t.Run("info", func(t *testing.T) {
 		for _, out := range []Output{Info, Error} {
 			t.Run(strconv.Itoa(int(out)), func(t *testing.T) {


### PR DESCRIPTION
the original caarlos0/log implementation used `PaddingLeft`, which prepend spaces before the color schemes et al - and is probably the right thing to do

but, and there's always a but, it seems like github actions trims whitespaces, which made the indentations not work.

so, moved to printing spaces inside the styled string... what can you do?

this version update also improves the output a bit by giving some extra right padding, which may make the log output a bit more columnar in most cases, and hopefully a bit more readable as well.

refs https://github.com/caarlos0/log/pull/1

special thanks to @muesli for the help!