### PR TITLE
test: reducing test ouput

### DIFF
--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -37,7 +37,7 @@ func TestSingleCommit(t *testing.T) {
 }
 
 func TestAnnotatedTags(t *testing.T) {
-	t.Log(testlib.Mktmp(t))
+	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	testlib.GitCommit(t, "commit1")

--- a/internal/pipe/universalbinary/universalbinary_test.go
+++ b/internal/pipe/universalbinary/universalbinary_test.go
@@ -206,8 +206,7 @@ func TestRun(t *testing.T) {
 	for arch, path := range paths {
 		cmd := exec.Command("go", "build", "-o", path, src)
 		cmd.Env = append(os.Environ(), "GOOS=darwin", "GOARCH="+arch)
-		out, err := cmd.CombinedOutput()
-		t.Log(string(out))
+		_, err := cmd.CombinedOutput()
 		require.NoError(t, err)
 
 		modTime := time.Unix(0, 0)

--- a/pkg/archive/tar/tar_test.go
+++ b/pkg/archive/tar/tar_test.go
@@ -82,7 +82,6 @@ func TestTarFile(t *testing.T) {
 		}
 		require.NoError(t, err)
 		paths = append(paths, next.Name)
-		t.Logf("%s: %v", next.Name, next.FileInfo().Mode())
 		if next.Name == "sub1/executable" {
 			ex := next.FileInfo().Mode() | 0o111
 			require.Equal(t, next.FileInfo().Mode().String(), ex.String())

--- a/pkg/archive/tarxz/tarxz_test.go
+++ b/pkg/archive/tarxz/tarxz_test.go
@@ -86,7 +86,6 @@ func TestTarXzFile(t *testing.T) {
 		}
 		require.NoError(t, err)
 		paths = append(paths, next.Name)
-		t.Logf("%s: %v", next.Name, next.FileInfo().Mode())
 		if next.Name == "sub1/executable" {
 			ex := next.FileInfo().Mode() | 0o111
 			require.Equal(t, next.FileInfo().Mode().String(), ex.String())

--- a/pkg/archive/zip/zip_test.go
+++ b/pkg/archive/zip/zip_test.go
@@ -79,7 +79,6 @@ func TestZipFile(t *testing.T) {
 	paths := make([]string, len(r.File))
 	for i, zf := range r.File {
 		paths[i] = zf.Name
-		t.Logf("%s: %v", zf.Name, zf.Mode())
 		if zf.Name == "sub1/executable" {
 			ex := zf.Mode() | 0o111
 			require.Equal(t, zf.Mode().String(), ex.String())


### PR DESCRIPTION
there is too much going on in our test logs, and we have a lot of tests.. so... its too much output to scroll over/read/etc.

Trying to reduce it to the necessary only.