### PR TITLE
chore: make skip messages more idiomatic

### DIFF
--- a/internal/middleware/errhandler/error.go
+++ b/internal/middleware/errhandler/error.go
@@ -16,7 +16,7 @@ func Handle(action middleware.Action) middleware.Action {
 			return nil
 		}
 		if pipe.IsSkip(err) {
-			log.WithError(err).Warn("pipe skipped")
+			log.WithField("reason", err.Error()).Warn("pipe skipped")
 			return nil
 		}
 		return err


### PR DESCRIPTION
Skip messages are not an error, in fact.

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/42675056/177215390-a514b67b-0345-4437-b38b-ddca2dd5170c.png">
