### PR TITLE
WIP: fix: propagate overridden env variables

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -162,7 +162,13 @@ func (*Builder) Build(ctx *context.Context, build config.Build, options api.Opti
 		"GOAMD64="+options.Goamd64,
 	)
 
-	cmd, err := buildGoBuildLine(ctx, build, options, artifact, env)
+	details, err := withOverrides(ctx, build, options)
+	if err != nil {
+		return err
+	}
+	env = append(env, details.Env...)
+
+	cmd, err := buildGoBuildLine(ctx, build, details, options, artifact, env)
 	if err != nil {
 		return err
 	}
@@ -218,13 +224,9 @@ func withOverrides(ctx *context.Context, build config.Build, options api.Options
 	return build.BuildDetails, nil
 }
 
-func buildGoBuildLine(ctx *context.Context, build config.Build, options api.Options, artifact *artifact.Artifact, env []string) ([]string, error) {
+func buildGoBuildLine(ctx *context.Context, build config.Build, details config.BuildDetails, options api.Options, artifact *artifact.Artifact, env []string) ([]string, error) {
 	cmd := []string{build.GoBinary, build.Command}
 
-	details, err := withOverrides(ctx, build, options)
-	if err != nil {
-		return cmd, err
-	}
 	flags, err := processFlags(ctx, artifact, env, details.Flags, "")
 	if err != nil {
 		return cmd, err

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -1054,11 +1054,16 @@ func TestBuildGoBuildLine(t *testing.T) {
 		ctx.Version = "1.2.3"
 		ctx.Git.Commit = "aaa"
 
-		line, err := buildGoBuildLine(ctx, config.Builds[0], api.Options{
+		options := api.Options{
 			Path:   config.Builds[0].Binary,
 			Goos:   "linux",
 			Goarch: "amd64",
-		}, &artifact.Artifact{}, []string{})
+		}
+
+		details, err := withOverrides(ctx, config.Builds[0], options)
+		require.NoError(t, err)
+
+		line, err := buildGoBuildLine(ctx, config.Builds[0], details, options, &artifact.Artifact{}, []string{})
 		require.NoError(t, err)
 		require.Equal(t, expected, line)
 	}
@@ -1096,6 +1101,7 @@ func TestBuildGoBuildLine(t *testing.T) {
 				Flags:    []string{"-flag1", "-flag2"},
 				Tags:     []string{"tag1", "tag2"},
 				Ldflags:  []string{"ldflag1", "ldflag2"},
+				Env:      []string{"FOO=bar"},
 			},
 			BuildDetailsOverrides: []config.BuildDetailsOverride{
 				{
@@ -1107,6 +1113,7 @@ func TestBuildGoBuildLine(t *testing.T) {
 						Flags:    []string{"-flag3"},
 						Tags:     []string{"tag3"},
 						Ldflags:  []string{"ldflag3"},
+						Env:      []string{"FOO=overridden"},
 					},
 				},
 			},


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

This is to use the overridden env variables in the build step.

<!-- Why is this change being made? -->

Right now, if providing environment variables as overrides, they are not used when invoking go build.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

This fixes #3230 .

This is to get some early feedback, because while this effectively fixes the issue, the unit test is not properly implemented.

I'm wondering whether it'd be more effective to move the 3 steps that prepare the env variables currently in `Build` into a separate function?