### PR TITLE
Added ppc64le support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,7 @@ builds:
     - amd64
     - arm
     - arm64
+    - ppc64le
   goarm:
     - "7"
   mod_timestamp: '{{ .CommitTimestamp }}'
@@ -111,24 +112,49 @@ dockers:
   goarch: arm64
   extra_files:
   - scripts/entrypoint.sh
+- image_templates:
+  - 'goreleaser/goreleaser:{{ .Tag }}-ppc64le'
+  - 'ghcr.io/goreleaser/goreleaser:{{ .Tag }}-ppc64le'
+  dockerfile: Dockerfile
+  use: buildx
+  build_flag_templates:
+  - "--pull"
+  - "--label=io.artifacthub.package.readme-url=https://raw.githubusercontent.com/goreleaser/goreleaser/main/README.md"
+  - "--label=io.artifacthub.package.logo-url=https://goreleaser.com/static/avatar.png"
+  - "--label=io.artifacthub.package.maintainers=[{\"name\":\"Carlos Alexandro Becker\",\"email\":\"carlos@carlosbecker.dev\"}]"
+  - "--label=io.artifacthub.package.license=MIT"
+  - "--label=org.opencontainers.image.description=Deliver Go binaries as fast and easily as possible"
+  - "--label=org.opencontainers.image.created={{.Date}}"
+  - "--label=org.opencontainers.image.name={{.ProjectName}}"
+  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  - "--label=org.opencontainers.image.version={{.Version}}"
+  - "--label=org.opencontainers.image.source={{.GitURL}}"
+  - "--platform=linux/ppc64le"
+  goarch: ppc64le
+  extra_files:
+  - scripts/entrypoint.sh
 
 docker_manifests:
 - name_template: 'goreleaser/goreleaser:{{ .Tag }}'
   image_templates:
   - 'goreleaser/goreleaser:{{ .Tag }}-amd64'
   - 'goreleaser/goreleaser:{{ .Tag }}-arm64'
+  - 'goreleaser/goreleaser:{{ .Tag }}-ppc64le'
 - name_template: 'ghcr.io/goreleaser/goreleaser:{{ .Tag }}'
   image_templates:
   - 'ghcr.io/goreleaser/goreleaser:{{ .Tag }}-amd64'
   - 'ghcr.io/goreleaser/goreleaser:{{ .Tag }}-arm64'
+  - 'ghcr.io/goreleaser/goreleaser:{{ .Tag }}-ppc64le'
 - name_template: 'goreleaser/goreleaser:latest'
   image_templates:
   - 'goreleaser/goreleaser:{{ .Tag }}-amd64'
   - 'goreleaser/goreleaser:{{ .Tag }}-arm64'
+  - 'goreleaser/goreleaser:{{ .Tag }}-ppc64le'
 - name_template: 'ghcr.io/goreleaser/goreleaser:latest'
   image_templates:
   - 'ghcr.io/goreleaser/goreleaser:{{ .Tag }}-amd64'
   - 'ghcr.io/goreleaser/goreleaser:{{ .Tag }}-arm64'
+  - 'ghcr.io/goreleaser/goreleaser:{{ .Tag }}-ppc64le'
 
 archives:
   - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'


### PR DESCRIPTION
This PR will add ppc64le support

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->
ppc64le is one of the most commonly and rapidly growing architectures. Many developers and mid-range to large enterprises also used this architecture for their daily usage.
Having official ppc64le support to goreleaser will help developers with their development.


