### PR TITLE
refactor(build): remove unused param

### DIFF
--- a/internal/builders/buildtarget/targets.go
+++ b/internal/builders/buildtarget/targets.go
@@ -4,8 +4,6 @@ package buildtarget
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/caarlos0/log"
@@ -25,14 +23,6 @@ func (t target) String() string {
 
 // List compiles the list of targets for the given builds.
 func List(build config.Build) ([]string, error) {
-	version, err := goVersion(build)
-	if err != nil {
-		return nil, err
-	}
-	return matrix(build, version)
-}
-
-func matrix(build config.Build, version []byte) ([]string, error) {
 	// nolint:prealloc
 	var targets []target
 	// nolint:prealloc
@@ -133,23 +123,6 @@ func ignored(build config.Build, target target) bool {
 		return true
 	}
 	return false
-}
-
-func goVersion(build config.Build) ([]byte, error) {
-	cmd := exec.Command(build.GoBinary, "version")
-	// If the build.Dir is acessible, set the cmd dir to it in case
-	// of reletive path to GoBinary
-	if fileInfo, err := os.Stat(build.Dir); err == nil {
-		if !fileInfo.IsDir() {
-			return nil, fmt.Errorf("invalid builds.dir property, it should be a directory: %s", build.Dir)
-		}
-		cmd.Dir = build.Dir
-	}
-	bts, err := cmd.CombinedOutput()
-	if err != nil {
-		return nil, fmt.Errorf("unable to determine version of go binary (%s): %w", build.GoBinary, err)
-	}
-	return bts, nil
 }
 
 func valid(target target) bool {

--- a/internal/builders/buildtarget/targets_test.go
+++ b/internal/builders/buildtarget/targets_test.go
@@ -67,7 +67,7 @@ func TestAllBuildTargets(t *testing.T) {
 	}
 
 	t.Run("go 1.18", func(t *testing.T) {
-		result, err := matrix(build, []byte("go version go1.18.0"))
+		result, err := List(build)
 		require.NoError(t, err)
 		require.Equal(t, []string{
 			"linux_386",
@@ -111,46 +111,46 @@ func TestAllBuildTargets(t *testing.T) {
 	})
 
 	t.Run("invalid goos", func(t *testing.T) {
-		_, err := matrix(config.Build{
+		_, err := List(config.Build{
 			Goos:    []string{"invalid"},
 			Goarch:  []string{"amd64"},
 			Goamd64: []string{"v2"},
-		}, []byte("go version go1.18.0"))
+		})
 		require.EqualError(t, err, "invalid goos: invalid")
 	})
 
 	t.Run("invalid goarch", func(t *testing.T) {
-		_, err := matrix(config.Build{
+		_, err := List(config.Build{
 			Goos:   []string{"linux"},
 			Goarch: []string{"invalid"},
-		}, []byte("go version go1.18.0"))
+		})
 		require.EqualError(t, err, "invalid goarch: invalid")
 	})
 
 	t.Run("invalid goarm", func(t *testing.T) {
-		_, err := matrix(config.Build{
+		_, err := List(config.Build{
 			Goos:   []string{"linux"},
 			Goarch: []string{"arm"},
 			Goarm:  []string{"invalid"},
-		}, []byte("go version go1.18.0"))
+		})
 		require.EqualError(t, err, "invalid goarm: invalid")
 	})
 
 	t.Run("invalid gomips", func(t *testing.T) {
-		_, err := matrix(config.Build{
+		_, err := List(config.Build{
 			Goos:   []string{"linux"},
 			Goarch: []string{"mips"},
 			Gomips: []string{"invalid"},
-		}, []byte("go version go1.18.0"))
+		})
 		require.EqualError(t, err, "invalid gomips: invalid")
 	})
 
 	t.Run("invalid goamd64", func(t *testing.T) {
-		_, err := matrix(config.Build{
+		_, err := List(config.Build{
 			Goos:    []string{"linux"},
 			Goarch:  []string{"amd64"},
 			Goamd64: []string{"invalid"},
-		}, []byte("go version go1.18.0"))
+		})
 		require.EqualError(t, err, "invalid goamd64: invalid")
 	})
 }
@@ -235,26 +235,5 @@ func TestList(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, []string{"linux_amd64_v2"}, targets)
-	})
-
-	t.Run("error with dir", func(t *testing.T) {
-		_, err := List(config.Build{
-			Goos:     []string{"linux"},
-			Goarch:   []string{"amd64"},
-			Goamd64:  []string{"v2"},
-			GoBinary: "go",
-			Dir:      "targets.go",
-		})
-		require.EqualError(t, err, "invalid builds.dir property, it should be a directory: targets.go")
-	})
-
-	t.Run("fail", func(t *testing.T) {
-		_, err := List(config.Build{
-			Goos:     []string{"linux"},
-			Goarch:   []string{"amd64"},
-			Goamd64:  []string{"v2"},
-			GoBinary: "nope",
-		})
-		require.EqualError(t, err, `unable to determine version of go binary (nope): exec: "nope": executable file not found in $PATH`)
 	})
 }


### PR DESCRIPTION
we dont need to check the go version anymore, so we can remove all this
now.
