### PR TITLE
Always strip parents.

### DIFF
--- a/internal/archivefiles/archivefiles.go
+++ b/internal/archivefiles/archivefiles.go
@@ -64,11 +64,17 @@ func unique(in []config.File) []config.File {
 }
 
 func destinationFor(f config.File, path string) string {
-	if f.Destination == "" {
-		return path
-	}
+	var filePath string
+
 	if f.StripParent {
-		return filepath.Join(f.Destination, filepath.Base(path))
+		filePath = filepath.Base(path)
+	} else {
+		filePath = path
 	}
-	return filepath.Join(f.Destination, path)
+
+	if f.Destination == "" {
+		return filePath
+	} else {
+		return filepath.Join(f.Destination, filePath)
+	}
 }

--- a/internal/archivefiles/archivefiles_test.go
+++ b/internal/archivefiles/archivefiles_test.go
@@ -31,6 +31,26 @@ func TestEval(t *testing.T) {
 		}, result)
 	})
 
+	t.Run("strip parent plays nicely with destination omitted", func(t *testing.T) {
+		result, err := Eval(tmpl, []config.File{{Source: "./testdata/a/b", StripParent: true}})
+
+		require.NoError(t, err)
+		require.Equal(t, []config.File{
+			{Source: "testdata/a/b/a.txt", Destination: "a.txt"},
+			{Source: "testdata/a/b/c/d.txt", Destination: "d.txt"},
+		}, result)
+	})
+
+	t.Run("strip parent plays nicely with destination as an empty string", func(t *testing.T) {
+		result, err := Eval(tmpl, []config.File{{Source: "./testdata/a/b", Destination: "", StripParent: true}})
+
+		require.NoError(t, err)
+		require.Equal(t, []config.File{
+			{Source: "testdata/a/b/a.txt", Destination: "a.txt"},
+			{Source: "testdata/a/b/c/d.txt", Destination: "d.txt"},
+		}, result)
+	})
+
 	t.Run("match multiple files within tree without destination", func(t *testing.T) {
 		result, err := Eval(tmpl, []config.File{{Source: "./testdata/a"}})
 

--- a/www/docs/customization/archive.md
+++ b/www/docs/customization/archive.md
@@ -142,9 +142,6 @@ files:
 # ...
 ```
 
-!!! warning
-    `strip_parent` is only effective if `dst` is not empty.
-
 ## Packaging only the binaries
 
 Since GoReleaser will always add the `README` and `LICENSE` files to the


### PR DESCRIPTION
The goal of this commit is to ensure that `strip_parent` is respected, even if `dst` is unset.

This enables placing assets at the root of output archives, which is presently impossible unless they are in `cwd`. Not supporting `strip_parent` in this way resulted in a hard-to-detect bug where a path within the archive would surprisingly attempt to traverse outside of the folder:

https://github.com/vercel/turborepo/pull/1455/files#diff-753cc4c452735002ee9b8c2feb79f048956800076a027594557aa230d428d82dR77

Two variations on the test were added to protect against what I believe may be an `omit_empty` refactoring hazard.