### PR TITLE
feat: support goarch=loong64

### DIFF
--- a/internal/builders/buildtarget/targets.go
+++ b/internal/builders/buildtarget/targets.go
@@ -169,6 +169,7 @@ var (
 		"linuxmips64le",
 		"linuxs390x",
 		"linuxriscv64",
+		"linuxloong64",
 		"netbsd386",
 		"netbsdamd64",
 		"netbsdarm",
@@ -217,6 +218,7 @@ var (
 		"s390x",
 		"wasm",
 		"riscv64",
+		"loong64",
 	}
 
 	validGoarm   = []string{"5", "6", "7"}

--- a/internal/builders/buildtarget/targets_test.go
+++ b/internal/builders/buildtarget/targets_test.go
@@ -31,6 +31,7 @@ func TestAllBuildTargets(t *testing.T) {
 			"mipsle",
 			"mips64le",
 			"riscv64",
+			"loong64",
 		},
 		Goarm: []string{
 			"6",
@@ -84,6 +85,7 @@ func TestAllBuildTargets(t *testing.T) {
 			"linux_mipsle_softfloat",
 			"linux_mips64le_hardfloat",
 			"linux_riscv64",
+			"linux_loong64",
 			"darwin_amd64_v1",
 			"darwin_amd64_v2",
 			"darwin_amd64_v4",
@@ -189,6 +191,7 @@ func TestGoosGoarchCombos(t *testing.T) {
 		{"linux", "ppc64le", true},
 		{"linux", "s390x", true},
 		{"linux", "riscv64", true},
+		{"linux", "loong64", true},
 		{"netbsd", "386", true},
 		{"netbsd", "amd64", true},
 		{"netbsd", "arm", true},


### PR DESCRIPTION
go 1.19 supports linux loong64: https://go.dev/doc/go1.19