### PR TITLE
Add split function

### DIFF
--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -174,6 +174,7 @@ func (t *Template) Apply(s string) (string, error) {
 		Option("missingkey=error").
 		Funcs(template.FuncMap{
 			"replace": strings.ReplaceAll,
+			"split":   strings.Split,
 			"time": func(s string) string {
 				return time.Now().UTC().Format(s)
 			},

--- a/www/docs/customization/templates.md
+++ b/www/docs/customization/templates.md
@@ -95,6 +95,7 @@ On all fields, you have these available functions:
 | Usage                          | Description                                                                                                                    |
 |--------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
 | `replace "v1.2" "v" ""`        | replaces all matches. See [ReplaceAll](https://golang.org/pkg/strings/#ReplaceAll)                                             |
+| `split "1.2" "."`              | split string at separator. See [Split](https://golang.org/pkg/strings/#Split)                                             |
 | `time "01/02/2006"`            | current UTC time in the specified format (this is not deterministic, a new time for every call)                                |
 | `tolower "V1.2"`               | makes input string lowercase. See [ToLower](https://golang.org/pkg/strings/#ToLower)                                           |
 | `toupper "v1.2"`               | makes input string uppercase. See [ToUpper](https://golang.org/pkg/strings/#ToUpper)                                           |


### PR DESCRIPTION
Fix https://github.com/goreleaser/goreleaser/issues/3269 by adding the `split` template function for `strings.Split()`