### PR TITLE
fix: do not push snaps concurrently

### DIFF
--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -201,14 +201,12 @@ func (Pipe) Publish(ctx *context.Context) error {
 		return pipe.ErrSkipPublishEnabled
 	}
 	snaps := ctx.Artifacts.Filter(artifact.ByType(artifact.PublishableSnapcraft)).List()
-	g := semerrgroup.New(ctx.Parallelism)
 	for _, snap := range snaps {
-		snap := snap
-		g.Go(func() error {
-			return push(ctx, snap)
-		})
+		if err := push(ctx, snap); err != nil {
+			return err
+		}
 	}
-	return g.Wait()
+	return nil
 }
 
 func create(ctx *context.Context, snap config.Snapcraft, arch string, binaries []*artifact.Artifact) error {


### PR DESCRIPTION
It seems that the error I get sometimes (#3257) is related to snap push
not being able to work concurrently.

I'm not a 100% sure though, so I'll try this and see how it goes.
If the error still happens, we can ignore the error or retry.

closes #3257
