### PR TITLE
fix: guard changelog commit abbrev behind config

### DIFF
--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -13,7 +13,6 @@ import (
 	"github.com/caarlos0/log"
 	"github.com/google/go-github/v47/github"
 	"github.com/goreleaser/goreleaser/internal/artifact"
-	"github.com/goreleaser/goreleaser/internal/git"
 	"github.com/goreleaser/goreleaser/internal/tmpl"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
@@ -64,17 +63,8 @@ func (c *githubClient) GenerateReleaseNotes(ctx *context.Context, repo Repo, pre
 	return notes.Body, err
 }
 
-func commitAbbrevLen(ctx *context.Context) int {
-	hash, err := git.Clean(git.Run(ctx, "rev-parse", "--short", "HEAD", "--quiet"))
-	if err != nil || len(hash) > 40 {
-		return 40 // max sha1 len
-	}
-	return len(hash)
-}
-
 func (c *githubClient) Changelog(ctx *context.Context, repo Repo, prev, current string) (string, error) {
 	var log []string
-	commitlen := commitAbbrevLen(ctx)
 	opts := &github.ListOptions{PerPage: 100}
 
 	for {
@@ -85,7 +75,7 @@ func (c *githubClient) Changelog(ctx *context.Context, repo Repo, prev, current 
 		for _, commit := range result.Commits {
 			log = append(log, fmt.Sprintf(
 				"%s: %s (@%s)",
-				commit.GetSHA()[0:commitlen-1],
+				commit.GetSHA(),
 				strings.Split(commit.Commit.GetMessage(), "\n")[0],
 				commit.GetAuthor().GetLogin(),
 			))

--- a/internal/client/github_test.go
+++ b/internal/client/github_test.go
@@ -289,7 +289,7 @@ func TestChangelog(t *testing.T) {
 
 	log, err := client.Changelog(ctx, repo, "v1.0.0", "v1.1.0")
 	require.NoError(t, err)
-	require.Equal(t, "6dcb09b: Fix all the bugs (@octocat)", log)
+	require.Equal(t, "6dcb09b5b57875f334f61aebed695e2e4193db5e: Fix all the bugs (@octocat)", log)
 }
 
 func TestReleaseNotes(t *testing.T) {

--- a/internal/pipe/changelog/changelog.go
+++ b/internal/pipe/changelog/changelog.go
@@ -114,6 +114,24 @@ func formatChangelog(ctx *context.Context, entries []string) (string, error) {
 		return strings.Join(entries, newLine), nil
 	}
 
+	for i := range entries {
+		entry := entries[i]
+		abbr := ctx.Config.Changelog.Abbrev
+		switch abbr {
+		case 0:
+			continue
+		case -1:
+			_, rest, _ := strings.Cut(entry, " ")
+			entries[i] = rest
+		default:
+			commit, rest, _ := strings.Cut(entry, " ")
+			if abbr > len(commit) {
+				continue
+			}
+			entries[i] = fmt.Sprintf("%s %s", commit[:abbr], rest)
+		}
+	}
+
 	result := []string{"## Changelog"}
 	if len(ctx.Config.Changelog.Groups) == 0 {
 		log.Debug("not grouping entries")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -808,6 +808,7 @@ type Changelog struct {
 	Skip    bool             `yaml:"skip,omitempty" json:"skip,omitempty"` // TODO(caarlos0): rename to Disable to match other pipes
 	Use     string           `yaml:"use,omitempty" json:"use,omitempty" jsonschema:"enum=git,enum=github,enum=github-native,enum=gitlab,default=git"`
 	Groups  []ChangeLogGroup `yaml:"groups,omitempty" json:"groups,omitempty"`
+	Abbrev  int              `yaml:"abbrev,omitempty" json:"abbrev,omitempty"`
 }
 
 // ChangeLogGroup holds the grouping criteria for the changelog.

--- a/www/docs/customization/changelog.md
+++ b/www/docs/customization/changelog.md
@@ -28,9 +28,12 @@ changelog:
   sort: asc
 
   # Max commit hash length to use in the changelog.
+  #
   # 0: use whatever the changelog implementation gives you
   # -1: remove the commit hash from the changelog
   # any other number: max length.
+  #
+  # Default is 0.
   abbrev: -1
 
   # Group commits messages by given regex and title.

--- a/www/docs/customization/changelog.md
+++ b/www/docs/customization/changelog.md
@@ -27,6 +27,12 @@ changelog:
   # Default is empty
   sort: asc
 
+  # Max commit hash length to use in the changelog.
+  # 0: use whatever the changelog implementation gives you
+  # -1: remove the commit hash from the changelog
+  # any other number: max length.
+  abbrev: -1
+
   # Group commits messages by given regex and title.
   # Order value defines the order of the groups.
   # Proving no regex means all commits will be grouped under the default group.


### PR DESCRIPTION
this allows the user to specify the abbrev lenght to use, and will also add the option to omit the commit hash altogether by setting it to -1.
default is doing nothing

closes #3348
