### PR TITLE
fix: yaml-lang-server modelines in init config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -318,3 +318,8 @@ announce:
   discord:
     enabled: true
     message_template: 'GoReleaser {{ .Tag }} is out! Check it out: https://github.com/goreleaser/goreleaser/releases/tag/{{ .Tag }}'
+
+
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=4 sw=4 tw=0 fo=jcroql
+

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -321,5 +321,5 @@ announce:
 
 
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
-# vim: set ts=4 sw=4 tw=0 fo=jcroql
+# vim: set ts=2 sw=2 tw=0 fo=jcroql
 

--- a/internal/static/config.go
+++ b/internal/static/config.go
@@ -36,4 +36,8 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+
+# modelines, feel free to remove those if you don't want/use them:
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=4 sw=4 tw=0 fo=cnqoj
 `

--- a/internal/static/config.go
+++ b/internal/static/config.go
@@ -39,5 +39,5 @@ changelog:
 
 # modelines, feel free to remove those if you don't want/use them:
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
-# vim: set ts=4 sw=4 tw=0 fo=cnqoj
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
 `

--- a/www/docs/customization/index.md
+++ b/www/docs/customization/index.md
@@ -15,9 +15,21 @@ GoReleaser also has a [jsonschema][] file which you can use to have better edito
     https://goreleaser.com/static/schema.json
     ```
 
+    You can also specify it in your `.goreleaser.yml` config file by adding a
+    comment like the following:
+    ```yaml
+    # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+    ```
+
 === "Pro"
     ```sh
     https://goreleaser.com/static/schema-pro.json
+    ```
+
+    You can also specify it in your `.goreleaser.yml` config file by adding a
+    comment like the following:
+    ```yaml
+    # yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
     ```
 
 You can also generate it for your specific version using the [`goreleaser jsonschema`][schema] command.


### PR DESCRIPTION
- docs on how to specify the schema to the lang server
- add it automatically along with vim modelines to the init config
- added it to our config as well

this should prevent some "out of date" schema issues, as well as mixing tabs with spaces and whatnot when an editorconfig plugin is not installed.