### PR TITLE
fix: build --single-target when using specific targets

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -165,6 +165,10 @@ func setupBuildSingleTarget(ctx *context.Context) {
 		build := &ctx.Config.Builds[i]
 		build.Goos = []string{goos}
 		build.Goarch = []string{goarch}
+		build.Goarm = nil
+		build.Gomips = nil
+		build.Goamd64 = nil
+		build.Targets = nil
 	}
 }
 

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -278,3 +278,49 @@ func TestBuildFlags(t *testing.T) {
 		})
 	})
 }
+
+func TestBuildSingleTargetWithSpecificTargets(t *testing.T) {
+	ctx := context.New(config.Project{
+		ProjectName: "test",
+		Builds: []config.Build{
+			{
+				Targets: []string{
+					"linux_amd64_v1",
+					"darwin_arm64",
+					"darwin_amd64_v1",
+				},
+			},
+		},
+	})
+
+	t.Setenv("GOOS", "linux")
+	t.Setenv("GOARCH", "amd64")
+	setupBuildSingleTarget(ctx)
+	require.Equal(t, config.Build{
+		Goos:   []string{"linux"},
+		Goarch: []string{"amd64"},
+	}, ctx.Config.Builds[0])
+}
+
+func TestBuildSingleTargetRemoveOtherOptions(t *testing.T) {
+	ctx := context.New(config.Project{
+		ProjectName: "test",
+		Builds: []config.Build{
+			{
+				Goos:    []string{"linux", "darwin"},
+				Goarch:  []string{"amd64", "arm64"},
+				Goamd64: []string{"v1", "v2"},
+				Goarm:   []string{"6"},
+				Gomips:  []string{"anything"},
+			},
+		},
+	})
+
+	t.Setenv("GOOS", "linux")
+	t.Setenv("GOARCH", "amd64")
+	setupBuildSingleTarget(ctx)
+	require.Equal(t, config.Build{
+		Goos:   []string{"linux"},
+		Goarch: []string{"amd64"},
+	}, ctx.Config.Builds[0])
+}


### PR DESCRIPTION
When using specific targets in the config, single target becomes ineffective. This should fix it.  This also removes other build options like gomips, goarm, goamd64, etc, as go will infer them from the current OS.  In theory we should one day support all the GO* flags go build supports.  