### PR TITLE
chore: avoid running actions when not needed/possible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,17 @@ on:
   push:
     branches:
       - 'main'
+    paths:
+      - 'go.*'
+      - '**/*.go'
+      - 'Taskfile.yml'
+      - 'Dockerfile'
   pull_request:
+    paths:
+      - 'go.*'
+      - '**/*.go'
+      - 'Taskfile.yml'
+      - 'Dockerfile'
 
 permissions:
   contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,12 +9,14 @@ on:
       - '**/*.go'
       - 'Taskfile.yml'
       - 'Dockerfile'
+      - '.github/workflows/build.yml'
   pull_request:
     paths:
       - 'go.*'
       - '**/*.go'
       - 'Taskfile.yml'
       - 'Dockerfile'
+      - '.github/workflows/build.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   gitleaks:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
         with:

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       issues: write  # for dessant/lock-threads to lock issues
       pull-requests: write  # for dessant/lock-threads to lock PRs
-    if: github.repository == 'goreleaser/goreleaser'
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@e460dfeb36e731f3aeb214be6b0c9a9d9a67eda6 # v3

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   milestone:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     permissions:
       actions: none

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
       - run: task goreleaser:test:${{ matrix.format }}
   goreleaser:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:


### PR DESCRIPTION
- only run the build action when actual go files changed
- only run some actions on the main fork to avoid errors 