### PR TITLE
fix: skip instead of hard fail

### DIFF
--- a/internal/pipe/aur/aur_test.go
+++ b/internal/pipe/aur/aur_test.go
@@ -720,6 +720,20 @@ func TestSkip(t *testing.T) {
 	})
 }
 
+func TestRunSkipNoArchives(t *testing.T) {
+	ctx := context.New(config.Project{
+		AURs: []config.AUR{{
+			Name:        "foo",
+			Description: "foo",
+		}},
+	})
+
+	client := client.NewMock()
+	err := runAll(ctx, client)
+	testlib.AssertSkipped(t, err)
+	require.EqualError(t, err, ErrNoArchivesFound.Error())
+}
+
 func TestKeyPath(t *testing.T) {
 	t.Run("with valid path", func(t *testing.T) {
 		path := makeKey(t, keygen.Ed25519)

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -1114,6 +1114,25 @@ func TestRunSkipNoName(t *testing.T) {
 	testlib.AssertSkipped(t, runAll(ctx, client))
 }
 
+func TestRunSkipNoArchives(t *testing.T) {
+	ctx := context.New(config.Project{
+		Brews: []config.Homebrew{{
+			Name: "foo",
+			Tap: config.RepoRef{
+				Owner:  "aa",
+				Name:   "aa",
+				Token:  "aa",
+				Branch: "aa",
+			},
+		}},
+	})
+
+	client := client.NewMock()
+	err := runAll(ctx, client)
+	testlib.AssertSkipped(t, err)
+	require.EqualError(t, err, ErrNoArchivesFound.Error())
+}
+
 func TestInstalls(t *testing.T) {
 	t.Run("provided", func(t *testing.T) {
 		require.Equal(t, []string{

--- a/internal/pipe/krew/krew_test.go
+++ b/internal/pipe/krew/krew_test.go
@@ -940,6 +940,27 @@ func TestRunSkipNoName(t *testing.T) {
 	testlib.AssertSkipped(t, runAll(ctx, client))
 }
 
+func TestRunSkipNoArchives(t *testing.T) {
+	ctx := context.New(config.Project{
+		Krews: []config.Krew{{
+			Name:             "foo",
+			Description:      "foo",
+			ShortDescription: "foo",
+			Index: config.RepoRef{
+				Owner:  "aa",
+				Name:   "aa",
+				Token:  "aa",
+				Branch: "aa",
+			},
+		}},
+	})
+
+	client := client.NewMock()
+	err := runAll(ctx, client)
+	testlib.AssertSkipped(t, err)
+	require.EqualError(t, err, ErrNoArchivesFound.Error())
+}
+
 func manifestName(tb testing.TB) string {
 	tb.Helper()
 	return path.Base(tb.Name())

--- a/internal/pipe/pipe.go
+++ b/internal/pipe/pipe.go
@@ -35,7 +35,7 @@ type ErrSkip struct {
 	reason string
 }
 
-// Error implements the error interface. returns the reason the pipe was skipped.
+// Error implements the error interface. Returns the reason the pipe was skipped.
 func (e ErrSkip) Error() string {
 	return e.reason
 }

--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -4,7 +4,6 @@ package scoop
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -22,7 +21,7 @@ import (
 )
 
 // ErrNoWindows when there is no build for windows (goos doesn't contain windows).
-var ErrNoWindows = errors.New("scoop requires a windows build and archive")
+var ErrNoWindows = pipe.Skip("scoop requires a windows build and archive")
 
 const scoopConfigExtra = "ScoopConfig"
 

--- a/internal/pipe/scoop/scoop_test.go
+++ b/internal/pipe/scoop/scoop_test.go
@@ -295,7 +295,11 @@ func Test_doRun(t *testing.T) {
 				client.NewMock(),
 			},
 			[]artifact.Artifact{},
-			shouldErr(ErrNoWindows.Error()),
+			func(t *testing.T, err error) {
+				t.Helper()
+				testlib.AssertSkipped(t, err)
+				require.EqualError(t, err, ErrNoWindows.Error())
+			},
 			shouldNotErr,
 			noAssertions,
 		},


### PR DESCRIPTION
This makes partially set up brews, krews, etc skip when no archives match, instead of hard-failing.

I'm not sure if this is better or not, but it would make sense for things like partial builds (e.g. build for linux only), so the config might get reused.

Moreover, IMHO, its better to skip than hard fail because people will likely have to create a new tag anyway, due to go mod caching et al... so with this at least they don't get a broken release.

tl;dr: still thinking about it. 