### PR TITLE
feat: docker meta images

### DIFF
--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -142,6 +142,9 @@ func (Pipe) Run(ctx *context.Context) error {
 }
 
 func process(ctx *context.Context, docker config.Docker, artifacts []*artifact.Artifact) error {
+	if len(artifacts) == 0 && !docker.Meta {
+		return pipe.Skip("no binaries matching the filters")
+	}
 	tmp, err := os.MkdirTemp(ctx.Config.Dist, "goreleaserdocker")
 	if err != nil {
 		return fmt.Errorf("failed to create temporary dir: %w", err)

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -974,6 +974,24 @@ func TestRunPipe(t *testing.T) {
 				registry + "goreleaser/nfpm_arm:latest",
 			},
 		},
+		"meta": {
+			dockers: []config.Docker{
+				{
+					ImageTemplates: []string{registry + "goreleaser/nfpm_meta:latest"},
+					Goos:           "linuxxx",
+					IDs:            []string{"mybin", "anotherbin"},
+					Dockerfile:     "testdata/Dockerfile.true",
+					Meta:           true,
+				},
+			},
+			assertImageLabels:   noLabels,
+			assertError:         shouldNotErr,
+			pubAssertError:      shouldNotErr,
+			manifestAssertError: shouldNotErr,
+			expect: []string{
+				registry + "goreleaser/nfpm_meta:latest",
+			},
+		},
 	}
 
 	killAndRm(t)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -782,6 +782,7 @@ type Docker struct {
 	Files              []string `yaml:"extra_files,omitempty" json:"extra_files,omitempty"`
 	BuildFlagTemplates []string `yaml:"build_flag_templates,omitempty" json:"build_flag_templates,omitempty"`
 	PushFlags          []string `yaml:"push_flags,omitempty" json:"push_flags,omitempty"`
+	Meta               bool     `yaml:"meta,omitempty" json:"meta,omitempty"`
 	Use                string   `yaml:"use,omitempty" json:"use,omitempty"`
 }
 

--- a/www/docs/customization/docker.md
+++ b/www/docs/customization/docker.md
@@ -83,6 +83,15 @@ dockers:
     # Defaults to false.
     skip_push: false
 
+    # Allows to create Docker images that do not use any other artifacts managed
+    # by GoReleaser.
+    # If your Docker image does not use any previously generated artifact, this
+    # option can be useful.
+    #
+    # Defaults to false.
+    # Since: v1.12.
+    meta: true
+
     # Path to the Dockerfile (from the project root).
     #
     # Defaults to `Dockerfile`.


### PR DESCRIPTION
Until now, GoReleaser was not complaining when no artifacts were found, which could cause the actual docker build to fail if the `Dockerfile` expects them to be there.

So, from now on, this will be explicit, more or less like the `meta` option in the archives config.