### PR TITLE
Error in the doc: archives.*.builds is type []string

### DIFF
--- a/www/docs/errors/multiple-binaries-archive.md
+++ b/www/docs/errors/multiple-binaries-archive.md
@@ -36,10 +36,10 @@ From here on, you have a couple of options:
   ```yaml
   archives:
   - id: a1
-    builds: b1
+    builds: [b1]
     name_template: something-unique-for-a1
   - id: a2
-    builds: b2
+    builds: [b2]
     name_template: something-unique-for-a2
   ```
 - if you really want to have the mixed archive, you can add


### PR DESCRIPTION
The example creates an error because builds is supposed to be an array here is shown as a string

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

...

<!-- Why is this change being made? -->

...

<!-- # Provide links to any relevant tickets, URLs or other resources -->

...
