### PR TITLE
bugfix: handle mixing of job and normal tokens

### DIFF
--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -47,7 +47,9 @@ func NewGitLab(ctx *context.Context, token string) (Client, error) {
 
 	var client *gitlab.Client
 	var err error
-	if ctx.Config.GitLabURLs.UseJobToken {
+	useJobClient := checkUseJobToken(*ctx, token)
+
+	if useJobClient {
 		client, err = gitlab.NewJobClient(token, options...)
 	} else {
 		client, err = gitlab.NewClient(token, options...)
@@ -494,4 +496,28 @@ func (c *gitlabClient) getMilestoneByTitle(repo Repo, title string) (*gitlab.Mil
 	}
 
 	return nil, nil
+}
+
+// checkUseJobToken examines the context and given token, and determines if We should use NewJobClient vs NewClient
+func checkUseJobToken(ctx context.Context, token string) bool {
+	// The CI_JOB_TOKEN env var is set automatically in all GitLab runners.
+	// If this comes back as empty, we aren't in a functional GitLab runner
+	ciToken := os.Getenv("CI_JOB_TOKEN")
+	if ciToken == "" {
+		return false
+	}
+
+	// We only want to use the JobToken client if we have specified
+	// UseJobToken. Older versions of GitLab don't work with this, so we
+	// want to be specific
+	if ctx.Config.GitLabURLs.UseJobToken {
+		// We may be creating a new client with a non-CI_JOB_TOKEN, for
+		// things like Homebrew publishing. We can't use the
+		// CI_JOB_TOKEN there
+		if token != ciToken {
+			return false
+		}
+		return true
+	}
+	return false
 }

--- a/internal/client/gitlab_test.go
+++ b/internal/client/gitlab_test.go
@@ -596,9 +596,8 @@ func TestCheckUseJobToken(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		os.Setenv("CI_JOB_TOKEN", tt.ciToken)
+		t.Setenv("CI_JOB_TOKEN", tt.ciToken)
 		got := checkUseJobToken(tt.ctx, tt.token)
 		require.Equal(t, tt.want, got, tt.desc)
-		os.Unsetenv("CI_JOB_TOKEN")
 	}
 }


### PR DESCRIPTION
If applied, this commit will allow for new GitLab clients to use both ci job tokens and plain tokens (for things like brew publishing where the CI_JOB_TOKEN isn't applicable)

This provides a fix for #3399

---

closes #3399