### PR TITLE
docs: adds Meroxa to USERS.md

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -26,6 +26,7 @@ Here's a running list of some organizations using GoReleaser[^1]:
 1. [Hugo](https://gohugo.io)
 1. [IRON Security](https://iron.security)
 1. [Koordinator](https://koordinator.sh)
+1. [Meroxa](https://meroxa.com/)
 1. [Microsoft](https://microsoft.com)
 1. [Minio](https://min.io)
 1. [Ministry of Justice (UK)](https://mojdigital.blog.gov.uk)


### PR DESCRIPTION
One of the examples of where we use it https://github.com/meroxa/cli/blob/master/.github/workflows/release.yml#L31-L32.

Thank you for such fantastic tool!