### PR TITLE
docs: add Goldenhand Software to users

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -20,6 +20,7 @@ Here's a running list of some organizations using GoReleaser[^1]:
 1. [GitHub](https://github.com)
 1. [Go Buffalo](https://gobuffalo.io)
 1. [GolangCI](https://golangci.com)
+1. [Goldenhand Software](https://www.goldenhandsoftware.co.uk)
 1. [Google](https://google.com)
 1. [Hashicorp](https://hashicorp.com)
 1. [Helm](https://helm.sh)


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

This will add Goldenhand Software to users' list 

<!-- Why is this change being made? -->

I would like to support GoReleaser as a solo contactor

<!-- # Provide links to any relevant tickets, URLs or other resources -->

https://www.goldenhandsoftware.co.uk/

Note: I love the announce functionality of GoReleaser and I do think anything other than Slack should be included in GoReleaser PRO. Announce requires a good time of development for change notes to be announced in different integrations. As a developer who do integrations every day, I do think announce section should require PRO (excluding slack and webhook one)

![image](https://user-images.githubusercontent.com/22800416/193356196-e7597d37-8b2d-43ae-b81d-a595c99166ef.png)

