### PR TITLE
Fix the `url_template` line of the brew example

### DIFF
--- a/www/docs/customization/homebrew.md
+++ b/www/docs/customization/homebrew.md
@@ -57,7 +57,7 @@ brews:
     # gitlab or gitea)
     #
     # Default depends on the client.
-    url_template: "http://github.mycompany.com/foo/bar/releases/{{ .Tag }}/{{ .ArtifactName }}"
+    url_template: "http://github.mycompany.com/foo/bar/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
 
     # Allows you to set a custom download strategy. Note that you'll need
     # to implement the strategy and add it to your tap repository.


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


## If applied, this commit will...

This PR fixes one line in the `homebrew` example section.

## Why is this change being made?

In the example of the `homebrew` section, the `url_template` value seems to be wrong. 