### PR TITLE
feat: MarkdownV2 for Telegram announcer

### DIFF
--- a/internal/pipe/telegram/telegram.go
+++ b/internal/pipe/telegram/telegram.go
@@ -46,6 +46,7 @@ func (Pipe) Announce(ctx *context.Context) error {
 	}
 
 	tm := api.NewMessage(ctx.Config.Announce.Telegram.ChatID, msg)
+	tm.ParseMode = "MarkdownV2"
 	_, err = bot.Send(tm)
 	if err != nil {
 		return fmt.Errorf("announce: failed to announce to telegram: %w", err)

--- a/www/docs/customization/announce/telegram.md
+++ b/www/docs/customization/announce/telegram.md
@@ -25,5 +25,7 @@ announce:
     message_template: 'Awesome project {{.Tag}} is out!'
 ```
 
+You can format your message using MarkdownV2, for reference, see the [Telegram Bot API](https://core.telegram.org/bots/api#markdownv2-style).
+
 !!! tip
     Learn more about the [name template engine](/customization/templates/).


### PR DESCRIPTION
Set MarkdownV2 as parse mode for Telegram announcer.

This allows for additional formatting in the announcement, such as `code` or _italic_ sections. For details, see the official [Telegram Bot API](https://core.telegram.org/bots/api#markdownv2-style).

If someone has the time (not added in this PR), I think it would be great to add a field to the Telegram config for the parse mode. This would allow setting a different parse mode than MarkdownV2, such as HTML.

This fixes #3431.