### PR TITLE
docs: fix url misspelling

### DIFF
--- a/www/docs/customization/homebrew.md
+++ b/www/docs/customization/homebrew.md
@@ -57,7 +57,7 @@ brews:
     # gitlab or gitea)
     #
     # Default depends on the client.
-    url_template: "http://github.mycompany.com/foo/bar/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    url_template: "https://github.mycompany.com/foo/bar/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
 
     # Allows you to set a custom download strategy. Note that you'll need
     # to implement the strategy and add it to your tap repository.


### PR DESCRIPTION
* Fix `http` with `https`.

Signed-off-by: Gökhan Özeloğlu <gokhan.ozeloglu@deliveryhero.com>