### PR TITLE
 feat: integrate ConventionalExtension from nfpm v2.20.0 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/google/go-github/v47 v47.1.0
 	github.com/google/uuid v1.3.0
 	github.com/goreleaser/fileglob v1.3.0
-	github.com/goreleaser/nfpm/v2 v2.19.2
+	github.com/goreleaser/nfpm/v2 v2.20.0
 	github.com/imdario/mergo v0.3.13
 	github.com/invopop/jsonschema v0.6.0
 	github.com/jarcoal/httpmock v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -878,8 +878,8 @@ github.com/goreleaser/chglog v0.2.2 h1:V7nf07baXtGAgGevvqgW2MM4kZ6gOr12vKNSAU3VI
 github.com/goreleaser/chglog v0.2.2/go.mod h1:2s5JwtCOWjZa8AIneL+xdUl9SRuigCjRHNHsX30dupE=
 github.com/goreleaser/fileglob v1.3.0 h1:/X6J7U8lbDpQtBvGcwwPS6OpzkNVlVEsFUVRx9+k+7I=
 github.com/goreleaser/fileglob v1.3.0/go.mod h1:Jx6BoXv3mbYkEzwm9THo7xbr5egkAraxkGorbJb4RxU=
-github.com/goreleaser/nfpm/v2 v2.19.2 h1:6t6vP9omE9zA0IHBRJEB3dYxEMr12+pi3XXQmZMVGL4=
-github.com/goreleaser/nfpm/v2 v2.19.2/go.mod h1:2acYIovWEOxohlx7FxexG47BV8E03ZEmQ2dX8wkl7AY=
+github.com/goreleaser/nfpm/v2 v2.20.0 h1:Q/CrX54KUMluz6+M/pjTbknFd5Dao8qXi0C6ZuFCtfY=
+github.com/goreleaser/nfpm/v2 v2.20.0/go.mod h1:/Fh6XfwT/T+D4qtNC2iXmHSD/1UT20JkvBXyJ6nFmOY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=

--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -377,11 +377,11 @@ func create(ctx *context.Context, fpm config.NFPM, format string, binaries []*ar
 		return err
 	}
 
-	var ext string
+	ext := "." + format
 	if packager, ok := packager.(nfpm.PackagerWithExtension); ok {
-		ext = packager.ConventionalExtension()
-	} else {
-		ext = "." + format
+		if format != "termux.deb" {
+			ext = packager.ConventionalExtension()
+		}
 	}
 
 	if !strings.HasSuffix(name, ext) {

--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -376,8 +376,16 @@ func create(ctx *context.Context, fpm config.NFPM, format string, binaries []*ar
 	if err != nil {
 		return err
 	}
-	if !strings.HasSuffix(name, "."+format) {
-		name = name + "." + format
+
+	var ext string
+	if packager, ok := packager.(nfpm.PackagerWithExtension); ok {
+		ext = packager.ConventionalExtension()
+	} else {
+		ext = "." + format
+	}
+
+	if !strings.HasSuffix(name, ext) {
+		name = name + ext
 	}
 
 	path := filepath.Join(ctx.Config.Dist, name)


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

This PR upgrades nFPM to v0.20.0, and integrates the new `ConventionalExtension` method to use the correct extension for the packaging format that is being used.

<!-- Why is this change being made? -->

Currently, goreleaser uses the name of the format to determine the extension. This has worked fine, but with the introduction of Archlinux packages, goreleaser has to handle packages with extensions that don't match the name of the format, since Archlinux uses `.pkg.tar.zst` as the extension.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

goreleaser/nfpm#546
goreleaser/nfpm#543