### PR TITLE
fix: Trim trailing slash from Gitea URL

### DIFF
--- a/internal/pipe/defaults/defaults.go
+++ b/internal/pipe/defaults/defaults.go
@@ -36,6 +36,7 @@ func (Pipe) Run(ctx *context.Context) error {
 		}
 
 		ctx.Config.GiteaURLs.Download = strings.ReplaceAll(apiURL, "/api/v1", "")
+		ctx.Config.GiteaURLs.Download = strings.TrimSuffix(apiURL, "/")
 	}
 	for _, defaulter := range defaults.Defaulters {
 		if err := errhandler.Handle(defaulter.Default)(ctx); err != nil {

--- a/internal/pipe/defaults/defaults.go
+++ b/internal/pipe/defaults/defaults.go
@@ -35,8 +35,7 @@ func (Pipe) Run(ctx *context.Context) error {
 			return fmt.Errorf("templating Gitea API URL: %w", err)
 		}
 
-		ctx.Config.GiteaURLs.Download = strings.ReplaceAll(apiURL, "/api/v1", "")
-		ctx.Config.GiteaURLs.Download = strings.TrimSuffix(ctx.Config.GiteaURLs.Download, "/")
+		ctx.Config.GiteaURLs.Download = strings.TrimSuffix(strings.ReplaceAll(apiURL, "/api/v1", ""), "/")
 	}
 	for _, defaulter := range defaults.Defaulters {
 		if err := errhandler.Handle(defaulter.Default)(ctx); err != nil {

--- a/internal/pipe/defaults/defaults.go
+++ b/internal/pipe/defaults/defaults.go
@@ -36,7 +36,7 @@ func (Pipe) Run(ctx *context.Context) error {
 		}
 
 		ctx.Config.GiteaURLs.Download = strings.ReplaceAll(apiURL, "/api/v1", "")
-		ctx.Config.GiteaURLs.Download = strings.TrimSuffix(apiURL, "/")
+		ctx.Config.GiteaURLs.Download = strings.TrimSuffix(ctx.Config.GiteaURLs.Download, "/")
 	}
 	for _, defaulter := range defaults.Defaulters {
 		if err := errhandler.Handle(defaulter.Default)(ctx); err != nil {


### PR DESCRIPTION
This PR will truncate any trailing slash left by specifying only a Gitea API URL.

Fixes #3487

I have not added any tests for this.