### PR TITLE
docs: Mention Gitea explicitly

### DIFF
--- a/www/docs/customization/aur.md
+++ b/www/docs/customization/aur.md
@@ -2,7 +2,7 @@
 
 Since: v1.4.
 
-After releasing to GitHub or GitLab, GoReleaser can generate and publish
+After releasing to GitHub, GitLab, or Gitea, GoReleaser can generate and publish
 a `PKGBUILD` to an _Arch User Repository_.
 
 !!! warning

--- a/www/docs/customization/homebrew.md
+++ b/www/docs/customization/homebrew.md
@@ -1,6 +1,6 @@
 # Homebrew Taps
 
-After releasing to GitHub or GitLab, GoReleaser can generate and publish
+After releasing to GitHub, GitLab, or Gitea, GoReleaser can generate and publish
 a _homebrew-tap_ recipe into a repository that you have access to.
 
 The `brews` section specifies how the formula should be created.

--- a/www/docs/customization/scoop.md
+++ b/www/docs/customization/scoop.md
@@ -1,6 +1,6 @@
 # Scoop Manifests
 
-After releasing to GitHub or GitLab, GoReleaser can generate and publish a
+After releasing to GitHub, GitLab, or Gitea, GoReleaser can generate and publish a
 _Scoop App Manifest_ into a repository that you have access to.
 
 The `scoop` section specifies how the manifest should be created. See the

--- a/www/docs/scm/gitea.md
+++ b/www/docs/scm/gitea.md
@@ -24,7 +24,7 @@ the `.goreleaser.yaml` configuration file. This takes a normal string, or a temp
 ```yaml
 # .goreleaser.yaml
 gitea_urls:
-  api: https://gitea.myinstance.com/api/v1/
+  api: https://gitea.myinstance.com/api/v1
   download: https://gitea.myinstance.com
   # set to true if you use a self-signed certificate
   skip_tls_verify: false


### PR DESCRIPTION
This PR adds explicit mention of Gitea in the AUR, Homebrew and Scoop sections.

I have tested and tried using Homebrew and Scoop with a Gitea instance, I have not tried the AUR but it should work the same.