### PR TITLE
fix(changelog): group regexps

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,16 +53,16 @@ changelog:
     - go mod tidy
   groups:
     - title: Dependency updates
-      regexp: '^[0-9a-h]+ (feat|fix)\(deps\)!?:.+$'
+      regexp: '^[[:xdigit:]]+ (feat|fix)\(deps\)!?:.+$'
       order: 300
     - title: 'New Features'
-      regexp: '^[0-9a-h]+ feat(\([[:word:]]+\))??!?:.+$'
+      regexp: '^[[:xdigit:]]+ feat(\([[:word:]]+\))??!?:.+$'
       order: 100
     - title: 'Bug fixes'
-      regexp: '^[0-9a-h]+ fix(\([[:word:]]+\))??!?:.+$'
+      regexp: '^[[:xdigit:]]+ fix(\([[:word:]]+\))??!?:.+$'
       order: 200
     - title: 'Documentation updates'
-      regexp: ^[0-9a-h]+ doc(\([[:word:]]+\))??!?:.+$
+      regexp: ^[[:xdigit:]]+ doc(\([[:word:]]+\))??!?:.+$
       order: 400
     - title: Other work
       order: 9999

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,16 +53,16 @@ changelog:
     - go mod tidy
   groups:
     - title: Dependency updates
-      regexp: '^[[:xdigit:]]+ (feat|fix)\(deps\)!?:.+$'
+      regexp: '^.*?(feat|fix)\(deps\)!?:.+$'
       order: 300
     - title: 'New Features'
-      regexp: '^[[:xdigit:]]+ feat(\([[:word:]]+\))??!?:.+$'
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
       order: 100
     - title: 'Bug fixes'
-      regexp: '^[[:xdigit:]]+ fix(\([[:word:]]+\))??!?:.+$'
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
       order: 200
     - title: 'Documentation updates'
-      regexp: ^[[:xdigit:]]+ doc(\([[:word:]]+\))??!?:.+$
+      regexp: ^.*?doc(\([[:word:]]+\))??!?:.+$
       order: 400
     - title: Other work
       order: 9999

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,16 +53,16 @@ changelog:
     - go mod tidy
   groups:
     - title: Dependency updates
-      regexp: "^.*(feat|fix)\\(deps\\)*:+.*$"
+      regexp: '^[0-9a-h]+ (feat|fix)\(deps\)!?:.+$'
       order: 300
     - title: 'New Features'
-      regexp: "^.*feat[(\\w)]*:+.*$"
+      regexp: '^[0-9a-h]+ feat(\([[:word:]]+\))??!?:.+$'
       order: 100
     - title: 'Bug fixes'
-      regexp: "^.*fix[(\\w)]*:+.*$"
+      regexp: '^[0-9a-h]+ fix(\([[:word:]]+\))??!?:.+$'
       order: 200
     - title: 'Documentation updates'
-      regexp: "^.*docs[(\\w)]*:+.*$"
+      regexp: ^[0-9a-h]+ doc(\([[:word:]]+\))??!?:.+$
       order: 400
     - title: Other work
       order: 9999

--- a/internal/pipe/changelog/changelog.go
+++ b/internal/pipe/changelog/changelog.go
@@ -155,16 +155,23 @@ func formatChangelog(ctx *context.Context, entries []string) (string, error) {
 			if err != nil {
 				return "", fmt.Errorf("failed to group into %q: %w", group.Title, err)
 			}
+
+			log.Debugf("group: %#v", group)
 			for i, entry := range entries {
 				match := regex.MatchString(entry)
+				log.Debugf("match[%d]: %s = %v\n", i, entry, match)
 				if match {
 					item.entries = append(item.entries, li+entry)
-					// Striking out the matched entry
-					entries[i] = ""
+					// Remove matched entry.
+					entries = append(entries[:i], entries[i+1:]...)
 				}
 			}
 		}
 		groups = append(groups, item)
+
+		if len(entries) == 0 {
+			break // No more entries to process.
+		}
 	}
 
 	sort.Slice(groups, func(i, j int) bool { return groups[i].order < groups[j].order })

--- a/internal/pipe/changelog/changelog.go
+++ b/internal/pipe/changelog/changelog.go
@@ -157,15 +157,19 @@ func formatChangelog(ctx *context.Context, entries []string) (string, error) {
 			}
 
 			log.Debugf("group: %#v", group)
-			for i, entry := range entries {
+			i := 0
+			for _, entry := range entries {
 				match := regex.MatchString(entry)
-				log.Debugf("match[%d]: %s = %v\n", i, entry, match)
+				log.Debugf("entry: %s match: %b\n", entry, match)
 				if match {
 					item.entries = append(item.entries, li+entry)
-					// Remove matched entry.
-					entries = append(entries[:i], entries[i+1:]...)
+				} else {
+					// Keep unmatched entry.
+					entries[i] = entry
+					i++
 				}
 			}
+			entries = entries[:i]
 		}
 		groups = append(groups, item)
 

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -638,12 +638,12 @@ func TestGroup(t *testing.T) {
 				},
 				{
 					Title:  "Features",
-					Regexp: "^.*feat[(\\w)]*:+.*$",
+					Regexp: `^[0-9a-h]+ feat(\([[:word:]]+\))??!?:.+$`,
 					Order:  0,
 				},
 				{
 					Title:  "Bug Fixes",
-					Regexp: "^.*bug[(\\w)]*:+.*$",
+					Regexp: `^[0-9a-h]+ bug(\([[:word:]]+\))??!?:.+$`,
 					Order:  1,
 				},
 				{
@@ -680,13 +680,13 @@ func TestGroupBadRegex(t *testing.T) {
 			Groups: []config.ChangeLogGroup{
 				{
 					Title:  "Something",
-					Regexp: "^.*feat[(\\w", // unterminated regex
+					Regexp: "^.*feat[a-z", // unterminated regex
 				},
 			},
 		},
 	})
 	ctx.Git.CurrentTag = "v0.0.2"
-	require.EqualError(t, Pipe{}.Run(ctx), `failed to group into "Something": error parsing regexp: missing closing ]: `+"`"+`[(\w`+"`")
+	require.EqualError(t, Pipe{}.Run(ctx), "failed to group into \"Something\": error parsing regexp: missing closing ]: `[a-z`")
 }
 
 func TestChangelogFormat(t *testing.T) {

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -638,12 +638,12 @@ func TestGroup(t *testing.T) {
 				},
 				{
 					Title:  "Features",
-					Regexp: `^[0-9a-h]+ feat(\([[:word:]]+\))??!?:.+$`,
+					Regexp: `^.*?feat(\([[:word:]]+\))??!?:.+$`,
 					Order:  0,
 				},
 				{
 					Title:  "Bug Fixes",
-					Regexp: `^[0-9a-h]+ bug(\([[:word:]]+\))??!?:.+$`,
+					Regexp: `^.*?bug(\([[:word:]]+\))??!?:.+$`,
 					Order:  1,
 				},
 				{

--- a/www/docs/customization/changelog.md
+++ b/www/docs/customization/changelog.md
@@ -52,6 +52,7 @@ changelog:
   # Proving no regex means all commits will be grouped under the default group.
   # Groups are disabled when using github-native, as it already groups things by itself.
   # Matches are performed against strings of the form: "<abbrev-commit> <title-commit>".
+  # Regex use RE2 syntax as defined here: https://github.com/google/re2/wiki/Syntax.
   #
   # Default is no groups.
   groups:

--- a/www/docs/customization/changelog.md
+++ b/www/docs/customization/changelog.md
@@ -51,16 +51,16 @@ changelog:
   # Order value defines the order of the groups.
   # Proving no regex means all commits will be grouped under the default group.
   # Groups are disabled when using github-native, as it already groups things by itself.
-  # Matches are performed against strings of the form: "<abbrev-commit> <title-commit>".
+  # Matches are performed against strings of the form: "<abbrev-commit>[:] <title-commit>".
   # Regex use RE2 syntax as defined here: https://github.com/google/re2/wiki/Syntax.
   #
   # Default is no groups.
   groups:
     - title: Features
-      regexp: '^[[:xdigit:]]+ feat(\([[:word:]]+\))??!?:.+$'
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
       order: 0
     - title: 'Bug fixes'
-      regexp: '^[[:xdigit:]]+ bug(\([[:word:]]+\))??!?:.+$'
+      regexp: '^.*?bug(\([[:word:]]+\))??!?:.+$'
       order: 1
     - title: Others
       order: 999

--- a/www/docs/customization/changelog.md
+++ b/www/docs/customization/changelog.md
@@ -57,10 +57,10 @@ changelog:
   # Default is no groups.
   groups:
     - title: Features
-      regexp: '^[0-9a-h]+ feat(\([[:word:]]+\))??!?:.+$'
+      regexp: '^[[:xdigit:]]+ feat(\([[:word:]]+\))??!?:.+$'
       order: 0
     - title: 'Bug fixes'
-      regexp: '^[0-9a-h]+ bug(\([[:word:]]+\))??!?:.+$'
+      regexp: '^[[:xdigit:]]+ bug(\([[:word:]]+\))??!?:.+$'
       order: 1
     - title: Others
       order: 999

--- a/www/docs/customization/changelog.md
+++ b/www/docs/customization/changelog.md
@@ -51,14 +51,15 @@ changelog:
   # Order value defines the order of the groups.
   # Proving no regex means all commits will be grouped under the default group.
   # Groups are disabled when using github-native, as it already groups things by itself.
+  # Matches are performed against strings of the form: "<abbrev-commit> <title-commit>".
   #
   # Default is no groups.
   groups:
     - title: Features
-      regexp: "^.*feat[(\\w)]*:+.*$"
+      regexp: '^[0-9a-h]+ feat(\([[:word:]]+\))??!?:.+$'
       order: 0
     - title: 'Bug fixes'
-      regexp: "^.*fix[(\\w)]*:+.*$"
+      regexp: '^[0-9a-h]+ bug(\([[:word:]]+\))??!?:.+$'
       order: 1
     - title: Others
       order: 999


### PR DESCRIPTION
Fix the regular expressions used in changelog group processing to valid golang (RE2) regexps. These previously used PCRE character class `\w` which is not supported in RE2 which is what golang regexp uses.

Also document that format matches not just title as some may thing but the format `<abbrev-commit> <title-commit>`.