### PR TITLE
docs: update docs to mention gitlab protected vars

### DIFF
--- a/www/docs/ci/gitlab.md
+++ b/www/docs/ci/gitlab.md
@@ -17,6 +17,13 @@ protected branches and tags.
     If you use a project access token, make sure to set `use_package_registry`
     to `true` as well, otherwise it might not work.
 
+!!! warning
+    If you are using a [protected variable](https://docs.gitlab.com/ee/ci/variables/#protected-cicd-variables)
+    to store any of the values needed by goreleaser, ensure that you are protecting the tags as CI jobs in
+    Gitlab only may access protected variables if the job is run for protected refs
+    ([branches](https://docs.gitlab.com/ee/user/project/protected_branches.html),
+    [tags](https://docs.gitlab.com/ee/user/project/protected_tags.html)).
+
 See [Quick Start](https://goreleaser.com/quick-start/) for more information on
 GoReleaser's environment variables.
 

--- a/www/docs/scm/gitlab.md
+++ b/www/docs/scm/gitlab.md
@@ -20,6 +20,13 @@ env_files:
     If you use a project access token, make sure to set `use_package_registry`
     to `true` as well, otherwise it might not work.
 
+!!! warning
+    If you are using a [protected variable](https://docs.gitlab.com/ee/ci/variables/#protected-cicd-variables)
+    to store any of the values needed by goreleaser, ensure that you are protecting the tags as CI jobs in
+    Gitlab only may access protected variables if the job is run for protected refs
+    ([branches](https://docs.gitlab.com/ee/user/project/protected_branches.html),
+    [tags](https://docs.gitlab.com/ee/user/project/protected_tags.html)).
+
 ## GitLab Enterprise or private hosted
 
 You can use GoReleaser with GitLab Enterprise by providing its URLs in the


### PR DESCRIPTION
add warning about gitlab-ci protected variables for both CI/gitlab and SCM/gitlab. 
Failing to run the pipelines on a protected ref will cause goreleaser to fail with `401: unauthorized` if for example, GITLAB_TOKEN is a protected variable and the CI Job is running on a tag that is not protected.

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

Add a warning about Gitlab CI and protected variables

<!-- Why is this change being made? -->

To prevent future users from running into issues with protected variables.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

[Discord Convo](https://discord.com/channels/890434333251362866/890434334803247126/1038130560293412955)
