### PR TITLE
Update .goreleaser.yaml

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -306,7 +306,7 @@ release:
 
     * * *
 
-    <a href="https://goreleser.com"><img src="https://raw.githubusercontent.com/goreleaser/artwork/master/opencollective-header.png" with="100%" alt="GoReleaser logo"></a>
+    <a href="https://goreleaser.com"><img src="https://raw.githubusercontent.com/goreleaser/artwork/master/opencollective-header.png" with="100%" alt="GoReleaser logo"></a>
 
     Find examples and commented usage of all options in our [website](https://goreleaser.com/intro/).
     Want to help? You can [sponsor](https://goreleaser.com/sponsors/),get a [Pro License](https://goreleaser.com/pro) or [contribute](https://goreleaser.com/contributing).


### PR DESCRIPTION
URL in `.goreleaser.yaml` pointed to https://goreleser.com which doesn't exit, presumably it was intended to point to https://goreleaser.com