### PR TITLE
feat: output checksums to artifacts info

### DIFF
--- a/internal/pipe/checksums/checksums_test.go
+++ b/internal/pipe/checksums/checksums_test.go
@@ -381,7 +381,7 @@ func TestPipeCheckSumsWithExtraFiles(t *testing.T) {
 							return nil
 						}
 
-						algoTestCounter += 1
+						algoTestCounter++
 						checksum, ok := a.Extra[artifactChecksumExtra]
 						require.True(t, ok)
 
@@ -393,8 +393,8 @@ func TestPipeCheckSumsWithExtraFiles(t *testing.T) {
 				}
 			})
 		}
-		const tests_that_include_binary = 2
-		require.Equal(t, tests_that_include_binary, algoTestCounter)
+		const testsThatIncludeBinary = 2
+		require.Equal(t, testsThatIncludeBinary, algoTestCounter)
 	}
 }
 

--- a/internal/pipe/checksums/checksums_test.go
+++ b/internal/pipe/checksums/checksums_test.go
@@ -345,7 +345,7 @@ func TestPipeCheckSumsWithExtraFiles(t *testing.T) {
 				}
 			}
 
-			ctx.Artifacts.Visit(func(a *artifact.Artifact) error {
+			_ = ctx.Artifacts.Visit(func(a *artifact.Artifact) error {
 				if a.Path != file {
 					return nil
 				}

--- a/internal/pipe/checksums/checksums_test.go
+++ b/internal/pipe/checksums/checksums_test.go
@@ -1,7 +1,6 @@
 package checksums
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -277,15 +276,6 @@ func TestPipeCheckSumsWithExtraFiles(t *testing.T) {
 				binary,
 			},
 		},
-		"default_plus_extra": {
-			extraFiles: []config.ExtraFile{
-				{Glob: extraFileFooRelPath},
-			},
-			want: []string{
-				binary,
-				extraFileFoo,
-			},
-		},
 		"one extra file": {
 			extraFiles: []config.ExtraFile{
 				{Glob: extraFileFooRelPath},
@@ -314,87 +304,60 @@ func TestPipeCheckSumsWithExtraFiles(t *testing.T) {
 			},
 		},
 	}
-	checksumsMap := map[string]string{
-		"crc32":  "f94d3859",
-		"md5":    "5ac749fbeec93607fc28d666be85e73a",
-		"sha1":   "8b45e4bd1c6acb88bebf6407d16205f567e62a3e",
-		"sha224": "21bc225587d8768058837b68fe7e0341e87b972f02fd8fb0c236d1d3",
-		"sha256": "61d034473102d7dac305902770471fd50f4c5b26f6831a56dd90b5184b3c30fc",
-		"sha384": "f6055a96a105d2fb5941a616964ffda8294fd415730cc4154a602062bc3d00e99d3c6f4a11af8c965a343de4afca3c2b",
-		"sha512": "14925e01a7a0cf0801aa95fe52d542b578af58ae7997ada66db3a6eae68a329d50600a5b7b442eabf4ea77ea8ef5fe40acf2ab31d47311b2a232c4f64009aac1",
-	}
 
-	for algo, value := range checksumsMap {
-		algoTestCounter := 0
-		for name, tt := range tests {
-			t.Run(name, func(t *testing.T) {
-				folder := t.TempDir()
-				file := filepath.Join(folder, binary)
-				require.NoError(t, os.WriteFile(file, []byte("some string"), 0o644))
-				ctx := context.New(
-					config.Project{
-						Dist:        folder,
-						ProjectName: binary,
-						Checksum: config.Checksum{
-							Algorithm:    algo,
-							NameTemplate: "checksums.txt",
-							ExtraFiles:   tt.extraFiles,
-							IDs:          tt.ids,
-						},
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			folder := t.TempDir()
+			file := filepath.Join(folder, binary)
+			require.NoError(t, os.WriteFile(file, []byte("some string"), 0o644))
+			ctx := context.New(
+				config.Project{
+					Dist:        folder,
+					ProjectName: binary,
+					Checksum: config.Checksum{
+						Algorithm:    "sha256",
+						NameTemplate: "checksums.txt",
+						ExtraFiles:   tt.extraFiles,
+						IDs:          tt.ids,
 					},
-				)
+				},
+			)
 
-				ctx.Artifacts.Add(&artifact.Artifact{
-					Name: binary,
-					Path: file,
-					Type: artifact.UploadableBinary,
-					Extra: map[string]interface{}{
-						artifact.ExtraID: "id-1",
-					},
-				})
-
-				require.NoError(t, Pipe{}.Run(ctx))
-
-				bts, err := os.ReadFile(filepath.Join(folder, checksums))
-
-				require.NoError(t, err)
-				if algo == "sha256" {
-					for _, want := range tt.want {
-						if want == binary {
-							require.Contains(t, string(bts), "61d034473102d7dac305902770471fd50f4c5b26f6831a56dd90b5184b3c30fc  "+want)
-						} else if want == extraFileFoo {
-							require.Contains(t, string(bts), "3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  "+want)
-						}
-					}
-				}
-
-				wantBinary := false
-				for _, want := range tt.want {
-					if want == binary {
-						wantBinary = true
-						break
-					}
-				}
-				if wantBinary {
-					_ = ctx.Artifacts.Filter(artifact.ByType(artifact.UploadableBinary)).Visit(func(a *artifact.Artifact) error {
-						if a.Path != file {
-							return nil
-						}
-
-						algoTestCounter++
-						checksum, ok := a.Extra[artifactChecksumExtra]
-						require.True(t, ok)
-
-						expectedChecksum := fmt.Sprintf("%s:%s", algo, value)
-						require.Equal(t, expectedChecksum, checksum)
-
-						return nil
-					})
-				}
+			ctx.Artifacts.Add(&artifact.Artifact{
+				Name: binary,
+				Path: file,
+				Type: artifact.UploadableBinary,
+				Extra: map[string]interface{}{
+					artifact.ExtraID: "id-1",
+				},
 			})
-		}
-		const testsThatIncludeBinary = 2
-		require.Equal(t, testsThatIncludeBinary, algoTestCounter)
+
+			require.NoError(t, Pipe{}.Run(ctx))
+
+			bts, err := os.ReadFile(filepath.Join(folder, checksums))
+
+			require.NoError(t, err)
+			for _, want := range tt.want {
+				if tt.extraFiles == nil {
+					require.Contains(t, string(bts), "61d034473102d7dac305902770471fd50f4c5b26f6831a56dd90b5184b3c30fc  "+want)
+				} else {
+					require.Contains(t, string(bts), "3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  "+want)
+				}
+			}
+
+			ctx.Artifacts.Visit(func(a *artifact.Artifact) error {
+				if a.Path != file {
+					return nil
+				}
+				if len(tt.ids) > 0 {
+					return nil
+				}
+				checkSum, err := artifact.Extra[string](*a, artifactChecksumExtra)
+				require.Nil(t, err)
+				require.NotEmptyf(t, checkSum, "failed: %v", a.Path)
+				return nil
+			})
+		})
 	}
 }
 

--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	dockerConfigExtra = "DockerConfig"
-	dockerDigestExtra = "digest"
+	dockerDigestExtra = "Digest"
 
 	useBuildx = "buildx"
 	useDocker = "docker"


### PR DESCRIPTION
Following #3540, output artifacts' checksums to the artifact info.
This addition makes it easier to consume the checksums, especially when running from e.g. GitHub Actions.

New tests:
1. Add a check for the checksum in the extra field. 
2. Add a test for every checksum algorithm (to see that it doesn't break for any algo's output).
3. Add a case of a binary and an extra file (to see that the logic doesn't break when there's a mix).

p.s.
While working on that, I noticed that the convention for extra fields is actually to use UpperCamelCase rather than lower. 
I was mistaken because I looked at the subfields of the "DockerConfig" extra field.
I think it's a good idea to fix it quickly, before the next release rolls and it becomes a compatibility issue.
I took the liberty to fix it here as an extra commit. Please let me know if you want it to be in a separate PR.

---
Tests:
```
go test
  • refreshing checksums                             file=binary_bar_checksums.txt
  • refreshing checksums                             file=binary_bar_checksums.txt
  • refreshing checksums                             file=binary_bar_checksums.txt
PASS
ok  	github.com/goreleaser/goreleaser/internal/pipe/checksums	0.184s
```