### PR TITLE
docs: improve schema

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -300,7 +300,7 @@ type Build struct {
 	ID              string          `yaml:"id,omitempty" json:"id,omitempty"`
 	Goos            []string        `yaml:"goos,omitempty" json:"goos,omitempty"`
 	Goarch          []string        `yaml:"goarch,omitempty" json:"goarch,omitempty"`
-	Goarm           []string        `yaml:"goarm,omitempty" json:"goarm,omitempty"nt`
+	Goarm           []string        `yaml:"goarm,omitempty" json:"goarm,omitempty"`
 	Gomips          []string        `yaml:"gomips,omitempty" json:"gomips,omitempty"`
 	Goamd64         []string        `yaml:"goamd64,omitempty" json:"goamd64,omitempty"`
 	Targets         []string        `yaml:"targets,omitempty" json:"targets,omitempty"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -172,7 +172,7 @@ type Homebrew struct {
 	CustomRequire         string               `yaml:"custom_require,omitempty" json:"custom_require,omitempty"`
 	CustomBlock           string               `yaml:"custom_block,omitempty" json:"custom_block,omitempty"`
 	IDs                   []string             `yaml:"ids,omitempty" json:"ids,omitempty"`
-	Goarm                 string               `yaml:"goarm,omitempty" json:"goarm,omitempty" jsonschema:"oneof_type=string;int"`
+	Goarm                 string               `yaml:"goarm,omitempty" json:"goarm,omitempty" jsonschema:"oneof_type=string;integer"`
 	Goamd64               string               `yaml:"goamd64,omitempty" json:"goamd64,omitempty"`
 	Service               string               `yaml:"service,omitempty" json:"service,omitempty"`
 }
@@ -189,7 +189,7 @@ type Krew struct {
 	Description           string       `yaml:"description,omitempty" json:"description,omitempty"`
 	Homepage              string       `yaml:"homepage,omitempty" json:"homepage,omitempty"`
 	URLTemplate           string       `yaml:"url_template,omitempty" json:"url_template,omitempty"`
-	Goarm                 string       `yaml:"goarm,omitempty" json:"goarm,omitempty" jsonschema:"oneof_type=string;int"`
+	Goarm                 string       `yaml:"goarm,omitempty" json:"goarm,omitempty" jsonschema:"oneof_type=string;integer"`
 	Goamd64               string       `yaml:"goamd64,omitempty" json:"goamd64,omitempty"`
 	SkipUpload            string       `yaml:"skip_upload,omitempty" json:"skip_upload,omitempty" jsonschema:"oneof_type=string;boolean"`
 }
@@ -300,7 +300,7 @@ type Build struct {
 	ID              string          `yaml:"id,omitempty" json:"id,omitempty"`
 	Goos            []string        `yaml:"goos,omitempty" json:"goos,omitempty"`
 	Goarch          []string        `yaml:"goarch,omitempty" json:"goarch,omitempty"`
-	Goarm           []string        `yaml:"goarm,omitempty" json:"goarm,omitempty"`
+	Goarm           []string        `yaml:"goarm,omitempty" json:"goarm,omitempty"nt`
 	Gomips          []string        `yaml:"gomips,omitempty" json:"gomips,omitempty"`
 	Goamd64         []string        `yaml:"goamd64,omitempty" json:"goamd64,omitempty"`
 	Targets         []string        `yaml:"targets,omitempty" json:"targets,omitempty"`
@@ -326,7 +326,7 @@ type Build struct {
 type BuildDetailsOverride struct {
 	Goos         string                          `yaml:"goos,omitempty" json:"goos,omitempty"`
 	Goarch       string                          `yaml:"goarch,omitempty" json:"goarch,omitempty"`
-	Goarm        string                          `yaml:"goarm,omitempty" json:"goarm,omitempty" jsonschema:"oneof_type=string;int"`
+	Goarm        string                          `yaml:"goarm,omitempty" json:"goarm,omitempty" jsonschema:"oneof_type=string;integer"`
 	Gomips       string                          `yaml:"gomips,omitempty" json:"gomips,omitempty"`
 	Goamd64      string                          `yaml:"goamd64,omitempty" json:"goamd64,omitempty"`
 	BuildDetails `yaml:",inline" json:",inline"` // nolint: tagliatelle
@@ -788,7 +788,7 @@ type Docker struct {
 	IDs                []string `yaml:"ids,omitempty" json:"ids,omitempty"`
 	Goos               string   `yaml:"goos,omitempty" json:"goos,omitempty"`
 	Goarch             string   `yaml:"goarch,omitempty" json:"goarch,omitempty"`
-	Goarm              string   `yaml:"goarm,omitempty" json:"goarm,omitempty" jsonschema:"oneof_type=string;int"`
+	Goarm              string   `yaml:"goarm,omitempty" json:"goarm,omitempty" jsonschema:"oneof_type=string;integer"`
 	Goamd64            string   `yaml:"goamd64,omitempty" json:"goamd64,omitempty"`
 	Dockerfile         string   `yaml:"dockerfile,omitempty" json:"dockerfile,omitempty"`
 	ImageTemplates     []string `yaml:"image_templates,omitempty" json:"image_templates,omitempty"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -228,7 +228,7 @@ type BuildHooks struct { // renamed on pro
 type IgnoredBuild struct {
 	Goos    string `yaml:"goos,omitempty" json:"goos,omitempty"`
 	Goarch  string `yaml:"goarch,omitempty" json:"goarch,omitempty"`
-	Goarm   string `yaml:"goarm,omitempty" json:"goarm,omitempty" jsonschema:"oneof_type=string;int"`
+	Goarm   string `yaml:"goarm,omitempty" json:"goarm,omitempty" jsonschema:"oneof_type=string;integer"`
 	Gomips  string `yaml:"gomips,omitempty" json:"gomips,omitempty"`
 	Goamd64 string `yaml:"goamd64,omitempty" json:"goamd64,omitempty"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -132,7 +132,7 @@ type AUR struct {
 	Description           string       `yaml:"description,omitempty" json:"description,omitempty"`
 	Homepage              string       `yaml:"homepage,omitempty" json:"homepage,omitempty"`
 	License               string       `yaml:"license,omitempty" json:"license,omitempty"`
-	SkipUpload            string       `yaml:"skip_upload,omitempty" json:"skip_upload,omitempty"`
+	SkipUpload            string       `yaml:"skip_upload,omitempty" json:"skip_upload,omitempty" jsonschema:"oneof_type=string;boolean"`
 	URLTemplate           string       `yaml:"url_template,omitempty" json:"url_template,omitempty"`
 	Maintainers           []string     `yaml:"maintainers,omitempty" json:"maintainers,omitempty"`
 	Contributors          []string     `yaml:"contributors,omitempty" json:"contributors,omitempty"`
@@ -166,13 +166,13 @@ type Homebrew struct {
 	Description           string               `yaml:"description,omitempty" json:"description,omitempty"`
 	Homepage              string               `yaml:"homepage,omitempty" json:"homepage,omitempty"`
 	License               string               `yaml:"license,omitempty" json:"license,omitempty"`
-	SkipUpload            string               `yaml:"skip_upload,omitempty" json:"skip_upload,omitempty"`
+	SkipUpload            string               `yaml:"skip_upload,omitempty" json:"skip_upload,omitempty" jsonschema:"oneof_type=string;boolean"`
 	DownloadStrategy      string               `yaml:"download_strategy,omitempty" json:"download_strategy,omitempty"`
 	URLTemplate           string               `yaml:"url_template,omitempty" json:"url_template,omitempty"`
 	CustomRequire         string               `yaml:"custom_require,omitempty" json:"custom_require,omitempty"`
 	CustomBlock           string               `yaml:"custom_block,omitempty" json:"custom_block,omitempty"`
 	IDs                   []string             `yaml:"ids,omitempty" json:"ids,omitempty"`
-	Goarm                 string               `yaml:"goarm,omitempty" json:"goarm,omitempty"`
+	Goarm                 string               `yaml:"goarm,omitempty" json:"goarm,omitempty" jsonschema:"oneof_type=string;int"`
 	Goamd64               string               `yaml:"goamd64,omitempty" json:"goamd64,omitempty"`
 	Service               string               `yaml:"service,omitempty" json:"service,omitempty"`
 }
@@ -189,9 +189,9 @@ type Krew struct {
 	Description           string       `yaml:"description,omitempty" json:"description,omitempty"`
 	Homepage              string       `yaml:"homepage,omitempty" json:"homepage,omitempty"`
 	URLTemplate           string       `yaml:"url_template,omitempty" json:"url_template,omitempty"`
-	Goarm                 string       `yaml:"goarm,omitempty" json:"goarm,omitempty"`
+	Goarm                 string       `yaml:"goarm,omitempty" json:"goarm,omitempty" jsonschema:"oneof_type=string;int"`
 	Goamd64               string       `yaml:"goamd64,omitempty" json:"goamd64,omitempty"`
-	SkipUpload            string       `yaml:"skip_upload,omitempty" json:"skip_upload,omitempty"`
+	SkipUpload            string       `yaml:"skip_upload,omitempty" json:"skip_upload,omitempty" jsonschema:"oneof_type=string;boolean"`
 }
 
 // Scoop contains the scoop.sh section.
@@ -206,7 +206,7 @@ type Scoop struct {
 	License               string       `yaml:"license,omitempty" json:"license,omitempty"`
 	URLTemplate           string       `yaml:"url_template,omitempty" json:"url_template,omitempty"`
 	Persist               []string     `yaml:"persist,omitempty" json:"persist,omitempty"`
-	SkipUpload            string       `yaml:"skip_upload,omitempty" json:"skip_upload,omitempty"`
+	SkipUpload            string       `yaml:"skip_upload,omitempty" json:"skip_upload,omitempty" jsonschema:"oneof_type=string;boolean"`
 	PreInstall            []string     `yaml:"pre_install,omitempty" json:"pre_install,omitempty"`
 	PostInstall           []string     `yaml:"post_install,omitempty" json:"post_install,omitempty"`
 	Goamd64               string       `yaml:"goamd64,omitempty" json:"goamd64,omitempty"`
@@ -228,7 +228,7 @@ type BuildHooks struct { // renamed on pro
 type IgnoredBuild struct {
 	Goos    string `yaml:"goos,omitempty" json:"goos,omitempty"`
 	Goarch  string `yaml:"goarch,omitempty" json:"goarch,omitempty"`
-	Goarm   string `yaml:"goarm,omitempty" json:"goarm,omitempty"`
+	Goarm   string `yaml:"goarm,omitempty" json:"goarm,omitempty" jsonschema:"oneof_type=string;int"`
 	Gomips  string `yaml:"gomips,omitempty" json:"gomips,omitempty"`
 	Goamd64 string `yaml:"goamd64,omitempty" json:"goamd64,omitempty"`
 }
@@ -311,7 +311,7 @@ type Build struct {
 	Hooks           BuildHookConfig `yaml:"hooks,omitempty" json:"hooks,omitempty"`
 	Builder         string          `yaml:"builder,omitempty" json:"builder,omitempty"`
 	ModTimestamp    string          `yaml:"mod_timestamp,omitempty" json:"mod_timestamp,omitempty"`
-	Skip            bool            `yaml:"skip,omitempty" json:"skip,omitempty"`
+	Skip            bool            `yaml:"skip,omitempty" json:"skip,omitempty" jsonschema:"oneof_type=string;boolean"`
 	GoBinary        string          `yaml:"gobinary,omitempty" json:"gobinary,omitempty"`
 	Command         string          `yaml:"command,omitempty" json:"command,omitempty"`
 	NoUniqueDistDir bool            `yaml:"no_unique_dist_dir,omitempty" json:"no_unique_dist_dir,omitempty"`
@@ -326,7 +326,7 @@ type Build struct {
 type BuildDetailsOverride struct {
 	Goos         string                          `yaml:"goos,omitempty" json:"goos,omitempty"`
 	Goarch       string                          `yaml:"goarch,omitempty" json:"goarch,omitempty"`
-	Goarm        string                          `yaml:"goarm,omitempty" json:"goarm,omitempty"`
+	Goarm        string                          `yaml:"goarm,omitempty" json:"goarm,omitempty" jsonschema:"oneof_type=string;int"`
 	Gomips       string                          `yaml:"gomips,omitempty" json:"gomips,omitempty"`
 	Goamd64      string                          `yaml:"goamd64,omitempty" json:"goamd64,omitempty"`
 	BuildDetails `yaml:",inline" json:",inline"` // nolint: tagliatelle
@@ -788,11 +788,11 @@ type Docker struct {
 	IDs                []string `yaml:"ids,omitempty" json:"ids,omitempty"`
 	Goos               string   `yaml:"goos,omitempty" json:"goos,omitempty"`
 	Goarch             string   `yaml:"goarch,omitempty" json:"goarch,omitempty"`
-	Goarm              string   `yaml:"goarm,omitempty" json:"goarm,omitempty"`
+	Goarm              string   `yaml:"goarm,omitempty" json:"goarm,omitempty" jsonschema:"oneof_type=string;int"`
 	Goamd64            string   `yaml:"goamd64,omitempty" json:"goamd64,omitempty"`
 	Dockerfile         string   `yaml:"dockerfile,omitempty" json:"dockerfile,omitempty"`
 	ImageTemplates     []string `yaml:"image_templates,omitempty" json:"image_templates,omitempty"`
-	SkipPush           string   `yaml:"skip_push,omitempty" json:"skip_push,omitempty"`
+	SkipPush           string   `yaml:"skip_push,omitempty" json:"skip_push,omitempty" jsonschema:"oneof_type=string;boolean"`
 	Files              []string `yaml:"extra_files,omitempty" json:"extra_files,omitempty"`
 	BuildFlagTemplates []string `yaml:"build_flag_templates,omitempty" json:"build_flag_templates,omitempty"`
 	PushFlags          []string `yaml:"push_flags,omitempty" json:"push_flags,omitempty"`
@@ -803,7 +803,7 @@ type Docker struct {
 type DockerManifest struct {
 	ID             string   `yaml:"id,omitempty" json:"id,omitempty"`
 	NameTemplate   string   `yaml:"name_template,omitempty" json:"name_template,omitempty"`
-	SkipPush       string   `yaml:"skip_push,omitempty" json:"skip_push,omitempty"`
+	SkipPush       string   `yaml:"skip_push,omitempty" json:"skip_push,omitempty" jsonschema:"oneof_type=string;boolean"`
 	ImageTemplates []string `yaml:"image_templates,omitempty" json:"image_templates,omitempty"`
 	CreateFlags    []string `yaml:"create_flags,omitempty" json:"create_flags,omitempty"`
 	PushFlags      []string `yaml:"push_flags,omitempty" json:"push_flags,omitempty"`
@@ -955,7 +955,7 @@ type GoMod struct {
 }
 
 type Announce struct {
-	Skip       string     `yaml:"skip,omitempty" json:"skip,omitempty"`
+	Skip       string     `yaml:"skip,omitempty" json:"skip,omitempty" jsonschema:"oneof_type=string;boolean"`
 	Twitter    Twitter    `yaml:"twitter,omitempty" json:"twitter,omitempty"`
 	Reddit     Reddit     `yaml:"reddit,omitempty" json:"reddit,omitempty"`
 	Slack      Slack      `yaml:"slack,omitempty" json:"slack,omitempty"`

--- a/www/docs/static/schema.json
+++ b/www/docs/static/schema.json
@@ -1204,7 +1204,7 @@
 								"type": "string"
 							},
 							{
-								"type": "int"
+								"type": "integer"
 							}
 						]
 					},

--- a/www/docs/static/schema.json
+++ b/www/docs/static/schema.json
@@ -30,7 +30,14 @@
 						"type": "string"
 					},
 					"skip_upload": {
-						"type": "string"
+						"oneOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "boolean"
+							}
+						]
 					},
 					"url_template": {
 						"type": "string"
@@ -102,7 +109,14 @@
 			"Announce": {
 				"properties": {
 					"skip": {
-						"type": "string"
+						"oneOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "boolean"
+							}
+						]
 					},
 					"twitter": {
 						"$ref": "#/$defs/Twitter"
@@ -315,7 +329,14 @@
 						"type": "string"
 					},
 					"skip": {
-						"type": "boolean"
+						"oneOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "boolean"
+							}
+						]
 					},
 					"gobinary": {
 						"type": "string"
@@ -372,7 +393,14 @@
 						"type": "string"
 					},
 					"goarm": {
-						"type": "string"
+						"oneOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "int"
+							}
+						]
 					},
 					"gomips": {
 						"type": "string"
@@ -689,7 +717,14 @@
 						"type": "string"
 					},
 					"goarm": {
-						"type": "string"
+						"oneOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "int"
+							}
+						]
 					},
 					"goamd64": {
 						"type": "string"
@@ -704,7 +739,14 @@
 						"type": "array"
 					},
 					"skip_push": {
-						"type": "string"
+						"oneOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "boolean"
+							}
+						]
 					},
 					"extra_files": {
 						"items": {
@@ -740,7 +782,14 @@
 						"type": "string"
 					},
 					"skip_push": {
-						"type": "string"
+						"oneOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "boolean"
+							}
+						]
 					},
 					"image_templates": {
 						"items": {
@@ -1034,7 +1083,14 @@
 						"type": "string"
 					},
 					"skip_upload": {
-						"type": "string"
+						"oneOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "boolean"
+							}
+						]
 					},
 					"download_strategy": {
 						"type": "string"
@@ -1055,7 +1111,14 @@
 						"type": "array"
 					},
 					"goarm": {
-						"type": "string"
+						"oneOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "int"
+							}
+						]
 					},
 					"goamd64": {
 						"type": "string"
@@ -1136,7 +1199,14 @@
 						"type": "string"
 					},
 					"goarm": {
-						"type": "string"
+						"oneOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "int"
+							}
+						]
 					},
 					"gomips": {
 						"type": "string"
@@ -1184,13 +1254,27 @@
 						"type": "string"
 					},
 					"goarm": {
-						"type": "string"
+						"oneOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "int"
+							}
+						]
 					},
 					"goamd64": {
 						"type": "string"
 					},
 					"skip_upload": {
-						"type": "string"
+						"oneOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "boolean"
+							}
+						]
 					}
 				},
 				"additionalProperties": false,
@@ -2142,7 +2226,14 @@
 						"type": "array"
 					},
 					"skip_upload": {
-						"type": "string"
+						"oneOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "boolean"
+							}
+						]
 					},
 					"pre_install": {
 						"items": {

--- a/www/docs/static/schema.json
+++ b/www/docs/static/schema.json
@@ -398,7 +398,7 @@
 								"type": "string"
 							},
 							{
-								"type": "int"
+								"type": "integer"
 							}
 						]
 					},
@@ -722,7 +722,7 @@
 								"type": "string"
 							},
 							{
-								"type": "int"
+								"type": "integer"
 							}
 						]
 					},
@@ -1116,7 +1116,7 @@
 								"type": "string"
 							},
 							{
-								"type": "int"
+								"type": "integer"
 							}
 						]
 					},
@@ -1259,7 +1259,7 @@
 								"type": "string"
 							},
 							{
-								"type": "int"
+								"type": "integer"
 							}
 						]
 					},


### PR DESCRIPTION
this should prevent yamlschema from complaining on some fields that accept an integer or string (goarm) and a bool or string (skip*)