### PR TITLE
feat: use digest on manifests

### DIFF
--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -1423,3 +1423,37 @@ func TestSkip(t *testing.T) {
 		})
 	})
 }
+
+func TestWithDigest(t *testing.T) {
+	artifacts := artifact.New()
+	artifacts.Add(&artifact.Artifact{
+		Name: "owner/img:t1",
+		Type: artifact.DockerImage,
+		Extra: artifact.Extras{
+			dockerDigestExtra: "sha256:d1",
+		},
+	})
+	artifacts.Add(&artifact.Artifact{
+		Name: "owner/img:t2",
+		Type: artifact.DockerImage,
+		Extra: artifact.Extras{
+			dockerDigestExtra: "sha256:d2",
+		},
+	})
+	artifacts.Add(&artifact.Artifact{
+		Name: "owner/img:t3",
+		Type: artifact.DockerImage,
+	})
+
+	t.Run("good", func(t *testing.T) {
+		require.Equal(t, "owner/img:t1@sha256:d1", withDigest("owner/img:t1", artifacts.List()))
+	})
+
+	t.Run("no digest", func(t *testing.T) {
+		require.Equal(t, "owner/img:t3", withDigest("owner/img:t3", artifacts.List()))
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		require.Equal(t, "owner/img:t4", withDigest("owner/img:t4", artifacts.List()))
+	})
+}

--- a/internal/pipe/docker/manifest.go
+++ b/internal/pipe/docker/manifest.go
@@ -116,16 +116,30 @@ func manifestName(ctx *context.Context, manifest config.DockerManifest) (string,
 }
 
 func manifestImages(ctx *context.Context, manifest config.DockerManifest) ([]string, error) {
+	artifacts := ctx.Artifacts.Filter(artifact.ByType(artifact.DockerImage)).List()
 	imgs := make([]string, 0, len(manifest.ImageTemplates))
 	for _, img := range manifest.ImageTemplates {
 		str, err := tmpl.New(ctx).Apply(img)
 		if err != nil {
 			return []string{}, err
 		}
-		imgs = append(imgs, str)
+		imgs = append(imgs, withDigest(str, artifacts))
 	}
 	if strings.TrimSpace(strings.Join(manifest.ImageTemplates, "")) == "" {
 		return imgs, pipe.Skip("manifest has no images")
 	}
 	return imgs, nil
+}
+
+func withDigest(name string, images []*artifact.Artifact) string {
+	for _, art := range images {
+		if art.Name == name {
+			if digest := artifact.ExtraOr(*art, dockerDigestExtra, ""); digest != "" {
+				return name + "@" + digest
+			}
+			break
+		}
+	}
+	log.Warnf("did not find the digest for %s, defaulting to insecure mode")
+	return name
 }


### PR DESCRIPTION
this use the digests on the manifest creation.
Another PR will add it to signing too.

refs #3496
refs #3540 