### PR TITLE
feat: use digest to sign docker images/manifests

### DIFF
--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -137,6 +137,7 @@ const (
 	ExtraBinaries  = "Binaries"
 	ExtraRefresh   = "Refresh"
 	ExtraReplaces  = "Replaces"
+	ExtraDigest    = "Digest"
 )
 
 // Extras represents the extra fields in an artifact.

--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	dockerConfigExtra = "DockerConfig"
-	dockerDigestExtra = "Digest"
+	dockerDigestExtra = artifact.ExtraDigest
 
 	useBuildx = "buildx"
 	useDocker = "docker"

--- a/internal/pipe/sign/sign.go
+++ b/internal/pipe/sign/sign.go
@@ -154,6 +154,7 @@ func signone(ctx *context.Context, cfg config.Sign, art *artifact.Artifact) ([]*
 	env["artifactName"] = art.Name // shouldn't be used
 	env["artifact"] = art.Path
 	env["artifactID"] = art.ID()
+	env["digest"] = artifact.ExtraOr(*art, artifact.ExtraDigest, "")
 
 	tmplEnv, err := templateEnvS(ctx, cfg.Env)
 	if err != nil {

--- a/internal/pipe/sign/sign_docker.go
+++ b/internal/pipe/sign/sign_docker.go
@@ -28,7 +28,7 @@ func (DockerPipe) Default(ctx *context.Context) error {
 			cfg.Cmd = "cosign"
 		}
 		if len(cfg.Args) == 0 {
-			cfg.Args = []string{"sign", "--key=cosign.key", "$artifact"}
+			cfg.Args = []string{"sign", "--key=cosign.key", "${artifact}@${digest}"}
 		}
 		if cfg.Artifacts == "" {
 			cfg.Artifacts = "none"

--- a/www/docs/customization/docker_sign.md
+++ b/www/docs/customization/docker_sign.md
@@ -28,7 +28,7 @@ docker_signs:
 
     # Command line templateable arguments for the command
     #
-    # defaults to `["sign", "--key=cosign.key", "${artifact}"]`
+    # defaults to `["sign", "--key=cosign.key", "${artifact}@${digest}"]`
     args: ["sign", "--key=cosign.key", "--upload=false", "${artifact}"]
 
 
@@ -77,12 +77,16 @@ docker_signs:
 These environment variables might be available in the fields that are templateable:
 
 - `${artifact}`: the path to the artifact that will be signed [^1]
+- `${digest}`: the digest of the image/manifest that will be signed [^2]
 - `${artifactID}`: the ID of the artifact that will be signed
 - `${certificate}`: the certificate file name, if provided
 
 [^1]: notice that this might contain `/` characters, which depending on how
   you use it might evaluate to actual paths within the file system. Use with
   care.
+[^2]: those are extracted automatically when running Docker push from within
+  GoReleaser. Using the digest helps making sure you're signing the right image
+  and avoid concurrency issues.
 
 
 ## Common usage example


### PR DESCRIPTION
this drives it home by using the actual images/manifest digests to sign with cosign by default.

the default signing command is changing in this PR, but since `digest` should be always there (if not, the pipeline will fail way earlier), it should be fine.

refs https://github.com/goreleaser/goreleaser/issues/3496
refs https://github.com/goreleaser/goreleaser/pull/3540
