### PR TITLE
chore: verify website for mastodon

### DIFF
--- a/www/docs/overrides/home.html
+++ b/www/docs/overrides/home.html
@@ -150,6 +150,7 @@
 		</div>
 	</div>
 </section>
+<a style="display: none;" rel="me" href="https://fosstodon.org/@goreleaser"></a>
 {% endblock %}
 {% block content %}{% endblock %}
 {% block footer %}{% endblock %}


### PR DESCRIPTION
> You can verify yourself as the owner of the links in your profile metadata. For that, the linked website must contain a link back to your Mastodon profile. The link back must have a `rel="me"` attribute. The text content of the link does not matter. 

I checked that `display: none;` doesn't affect the verification process, I was able to "verify" a link using a quick test on my own profile.

I'm not convinced this is the _best_ way, but it is _a_ way. On other pages on the site you have a mastodon link, if those were added to the front page they would also suffice (assuming the above criteria are met).