### PR TITLE
fix: validate env templates

### DIFF
--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -119,7 +119,10 @@ func New(ctx *context.Context) *Template {
 func (t *Template) WithEnvS(envs []string) *Template {
 	result := map[string]string{}
 	for _, env := range envs {
-		k, v, _ := strings.Cut(env, "=")
+		k, v, ok := strings.Cut(env, "=")
+		if !ok || k == "" || v == "" {
+			continue
+		}
 		result[k] = v
 	}
 	return t.WithEnv(result)

--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -120,7 +120,7 @@ func (t *Template) WithEnvS(envs []string) *Template {
 	result := map[string]string{}
 	for _, env := range envs {
 		k, v, ok := strings.Cut(env, "=")
-		if !ok || k == "" || v == "" {
+		if !ok || k == "" {
 			continue
 		}
 		result[k] = v

--- a/internal/tmpl/tmpl_test.go
+++ b/internal/tmpl/tmpl_test.go
@@ -159,12 +159,21 @@ func TestWithEnv(t *testing.T) {
 		"FOO": "BAR",
 	}
 	ctx.Git.CurrentTag = "v1.2.3"
-	out, err := New(ctx).WithEnvS([]string{
+	tpl := New(ctx).WithEnvS([]string{
 		"FOO=foo",
 		"BAR=bar",
-	}).Apply("{{ .Env.FOO }}-{{ .Env.BAR }}")
+		"NOVAL=",
+		"=NOKEY",
+		"=",
+		"NOTHING",
+	})
+	out, err := tpl.Apply("{{ .Env.FOO }}-{{ .Env.BAR }}")
 	require.NoError(t, err)
 	require.Equal(t, "foo-bar", out)
+
+	out, err = tpl.Apply(`{{ range $idx, $key := .Env }}{{ $idx }},{{ end }}`)
+	require.NoError(t, err)
+	require.Equal(t, "BAR,FOO,", out)
 }
 
 func TestFuncMap(t *testing.T) {

--- a/internal/tmpl/tmpl_test.go
+++ b/internal/tmpl/tmpl_test.go
@@ -173,7 +173,7 @@ func TestWithEnv(t *testing.T) {
 
 	out, err = tpl.Apply(`{{ range $idx, $key := .Env }}{{ $idx }},{{ end }}`)
 	require.NoError(t, err)
-	require.Equal(t, "BAR,FOO,", out)
+	require.Equal(t, "BAR,FOO,NOVAL,", out)
 }
 
 func TestFuncMap(t *testing.T) {

--- a/www/docs/customization/build.md
+++ b/www/docs/customization/build.md
@@ -71,6 +71,8 @@ builds:
 
     # Custom environment variables to be set during the builds.
     #
+    # Invalid and empty environment variables are ignored.
+    #
     # Default: `os.Environ()` merged with what you set the root `env` section.
     env:
       - CGO_ENABLED=0

--- a/www/docs/customization/build.md
+++ b/www/docs/customization/build.md
@@ -71,7 +71,7 @@ builds:
 
     # Custom environment variables to be set during the builds.
     #
-    # Invalid and empty environment variables are ignored.
+    # Invalid environment variables will be ignored.
     #
     # Default: `os.Environ()` merged with what you set the root `env` section.
     env:


### PR DESCRIPTION
ignore invalid environment variables (e.g. no key, no value, or no equal sign)