### PR TITLE
fix: improve schema for signs

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -686,7 +686,7 @@ type Sign struct {
 	Cmd         string   `yaml:"cmd,omitempty" json:"cmd,omitempty"`
 	Args        []string `yaml:"args,omitempty" json:"args,omitempty"`
 	Signature   string   `yaml:"signature,omitempty" json:"signature,omitempty"`
-	Artifacts   string   `yaml:"artifacts,omitempty" json:"artifacts,omitempty"`
+	Artifacts   string   `yaml:"artifacts,omitempty" json:"artifacts,omitempty" jsonschema:"enum=all,enum=manifests,enum=images,enum=checksum,enum=source,enum=package,enum=archive,enum=binary,enum=sbom"`
 	IDs         []string `yaml:"ids,omitempty" json:"ids,omitempty"`
 	Stdin       *string  `yaml:"stdin,omitempty" json:"stdin,omitempty"`
 	StdinFile   string   `yaml:"stdin_file,omitempty" json:"stdin_file,omitempty"`

--- a/www/docs/static/schema.json
+++ b/www/docs/static/schema.json
@@ -2293,7 +2293,18 @@
 						"type": "string"
 					},
 					"artifacts": {
-						"type": "string"
+						"type": "string",
+						"enum": [
+							"all",
+							"manifests",
+							"images",
+							"checksum",
+							"source",
+							"package",
+							"archive",
+							"binary",
+							"sbom"
+						]
 					},
 					"ids": {
 						"items": {


### PR DESCRIPTION
adds all the options allowed in the `artifacts` field to the schema