### PR TITLE
fix: warn if list has multiple files with same name

### DIFF
--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -289,6 +289,17 @@ func New() Artifacts {
 func (artifacts Artifacts) List() []*Artifact {
 	artifacts.lock.Lock()
 	defer artifacts.lock.Unlock()
+	names := map[string]bool{}
+	for _, item := range artifacts.items {
+		if item.Name == "" {
+			continue
+		}
+		if names[item.Name] {
+			log.WithField("name", item.Name).
+				Warn("multiple artifacts with the same name: this may cause errors")
+		}
+		names[item.Name] = true
+	}
 	return artifacts.items
 }
 


### PR DESCRIPTION
`List()` "materializes" the filters, so its used everywhere... if we have multiple files with the same name there, its likely some filter wasn't enough, or that the user configuration is faulty. Either way, we should warn about it to help prevent release issues (like duplicated assets on github).