### PR TITLE
doc: fix `skip_push` parameter to `skip_build`

### DIFF
--- a/www/docs/customization/docker.md
+++ b/www/docs/customization/docker.md
@@ -89,7 +89,7 @@ dockers:
     # This option is only available on GoReleaser Pro.
     #
     # Defaults to false.
-    skip_push: false
+    skip_build: false
 
     # Skips the docker push.
     # Could be useful if you also do draft releases.


### PR DESCRIPTION
Fix the wrong `skip_push` to `skip_build` in `docker.md`.