### PR TITLE
feat: allow to template archives.files.info

### DIFF
--- a/internal/archivefiles/archivefiles.go
+++ b/internal/archivefiles/archivefiles.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"sort"
+	"time"
 
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/fileglob"
@@ -24,6 +25,25 @@ func Eval(template *tmpl.Template, files []config.File) ([]config.File, error) {
 		files, err := fileglob.Glob(replaced)
 		if err != nil {
 			return result, fmt.Errorf("globbing failed for pattern %s: %w", replaced, err)
+		}
+
+		f.Info.Owner, err = template.Apply(f.Info.Owner)
+		if err != nil {
+			return result, fmt.Errorf("failed to apply template %s: %w", f.Info.Owner, err)
+		}
+		f.Info.Group, err = template.Apply(f.Info.Group)
+		if err != nil {
+			return result, fmt.Errorf("failed to apply template %s: %w", f.Info.Group, err)
+		}
+		f.Info.MTime, err = template.Apply(f.Info.MTime)
+		if err != nil {
+			return result, fmt.Errorf("failed to apply template %s: %w", f.Info.MTime, err)
+		}
+		if f.Info.MTime != "" {
+			f.Info.ParsedMTime, err = time.Parse(time.RFC3339Nano, f.Info.MTime)
+			if err != nil {
+				return result, fmt.Errorf("failed to parse %s: %w", f.Info.MTime, err)
+			}
 		}
 
 		for _, file := range files {

--- a/pkg/archive/gzip/gzip.go
+++ b/pkg/archive/gzip/gzip.go
@@ -48,10 +48,10 @@ func (a Archive) Add(f config.File) error {
 		return nil
 	}
 	a.gw.Header.Name = f.Destination
-	if f.Info.MTime.IsZero() {
+	if f.Info.ParsedMTime.IsZero() {
 		a.gw.Header.ModTime = info.ModTime()
 	} else {
-		a.gw.Header.ModTime = f.Info.MTime
+		a.gw.Header.ModTime = f.Info.ParsedMTime
 	}
 	_, err = io.Copy(a.gw, file)
 	return err

--- a/pkg/archive/gzip/gzip_test.go
+++ b/pkg/archive/gzip/gzip_test.go
@@ -63,7 +63,7 @@ func TestGzFileCustomMtime(t *testing.T) {
 		Destination: "sub1/sub2/subfoo.txt",
 		Source:      "../testdata/sub1/sub2/subfoo.txt",
 		Info: config.FileInfo{
-			MTime: now,
+			ParsedMTime: now,
 		},
 	}))
 	require.NoError(t, archive.Close())

--- a/pkg/archive/tar/tar.go
+++ b/pkg/archive/tar/tar.go
@@ -45,8 +45,8 @@ func (a Archive) Add(f config.File) error {
 		return fmt.Errorf("%s: %w", f.Source, err)
 	}
 	header.Name = f.Destination
-	if !f.Info.MTime.IsZero() {
-		header.ModTime = f.Info.MTime
+	if !f.Info.ParsedMTime.IsZero() {
+		header.ModTime = f.Info.ParsedMTime
 	}
 	if f.Info.Mode != 0 {
 		header.Mode = int64(f.Info.Mode)

--- a/pkg/archive/tar/tar_test.go
+++ b/pkg/archive/tar/tar_test.go
@@ -114,10 +114,10 @@ func TestTarFileInfo(t *testing.T) {
 		Source:      "../testdata/foo.txt",
 		Destination: "nope.txt",
 		Info: config.FileInfo{
-			Mode:  0o755,
-			Owner: "carlos",
-			Group: "root",
-			MTime: now,
+			Mode:        0o755,
+			Owner:       "carlos",
+			Group:       "root",
+			ParsedMTime: now,
 		},
 	}))
 

--- a/pkg/archive/targz/targz_test.go
+++ b/pkg/archive/targz/targz_test.go
@@ -119,10 +119,10 @@ func TestTarGzFileInfo(t *testing.T) {
 		Source:      "../testdata/foo.txt",
 		Destination: "nope.txt",
 		Info: config.FileInfo{
-			Mode:  0o755,
-			Owner: "carlos",
-			Group: "root",
-			MTime: now,
+			Mode:        0o755,
+			Owner:       "carlos",
+			Group:       "root",
+			ParsedMTime: now,
 		},
 	}))
 

--- a/pkg/archive/tarxz/tarxz_test.go
+++ b/pkg/archive/tarxz/tarxz_test.go
@@ -118,10 +118,10 @@ func TestTarXzFileInfo(t *testing.T) {
 		Source:      "../testdata/foo.txt",
 		Destination: "nope.txt",
 		Info: config.FileInfo{
-			Mode:  0o755,
-			Owner: "carlos",
-			Group: "root",
-			MTime: now,
+			Mode:        0o755,
+			Owner:       "carlos",
+			Group:       "root",
+			ParsedMTime: now,
 		},
 	}))
 

--- a/pkg/archive/zip/zip.go
+++ b/pkg/archive/zip/zip.go
@@ -49,8 +49,8 @@ func (a Archive) Add(f config.File) error {
 	}
 	header.Name = f.Destination
 	header.Method = zip.Deflate
-	if !f.Info.MTime.IsZero() {
-		header.Modified = f.Info.MTime
+	if !f.Info.ParsedMTime.IsZero() {
+		header.Modified = f.Info.ParsedMTime
 	}
 	if f.Info.Mode != 0 {
 		header.SetMode(f.Info.Mode)

--- a/pkg/archive/zip/zip_test.go
+++ b/pkg/archive/zip/zip_test.go
@@ -117,10 +117,10 @@ func TestZipFileInfo(t *testing.T) {
 		Source:      "../testdata/foo.txt",
 		Destination: "nope.txt",
 		Info: config.FileInfo{
-			Mode:  0o755,
-			Owner: "carlos",
-			Group: "root",
-			MTime: now,
+			Mode:        0o755,
+			Owner:       "carlos",
+			Group:       "root",
+			ParsedMTime: now,
 		},
 	}))
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -428,10 +428,11 @@ type File struct {
 
 // FileInfo is the file info of a file.
 type FileInfo struct {
-	Owner string      `yaml:"owner,omitempty" json:"owner,omitempty"`
-	Group string      `yaml:"group,omitempty" json:"group,omitempty"`
-	Mode  os.FileMode `yaml:"mode,omitempty" json:"mode,omitempty"`
-	MTime time.Time   `yaml:"mtime,omitempty" json:"mtime,omitempty"`
+	Owner       string      `yaml:"owner,omitempty" json:"owner,omitempty"`
+	Group       string      `yaml:"group,omitempty" json:"group,omitempty"`
+	Mode        os.FileMode `yaml:"mode,omitempty" json:"mode,omitempty"`
+	MTime       string      `yaml:"mtime,omitempty" json:"mtime,omitempty"`
+	ParsedMTime time.Time   `yaml:"-" json:"-"`
 }
 
 // UnmarshalYAML is a custom unmarshaler that wraps strings in arrays.

--- a/pkg/config/config_archive_files_test.go
+++ b/pkg/config/config_archive_files_test.go
@@ -84,10 +84,11 @@ files:
 			Source:      "./foobar",
 			Destination: "./barzaz",
 			Info: FileInfo{
-				Owner: "carlos",
-				Group: "users",
-				Mode:  0o644,
-				MTime: now,
+				Owner:       "carlos",
+				Group:       "users",
+				Mode:        0o644,
+				MTime:       now.Format(time.RFC3339Nano),
+				ParsedMTime: time.Time{},
 			},
 		},
 	}, actual.Files)

--- a/www/docs/customization/archive.md
+++ b/www/docs/customization/archive.md
@@ -83,11 +83,18 @@ archives:
         # Not all fields are supported by all formats available formats.
         # Defaults to the file info of the actual file if not provided.
         info:
+          # Templateable (since v1.14.0)
           owner: root
+
+          # Templateable (since v1.14.0)
           group: root
+
+          # Must be in time.RFC3339Nano format.
+          # Templateable (since v1.14.0)
+          mtime: '{{ .CommitDate }}'
+
+          # File mode.
           mode: 0644
-          # format is `time.RFC3339Nano`
-          mtime: 2008-01-02T15:04:05Z
 
     # Before and after hooks for each archive.
     # Skipped if archive format is binary.


### PR DESCRIPTION
this allows to template the owner, group and mtime in file infos inside archives.

should help towards reproducible builds!

goes well with #3618 