### PR TITLE
feat: better archives relative paths

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -142,6 +142,7 @@ archives:
     builds_info:
       group: root
       owner: root
+    rlcp: true
     files:
       - README.md
       - LICENSE.md

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,8 +18,8 @@ builds:
     - CGO_ENABLED=0
   goos:
     - linux
-    - darwin
-    - windows
+    # - darwin
+    # - windows
   goarch:
     - "386"
     - amd64
@@ -256,17 +256,17 @@ nfpms:
         - statically-linked-binary
         - changelog-file-missing-in-native-package
 
-snapcrafts:
-  - name_template: '{{ .ProjectName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
-    summary: Deliver Go binaries as fast and easily as possible
-    description: |
-      GoReleaser builds Go binaries for several platforms, creates a GitHub
-      release and then pushes a Homebrew formula to a repository. All that
-      wrapped in your favorite CI.
-    grade: stable
-    confinement: classic
-    publish: true
-
+# snapcrafts:
+#   - name_template: '{{ .ProjectName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+#     summary: Deliver Go binaries as fast and easily as possible
+#     description: |
+#       GoReleaser builds Go binaries for several platforms, creates a GitHub
+#       release and then pushes a Homebrew formula to a repository. All that
+#       wrapped in your favorite CI.
+#     grade: stable
+#     confinement: classic
+#     publish: true
+#
 sboms:
   - artifacts: archive
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -136,6 +136,7 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
+    rlcp: true
     format_overrides:
     - goos: windows
       format: zip

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,8 +18,8 @@ builds:
     - CGO_ENABLED=0
   goos:
     - linux
-    # - darwin
-    # - windows
+    - darwin
+    - windows
   goarch:
     - "386"
     - amd64
@@ -136,7 +136,6 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-    rlcp: true
     format_overrides:
     - goos: windows
       format: zip
@@ -256,17 +255,17 @@ nfpms:
         - statically-linked-binary
         - changelog-file-missing-in-native-package
 
-# snapcrafts:
-#   - name_template: '{{ .ProjectName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
-#     summary: Deliver Go binaries as fast and easily as possible
-#     description: |
-#       GoReleaser builds Go binaries for several platforms, creates a GitHub
-#       release and then pushes a Homebrew formula to a repository. All that
-#       wrapped in your favorite CI.
-#     grade: stable
-#     confinement: classic
-#     publish: true
-#
+snapcrafts:
+  - name_template: '{{ .ProjectName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    summary: Deliver Go binaries as fast and easily as possible
+    description: |
+      GoReleaser builds Go binaries for several platforms, creates a GitHub
+      release and then pushes a Homebrew formula to a repository. All that
+      wrapped in your favorite CI.
+    grade: stable
+    confinement: classic
+    publish: true
+
 sboms:
   - artifacts: archive
 

--- a/internal/archivefiles/archivefiles.go
+++ b/internal/archivefiles/archivefiles.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Eval evaluates the given list of files to their final form.
-func Eval(template *tmpl.Template, files []config.File) ([]config.File, error) {
+func Eval(template *tmpl.Template, rlcp bool, files []config.File) ([]config.File, error) {
 	var result []config.File
 	for _, f := range files {
 		replaced, err := template.Apply(f.Source)
@@ -56,7 +56,7 @@ func Eval(template *tmpl.Template, files []config.File) ([]config.File, error) {
 		}
 
 		for _, file := range files {
-			dst, err := destinationFor(f, prefix, file)
+			dst, err := destinationFor(f, prefix, file, rlcp)
 			if err != nil {
 				return nil, err
 			}
@@ -96,12 +96,12 @@ func unique(in []config.File) []config.File {
 	return result
 }
 
-func destinationFor(f config.File, prefix, path string) (string, error) {
+func destinationFor(f config.File, prefix, path string, rlcp bool) (string, error) {
 	if f.StripParent {
 		return filepath.Join(f.Destination, filepath.Base(path)), nil
 	}
 
-	if f.RelativeLongestCommonPath {
+	if rlcp {
 		relpath, err := filepath.Rel(prefix, path)
 		if err != nil {
 			// since prefix is a prefix of src a relative path should always be found

--- a/internal/archivefiles/archivefiles.go
+++ b/internal/archivefiles/archivefiles.go
@@ -101,7 +101,7 @@ func destinationFor(f config.File, prefix, path string) (string, error) {
 		return filepath.Join(f.Destination, filepath.Base(path)), nil
 	}
 
-	if f.RelativeParent {
+	if f.RelativeLongestCommonPath {
 		relpath, err := filepath.Rel(prefix, path)
 		if err != nil {
 			// since prefix is a prefix of src a relative path should always be found

--- a/internal/archivefiles/archivefiles.go
+++ b/internal/archivefiles/archivefiles.go
@@ -101,7 +101,7 @@ func destinationFor(f config.File, prefix, path string, rlcp bool) (string, erro
 		return filepath.Join(f.Destination, filepath.Base(path)), nil
 	}
 
-	if rlcp {
+	if rlcp && f.Destination != "" {
 		relpath, err := filepath.Rel(prefix, path)
 		if err != nil {
 			// since prefix is a prefix of src a relative path should always be found

--- a/internal/archivefiles/archivefiles.go
+++ b/internal/archivefiles/archivefiles.go
@@ -2,7 +2,10 @@
 package archivefiles
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
+	"os"
 	"path/filepath"
 	"sort"
 	"time"
@@ -46,10 +49,20 @@ func Eval(template *tmpl.Template, files []config.File) ([]config.File, error) {
 			}
 		}
 
+		// the prefix may not be a complete path or may use glob patterns, in that case use the parent directory
+		prefix := replaced
+		if _, err := os.Stat(prefix); errors.Is(err, fs.ErrNotExist) || fileglob.ContainsMatchers(prefix) {
+			prefix = filepath.Dir(longestCommonPrefix(files))
+		}
+
 		for _, file := range files {
+			dst, err := destinationFor(f, prefix, file)
+			if err != nil {
+				return nil, err
+			}
 			result = append(result, config.File{
 				Source:      file,
-				Destination: destinationFor(f, file),
+				Destination: dst,
 				Info:        f.Info,
 			})
 		}
@@ -83,9 +96,49 @@ func unique(in []config.File) []config.File {
 	return result
 }
 
-func destinationFor(f config.File, path string) string {
+func destinationFor(f config.File, prefix, path string) (string, error) {
 	if f.StripParent {
-		return filepath.Join(f.Destination, filepath.Base(path))
+		return filepath.Join(f.Destination, filepath.Base(path)), nil
 	}
-	return filepath.Join(f.Destination, path)
+
+	if f.RelativeParent {
+		relpath, err := filepath.Rel(prefix, path)
+		if err != nil {
+			// since prefix is a prefix of src a relative path should always be found
+			return "", err
+		}
+		return filepath.ToSlash(filepath.Join(f.Destination, relpath)), nil
+	}
+
+	return filepath.Join(f.Destination, path), nil
+}
+
+// longestCommonPrefix returns the longest prefix of all strings the argument
+// slice. If the slice is empty the empty string is returned.
+// copied from nfpm
+func longestCommonPrefix(strs []string) string {
+	if len(strs) == 0 {
+		return ""
+	}
+	lcp := strs[0]
+	for _, str := range strs {
+		lcp = strlcp(lcp, str)
+	}
+	return lcp
+}
+
+// copied from nfpm
+func strlcp(a, b string) string {
+	var min int
+	if len(a) > len(b) {
+		min = len(b)
+	} else {
+		min = len(a)
+	}
+	for i := 0; i < min; i++ {
+		if a[i] != b[i] {
+			return a[0:i]
+		}
+	}
+	return a[0:min]
 }

--- a/internal/archivefiles/archivefiles_test.go
+++ b/internal/archivefiles/archivefiles_test.go
@@ -145,9 +145,9 @@ func TestEval(t *testing.T) {
 
 	t.Run("relativeparent is set", func(t *testing.T) {
 		result, err := Eval(tmpl, []config.File{{
-			Source:         "./testdata/a/**/*",
-			Destination:    "foo/bar",
-			RelativeParent: true,
+			Source:                    "./testdata/a/**/*",
+			Destination:               "foo/bar",
+			RelativeLongestCommonPath: true,
 		}})
 
 		require.NoError(t, err)
@@ -159,9 +159,9 @@ func TestEval(t *testing.T) {
 
 	t.Run("relativeparent no results", func(t *testing.T) {
 		result, err := Eval(tmpl, []config.File{{
-			Source:         "./testdata/abc/**/*",
-			Destination:    "foo/bar",
-			RelativeParent: true,
+			Source:                    "./testdata/abc/**/*",
+			Destination:               "foo/bar",
+			RelativeLongestCommonPath: true,
 		}})
 
 		require.NoError(t, err)

--- a/internal/archivefiles/archivefiles_test.go
+++ b/internal/archivefiles/archivefiles_test.go
@@ -288,3 +288,16 @@ func TestEval(t *testing.T) {
 		}, result)
 	})
 }
+
+func TestStrlcp(t *testing.T) {
+	for k, v := range map[string][2]string{
+		"/var/":       {"/var/lib/foo", "/var/share/aaa"},
+		"/var/lib/":   {"/var/lib/foo", "/var/lib/share/aaa"},
+		"/usr/share/": {"/usr/share/lib", "/usr/share/bin"},
+		"/usr/":       {"/usr/share/lib", "/usr/bin"},
+	} {
+		t.Run(k, func(t *testing.T) {
+			require.Equal(t, k, strlcp(v[0], v[1]))
+		})
+	}
+}

--- a/internal/archivefiles/archivefiles_test.go
+++ b/internal/archivefiles/archivefiles_test.go
@@ -157,6 +157,17 @@ func TestEval(t *testing.T) {
 		}, result)
 	})
 
+	t.Run("relativeparent no results", func(t *testing.T) {
+		result, err := Eval(tmpl, []config.File{{
+			Source:         "./testdata/abc/**/*",
+			Destination:    "foo/bar",
+			RelativeParent: true,
+		}})
+
+		require.NoError(t, err)
+		require.Empty(t, result)
+	})
+
 	t.Run("strip parent plays nicely with destination omitted", func(t *testing.T) {
 		result, err := Eval(tmpl, []config.File{{Source: "./testdata/a/b", StripParent: true}})
 

--- a/internal/archivefiles/archivefiles_test.go
+++ b/internal/archivefiles/archivefiles_test.go
@@ -143,7 +143,7 @@ func TestEval(t *testing.T) {
 		}, result)
 	})
 
-	t.Run("rlcp is set", func(t *testing.T) {
+	t.Run("rlcp", func(t *testing.T) {
 		result, err := Eval(tmpl, true, []config.File{{
 			Source:      "./testdata/a/**/*",
 			Destination: "foo/bar",
@@ -153,6 +153,18 @@ func TestEval(t *testing.T) {
 		require.Equal(t, []config.File{
 			{Source: "testdata/a/b/a.txt", Destination: "foo/bar/a.txt"},
 			{Source: "testdata/a/b/c/d.txt", Destination: "foo/bar/c/d.txt"},
+		}, result)
+	})
+
+	t.Run("rlcp empty destination", func(t *testing.T) {
+		result, err := Eval(tmpl, true, []config.File{{
+			Source: "./testdata/a/**/*",
+		}})
+
+		require.NoError(t, err)
+		require.Equal(t, []config.File{
+			{Source: "testdata/a/b/a.txt", Destination: "testdata/a/b/a.txt"},
+			{Source: "testdata/a/b/c/d.txt", Destination: "testdata/a/b/c/d.txt"},
 		}, result)
 	})
 

--- a/internal/archivefiles/archivefiles_test.go
+++ b/internal/archivefiles/archivefiles_test.go
@@ -107,6 +107,20 @@ func TestEval(t *testing.T) {
 		}, result)
 	})
 
+	t.Run("relativeparent is set", func(t *testing.T) {
+		result, err := Eval(tmpl, []config.File{{
+			Source:         "./testdata/a/**/*",
+			Destination:    "foo/bar",
+			RelativeParent: true,
+		}})
+
+		require.NoError(t, err)
+		require.Equal(t, []config.File{
+			{Source: "testdata/a/b/a.txt", Destination: "foo/bar/a.txt"},
+			{Source: "testdata/a/b/c/d.txt", Destination: "foo/bar/c/d.txt"},
+		}, result)
+	})
+
 	t.Run("strip parent plays nicely with destination omitted", func(t *testing.T) {
 		result, err := Eval(tmpl, []config.File{{Source: "./testdata/a/b", StripParent: true}})
 

--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -49,9 +49,7 @@ func (Pipe) String() string {
 func (Pipe) Default(ctx *context.Context) error {
 	ids := ids.New("archives")
 	if len(ctx.Config.Archives) == 0 {
-		ctx.Config.Archives = append(ctx.Config.Archives, config.Archive{
-			RLCP: true,
-		})
+		ctx.Config.Archives = append(ctx.Config.Archives, config.Archive{})
 	}
 	for i := range ctx.Config.Archives {
 		archive := &ctx.Config.Archives[i]
@@ -60,6 +58,9 @@ func (Pipe) Default(ctx *context.Context) error {
 		}
 		if archive.ID == "" {
 			archive.ID = "default"
+		}
+		if !archive.RLCP && archive.Format != "binary" && len(archive.Files) > 0 {
+			deprecate.NoticeCustom(ctx, "archives.rclp", "`{{ .Property }}` will be the default soon, check {{ .URL }} for more info")
 		}
 		if len(archive.Files) == 0 {
 			archive.Files = []config.File{
@@ -79,9 +80,6 @@ func (Pipe) Default(ctx *context.Context) error {
 		}
 		if len(archive.Replacements) != 0 {
 			deprecate.Notice(ctx, "archives.replacements")
-		}
-		if !archive.RLCP && archive.Format != "binary" {
-			deprecate.NoticeCustom(ctx, "archives.rclp", "`{{ .Property }}` will be the default soon, check {{ .URL }} for more info")
 		}
 		ids.Inc(archive.ID)
 	}

--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -60,7 +60,7 @@ func (Pipe) Default(ctx *context.Context) error {
 			archive.ID = "default"
 		}
 		if !archive.RLCP && archive.Format != "binary" && len(archive.Files) > 0 {
-			deprecate.NoticeCustom(ctx, "archives.rclp", "`{{ .Property }}` will be the default soon, check {{ .URL }} for more info")
+			deprecate.NoticeCustom(ctx, "archives.rlcp", "`{{ .Property }}` will be the default soon, check {{ .URL }} for more info")
 		}
 		if len(archive.Files) == 0 {
 			archive.Files = []config.File{

--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -49,7 +49,9 @@ func (Pipe) String() string {
 func (Pipe) Default(ctx *context.Context) error {
 	ids := ids.New("archives")
 	if len(ctx.Config.Archives) == 0 {
-		ctx.Config.Archives = append(ctx.Config.Archives, config.Archive{})
+		ctx.Config.Archives = append(ctx.Config.Archives, config.Archive{
+			RLCP: true,
+		})
 	}
 	for i := range ctx.Config.Archives {
 		archive := &ctx.Config.Archives[i]

--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -78,6 +78,9 @@ func (Pipe) Default(ctx *context.Context) error {
 		if len(archive.Replacements) != 0 {
 			deprecate.Notice(ctx, "archives.replacements")
 		}
+		if !archive.RLCP {
+			deprecate.NoticeCustom(ctx, "archives.rclp", "`{{ .Property }}` will be the default soon, check {{ .URL }} for more info")
+		}
 		ids.Inc(archive.ID)
 	}
 	return ids.Validate()
@@ -185,7 +188,7 @@ func doCreate(ctx *context.Context, arch config.Archive, binaries []*artifact.Ar
 	a = NewEnhancedArchive(a, wrap)
 	defer a.Close()
 
-	files, err := archivefiles.Eval(template, arch.Files)
+	files, err := archivefiles.Eval(template, arch.RLCP, arch.Files)
 	if err != nil {
 		return fmt.Errorf("failed to find files to archive: %w", err)
 	}

--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -78,7 +78,7 @@ func (Pipe) Default(ctx *context.Context) error {
 		if len(archive.Replacements) != 0 {
 			deprecate.Notice(ctx, "archives.replacements")
 		}
-		if !archive.RLCP {
+		if !archive.RLCP && archive.Format != "binary" {
 			deprecate.NoticeCustom(ctx, "archives.rclp", "`{{ .Property }}` will be the default soon, check {{ .URL }} for more info")
 		}
 		ids.Inc(archive.ID)

--- a/internal/pipe/archive/archive_test.go
+++ b/internal/pipe/archive/archive_test.go
@@ -771,6 +771,7 @@ func TestDefault(t *testing.T) {
 	require.NotEmpty(t, ctx.Config.Archives[0].NameTemplate)
 	require.Equal(t, "tar.gz", ctx.Config.Archives[0].Format)
 	require.NotEmpty(t, ctx.Config.Archives[0].Files)
+	require.True(t, ctx.Config.Archives[0].RLCP)
 }
 
 func TestDefaultSet(t *testing.T) {
@@ -791,6 +792,7 @@ func TestDefaultSet(t *testing.T) {
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "foo", ctx.Config.Archives[0].NameTemplate)
 	require.Equal(t, "zip", ctx.Config.Archives[0].Format)
+	require.False(t, ctx.Config.Archives[0].RLCP)
 	require.Equal(t, config.File{Source: "foo"}, ctx.Config.Archives[0].Files[0])
 }
 

--- a/internal/pipe/archive/archive_test.go
+++ b/internal/pipe/archive/archive_test.go
@@ -771,7 +771,7 @@ func TestDefault(t *testing.T) {
 	require.NotEmpty(t, ctx.Config.Archives[0].NameTemplate)
 	require.Equal(t, "tar.gz", ctx.Config.Archives[0].Format)
 	require.NotEmpty(t, ctx.Config.Archives[0].Files)
-	require.True(t, ctx.Config.Archives[0].RLCP)
+	require.False(t, ctx.Config.Archives[0].RLCP)
 }
 
 func TestDefaultSet(t *testing.T) {
@@ -796,6 +796,21 @@ func TestDefaultSet(t *testing.T) {
 	require.Equal(t, config.File{Source: "foo"}, ctx.Config.Archives[0].Files[0])
 }
 
+func TestDefaultNoFiles(t *testing.T) {
+	ctx := &context.Context{
+		Config: config.Project{
+			Archives: []config.Archive{
+				{
+					Format: "tar.gz",
+				},
+			},
+		},
+	}
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, defaultNameTemplate, ctx.Config.Archives[0].NameTemplate)
+	require.False(t, ctx.Config.Archives[0].RLCP)
+}
+
 func TestDefaultFormatBinary(t *testing.T) {
 	ctx := &context.Context{
 		Config: config.Project{
@@ -808,6 +823,7 @@ func TestDefaultFormatBinary(t *testing.T) {
 	}
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, defaultBinaryNameTemplate, ctx.Config.Archives[0].NameTemplate)
+	require.False(t, ctx.Config.Archives[0].RLCP)
 }
 
 func TestFormatFor(t *testing.T) {

--- a/internal/pipe/sourcearchive/source.go
+++ b/internal/pipe/sourcearchive/source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/internal/archivefiles"
 	"github.com/goreleaser/goreleaser/internal/artifact"
+	"github.com/goreleaser/goreleaser/internal/deprecate"
 	"github.com/goreleaser/goreleaser/internal/git"
 	"github.com/goreleaser/goreleaser/internal/tmpl"
 	"github.com/goreleaser/goreleaser/pkg/archive"
@@ -68,7 +69,11 @@ func (Pipe) Run(ctx *context.Context) (err error) {
 			Source: f,
 		})
 	}
-	files, err := archivefiles.Eval(tmpl.New(ctx), append(ff, ctx.Config.Source.Files...))
+	files, err := archivefiles.Eval(
+		tmpl.New(ctx),
+		ctx.Config.Source.RLCP,
+		append(ff, ctx.Config.Source.Files...),
+	)
 	if err != nil {
 		return err
 	}
@@ -106,6 +111,10 @@ func (Pipe) Default(ctx *context.Context) error {
 
 	if archive.NameTemplate == "" {
 		archive.NameTemplate = "{{ .ProjectName }}-{{ .Version }}"
+	}
+
+	if !archive.RLCP {
+		deprecate.NoticeCustom(ctx, "source.rclp", "`{{ .Property }}` will be the default soon, check {{ .URL }} for more info")
 	}
 	return nil
 }

--- a/internal/pipe/sourcearchive/source.go
+++ b/internal/pipe/sourcearchive/source.go
@@ -114,7 +114,7 @@ func (Pipe) Default(ctx *context.Context) error {
 	}
 
 	if archive.Enabled && !archive.RLCP {
-		deprecate.NoticeCustom(ctx, "source.rclp", "`{{ .Property }}` will be the default soon, check {{ .URL }} for more info")
+		deprecate.NoticeCustom(ctx, "source.rlcp", "`{{ .Property }}` will be the default soon, check {{ .URL }} for more info")
 	}
 	return nil
 }

--- a/internal/pipe/sourcearchive/source.go
+++ b/internal/pipe/sourcearchive/source.go
@@ -113,7 +113,7 @@ func (Pipe) Default(ctx *context.Context) error {
 		archive.NameTemplate = "{{ .ProjectName }}-{{ .Version }}"
 	}
 
-	if !archive.RLCP {
+	if archive.Enabled && !archive.RLCP {
 		deprecate.NoticeCustom(ctx, "source.rclp", "`{{ .Property }}` will be the default soon, check {{ .URL }} for more info")
 	}
 	return nil

--- a/internal/static/config.yaml
+++ b/internal/static/config.yaml
@@ -23,7 +23,7 @@ archives:
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end }}'
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
     # use zip for windows archives
     format_overrides:
     - goos: windows

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -420,11 +420,12 @@ type FormatOverride struct {
 
 // File is a file inside an archive.
 type File struct {
-	Source         string   `yaml:"src,omitempty" json:"src,omitempty"`
-	Destination    string   `yaml:"dst,omitempty" json:"dst,omitempty"`
-	StripParent    bool     `yaml:"strip_parent,omitempty" json:"strip_parent,omitempty"`
-	RelativeParent bool     `yaml:"relative,omitempty" json:"relative,omitempty"`
-	Info           FileInfo `yaml:"info,omitempty" json:"info,omitempty"`
+	Source      string   `yaml:"src,omitempty" json:"src,omitempty"`
+	Destination string   `yaml:"dst,omitempty" json:"dst,omitempty"`
+	Info        FileInfo `yaml:"info,omitempty" json:"info,omitempty"`
+
+	StripParent               bool `yaml:"strip_parent,omitempty" json:"strip_parent,omitempty"`
+	RelativeLongestCommonPath bool `yaml:"rlcp,omitempty" json:"rlcp,omitempty"`
 }
 
 // FileInfo is the file info of a file.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -422,10 +422,8 @@ type FormatOverride struct {
 type File struct {
 	Source      string   `yaml:"src,omitempty" json:"src,omitempty"`
 	Destination string   `yaml:"dst,omitempty" json:"dst,omitempty"`
+	StripParent bool     `yaml:"strip_parent,omitempty" json:"strip_parent,omitempty"`
 	Info        FileInfo `yaml:"info,omitempty" json:"info,omitempty"`
-
-	StripParent               bool `yaml:"strip_parent,omitempty" json:"strip_parent,omitempty"`
-	RelativeLongestCommonPath bool `yaml:"rlcp,omitempty" json:"rlcp,omitempty"`
 }
 
 // FileInfo is the file info of a file.
@@ -490,6 +488,7 @@ type Archive struct {
 	FormatOverrides           []FormatOverride  `yaml:"format_overrides,omitempty" json:"format_overrides,omitempty"`
 	WrapInDirectory           string            `yaml:"wrap_in_directory,omitempty" json:"wrap_in_directory,omitempty" jsonschema:"oneof_type=string;boolean"`
 	StripParentBinaryFolder   bool              `yaml:"strip_parent_binary_folder,omitempty" json:"strip_parent_binary_folder,omitempty"`
+	RLCP                      bool              `yaml:"rlcp,omitempty" json:"rlcp,omitempty"`
 	Files                     []File            `yaml:"files,omitempty" json:"files,omitempty"`
 	Meta                      bool              `yaml:"meta,omitempty" json:"meta,omitempty"`
 	AllowDifferentBinaryCount bool              `yaml:"allow_different_binary_count,omitempty" json:"allow_different_binary_count,omitempty"`
@@ -905,6 +904,7 @@ type Source struct {
 	Enabled        bool   `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	PrefixTemplate string `yaml:"prefix_template,omitempty" json:"prefix_template,omitempty"`
 	Files          []File `yaml:"files,omitempty" json:"files,omitempty"`
+	RLCP           bool   `yaml:"rlcp,omitempty" json:"rlcp,omitempty"`
 }
 
 // Project includes all project configuration.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -420,10 +420,11 @@ type FormatOverride struct {
 
 // File is a file inside an archive.
 type File struct {
-	Source      string   `yaml:"src,omitempty" json:"src,omitempty"`
-	Destination string   `yaml:"dst,omitempty" json:"dst,omitempty"`
-	StripParent bool     `yaml:"strip_parent,omitempty" json:"strip_parent,omitempty"`
-	Info        FileInfo `yaml:"info,omitempty" json:"info,omitempty"`
+	Source         string   `yaml:"src,omitempty" json:"src,omitempty"`
+	Destination    string   `yaml:"dst,omitempty" json:"dst,omitempty"`
+	StripParent    bool     `yaml:"strip_parent,omitempty" json:"strip_parent,omitempty"`
+	RelativeParent bool     `yaml:"relative,omitempty" json:"relative,omitempty"`
+	Info           FileInfo `yaml:"info,omitempty" json:"info,omitempty"`
 }
 
 // FileInfo is the file info of a file.

--- a/www/docs/customization/archive.md
+++ b/www/docs/customization/archive.md
@@ -89,9 +89,19 @@ archives:
       # a more complete example, check the globbing deep dive below
       - src: '*.md'
         dst: docs
+
         # Strip parent folders when adding files to the archive.
         # Default: false
         strip_parent: true
+
+        # This will make the destination paths be relative to the longest common
+        # prefix between all the files matched and the source glob.
+        # Enabling this essentially mimic the behavior of nfpm's contents section.
+        #
+        # Default: false
+        # Since: v1.14.
+        relative: true
+
         # File info.
         # Not all fields are supported by all formats available formats.
         # Defaults to the file info of the actual file if not provided.

--- a/www/docs/customization/archive.md
+++ b/www/docs/customization/archive.md
@@ -95,12 +95,12 @@ archives:
         strip_parent: true
 
         # This will make the destination paths be relative to the longest common
-        # prefix between all the files matched and the source glob.
+        # path prefix between all the files matched and the source glob.
         # Enabling this essentially mimic the behavior of nfpm's contents section.
         #
         # Default: false
         # Since: v1.14.
-        relative: true
+        rlcp: true
 
         # File info.
         # Not all fields are supported by all formats available formats.

--- a/www/docs/customization/archive.md
+++ b/www/docs/customization/archive.md
@@ -69,6 +69,16 @@ archives:
     # Since: v1.11.
     strip_parent_binary_folder: true
 
+
+    # This will make the destination paths be relative to the longest common
+    # path prefix between all the files matched and the source glob.
+    # Enabling this essentially mimic the behavior of nfpm's contents section.
+    # It will be the default by June 2023.
+    #
+    # Default: false
+    # Since: v1.14.
+    rlcp: true
+
     # Can be used to change the archive formats for specific GOOSs.
     # Most common use case is to archive as zip on Windows.
     # Default is empty.
@@ -93,14 +103,6 @@ archives:
         # Strip parent folders when adding files to the archive.
         # Default: false
         strip_parent: true
-
-        # This will make the destination paths be relative to the longest common
-        # path prefix between all the files matched and the source glob.
-        # Enabling this essentially mimic the behavior of nfpm's contents section.
-        #
-        # Default: false
-        # Since: v1.14.
-        rlcp: true
 
         # File info.
         # Not all fields are supported by all formats available formats.

--- a/www/docs/customization/source.md
+++ b/www/docs/customization/source.md
@@ -24,6 +24,15 @@ source:
   # Defaults to empty
   prefix_template: '{{ .ProjectName }}-{{ .Version }}/'
 
+  # This will make the destination paths be relative to the longest common
+  # path prefix between all the files matched and the source glob.
+  # Enabling this essentially mimic the behavior of nfpm's contents section.
+  # It will be the default by June 2023.
+  #
+  # Default: false
+  # Since: v1.14.
+  rlcp: true
+
   # Additional files/template/globs you want to add to the source archive.
   #
   # Default: empty.
@@ -42,14 +51,6 @@ source:
       # Strip parent folders when adding files to the archive.
       # Default: false
       strip_parent: true
-
-      # This will make the destination paths be relative to the longest common
-      # path prefix between all the files matched and the source glob.
-      # Enabling this essentially mimic the behavior of nfpm's contents section.
-      #
-      # Default: false
-      # Since: v1.14.
-      rlcp: true
 
       # File info.
       # Not all fields are supported by all formats available formats.

--- a/www/docs/customization/source.md
+++ b/www/docs/customization/source.md
@@ -44,12 +44,12 @@ source:
       strip_parent: true
 
       # This will make the destination paths be relative to the longest common
-      # prefix between all the files matched and the source glob.
+      # path prefix between all the files matched and the source glob.
       # Enabling this essentially mimic the behavior of nfpm's contents section.
       #
       # Default: false
       # Since: v1.14.
-      relative: true
+      rlcp: true
 
       # File info.
       # Not all fields are supported by all formats available formats.

--- a/www/docs/customization/source.md
+++ b/www/docs/customization/source.md
@@ -38,9 +38,19 @@ source:
     # a more complete example, check the globbing deep dive below
     - src: '*.md'
       dst: docs
+
       # Strip parent folders when adding files to the archive.
       # Default: false
       strip_parent: true
+
+      # This will make the destination paths be relative to the longest common
+      # prefix between all the files matched and the source glob.
+      # Enabling this essentially mimic the behavior of nfpm's contents section.
+      #
+      # Default: false
+      # Since: v1.14.
+      relative: true
+
       # File info.
       # Not all fields are supported by all formats available formats.
       # Defaults to the file info of the actual file if not provided.
@@ -50,7 +60,6 @@ source:
         mode: 0644
         # format is `time.RFC3339Nano`
         mtime: 2008-01-02T15:04:05Z
-
 ```
 
 !!! tip

--- a/www/docs/deprecations.md
+++ b/www/docs/deprecations.md
@@ -36,6 +36,46 @@ Description.
 
 -->
 
+
+### archives.rlcp
+
+> since 2022-12-23 (v1.14.0)
+
+This is not so much a deprecation property (yet), as it is a default behavior
+change.
+
+The usage of relative longest common path (`rlcp`) on the destination side of
+archive files will be enabled by default by June 2023. Then, this option will be
+deprecated, and you will have another 6 months (until December 2023) to remove
+it.
+
+For now, if you want to keep the old behavior, no action is required, but it
+would be nice to have your opinion [here][rlcp-discuss].
+
+[rlcp-discuss]: https://github.com/goreleaser/goreleaser/discussions/3659
+
+If you want to make sure your releases will keep working properly, you can
+enable this option and test it out with
+`goreleaser release --snapshot --rm-dist`.
+
+=== "After"
+    ``` yaml
+    archives:
+      rlcp: true
+    ```
+
+### source.rlcp
+
+> since 2022-12-23 (v1.14.0)
+
+Same as [`archives.rlcp`](#archivesrlcp).
+
+=== "After"
+    ``` yaml
+    source:
+      rlcp: true
+    ```
+
 ### archives.replacements
 
 > since 2022-11-24 (v1.14.0)

--- a/www/docs/deprecations.md
+++ b/www/docs/deprecations.md
@@ -61,6 +61,7 @@ enable this option and test it out with
 === "After"
     ``` yaml
     archives:
+    -
       rlcp: true
     ```
 


### PR DESCRIPTION
with this patch, a config like:

```yaml
archives:
  - format: tar.gz
    # this name template makes the OS and Arch compatible with the results of uname.
    name_template: >-
      {{ .ProjectName }}_
      {{- title .Os }}_
      {{- if eq .Arch "amd64" }}x86_64
      {{- else if eq .Arch "386" }}i386
      {{- else }}{{ .Arch }}{{ end }}
      {{- if .Arm }}v{{ .Arm }}{{ end }}
    rlcp: true
    files:
      - src: "build/**/*"
        dst: .

nfpms:
  - package_name: foo
    contents:
      - src: "build/**/*"
        dst: usr/share/foo
    formats:
      - apk

```

will eval this:

<img width="1384" alt="CleanShot 2022-12-21 at 22 21 00@2x" src="https://user-images.githubusercontent.com/245435/209034244-7c31b5f7-cfcd-4825-bb2f-7dd463c5286a.png">

as much as I would like to make this the default, it would be a breaking change, so we really can't do it.

If `dst` is empty, it'll have the same behavior as before (no rlcp), and if `strip_parent` is set, it will also still have the same behavior. Finally, if the format is binary, `rlcp` is ignored too (as it doesn't make sense).

So, this only changes if:
- your format is not binary; and
- you have files with `src` and `dst` set

Then, goreleaser will warn you to set `rlcp: true`.

## todo

- [x] docs
- [x] more tests probably
- [x] any ideas for a better name for the new config option?

fixes #3655 

