### PR TITLE
feat: allow to template apk keyname

### DIFF
--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -212,6 +212,11 @@ func create(ctx *context.Context, fpm config.NFPM, format string, binaries []*ar
 	if err != nil {
 		return err
 	}
+	
+	apkKeyName, err := t.Apply(overridden.APK.Signature.KeyName)
+	if err != nil {
+		return err
+	}
 
 	contents := files.Contents{}
 	for _, content := range overridden.Contents {
@@ -353,7 +358,7 @@ func create(ctx *context.Context, fpm config.NFPM, format string, binaries []*ar
 						KeyFile:       apkKeyFile,
 						KeyPassphrase: getPassphraseFromEnv(ctx, "APK", fpm.ID),
 					},
-					KeyName: overridden.APK.Signature.KeyName,
+					KeyName: apkKeyName,
 				},
 				Scripts: nfpm.APKScripts{
 					PreUpgrade:  overridden.APK.Scripts.PreUpgrade,


### PR DESCRIPTION
To help solve this issue
```
    apk:
      signature:
        key_file: "{{ .Env.ABUILD_KEY_NAME }}.rsa"
        key_name: "{{ .Env.ABUILD_KEY_NAME }}"
```

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

Allow that the key_name in apk signature to be templated

<!-- Why is this change being made? -->

The name of the key might not be hardcoded, in a github workflow

<!-- # Provide links to any relevant tickets, URLs or other resources -->

...
