### PR TITLE
fix: do not put binaries in /usr/local/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --no-cache bash \
 	tini
 
 # install cosign
-COPY --from=gcr.io/projectsigstore/cosign:v1.12.1@sha256:ac8e08a2141e093f4fd7d1d0b05448804eb3771b66574b13ad73e31b460af64d /ko-app/cosign /usr/local/bin/cosign
+COPY --from=gcr.io/projectsigstore/cosign:v1.12.1@sha256:ac8e08a2141e093f4fd7d1d0b05448804eb3771b66574b13ad73e31b460af64d /ko-app/cosign /usr/bin/cosign
 
 ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]
 CMD [ "-h" ]

--- a/www/docs/customization/nfpm.md
+++ b/www/docs/customization/nfpm.md
@@ -137,18 +137,18 @@ nfpms:
     # GoReleaser will automatically add the binaries.
     contents:
       # Basic file that applies to all packagers
-      - src: path/to/local/foo
-        dst: /usr/local/bin/foo
+      - src: path/to/foo
+        dst: /usr/bin/foo
 
       # Simple config file
-      - src: path/to/local/foo.conf
+      - src: path/to/foo.conf
         dst: /etc/foo.conf
         type: config
 
       # Simple symlink.
       # Corresponds to `ln -s /sbin/foo /usr/local/bin/foo`
       - src: /sbin/foo
-        dst: /usr/local/bin/foo
+        dst: /usr/bin/foo
         type: "symlink"
 
       # Corresponds to `%config(noreplace)` if the packager is rpm, otherwise it


### PR DESCRIPTION
/usr/local/bin is for binaries compiled locally, which is not the case in our docker image or in our examples.