### PR TITLE
docs: rename `.goreleaser.yml` to `.goreleaser.yaml` in intro

### DIFF
--- a/www/docs/intro.md
+++ b/www/docs/intro.md
@@ -47,7 +47,7 @@ Installing it in your machine is entirely up to you, but still possible.
 
 ## Usage
 
-Your entire release process is customized through a `.goreleaser.yml` file.
+Your entire release process is customized through a `.goreleaser.yaml` file.
 
 Once you set it up, every time you want to create a new release, all you need to
 do is push a git tag and run `goreleaser release`:


### PR DESCRIPTION

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->

Every other instance I have seen so far uses `.yaml` so, for consistency, let's rename this one?

<!-- # Provide links to any relevant tickets, URLs or other resources -->

