### PR TITLE
feat: deprecate --rm-dist in favor of new --clean flag

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -223,4 +223,4 @@ tasks:
       SNAPSHOT:
         sh: 'if [[ $GITHUB_REF != refs/tags/v* ]]; then echo "--snapshot"; fi'
     cmds:
-      - ./goreleaser release --rm-dist {{.SNAPSHOT}}
+      - ./goreleaser release --clean {{.SNAPSHOT}}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -33,7 +33,7 @@ type buildOpts struct {
 	skipValidate  bool
 	skipBefore    bool
 	skipPostHooks bool
-	rmDist        bool
+	clean         bool
 	deprecated    bool
 	parallelism   int
 	timeout       time.Duration
@@ -74,7 +74,8 @@ When using ` + "`--single-target`" + `, the ` + "`GOOS`" + ` and ` + "`GOARCH`" 
 	cmd.Flags().BoolVar(&root.opts.skipValidate, "skip-validate", false, "Skips several sanity checks")
 	cmd.Flags().BoolVar(&root.opts.skipBefore, "skip-before", false, "Skips global before hooks")
 	cmd.Flags().BoolVar(&root.opts.skipPostHooks, "skip-post-hooks", false, "Skips all post-build hooks")
-	cmd.Flags().BoolVar(&root.opts.rmDist, "rm-dist", false, "Remove the dist folder before building")
+	cmd.Flags().BoolVar(&root.opts.clean, "clean", false, "Remove the dist folder before building")
+	cmd.Flags().BoolVar(&root.opts.clean, "rm-dist", false, "Remove the dist folder before building")
 	cmd.Flags().IntVarP(&root.opts.parallelism, "parallelism", "p", 0, "Amount tasks to run concurrently (default: number of CPUs)")
 	cmd.Flags().DurationVar(&root.opts.timeout, "timeout", 30*time.Minute, "Timeout to the entire build process")
 	cmd.Flags().BoolVar(&root.opts.singleTarget, "single-target", false, "Builds only for current GOOS and GOARCH, regardless of what's set in the configuration file")
@@ -82,6 +83,8 @@ When using ` + "`--single-target`" + `, the ` + "`GOOS`" + ` and ` + "`GOARCH`" 
 	cmd.Flags().BoolVar(&root.opts.deprecated, "deprecated", false, "Force print the deprecation message - tests only")
 	cmd.Flags().StringVarP(&root.opts.output, "output", "o", "", "Copy the binary to the path after the build. Only taken into account when using --single-target and a single id (either with --id or if configuration only has one build)")
 	_ = cmd.Flags().SetAnnotation("output", cobra.BashCompFilenameExt, []string{""})
+	_ = cmd.Flags().MarkHidden("rm-dist")
+	_ = cmd.Flags().MarkDeprecated("rm-dist", "please use --clean instead")
 	_ = cmd.Flags().MarkHidden("deprecated")
 
 	root.cmd = cmd
@@ -131,7 +134,7 @@ func setupBuildContext(ctx *context.Context, options buildOpts) error {
 	ctx.SkipValidate = ctx.Snapshot || options.skipValidate
 	ctx.SkipBefore = options.skipBefore
 	ctx.SkipPostBuildHooks = options.skipPostHooks
-	ctx.RmDist = options.rmDist
+	ctx.RmDist = options.clean
 	ctx.SkipTokenCheck = true
 
 	if options.singleTarget {

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -164,7 +164,7 @@ func TestBuildFlags(t *testing.T) {
 
 	t.Run("rm dist", func(t *testing.T) {
 		require.True(t, setup(buildOpts{
-			rmDist: true,
+			clean: true,
 		}).RmDist)
 	})
 

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -38,7 +38,7 @@ type releaseOpts struct {
 	skipDocker         bool
 	skipKo             bool
 	skipBefore         bool
-	rmDist             bool
+	clean              bool
 	deprecated         bool
 	parallelism        int
 	timeout            time.Duration
@@ -81,11 +81,14 @@ func newReleaseCmd() *releaseCmd {
 	cmd.Flags().BoolVar(&root.opts.skipKo, "skip-ko", false, "Skips Ko builds")
 	cmd.Flags().BoolVar(&root.opts.skipBefore, "skip-before", false, "Skips global before hooks")
 	cmd.Flags().BoolVar(&root.opts.skipValidate, "skip-validate", false, "Skips git checks")
-	cmd.Flags().BoolVar(&root.opts.rmDist, "rm-dist", false, "Removes the dist folder")
+	cmd.Flags().BoolVar(&root.opts.clean, "clean", false, "Removes the dist folder")
+	cmd.Flags().BoolVar(&root.opts.clean, "rm-dist", false, "Removes the dist folder")
 	cmd.Flags().IntVarP(&root.opts.parallelism, "parallelism", "p", 0, "Amount tasks to run concurrently (default: number of CPUs)")
 	cmd.Flags().DurationVar(&root.opts.timeout, "timeout", 30*time.Minute, "Timeout to the entire release process")
 	cmd.Flags().BoolVar(&root.opts.deprecated, "deprecated", false, "Force print the deprecation message - tests only")
 	_ = cmd.Flags().MarkHidden("deprecated")
+	_ = cmd.Flags().MarkHidden("rm-dist")
+	_ = cmd.Flags().MarkDeprecated("rm-dist", "please use --clean instead")
 	_ = cmd.Flags().SetAnnotation("config", cobra.BashCompFilenameExt, []string{"yaml", "yml"})
 
 	root.cmd = cmd
@@ -141,7 +144,7 @@ func setupReleaseContext(ctx *context.Context, options releaseOpts) {
 	ctx.SkipDocker = options.skipDocker
 	ctx.SkipKo = options.skipKo
 	ctx.SkipBefore = options.skipBefore
-	ctx.RmDist = options.rmDist
+	ctx.RmDist = options.clean
 
 	// test only
 	ctx.Deprecated = options.deprecated

--- a/cmd/release_test.go
+++ b/cmd/release_test.go
@@ -119,7 +119,7 @@ func TestReleaseFlags(t *testing.T) {
 
 	t.Run("rm dist", func(t *testing.T) {
 		require.True(t, setup(t, releaseOpts{
-			rmDist: true,
+			clean: true,
 		}).RmDist)
 	})
 }

--- a/internal/pipe/dist/dist.go
+++ b/internal/pipe/dist/dist.go
@@ -25,7 +25,7 @@ func (Pipe) Run(ctx *context.Context) (err error) {
 		return mkdir(ctx)
 	}
 	if ctx.RmDist {
-		log.Info("--rm-dist is set, cleaning it up")
+		log.Infof("cleaning %s", ctx.Config.Dist)
 		err = os.RemoveAll(ctx.Config.Dist)
 		if err == nil {
 			err = mkdir(ctx)
@@ -39,7 +39,7 @@ func (Pipe) Run(ctx *context.Context) (err error) {
 	if len(files) != 0 {
 		log.Debugf("there are %d files on %s", len(files), ctx.Config.Dist)
 		return fmt.Errorf(
-			"%s is not empty, remove it before running goreleaser or use the --rm-dist flag",
+			"%s is not empty, remove it before running goreleaser or use the --clean flag",
 			ctx.Config.Dist,
 		)
 	}

--- a/www/docs/ci/actions.md
+++ b/www/docs/ci/actions.md
@@ -45,7 +45,7 @@ jobs:
           # either 'goreleaser' (default) or 'goreleaser-pro':
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro'
@@ -97,7 +97,7 @@ the [Import GPG][import-gpg] GitHub Action along with this one:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
@@ -179,7 +179,7 @@ step will look like this:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 ```

--- a/www/docs/ci/codefresh.md
+++ b/www/docs/ci/codefresh.md
@@ -31,7 +31,7 @@ steps:
     stage: release
     image: 'goreleaser/goreleaser'
     commands:
-      - goreleaser --rm-dist
+      - goreleaser --clean
 ```
 
 You need to pass the variable `GITHUB_TOKEN` in the Codefresh UI that

--- a/www/docs/ci/gitlab.md
+++ b/www/docs/ci/gitlab.md
@@ -45,7 +45,7 @@ release:
     # generate a changelog.
     GIT_DEPTH: 0
   script:
-    - goreleaser release --rm-dist
+    - goreleaser release --clean
 ```
 
 Notice that `entrypoint` is intentionally blank. See the
@@ -99,7 +99,7 @@ release:
       -v /var/run/docker.sock:/var/run/docker.sock \
       -e DOCKER_USERNAME -e DOCKER_PASSWORD -e DOCKER_REGISTRY  \
       -e GITLAB_TOKEN \
-      goreleaser/goreleaser release --rm-dist
+      goreleaser/goreleaser release --clean
 ```
 
 In GitLab CI settings, add variables for `DOCKER_REGISTRY`, `DOCKER_USERNAME`,

--- a/www/docs/cmd/goreleaser_build.md
+++ b/www/docs/cmd/goreleaser_build.md
@@ -25,7 +25,7 @@ goreleaser build [flags]
       --id stringArray     Builds only the specified build ids
   -o, --output string      Copy the binary to the path after the build. Only taken into account when using --single-target and a single id (either with --id or if configuration only has one build)
   -p, --parallelism int    Amount tasks to run concurrently (default: number of CPUs)
-      --rm-dist            Remove the dist folder before building
+      --clean            Remove the dist folder before building
       --single-target      Builds only for current GOOS and GOARCH, regardless of what's set in the configuration file
       --skip-after         Skips global after hooks
       --skip-before        Skips global before hooks

--- a/www/docs/cmd/goreleaser_release.md
+++ b/www/docs/cmd/goreleaser_release.md
@@ -22,7 +22,7 @@ goreleaser release [flags]
       --release-header-tmpl string   Load custom release notes header from a templated markdown file (overrides --release-header)
       --release-notes string         Load custom release notes from a markdown file (will skip GoReleaser changelog generation)
       --release-notes-tmpl string    Load custom release notes from a templated markdown file (overrides --release-notes)
-      --rm-dist                      Removes the dist folder
+      --clean                      Removes the dist folder
       --skip-after                   Skips global after hooks
       --skip-announce                Skips announcing releases (implies --skip-validate)
       --skip-before                  Skips global before hooks

--- a/www/docs/cookbooks/override-image-name.md
+++ b/www/docs/cookbooks/override-image-name.md
@@ -33,7 +33,7 @@ Action like the following:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
        env:
          REGISTRY: ${{ env.REGISTRY }}
          IMAGE: ${{ env.IMAGE_NAME }}

--- a/www/docs/cookbooks/semantic-release.md
+++ b/www/docs/cookbooks/semantic-release.md
@@ -10,7 +10,7 @@ You can, though, leverage other tools to do the work for you, like for example
 ```bash
 git tag "$(svu next)"
 git push --tags
-goreleaser --rm-dist
+goreleaser --clean
 ```
 
 ## Example: semantic-release
@@ -27,7 +27,7 @@ plugins:
   - - "@semantic-release/exec"
     - publishCmd: |
         echo "${nextRelease.notes}" > /tmp/release-notes.md
-        goreleaser release --release-notes /tmp/release-notes.md --rm-dist
+        goreleaser release --release-notes /tmp/release-notes.md --clean
 ```
 
 ```bash

--- a/www/docs/customization/monorepo.md
+++ b/www/docs/customization/monorepo.md
@@ -33,7 +33,7 @@ monorepo:
 Then, you can release with (from the project's root directory):
 
 ```bash
-goreleaser release --rm-dist -f ./subproj1/.goreleaser.yaml
+goreleaser release --clean -f ./subproj1/.goreleaser.yaml
 ```
 
 Then, the following is different from a "regular" run:
@@ -69,7 +69,7 @@ monorepo:
 Then, you can release with:
 
 ```bash
-goreleaser release --rm-dist
+goreleaser release --clean
 ```
 
 GoReleaser will then ignore the tags that are not prefixed with `v`, and it

--- a/www/docs/customization/partial.md
+++ b/www/docs/customization/partial.md
@@ -19,9 +19,9 @@ This feature can help in some areas:
 You don't really need to set anything up. To get started, run:
 
 ```bash
-goreleaser release --rm-dist --split
-GOOS=darwin goreleaser release --rm-dist --split
-GGOOS=windows goreleaser release --rm-dist --split
+goreleaser release --clean --split
+GOOS=darwin goreleaser release --clean --split
+GGOOS=windows goreleaser release --clean --split
 ```
 
 Note that this step will push your Docker images as well.

--- a/www/docs/deprecations.md
+++ b/www/docs/deprecations.md
@@ -37,6 +37,23 @@ Description.
 -->
 
 
+### --rm-dist
+
+> since 2023-01-17 (v1.15.0)
+
+`--rm-dist` has been deprecated in favor of `--clean`.
+
+=== "Before"
+
+    ```bash
+    goreleaser --rm-dist
+    ```
+
+=== "After"
+    ```bash
+    goreleaser --clean
+    ```
+
 ### archives.rlcp
 
 > since 2022-12-23 (v1.14.0)
@@ -56,7 +73,7 @@ would be nice to have your opinion [here][rlcp-discuss].
 
 If you want to make sure your releases will keep working properly, you can
 enable this option and test it out with
-`goreleaser release --snapshot --rm-dist`.
+`goreleaser release --snapshot --clean`.
 
 === "After"
     ``` yaml

--- a/www/docs/errors/no-main.md
+++ b/www/docs/errors/no-main.md
@@ -35,3 +35,17 @@ For more info, check the [builds documentation](/customization/build/).
 ## If you ran goreleaser outside the root of the project
 
 Run goreleaser in the root of the project.
+
+## If you are building in `plugin`, `c-shared` or `c-archive` build modes
+
+You can set `no_main_check` to `true`:
+
+```yaml
+# .goreleaser.yaml
+builds:
+- main: ./path/...
+  buildmode: plugin
+  no_main_check: true
+```
+
+For more info, check the [builds documentation](/customization/build/).

--- a/www/docs/install.md
+++ b/www/docs/install.md
@@ -170,7 +170,7 @@ Use it for testing out new features only.
 === "Pro"
     ```bash
     curl -sfL https://goreleaser.com/static/run |
-      VERSION=nightly DISTRIBUTION=pro bash -s -- release --rm-dist
+      VERSION=nightly DISTRIBUTION=pro bash -s -- release --clean
     ```
 
 #### docker

--- a/www/docs/quick-start.md
+++ b/www/docs/quick-start.md
@@ -27,7 +27,7 @@ goreleaser init
 Now, lets run a "local-only" release to see if it works using the [release](/cmd/goreleaser_release/) command:
 
 ```sh
-goreleaser release --snapshot --rm-dist
+goreleaser release --snapshot --clean
 ```
 
 At this point, you can [customize](/customization/) the generated `.goreleaser.yaml` or leave it as-is, it's up to you.


### PR DESCRIPTION
After talking with @perylemke, we realized that probably most people will likely expect it to be called --clean instead of --rm-dist, as its more similar to the popular `make clean` task.

This adds the --clean flag, and make the --rm-dist one deprecated.
