### PR TITLE
fix: only debs should create iphoneos pkgs

### DIFF
--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -145,7 +145,11 @@ func create(ctx *context.Context, fpm config.NFPM, format string, binaries []*ar
 	arch := infoArch + binaries[0].Goamd64                                  // unique arch key
 	infoPlatform := binaries[0].Goos
 	if infoPlatform == "ios" {
-		infoPlatform = "iphoneos-arm64"
+		if format == "deb" {
+			infoPlatform = "iphoneos-arm64"
+		} else {
+			return nil
+		}
 	}
 
 	bindDir := fpm.Bindir

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -250,7 +250,7 @@ func TestRunPipe(t *testing.T) {
 	}
 	require.NoError(t, Pipe{}.Run(ctx))
 	packages := ctx.Artifacts.Filter(artifact.ByType(artifact.LinuxPackage)).List()
-	require.Len(t, packages, 51)
+	require.Len(t, packages, 47)
 	for _, pkg := range packages {
 		format := pkg.Format()
 		require.NotEmpty(t, format)


### PR DESCRIPTION
problem was made evident in the last nfpm update... this should fix it.

refs #3715