### PR TITLE
fix: improve handling of --rm-dist deprecation 

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -11,6 +11,7 @@ import (
 	"github.com/caarlos0/ctrlc"
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/internal/artifact"
+	"github.com/goreleaser/goreleaser/internal/deprecate"
 	"github.com/goreleaser/goreleaser/internal/gio"
 	"github.com/goreleaser/goreleaser/internal/middleware/errhandler"
 	"github.com/goreleaser/goreleaser/internal/middleware/logging"
@@ -34,6 +35,7 @@ type buildOpts struct {
 	skipBefore    bool
 	skipPostHooks bool
 	clean         bool
+	rmDist        bool // deprecated
 	deprecated    bool
 	parallelism   int
 	timeout       time.Duration
@@ -75,7 +77,7 @@ When using ` + "`--single-target`" + `, the ` + "`GOOS`" + ` and ` + "`GOARCH`" 
 	cmd.Flags().BoolVar(&root.opts.skipBefore, "skip-before", false, "Skips global before hooks")
 	cmd.Flags().BoolVar(&root.opts.skipPostHooks, "skip-post-hooks", false, "Skips all post-build hooks")
 	cmd.Flags().BoolVar(&root.opts.clean, "clean", false, "Remove the dist folder before building")
-	cmd.Flags().BoolVar(&root.opts.clean, "rm-dist", false, "Remove the dist folder before building")
+	cmd.Flags().BoolVar(&root.opts.rmDist, "rm-dist", false, "Remove the dist folder before building")
 	cmd.Flags().IntVarP(&root.opts.parallelism, "parallelism", "p", 0, "Amount tasks to run concurrently (default: number of CPUs)")
 	cmd.Flags().DurationVar(&root.opts.timeout, "timeout", 30*time.Minute, "Timeout to the entire build process")
 	cmd.Flags().BoolVar(&root.opts.singleTarget, "single-target", false, "Builds only for current GOOS and GOARCH, regardless of what's set in the configuration file")
@@ -84,7 +86,6 @@ When using ` + "`--single-target`" + `, the ` + "`GOOS`" + ` and ` + "`GOARCH`" 
 	cmd.Flags().StringVarP(&root.opts.output, "output", "o", "", "Copy the binary to the path after the build. Only taken into account when using --single-target and a single id (either with --id or if configuration only has one build)")
 	_ = cmd.Flags().SetAnnotation("output", cobra.BashCompFilenameExt, []string{""})
 	_ = cmd.Flags().MarkHidden("rm-dist")
-	_ = cmd.Flags().MarkDeprecated("rm-dist", "please use --clean instead")
 	_ = cmd.Flags().MarkHidden("deprecated")
 
 	root.cmd = cmd
@@ -125,6 +126,7 @@ func setupPipeline(ctx *context.Context, options buildOpts) []pipeline.Piper {
 }
 
 func setupBuildContext(ctx *context.Context, options buildOpts) error {
+	ctx.Deprecated = options.deprecated // test only
 	ctx.Parallelism = runtime.NumCPU()
 	if options.parallelism > 0 {
 		ctx.Parallelism = options.parallelism
@@ -134,8 +136,12 @@ func setupBuildContext(ctx *context.Context, options buildOpts) error {
 	ctx.SkipValidate = ctx.Snapshot || options.skipValidate
 	ctx.SkipBefore = options.skipBefore
 	ctx.SkipPostBuildHooks = options.skipPostHooks
-	ctx.RmDist = options.clean
 	ctx.SkipTokenCheck = true
+	ctx.Clean = options.clean || options.rmDist
+
+	if options.rmDist {
+		deprecate.NoticeCustom(ctx, "-rm-dist", "--rm-dist was deprecated in favor of --clean, check {{ .URL }} for more details")
+	}
 
 	if options.singleTarget {
 		setupBuildSingleTarget(ctx)
@@ -147,8 +153,6 @@ func setupBuildContext(ctx *context.Context, options buildOpts) error {
 		}
 	}
 
-	// test only
-	ctx.Deprecated = options.deprecated
 	return nil
 }
 

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -165,7 +165,7 @@ func TestBuildFlags(t *testing.T) {
 	t.Run("rm dist", func(t *testing.T) {
 		require.True(t, setup(buildOpts{
 			clean: true,
-		}).RmDist)
+		}).Clean)
 	})
 
 	t.Run("single-target", func(t *testing.T) {

--- a/cmd/release_test.go
+++ b/cmd/release_test.go
@@ -120,6 +120,6 @@ func TestReleaseFlags(t *testing.T) {
 	t.Run("rm dist", func(t *testing.T) {
 		require.True(t, setup(t, releaseOpts{
 			clean: true,
-		}).RmDist)
+		}).Clean)
 	})
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -123,7 +123,7 @@ func shouldPrependRelease(cmd *cobra.Command, args []string) bool {
 
 func deprecateWarn(ctx *context.Context) {
 	if ctx.Deprecated {
-		log.Warn(boldStyle.Render("your config is using deprecated properties, check logs above for details"))
+		log.Warn(boldStyle.Render("you are using deprecated options, check the output above for details"))
 	}
 }
 

--- a/internal/deprecate/deprecate.go
+++ b/internal/deprecate/deprecate.go
@@ -34,10 +34,12 @@ func NoticeCustom(ctx *context.Context, property, tmpl string) {
 		" ", "-",
 	).Replace(property)
 	var out bytes.Buffer
-	if err := template.Must(template.New("deprecation").Parse("DEPRECATED: "+tmpl)).Execute(&out, templateData{
-		URL:      url,
-		Property: property,
-	}); err != nil {
+	if err := template.
+		Must(template.New("deprecation").Parse("DEPRECATED: "+tmpl)).
+		Execute(&out, templateData{
+			URL:      url,
+			Property: property,
+		}); err != nil {
 		panic(err) // this should never happen
 	}
 

--- a/internal/pipe/dist/dist.go
+++ b/internal/pipe/dist/dist.go
@@ -24,7 +24,7 @@ func (Pipe) Run(ctx *context.Context) (err error) {
 		log.Debugf("%s doesn't exist, creating empty folder", ctx.Config.Dist)
 		return mkdir(ctx)
 	}
-	if ctx.RmDist {
+	if ctx.Clean {
 		log.Infof("cleaning %s", ctx.Config.Dist)
 		err = os.RemoveAll(ctx.Config.Dist)
 		if err == nil {

--- a/internal/pipe/dist/dist_test.go
+++ b/internal/pipe/dist/dist_test.go
@@ -38,7 +38,7 @@ func TestPopulatedDistExists(t *testing.T) {
 		},
 	}
 	require.Error(t, Pipe{}.Run(ctx))
-	ctx.RmDist = true
+	ctx.Clean = true
 	require.NoError(t, Pipe{}.Run(ctx))
 	_, err = os.Stat(dist)
 	require.False(t, os.IsExist(err))

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -99,7 +99,7 @@ type Context struct {
 	SkipKo             bool
 	SkipDocker         bool
 	SkipBefore         bool
-	RmDist             bool
+	Clean              bool
 	PreRelease         bool
 	Deprecated         bool
 	Parallelism        int


### PR DESCRIPTION
- improved how we handle `--rm-dist` deprecation so it looks more like other deprecations
- improved deprecation error message a bit as well