### PR TITLE
Fix deprecation notice for `--rm-dist` -> `--clean`

### DIFF
--- a/www/docs/deprecations.md
+++ b/www/docs/deprecations.md
@@ -41,7 +41,7 @@ Description.
 
 > since 2023-01-17 (v1.15.0)
 
-`--rm-dist` has been deprecated in favor of `--rm-dist`.
+`--rm-dist` has been deprecated in favor of `--clean`.
 
 === "Before"
 
@@ -50,8 +50,9 @@ Description.
     ```
 
 === "After"
+
     ```bash
-    goreleaser --rm-dist
+    goreleaser --clean
     ```
 
 ### archives.rlcp


### PR DESCRIPTION
<!-- If applied, this commit will... -->
Fix the deprecation notice page to reference the correct new flag replacing `--rm-dist`

...

<!-- Why is this change being made? -->
The documentation for this deprecation seems incorrect, and live on the main page.

...

<!-- # Provide links to any relevant tickets, URLs or other resources -->
https://goreleaser.com/deprecations/#-rm-dist
...

I used this commit to reference what it was being changed to: https://github.com/goreleaser/goreleaser/commit/4954815ae491b8c81f884660f76323d77218adf1