### PR TITLE
build: increase release timeout

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -223,4 +223,4 @@ tasks:
       SNAPSHOT:
         sh: 'if [[ $GITHUB_REF != refs/tags/v* ]]; then echo "--snapshot"; fi'
     cmds:
-      - ./goreleaser release --clean {{.SNAPSHOT}}
+      - ./goreleaser release --clean --timeout 60m {{.SNAPSHOT}}


### PR DESCRIPTION
our build is too close to the default 30m timeout, this should prevent it from failing, as it [did today](https://github.com/goreleaser/goreleaser/actions/runs/4049530951/jobs/6966004880)