### PR TITLE
fix: honouring ko bare option

### DIFF
--- a/internal/pipe/ko/ko.go
+++ b/internal/pipe/ko/ko.go
@@ -225,7 +225,7 @@ func doBuild(ctx *context.Context, ko config.Ko) func() error {
 			return fmt.Errorf("build: %w", err)
 		}
 
-		po := []publish.Option{publish.WithNamer(options.MakeNamer(&options.PublishOptions{
+		po := []publish.Option{publish.WithTags(opts.tags), publish.WithNamer(options.MakeNamer(&options.PublishOptions{
 			DockerRepo:          opts.imageRepo,
 			Bare:                opts.bare,
 			PreserveImportPaths: opts.preserveImportPaths,

--- a/internal/pipe/ko/ko.go
+++ b/internal/pipe/ko/ko.go
@@ -225,25 +225,15 @@ func doBuild(ctx *context.Context, ko config.Ko) func() error {
 			return fmt.Errorf("build: %w", err)
 		}
 
-		po := []publish.Option{publish.WithTags(opts.tags), publish.WithAuthFromKeychain(keychain)}
-
-		var repo string
-		if opts.fromEnv {
-			repo = opts.imageRepo
-		} else {
-			// image resource's `repo` takes precedence if set, and selects the
-			// `--bare` namer so the image is named exactly `repo`.
-			repo = opts.imageRepo
-		}
-		// irrespective of opts.fromEnv set other ko options, fixes issue-3472
-		po = append(po, publish.WithNamer(options.MakeNamer(&options.PublishOptions{
+		po := []publish.Option{publish.WithNamer(options.MakeNamer(&options.PublishOptions{
 			DockerRepo:          opts.imageRepo,
 			Bare:                opts.bare,
 			PreserveImportPaths: opts.preserveImportPaths,
 			BaseImportPaths:     opts.baseImportPaths,
-		})))
+			Tags:                opts.tags,
+		})), publish.WithAuthFromKeychain(keychain)}
 
-		p, err := publish.NewDefault(repo, po...)
+		p, err := publish.NewDefault(opts.imageRepo, po...)
 		if err != nil {
 			return fmt.Errorf("newDefault: %w", err)
 		}

--- a/internal/pipe/ko/ko.go
+++ b/internal/pipe/ko/ko.go
@@ -234,13 +234,14 @@ func doBuild(ctx *context.Context, ko config.Ko) func() error {
 			// image resource's `repo` takes precedence if set, and selects the
 			// `--bare` namer so the image is named exactly `repo`.
 			repo = opts.imageRepo
-			po = append(po, publish.WithNamer(options.MakeNamer(&options.PublishOptions{
-				DockerRepo:          opts.imageRepo,
-				Bare:                opts.bare,
-				PreserveImportPaths: opts.preserveImportPaths,
-				BaseImportPaths:     opts.baseImportPaths,
-			})))
 		}
+		// irrespective of opts.fromEnv set other ko options, fixes issue-3472
+		po = append(po, publish.WithNamer(options.MakeNamer(&options.PublishOptions{
+			DockerRepo:          opts.imageRepo,
+			Bare:                opts.bare,
+			PreserveImportPaths: opts.preserveImportPaths,
+			BaseImportPaths:     opts.baseImportPaths,
+		})))
 
 		p, err := publish.NewDefault(repo, po...)
 		if err != nil {

--- a/internal/pipe/ko/ko.go
+++ b/internal/pipe/ko/ko.go
@@ -109,7 +109,6 @@ func (Pipe) Default(ctx *context.Context) error {
 
 		if repo := ctx.Env["KO_DOCKER_REPO"]; repo != "" {
 			ko.Repository = repo
-			ko.RepositoryFromEnv = true
 		}
 
 		if ko.Repository == "" {
@@ -136,7 +135,6 @@ type buildOptions struct {
 	flags               []string
 	env                 []string
 	imageRepo           string
-	fromEnv             bool
 	workingDir          string
 	platforms           []string
 	baseImage           string
@@ -293,7 +291,6 @@ func buildBuildOptions(ctx *context.Context, cfg config.Ko) (*buildOptions, erro
 		platforms:           cfg.Platforms,
 		sbom:                cfg.SBOM,
 		imageRepo:           cfg.Repository,
-		fromEnv:             cfg.RepositoryFromEnv,
 	}
 
 	tags, err := applyTemplate(ctx, cfg.Tags)

--- a/internal/pipe/ko/ko_test.go
+++ b/internal/pipe/ko/ko_test.go
@@ -44,18 +44,17 @@ func TestDefault(t *testing.T) {
 	})
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, config.Ko{
-		ID:                "test",
-		Build:             "test",
-		BaseImage:         chainguardStatic,
-		Repository:        registry,
-		RepositoryFromEnv: true,
-		Platforms:         []string{"linux/amd64"},
-		SBOM:              "spdx",
-		Tags:              []string{"latest"},
-		WorkingDir:        ".",
-		Ldflags:           []string{"{{.Env.LDFLAGS}}"},
-		Flags:             []string{"{{.Env.FLAGS}}"},
-		Env:               []string{"SOME_ENV={{.Env.LE_ENV}}"},
+		ID:         "test",
+		Build:      "test",
+		BaseImage:  chainguardStatic,
+		Repository: registry,
+		Platforms:  []string{"linux/amd64"},
+		SBOM:       "spdx",
+		Tags:       []string{"latest"},
+		WorkingDir: ".",
+		Ldflags:    []string{"{{.Env.LDFLAGS}}"},
+		Flags:      []string{"{{.Env.FLAGS}}"},
+		Env:        []string{"SOME_ENV={{.Env.LE_ENV}}"},
 	}, ctx.Config.Kos[0])
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -207,7 +207,6 @@ type Ko struct {
 	WorkingDir          string   `yaml:"working_dir,omitempty" json:"working_dir,omitempty"`
 	BaseImage           string   `yaml:"base_image,omitempty" json:"base_image,omitempty"`
 	Repository          string   `yaml:"repository,omitempty" json:"repository,omitempty"`
-	RepositoryFromEnv   bool     `yaml:"-" json:"-"`
 	Platforms           []string `yaml:"platforms,omitempty" json:"platforms,omitempty"`
 	Tags                []string `yaml:"tags,omitempty" json:"tags,omitempty"`
 	SBOM                string   `yaml:"sbom,omitempty" json:"sbom,omitempty"`


### PR DESCRIPTION
The commit will add the `bare` option to ko publisher options when set/passed via config `.goreleaser.yaml`.

Currently, even the `bare: true` is set via config,  the option was never passed to `ko` PublisherOptions.

#3742 
