### PR TITLE
test: fix exec tests on go 1.20

### DIFF
--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/internal/artifact"
@@ -25,7 +26,6 @@ func TestExecute(t *testing.T) {
 	})
 	ctx.Env["TEST_A_SECRET"] = "x"
 	ctx.Env["TEST_A_USERNAME"] = "u2"
-	ctx.Env["GOCOVERDIR"] = t.TempDir() // needed for go1.20
 	ctx.Version = "2.1.0"
 
 	// Preload artifacts
@@ -362,7 +362,7 @@ func TestExecute(t *testing.T) {
 				return
 			}
 			require.Error(t, err)
-			require.Equal(t, tc.expectErr.Error(), err.Error())
+			require.True(t, strings.HasPrefix(err.Error(), tc.expectErr.Error()))
 		})
 	}
 }

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -25,6 +25,7 @@ func TestExecute(t *testing.T) {
 	})
 	ctx.Env["TEST_A_SECRET"] = "x"
 	ctx.Env["TEST_A_USERNAME"] = "u2"
+	ctx.Env["GOCOVERDIR"] = t.TempDir() // needed for go1.20
 	ctx.Version = "2.1.0"
 
 	// Preload artifacts


### PR DESCRIPTION
otherwise we might get warnings like

> warning: GOCOVERDIR not set, no coverage data emitted