### PR TITLE
fix(gitlab): correctly prepend/append/keep releases notes

### DIFF
--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -319,7 +319,7 @@ func (c *gitlabClient) CreateRelease(ctx *context.Context, body string) (release
 	} else {
 		desc := body
 		if release != nil {
-			desc = getReleaseNotes(release.DescriptionHTML, body, ctx.Config.Release.ReleaseNotesMode)
+			desc = getReleaseNotes(release.Description, body, ctx.Config.Release.ReleaseNotesMode)
 		}
 
 		release, _, err = c.client.Releases.UpdateRelease(projectID, tagName, &gitlab.UpdateReleaseOptions{


### PR DESCRIPTION
Hi, I found a bug in the GitLab client that leads to not correctly prepend/append/keep releases notes.

This will use the original `Description`  instead of the pre-rendered `DescriptionHTML`. Furthermore, as `include_html_description` is not enabled, the `DescriptionHTML` field is always empty.

[GitLab documentation](https://docs.gitlab.com/ee/api/releases/index.html#get-a-release-by-a-tag-name)