### PR TITLE
feat: extend s3 compatible config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	code.gitea.io/sdk/gitea v0.15.1
 	github.com/Masterminds/semver/v3 v3.2.0
 	github.com/atc0005/go-teams-notify/v2 v2.7.0
+	github.com/aws/aws-sdk-go v1.44.151
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20220517224237-e6f29200ae04
 	github.com/caarlos0/ctrlc v1.2.0
 	github.com/caarlos0/env/v6 v6.10.1
@@ -92,7 +93,6 @@ require (
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
-	github.com/aws/aws-sdk-go v1.44.151 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.17.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.9 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.18.3 // indirect

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -874,15 +874,17 @@ type Before struct {
 
 // Blob contains config for GO CDK blob.
 type Blob struct {
-	Bucket     string      `yaml:"bucket,omitempty" json:"bucket,omitempty"`
-	Provider   string      `yaml:"provider,omitempty" json:"provider,omitempty"`
-	Region     string      `yaml:"region,omitempty" json:"region,omitempty"`
-	DisableSSL bool        `yaml:"disableSSL,omitempty" json:"disableSSL,omitempty"` // nolint:tagliatelle // TODO(caarlos0): rename to disable_ssl
-	Folder     string      `yaml:"folder,omitempty" json:"folder,omitempty"`
-	KMSKey     string      `yaml:"kmskey,omitempty" json:"kmskey,omitempty"`
-	IDs        []string    `yaml:"ids,omitempty" json:"ids,omitempty"`
-	Endpoint   string      `yaml:"endpoint,omitempty" json:"endpoint,omitempty"` // used for minio for example
-	ExtraFiles []ExtraFile `yaml:"extra_files,omitempty" json:"extra_files,omitempty"`
+	Bucket           string      `yaml:"bucket,omitempty" json:"bucket,omitempty"`
+	Provider         string      `yaml:"provider,omitempty" json:"provider,omitempty"`
+	Region           string      `yaml:"region,omitempty" json:"region,omitempty"`
+	DisableSSL       bool        `yaml:"disableSSL,omitempty" json:"disableSSL,omitempty"` // nolint:tagliatelle // TODO(caarlos0): rename to disable_ssl
+	Folder           string      `yaml:"folder,omitempty" json:"folder,omitempty"`
+	KMSKey           string      `yaml:"kmskey,omitempty" json:"kmskey,omitempty"`
+	IDs              []string    `yaml:"ids,omitempty" json:"ids,omitempty"`
+	Endpoint         string      `yaml:"endpoint,omitempty" json:"endpoint,omitempty"` // used for minio for example
+	S3ForcePathStyle *bool       `yaml:"s3ForcePathStyle,omitempty" json:"s3ForcePathStyle,omitempty"`
+	ExtraFiles       []ExtraFile `yaml:"extra_files,omitempty" json:"extra_files,omitempty"`
+	ACL              string      `yaml:"acl,omitempty" json:"acl,omitempty"`
 }
 
 // Upload configuration.


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->



<!-- Why is this change being made? -->
1.  if user set the s3 endpoint,`goreleaser` will set `s3ForcePathStyle=true` in the query :
![image](https://user-images.githubusercontent.com/6478745/218016265-a32c00c1-4071-4e31-92bd-f894f23b688b.png)
this pr want to allow user make choice whether to set `s3ForcePathStyle=true`

2.  allow user set s3 upload policy, wants goreleaser support s3 acl policy 



In short, user will use goreleaser  s3 provider like this:
![image](https://user-images.githubusercontent.com/6478745/218017090-5331a556-d6ec-47de-8c15-4f23fd62f50e.png)

<!-- # Provide links to any relevant tickets, URLs or other resources -->


