### PR TITLE
fix: docker extra_files fails if path starts with dist path

### DIFF
--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -61,8 +61,10 @@ func (Pipe) Default(ctx *context.Context) error {
 		if err := validateImager(docker.Use); err != nil {
 			return err
 		}
+		distPath := filepath.Clean(ctx.Config.Dist) + "/"
 		for _, f := range docker.Files {
-			if f == "." || strings.HasPrefix(f, ctx.Config.Dist) {
+			file := filepath.Clean(f) + "/"
+			if file == "./" || strings.HasPrefix(file, distPath) {
 				return fmt.Errorf("invalid docker.files: can't be . or inside dist folder: %s", f)
 			}
 		}


### PR DESCRIPTION


<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->
Fix the handling of docker.extra_files to allow for folders that stars with the same pattern as `dist` folder, but isn't the a subfolder of `dist`
...

<!-- Why is this change being made? -->

...

<!-- # Provide links to any relevant tickets, URLs or other resources -->
Issue reference: #3790
...
