### PR TITLE
refactor: improve context on tests

### DIFF
--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -1017,7 +1017,7 @@ func TestProcessFlags(t *testing.T) {
 }
 
 func TestProcessFlagsInvalid(t *testing.T) {
-	ctx := &context.Context{}
+	ctx := context.New(config.Project{})
 
 	source := []string{
 		"{{.Version}",

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestClientEmpty(t *testing.T) {
-	ctx := &context.Context{}
+	ctx := context.New(config.Project{})
 	client, err := New(ctx)
 	require.Nil(t, client)
 	require.EqualError(t, err, `invalid client token type: ""`)

--- a/internal/pipe/archive/archive_test.go
+++ b/internal/pipe/archive/archive_test.go
@@ -762,11 +762,9 @@ func TestRunPipeWrap(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Archives: []config.Archive{},
-		},
-	}
+	ctx := context.New(config.Project{
+		Archives: []config.Archive{},
+	})
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.NotEmpty(t, ctx.Config.Archives[0].NameTemplate)
 	require.Equal(t, "tar.gz", ctx.Config.Archives[0].Format)
@@ -775,20 +773,18 @@ func TestDefault(t *testing.T) {
 }
 
 func TestDefaultSet(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Archives: []config.Archive{
-				{
-					Builds:       []string{"default"},
-					NameTemplate: "foo",
-					Format:       "zip",
-					Files: []config.File{
-						{Source: "foo"},
-					},
+	ctx := context.New(config.Project{
+		Archives: []config.Archive{
+			{
+				Builds:       []string{"default"},
+				NameTemplate: "foo",
+				Format:       "zip",
+				Files: []config.File{
+					{Source: "foo"},
 				},
 			},
 		},
-	}
+	})
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "foo", ctx.Config.Archives[0].NameTemplate)
 	require.Equal(t, "zip", ctx.Config.Archives[0].Format)
@@ -797,52 +793,46 @@ func TestDefaultSet(t *testing.T) {
 }
 
 func TestDefaultNoFiles(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Archives: []config.Archive{
-				{
-					Format: "tar.gz",
-				},
+	ctx := context.New(config.Project{
+		Archives: []config.Archive{
+			{
+				Format: "tar.gz",
 			},
 		},
-	}
+	})
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, defaultNameTemplate, ctx.Config.Archives[0].NameTemplate)
 	require.False(t, ctx.Config.Archives[0].RLCP)
 }
 
 func TestDefaultFormatBinary(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Archives: []config.Archive{
-				{
-					Format: "binary",
-				},
+	ctx := context.New(config.Project{
+		Archives: []config.Archive{
+			{
+				Format: "binary",
 			},
 		},
-	}
+	})
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, defaultBinaryNameTemplate, ctx.Config.Archives[0].NameTemplate)
 	require.False(t, ctx.Config.Archives[0].RLCP)
 }
 
 func TestFormatFor(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Archives: []config.Archive{
-				{
-					Builds: []string{"default"},
-					Format: "tar.gz",
-					FormatOverrides: []config.FormatOverride{
-						{
-							Goos:   "windows",
-							Format: "zip",
-						},
+	ctx := context.New(config.Project{
+		Archives: []config.Archive{
+			{
+				Builds: []string{"default"},
+				Format: "tar.gz",
+				FormatOverrides: []config.FormatOverride{
+					{
+						Goos:   "windows",
+						Format: "zip",
 					},
 				},
 			},
 		},
-	}
+	})
 	require.Equal(t, "zip", packageFormat(ctx.Config.Archives[0], "windows"))
 	require.Equal(t, "tar.gz", packageFormat(ctx.Config.Archives[0], "linux"))
 }
@@ -1036,18 +1026,16 @@ func TestWrapInDirectory(t *testing.T) {
 }
 
 func TestSeveralArchivesWithTheSameID(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Archives: []config.Archive{
-				{
-					ID: "a",
-				},
-				{
-					ID: "a",
-				},
+	ctx := context.New(config.Project{
+		Archives: []config.Archive{
+			{
+				ID: "a",
+			},
+			{
+				ID: "a",
 			},
 		},
-	}
+	})
 	require.EqualError(t, Pipe{}.Default(ctx), "found 2 archives with the ID 'a', please fix your config")
 }
 

--- a/internal/pipe/artifactory/artifactory_test.go
+++ b/internal/pipe/artifactory/artifactory_test.go
@@ -692,17 +692,15 @@ func TestArtifactoriesWithInvalidMode(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Artifactories: []config.Upload{
-				{
-					Name:     "production",
-					Target:   "http://artifacts.company.com/example-repo-local/{{ .ProjectName }}/{{ .Os }}/{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}",
-					Username: "deployuser",
-				},
+	ctx := context.New(config.Project{
+		Artifactories: []config.Upload{
+			{
+				Name:     "production",
+				Target:   "http://artifacts.company.com/example-repo-local/{{ .ProjectName }}/{{ .Os }}/{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}",
+				Username: "deployuser",
 			},
 		},
-	}
+	})
 
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Len(t, ctx.Config.Artifactories, 1)
@@ -711,26 +709,22 @@ func TestDefault(t *testing.T) {
 }
 
 func TestDefaultNoArtifactories(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Artifactories: []config.Upload{},
-		},
-	}
+	ctx := context.New(config.Project{
+		Artifactories: []config.Upload{},
+	})
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Empty(t, ctx.Config.Artifactories)
 }
 
 func TestDefaultSet(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Artifactories: []config.Upload{
-				{
-					Mode:           "custom",
-					ChecksumHeader: "foo",
-				},
+	ctx := context.New(config.Project{
+		Artifactories: []config.Upload{
+			{
+				Mode:           "custom",
+				ChecksumHeader: "foo",
 			},
 		},
-	}
+	})
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Len(t, ctx.Config.Artifactories, 1)
 	artifactory := ctx.Config.Artifactories[0]

--- a/internal/pipe/checksums/checksums_test.go
+++ b/internal/pipe/checksums/checksums_test.go
@@ -223,19 +223,15 @@ func TestPipeCouldNotOpenChecksumsTxt(t *testing.T) {
 }
 
 func TestPipeWhenNoArtifacts(t *testing.T) {
-	ctx := &context.Context{
-		Artifacts: artifact.New(),
-	}
+	ctx := context.New(config.Project{})
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Len(t, ctx.Artifacts.List(), 0)
 }
 
 func TestDefault(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Checksum: config.Checksum{},
-		},
-	}
+	ctx := context.New(config.Project{
+		Checksum: config.Checksum{},
+	})
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(
 		t,
@@ -246,13 +242,11 @@ func TestDefault(t *testing.T) {
 }
 
 func TestDefaultSet(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Checksum: config.Checksum{
-				NameTemplate: "checksums.txt",
-			},
+	ctx := context.New(config.Project{
+		Checksum: config.Checksum{
+			NameTemplate: "checksums.txt",
 		},
-	}
+	})
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "checksums.txt", ctx.Config.Checksum.NameTemplate)
 }

--- a/internal/pipe/chocolatey/chocolatey_test.go
+++ b/internal/pipe/chocolatey/chocolatey_test.go
@@ -297,10 +297,8 @@ func TestPublish(t *testing.T) {
 				cmd = stdCmd{}
 			})
 
-			ctx := &context.Context{
-				SkipPublish: tt.skip,
-				Artifacts:   artifact.New(),
-			}
+			ctx := context.New(config.Project{})
+			ctx.SkipPublish = tt.skip
 
 			for _, artifact := range tt.artifacts {
 				ctx.Artifacts.Add(&artifact)

--- a/internal/pipe/dist/dist_test.go
+++ b/internal/pipe/dist/dist_test.go
@@ -13,16 +13,7 @@ import (
 func TestDistDoesNotExist(t *testing.T) {
 	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
-	require.NoError(
-		t,
-		Pipe{}.Run(
-			&context.Context{
-				Config: config.Project{
-					Dist: dist,
-				},
-			},
-		),
-	)
+	require.NoError(t, Pipe{}.Run(context.New(config.Project{Dist: dist})))
 }
 
 func TestPopulatedDistExists(t *testing.T) {
@@ -32,11 +23,7 @@ func TestPopulatedDistExists(t *testing.T) {
 	f, err := os.Create(filepath.Join(dist, "mybin"))
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
-	ctx := &context.Context{
-		Config: config.Project{
-			Dist: dist,
-		},
-	}
+	ctx := context.New(config.Project{Dist: dist})
 	require.Error(t, Pipe{}.Run(ctx))
 	ctx.Clean = true
 	require.NoError(t, Pipe{}.Run(ctx))
@@ -48,11 +35,7 @@ func TestEmptyDistExists(t *testing.T) {
 	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
-	ctx := &context.Context{
-		Config: config.Project{
-			Dist: dist,
-		},
-	}
+	ctx := context.New(config.Project{Dist: dist})
 	require.NoError(t, Pipe{}.Run(ctx))
 	_, err := os.Stat(dist)
 	require.False(t, os.IsNotExist(err))

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -1126,24 +1126,22 @@ func TestNoDockerWithoutImageName(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Dockers: []config.Docker{
-				{
-					IDs: []string{"aa"},
-				},
-				{
-					Use: useBuildx,
-				},
+	ctx := context.New(config.Project{
+		Dockers: []config.Docker{
+			{
+				IDs: []string{"aa"},
 			},
-			DockerManifests: []config.DockerManifest{
-				{},
-				{
-					Use: useDocker,
-				},
+			{
+				Use: useBuildx,
 			},
 		},
-	}
+		DockerManifests: []config.DockerManifest{
+			{},
+			{
+				Use: useDocker,
+			},
+		},
+	})
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Len(t, ctx.Config.Dockers, 2)
 	docker := ctx.Config.Dockers[0]
@@ -1162,41 +1160,37 @@ func TestDefault(t *testing.T) {
 }
 
 func TestDefaultDuplicateID(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Dockers: []config.Docker{
-				{ID: "foo"},
-				{ /* empty */ },
-				{ID: "bar"},
-				{ID: "foo"},
-			},
-			DockerManifests: []config.DockerManifest{
-				{ID: "bar"},
-				{ /* empty */ },
-				{ID: "bar"},
-				{ID: "foo"},
-			},
+	ctx := context.New(config.Project{
+		Dockers: []config.Docker{
+			{ID: "foo"},
+			{ /* empty */ },
+			{ID: "bar"},
+			{ID: "foo"},
 		},
-	}
+		DockerManifests: []config.DockerManifest{
+			{ID: "bar"},
+			{ /* empty */ },
+			{ID: "bar"},
+			{ID: "foo"},
+		},
+	})
 	require.EqualError(t, Pipe{}.Default(ctx), "found 2 dockers with the ID 'foo', please fix your config")
 	require.EqualError(t, ManifestPipe{}.Default(ctx), "found 2 docker_manifests with the ID 'bar', please fix your config")
 }
 
 func TestDefaultInvalidUse(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Dockers: []config.Docker{
-				{
-					Use: "something",
-				},
-			},
-			DockerManifests: []config.DockerManifest{
-				{
-					Use: "something",
-				},
+	ctx := context.New(config.Project{
+		Dockers: []config.Docker{
+			{
+				Use: "something",
 			},
 		},
-	}
+		DockerManifests: []config.DockerManifest{
+			{
+				Use: "something",
+			},
+		},
+	})
 	err := Pipe{}.Default(ctx)
 	require.Error(t, err)
 	require.True(t, strings.HasPrefix(err.Error(), `docker: invalid use: something, valid options are`))
@@ -1207,17 +1201,15 @@ func TestDefaultInvalidUse(t *testing.T) {
 }
 
 func TestDefaultDockerfile(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Builds: []config.Build{
-				{},
-			},
-			Dockers: []config.Docker{
-				{},
-				{},
-			},
+	ctx := context.New(config.Project{
+		Builds: []config.Build{
+			{},
 		},
-	}
+		Dockers: []config.Docker{
+			{},
+			{},
+		},
+	})
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Len(t, ctx.Config.Dockers, 2)
 	require.Equal(t, "Dockerfile", ctx.Config.Dockers[0].Dockerfile)
@@ -1237,56 +1229,48 @@ func TestDraftRelease(t *testing.T) {
 }
 
 func TestDefaultNoDockers(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Dockers: []config.Docker{},
-		},
-	}
+	ctx := context.New(config.Project{
+		Dockers: []config.Docker{},
+	})
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Empty(t, ctx.Config.Dockers)
 }
 
 func TestDefaultFilesDot(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Dist: "/tmp/distt",
-			Dockers: []config.Docker{
-				{
-					Files: []string{"./lala", "./lolsob", "."},
-				},
+	ctx := context.New(config.Project{
+		Dist: "/tmp/distt",
+		Dockers: []config.Docker{
+			{
+				Files: []string{"./lala", "./lolsob", "."},
 			},
 		},
-	}
+	})
 	require.EqualError(t, Pipe{}.Default(ctx), `invalid docker.files: can't be . or inside dist folder: .`)
 }
 
 func TestDefaultFilesDis(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Dist: "/tmp/dist",
-			Dockers: []config.Docker{
-				{
-					Files: []string{"./fooo", "/tmp/dist/asdasd/asd", "./bar"},
-				},
+	ctx := context.New(config.Project{
+		Dist: "/tmp/dist",
+		Dockers: []config.Docker{
+			{
+				Files: []string{"./fooo", "/tmp/dist/asdasd/asd", "./bar"},
 			},
 		},
-	}
+	})
 	require.EqualError(t, Pipe{}.Default(ctx), `invalid docker.files: can't be . or inside dist folder: /tmp/dist/asdasd/asd`)
 }
 
 func TestDefaultSet(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Dockers: []config.Docker{
-				{
-					IDs:        []string{"foo"},
-					Goos:       "windows",
-					Goarch:     "i386",
-					Dockerfile: "Dockerfile.foo",
-				},
+	ctx := context.New(config.Project{
+		Dockers: []config.Docker{
+			{
+				IDs:        []string{"foo"},
+				Goos:       "windows",
+				Goarch:     "i386",
+				Dockerfile: "Dockerfile.foo",
 			},
 		},
-	}
+	})
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Len(t, ctx.Config.Dockers, 1)
 	docker := ctx.Config.Dockers[0]
@@ -1297,26 +1281,24 @@ func TestDefaultSet(t *testing.T) {
 }
 
 func Test_processImageTemplates(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Builds: []config.Build{
-				{
-					ID: "default",
-				},
-			},
-			Dockers: []config.Docker{
-				{
-					Dockerfile: "Dockerfile.foo",
-					ImageTemplates: []string{
-						"user/image:{{.Tag}}",
-						"gcr.io/image:{{.Tag}}-{{.Env.FOO}}",
-						"gcr.io/image:v{{.Major}}.{{.Minor}}",
-					},
-					SkipPush: "true",
-				},
+	ctx := context.New(config.Project{
+		Builds: []config.Build{
+			{
+				ID: "default",
 			},
 		},
-	}
+		Dockers: []config.Docker{
+			{
+				Dockerfile: "Dockerfile.foo",
+				ImageTemplates: []string{
+					"user/image:{{.Tag}}",
+					"gcr.io/image:{{.Tag}}-{{.Env.FOO}}",
+					"gcr.io/image:v{{.Major}}.{{.Minor}}",
+				},
+				SkipPush: "true",
+			},
+		},
+	})
 
 	ctx.Env = map[string]string{
 		"FOO": "123",

--- a/internal/pipe/env/env_test.go
+++ b/internal/pipe/env/env_test.go
@@ -69,9 +69,7 @@ func TestSetDefaultTokenFiles(t *testing.T) {
 
 func TestValidGithubEnv(t *testing.T) {
 	require.NoError(t, os.Setenv("GITHUB_TOKEN", "asdf"))
-	ctx := &context.Context{
-		Config: config.Project{},
-	}
+	ctx := context.New(config.Project{})
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Equal(t, "asdf", ctx.Token)
 	require.Equal(t, context.TokenTypeGitHub, ctx.TokenType)
@@ -81,9 +79,7 @@ func TestValidGithubEnv(t *testing.T) {
 
 func TestValidGitlabEnv(t *testing.T) {
 	require.NoError(t, os.Setenv("GITLAB_TOKEN", "qwertz"))
-	ctx := &context.Context{
-		Config: config.Project{},
-	}
+	ctx := context.New(config.Project{})
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Equal(t, "qwertz", ctx.Token)
 	require.Equal(t, context.TokenTypeGitLab, ctx.TokenType)
@@ -93,9 +89,7 @@ func TestValidGitlabEnv(t *testing.T) {
 
 func TestValidGiteaEnv(t *testing.T) {
 	require.NoError(t, os.Setenv("GITEA_TOKEN", "token"))
-	ctx := &context.Context{
-		Config: config.Project{},
-	}
+	ctx := context.New(config.Project{})
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Equal(t, "token", ctx.Token)
 	require.Equal(t, context.TokenTypeGitea, ctx.TokenType)
@@ -106,9 +100,7 @@ func TestValidGiteaEnv(t *testing.T) {
 func TestInvalidEnv(t *testing.T) {
 	require.NoError(t, os.Unsetenv("GITHUB_TOKEN"))
 	require.NoError(t, os.Unsetenv("GITLAB_TOKEN"))
-	ctx := &context.Context{
-		Config: config.Project{},
-	}
+	ctx := context.New(config.Project{})
 	require.Error(t, Pipe{}.Run(ctx))
 	require.EqualError(t, Pipe{}.Run(ctx), ErrMissingToken.Error())
 }
@@ -117,9 +109,7 @@ func TestMultipleEnvTokens(t *testing.T) {
 	require.NoError(t, os.Setenv("GITHUB_TOKEN", "asdf"))
 	require.NoError(t, os.Setenv("GITLAB_TOKEN", "qwertz"))
 	require.NoError(t, os.Setenv("GITEA_TOKEN", "token"))
-	ctx := &context.Context{
-		Config: config.Project{},
-	}
+	ctx := context.New(config.Project{})
 	require.Error(t, Pipe{}.Run(ctx))
 	require.EqualError(t, Pipe{}.Run(ctx), "multiple tokens found, but only one is allowed: GITHUB_TOKEN, GITLAB_TOKEN, GITEA_TOKEN\n\nLearn more at https://goreleaser.com/errors/multiple-tokens\n")
 	// so the tests do not depend on each other
@@ -130,25 +120,19 @@ func TestMultipleEnvTokens(t *testing.T) {
 
 func TestEmptyGithubFileEnv(t *testing.T) {
 	require.NoError(t, os.Unsetenv("GITHUB_TOKEN"))
-	ctx := &context.Context{
-		Config: config.Project{},
-	}
+	ctx := context.New(config.Project{})
 	require.Error(t, Pipe{}.Run(ctx))
 }
 
 func TestEmptyGitlabFileEnv(t *testing.T) {
 	require.NoError(t, os.Unsetenv("GITLAB_TOKEN"))
-	ctx := &context.Context{
-		Config: config.Project{},
-	}
+	ctx := context.New(config.Project{})
 	require.Error(t, Pipe{}.Run(ctx))
 }
 
 func TestEmptyGiteaFileEnv(t *testing.T) {
 	require.NoError(t, os.Unsetenv("GITEA_TOKEN"))
-	ctx := &context.Context{
-		Config: config.Project{},
-	}
+	ctx := context.New(config.Project{})
 	require.Error(t, Pipe{}.Run(ctx))
 }
 
@@ -158,13 +142,11 @@ func TestEmptyGithubEnvFile(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 	require.NoError(t, os.Chmod(f.Name(), 0o377))
-	ctx := &context.Context{
-		Config: config.Project{
-			EnvFiles: config.EnvFiles{
-				GitHubToken: f.Name(),
-			},
+	ctx := context.New(config.Project{
+		EnvFiles: config.EnvFiles{
+			GitHubToken: f.Name(),
 		},
-	}
+	})
 	require.EqualError(t, Pipe{}.Run(ctx), fmt.Sprintf("failed to load github token: open %s: permission denied", f.Name()))
 }
 
@@ -174,13 +156,11 @@ func TestEmptyGitlabEnvFile(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 	require.NoError(t, os.Chmod(f.Name(), 0o377))
-	ctx := &context.Context{
-		Config: config.Project{
-			EnvFiles: config.EnvFiles{
-				GitLabToken: f.Name(),
-			},
+	ctx := context.New(config.Project{
+		EnvFiles: config.EnvFiles{
+			GitLabToken: f.Name(),
 		},
-	}
+	})
 	require.EqualError(t, Pipe{}.Run(ctx), fmt.Sprintf("failed to load gitlab token: open %s: permission denied", f.Name()))
 }
 
@@ -190,22 +170,18 @@ func TestEmptyGiteaEnvFile(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 	require.NoError(t, os.Chmod(f.Name(), 0o377))
-	ctx := &context.Context{
-		Config: config.Project{
-			EnvFiles: config.EnvFiles{
-				GiteaToken: f.Name(),
-			},
+	ctx := context.New(config.Project{
+		EnvFiles: config.EnvFiles{
+			GiteaToken: f.Name(),
 		},
-	}
+	})
 	require.EqualError(t, Pipe{}.Run(ctx), fmt.Sprintf("failed to load gitea token: open %s: permission denied", f.Name()))
 }
 
 func TestInvalidEnvChecksSkipped(t *testing.T) {
 	require.NoError(t, os.Unsetenv("GITHUB_TOKEN"))
-	ctx := &context.Context{
-		Config:      config.Project{},
-		SkipPublish: true,
-	}
+	ctx := context.New(config.Project{})
+	ctx.SkipPublish = true
 	require.NoError(t, Pipe{}.Run(ctx))
 }
 

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -736,14 +736,12 @@ func TestInvalidConfig(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			ProjectName: "foobar",
-			NFPMs: []config.NFPM{
-				{},
-			},
+	ctx := context.New(config.Project{
+		ProjectName: "foobar",
+		NFPMs: []config.NFPM{
+			{},
 		},
-	}
+	})
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "/usr/bin", ctx.Config.NFPMs[0].Bindir)
 	require.Empty(t, ctx.Config.NFPMs[0].Builds)
@@ -752,19 +750,17 @@ func TestDefault(t *testing.T) {
 }
 
 func TestDefaultSet(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			NFPMs: []config.NFPM{
-				{
-					Builds: []string{"foo"},
-					Bindir: "/bin",
-					NFPMOverridables: config.NFPMOverridables{
-						FileNameTemplate: "foo",
-					},
+	ctx := context.New(config.Project{
+		NFPMs: []config.NFPM{
+			{
+				Builds: []string{"foo"},
+				Bindir: "/bin",
+				NFPMOverridables: config.NFPMOverridables{
+					FileNameTemplate: "foo",
 				},
 			},
 		},
-	}
+	})
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "/bin", ctx.Config.NFPMs[0].Bindir)
 	require.Equal(t, "foo", ctx.Config.NFPMs[0].FileNameTemplate)
@@ -773,23 +769,21 @@ func TestDefaultSet(t *testing.T) {
 }
 
 func TestOverrides(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			NFPMs: []config.NFPM{
-				{
-					Bindir: "/bin",
-					NFPMOverridables: config.NFPMOverridables{
-						FileNameTemplate: "foo",
-					},
-					Overrides: map[string]config.NFPMOverridables{
-						"deb": {
-							FileNameTemplate: "bar",
-						},
+	ctx := context.New(config.Project{
+		NFPMs: []config.NFPM{
+			{
+				Bindir: "/bin",
+				NFPMOverridables: config.NFPMOverridables{
+					FileNameTemplate: "foo",
+				},
+				Overrides: map[string]config.NFPMOverridables{
+					"deb": {
+						FileNameTemplate: "bar",
 					},
 				},
 			},
 		},
-	}
+	})
 	require.NoError(t, Pipe{}.Default(ctx))
 	merged, err := mergeOverrides(ctx.Config.NFPMs[0], "deb")
 	require.NoError(t, err)
@@ -1204,18 +1198,16 @@ func TestAPKSpecificScriptsConfig(t *testing.T) {
 }
 
 func TestSeveralNFPMsWithTheSameID(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			NFPMs: []config.NFPM{
-				{
-					ID: "a",
-				},
-				{
-					ID: "a",
-				},
+	ctx := context.New(config.Project{
+		NFPMs: []config.NFPM{
+			{
+				ID: "a",
+			},
+			{
+				ID: "a",
 			},
 		},
-	}
+	})
 	require.EqualError(t, Pipe{}.Default(ctx), "found 2 nfpms with the ID 'a', please fix your config")
 }
 

--- a/internal/pipe/sbom/sbom_test.go
+++ b/internal/pipe/sbom/sbom_test.go
@@ -145,11 +145,9 @@ func TestSBOMCatalogDefault(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("artifact=%q", test.configs[0].Artifacts), func(t *testing.T) {
 			testlib.CheckPath(t, "syft")
-			ctx := &context.Context{
-				Config: config.Project{
-					SBOMs: test.configs,
-				},
-			}
+			ctx := context.New(config.Project{
+				SBOMs: test.configs,
+			})
 			err := Pipe{}.Default(ctx)
 			if test.err {
 				require.Error(t, err)
@@ -175,18 +173,16 @@ func TestSBOMCatalogInvalidArtifacts(t *testing.T) {
 }
 
 func TestSeveralSBOMsWithTheSameID(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			SBOMs: []config.SBOM{
-				{
-					ID: "a",
-				},
-				{
-					ID: "a",
-				},
+	ctx := context.New(config.Project{
+		SBOMs: []config.SBOM{
+			{
+				ID: "a",
+			},
+			{
+				ID: "a",
 			},
 		},
-	}
+	})
 	require.EqualError(t, Pipe{}.Default(ctx), "found 2 sboms with the ID 'a', please fix your config")
 }
 

--- a/internal/pipe/sign/sign_docker_test.go
+++ b/internal/pipe/sign/sign_docker_test.go
@@ -19,11 +19,9 @@ func TestDockerSignDescription(t *testing.T) {
 }
 
 func TestDockerSignDefault(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			DockerSigns: []config.Sign{{}},
-		},
-	}
+	ctx := context.New(config.Project{
+		DockerSigns: []config.Sign{{}},
+	})
 	err := DockerPipe{}.Default(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "cosign", ctx.Config.DockerSigns[0].Cmd)

--- a/internal/pipe/sign/sign_test.go
+++ b/internal/pipe/sign/sign_test.go
@@ -50,11 +50,9 @@ func TestDescription(t *testing.T) {
 }
 
 func TestSignDefault(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Signs: []config.Sign{{}},
-		},
-	}
+	ctx := context.New(config.Project{
+		Signs: []config.Sign{{}},
+	})
 	err := Pipe{}.Default(ctx)
 	require.NoError(t, err)
 	require.Equal(t, ctx.Config.Signs[0].Cmd, "gpg")
@@ -748,18 +746,16 @@ func verifySignature(tb testing.TB, ctx *context.Context, sig string, user strin
 }
 
 func TestSeveralSignsWithTheSameID(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Signs: []config.Sign{
-				{
-					ID: "a",
-				},
-				{
-					ID: "a",
-				},
+	ctx := context.New(config.Project{
+		Signs: []config.Sign{
+			{
+				ID: "a",
+			},
+			{
+				ID: "a",
 			},
 		},
-	}
+	})
 	require.EqualError(t, Pipe{}.Default(ctx), "found 2 signs with the ID 'a', please fix your config")
 }
 

--- a/internal/pipe/snapcraft/snapcraft_test.go
+++ b/internal/pipe/snapcraft/snapcraft_test.go
@@ -31,13 +31,11 @@ func TestRunPipeMissingInfo(t *testing.T) {
 		pipe.Skip("no summary nor description were provided"): {},
 	} {
 		t.Run(fmt.Sprintf("testing if %v happens", eerr), func(t *testing.T) {
-			ctx := &context.Context{
-				Config: config.Project{
-					Snapcrafts: []config.Snapcraft{
-						snap,
-					},
+			ctx := context.New(config.Project{
+				Snapcrafts: []config.Snapcraft{
+					snap,
 				},
-			}
+			})
 			require.Equal(t, eerr, Pipe{}.Run(ctx))
 		})
 	}
@@ -580,24 +578,22 @@ func TestDefaultSet(t *testing.T) {
 }
 
 func Test_processChannelsTemplates(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Builds: []config.Build{
-				{
-					ID: "default",
-				},
+	ctx := context.New(config.Project{
+		Builds: []config.Build{
+			{
+				ID: "default",
 			},
-			Snapcrafts: []config.Snapcraft{
-				{
-					Name: "mybin",
-					ChannelTemplates: []string{
-						"{{.Major}}.{{.Minor}}/stable",
-						"stable",
-					},
+		},
+		Snapcrafts: []config.Snapcraft{
+			{
+				Name: "mybin",
+				ChannelTemplates: []string{
+					"{{.Major}}.{{.Minor}}/stable",
+					"stable",
 				},
 			},
 		},
-	}
+	})
 
 	ctx.SkipPublish = true
 	ctx.Env = map[string]string{
@@ -679,18 +675,16 @@ func addBinaries(t *testing.T, ctx *context.Context, name, dist string) {
 }
 
 func TestSeveralSnapssWithTheSameID(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Snapcrafts: []config.Snapcraft{
-				{
-					ID: "a",
-				},
-				{
-					ID: "a",
-				},
+	ctx := context.New(config.Project{
+		Snapcrafts: []config.Snapcraft{
+			{
+				ID: "a",
+			},
+			{
+				ID: "a",
 			},
 		},
-	}
+	})
 	require.EqualError(t, Pipe{}.Default(ctx), "found 2 snapcrafts with the ID 'a', please fix your config")
 }
 

--- a/internal/pipe/snapshot/snapshot_test.go
+++ b/internal/pipe/snapshot/snapshot_test.go
@@ -14,23 +14,19 @@ func TestStringer(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Snapshot: config.Snapshot{},
-		},
-	}
+	ctx := context.New(config.Project{
+		Snapshot: config.Snapshot{},
+	})
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "{{ .Version }}-SNAPSHOT-{{ .ShortCommit }}", ctx.Config.Snapshot.NameTemplate)
 }
 
 func TestDefaultSet(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Snapshot: config.Snapshot{
-				NameTemplate: "snap",
-			},
+	ctx := context.New(config.Project{
+		Snapshot: config.Snapshot{
+			NameTemplate: "snap",
 		},
-	}
+	})
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "snap", ctx.Config.Snapshot.NameTemplate)
 }

--- a/internal/pipe/universalbinary/universalbinary_test.go
+++ b/internal/pipe/universalbinary/universalbinary_test.go
@@ -22,14 +22,12 @@ func TestDescription(t *testing.T) {
 
 func TestDefault(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		ctx := &context.Context{
-			Config: config.Project{
-				ProjectName: "proj",
-				UniversalBinaries: []config.UniversalBinary{
-					{},
-				},
+		ctx := context.New(config.Project{
+			ProjectName: "proj",
+			UniversalBinaries: []config.UniversalBinary{
+				{},
 			},
-		}
+		})
 		require.NoError(t, Pipe{}.Default(ctx))
 		require.Equal(t, config.UniversalBinary{
 			ID:           "proj",
@@ -39,14 +37,12 @@ func TestDefault(t *testing.T) {
 	})
 
 	t.Run("given ids", func(t *testing.T) {
-		ctx := &context.Context{
-			Config: config.Project{
-				ProjectName: "proj",
-				UniversalBinaries: []config.UniversalBinary{
-					{IDs: []string{"foo"}},
-				},
+		ctx := context.New(config.Project{
+			ProjectName: "proj",
+			UniversalBinaries: []config.UniversalBinary{
+				{IDs: []string{"foo"}},
 			},
-		}
+		})
 		require.NoError(t, Pipe{}.Default(ctx))
 		require.Equal(t, config.UniversalBinary{
 			ID:           "proj",
@@ -56,14 +52,12 @@ func TestDefault(t *testing.T) {
 	})
 
 	t.Run("given id", func(t *testing.T) {
-		ctx := &context.Context{
-			Config: config.Project{
-				ProjectName: "proj",
-				UniversalBinaries: []config.UniversalBinary{
-					{ID: "foo"},
-				},
+		ctx := context.New(config.Project{
+			ProjectName: "proj",
+			UniversalBinaries: []config.UniversalBinary{
+				{ID: "foo"},
 			},
-		}
+		})
 		require.NoError(t, Pipe{}.Default(ctx))
 		require.Equal(t, config.UniversalBinary{
 			ID:           "foo",
@@ -73,14 +67,12 @@ func TestDefault(t *testing.T) {
 	})
 
 	t.Run("given name", func(t *testing.T) {
-		ctx := &context.Context{
-			Config: config.Project{
-				ProjectName: "proj",
-				UniversalBinaries: []config.UniversalBinary{
-					{NameTemplate: "foo"},
-				},
+		ctx := context.New(config.Project{
+			ProjectName: "proj",
+			UniversalBinaries: []config.UniversalBinary{
+				{NameTemplate: "foo"},
 			},
-		}
+		})
 		require.NoError(t, Pipe{}.Default(ctx))
 		require.Equal(t, config.UniversalBinary{
 			ID:           "proj",
@@ -90,15 +82,13 @@ func TestDefault(t *testing.T) {
 	})
 
 	t.Run("duplicated ids", func(t *testing.T) {
-		ctx := &context.Context{
-			Config: config.Project{
-				ProjectName: "proj",
-				UniversalBinaries: []config.UniversalBinary{
-					{ID: "foo"},
-					{ID: "foo"},
-				},
+		ctx := context.New(config.Project{
+			ProjectName: "proj",
+			UniversalBinaries: []config.UniversalBinary{
+				{ID: "foo"},
+				{ID: "foo"},
 			},
-		}
+		})
 		require.EqualError(t, Pipe{}.Default(ctx), `found 2 universal_binaries with the ID 'foo', please fix your config`)
 	})
 }

--- a/internal/pipe/upload/upload_test.go
+++ b/internal/pipe/upload/upload_test.go
@@ -667,17 +667,15 @@ func TestPutsWithInvalidMode(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Uploads: []config.Upload{
-				{
-					Name:     "production",
-					Target:   "http://artifacts.company.com/example-repo-local/{{ .ProjectName }}/{{ .Os }}/{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}",
-					Username: "deployuser",
-				},
+	ctx := context.New(config.Project{
+		Uploads: []config.Upload{
+			{
+				Name:     "production",
+				Target:   "http://artifacts.company.com/example-repo-local/{{ .ProjectName }}/{{ .Os }}/{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}",
+				Username: "deployuser",
 			},
 		},
-	}
+	})
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Len(t, ctx.Config.Uploads, 1)
 	upload := ctx.Config.Uploads[0]
@@ -686,26 +684,22 @@ func TestDefault(t *testing.T) {
 }
 
 func TestDefaultNoPuts(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Uploads: []config.Upload{},
-		},
-	}
+	ctx := context.New(config.Project{
+		Uploads: []config.Upload{},
+	})
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Empty(t, ctx.Config.Uploads)
 }
 
 func TestDefaultSet(t *testing.T) {
-	ctx := &context.Context{
-		Config: config.Project{
-			Uploads: []config.Upload{
-				{
-					Method: h.MethodPost,
-					Mode:   "custom",
-				},
+	ctx := context.New(config.Project{
+		Uploads: []config.Upload{
+			{
+				Method: h.MethodPost,
+				Mode:   "custom",
 			},
 		},
-	}
+	})
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Len(t, ctx.Config.Uploads, 1)
 	upload := ctx.Config.Uploads[0]


### PR DESCRIPTION
using `context.New` is the correct way, as it set up everything needed in the context.

using `context.Context{}` might break things eventually, or not test the same thing goreleaser does.

There's a lot more places to fix, those are the easy ones :P 