### PR TITLE
test: add identified failing condition in sourcearchive

### DIFF
--- a/internal/pipe/sourcearchive/source_test.go
+++ b/internal/pipe/sourcearchive/source_test.go
@@ -21,6 +21,7 @@ func TestArchive(t *testing.T) {
 			testlib.GitInit(t)
 			require.NoError(t, os.WriteFile("code.rb", []byte("not really code"), 0o655))
 			require.NoError(t, os.WriteFile("code.py", []byte("print 1"), 0o655))
+			require.NoError(t, os.WriteFile("ملف.txt", []byte("محتوى عربي"), 0o655))
 			require.NoError(t, os.WriteFile("README.md", []byte("# my dope fake project"), 0o655))
 			require.NoError(t, os.WriteFile(".gitignore", []byte(`
 added-later.txt
@@ -88,6 +89,7 @@ subfolder/
 				"foo-1.0.0/code.py",
 				"foo-1.0.0/code.rb",
 				"foo-1.0.0/code.txt",
+				"foo-1.0.0/ملف.txt",
 				"foo-1.0.0/added-later.txt",
 				"foo-1.0.0/subfolder/file.md",
 			}


### PR DESCRIPTION
We have recently enabled Source Archives in caddyserver/caddy#5403, which works fine when run on macOS. We found out it fails on Linux with this error:
```
  • creating source archive
    • creating source archive                        file=caddy_2.6.4-SNAPSHOT-096971e3_src.tar.gz
  ⨯ release failed after 20s                 error=globbing failed for pattern "modules/caddyhttp/fileserver/testdata/\331\205\331\204\331\201.txt": matching "./"modules/caddyhttp/fileserver/testdata/331205331204331201.txt"": file does not exist
```
It refers to a file with non-ASCII name, i.e. https://github.com/caddyserver/caddy/blob/master/modules/caddyhttp/fileserver/testdata/ملف.txt. Indeed, adding a file with non-ASCII name to the `source_test.go` file passes with flying colors on macOS but fails on Linux. I've run it on both machines and confirmed the discrepancy.

I don't know how to fix it yet because I haven't delved into goreleaser's codebase nor am I familiar with it. I need to investigate further and trace the execution path.

Thanks @IndeedNotJames for alerting me for the failure on Linux systems, which enabled me to find the issue.