### PR TITLE
fix: create temp docker outside dist

### DIFF
--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -61,11 +61,6 @@ func (Pipe) Default(ctx *context.Context) error {
 		if err := validateImager(docker.Use); err != nil {
 			return err
 		}
-		for _, f := range docker.Files {
-			if f == "." || strings.HasPrefix(f, ctx.Config.Dist) {
-				return fmt.Errorf("invalid docker.files: can't be . or inside dist folder: %s", f)
-			}
-		}
 	}
 	return ids.Validate()
 }
@@ -145,7 +140,7 @@ func process(ctx *context.Context, docker config.Docker, artifacts []*artifact.A
 	if len(artifacts) == 0 {
 		log.Warn("not binaries or packages found for the given platform - COPY/ADD may not work")
 	}
-	tmp, err := os.MkdirTemp(ctx.Config.Dist, "goreleaserdocker")
+	tmp, err := os.MkdirTemp("", "goreleaserdocker")
 	if err != nil {
 		return fmt.Errorf("failed to create temporary dir: %w", err)
 	}

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -1239,7 +1239,7 @@ func TestDefaultFilesDot(t *testing.T) {
 			},
 		},
 	})
-	require.EqualError(t, Pipe{}.Default(ctx), `invalid docker.files: can't be . or inside dist folder: .`)
+	require.NoError(t, Pipe{}.Default(ctx))
 }
 
 func TestDefaultFilesDis(t *testing.T) {
@@ -1251,7 +1251,7 @@ func TestDefaultFilesDis(t *testing.T) {
 			},
 		},
 	})
-	require.EqualError(t, Pipe{}.Default(ctx), `invalid docker.files: can't be . or inside dist folder: /tmp/dist/asdasd/asd`)
+	require.NoError(t, Pipe{}.Default(ctx))
 }
 
 func TestDefaultSet(t *testing.T) {


### PR DESCRIPTION
Creating the temp dir for docker builds was required back in the day because we symlinked the files, so to avoid different filesystems et al, this was the easier solution.

Since many versions ago, we switched to copying the files instead, which works a lot better.

This also means we don't need the dist check for extra files anymore, as long as we create the temp outside dist.

All that said, this PR does 2 things:
- changes the docker pipe to create the dist in the user's tempdir instead of dist
- removes the dist path check for docker's extra files

closes #3790
closes #3791

