### PR TITLE
feat: infer package name from go.mod

### DIFF
--- a/internal/pipe/project/project_test.go
+++ b/internal/pipe/project/project_test.go
@@ -1,15 +1,18 @@
 package project
 
 import (
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/goreleaser/goreleaser/internal/testctx"
+	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/goreleaser/goreleaser/pkg/config"
 )
 
 func TestCustomProjectName(t *testing.T) {
+	_ = testlib.Mktmp(t)
 	ctx := testctx.NewWithCfg(config.Project{
 		ProjectName: "foo",
 		Release: config.Release{
@@ -24,6 +27,7 @@ func TestCustomProjectName(t *testing.T) {
 }
 
 func TestEmptyProjectName_DefaultsToGitHubRelease(t *testing.T) {
+	_ = testlib.Mktmp(t)
 	ctx := testctx.NewWithCfg(config.Project{
 		Release: config.Release{
 			GitHub: config.Repo{
@@ -37,6 +41,7 @@ func TestEmptyProjectName_DefaultsToGitHubRelease(t *testing.T) {
 }
 
 func TestEmptyProjectName_DefaultsToGitLabRelease(t *testing.T) {
+	_ = testlib.Mktmp(t)
 	ctx := testctx.NewWithCfg(config.Project{
 		Release: config.Release{
 			GitLab: config.Repo{
@@ -50,6 +55,7 @@ func TestEmptyProjectName_DefaultsToGitLabRelease(t *testing.T) {
 }
 
 func TestEmptyProjectName_DefaultsToGiteaRelease(t *testing.T) {
+	_ = testlib.Mktmp(t)
 	ctx := testctx.NewWithCfg(config.Project{
 		Release: config.Release{
 			Gitea: config.Repo{
@@ -62,7 +68,16 @@ func TestEmptyProjectName_DefaultsToGiteaRelease(t *testing.T) {
 	require.Equal(t, "bar", ctx.Config.ProjectName)
 }
 
+func TestEmptyProjectName_DefaultsToGoModPath(t *testing.T) {
+	_ = testlib.Mktmp(t)
+	ctx := testctx.New()
+	require.NoError(t, exec.Command("go", "mod", "init", "github.com/foo/bar").Run())
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, "bar", ctx.Config.ProjectName)
+}
+
 func TestEmptyProjectNameAndRelease(t *testing.T) {
+	_ = testlib.Mktmp(t)
 	ctx := testctx.NewWithCfg(config.Project{
 		Release: config.Release{
 			GitHub: config.Repo{},


### PR DESCRIPTION
If all other strategies fail, try to infer the `package_name` property from the `go.mod` file, using its last segment as the actual package name.

This is not perfect, but usually this will only be used when running against a new project, with no git url, empty/default config, etc... so, in reality, it'll rarely be used.

closes #3825