### PR TITLE
feat: include prerelease suffix in git

### DIFF
--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -288,24 +288,22 @@ func getPreviousTag(ctx *context.Context, current string) (string, error) {
 }
 
 func gitTagsPointingAt(ctx *context.Context, ref string) ([]string, error) {
-	args := []string{
+	args := []string{}
+	if ctx.Config.Git.PrereleaseSuffix != "" {
+		args = append(
+			args,
+			"-c",
+			"versionsort.suffix="+ctx.Config.Git.PrereleaseSuffix,
+		)
+	}
+	args = append(
+		args,
 		"tag",
 		"--points-at",
 		ref,
 		"--sort",
 		ctx.Config.Git.TagSort,
-	}
-	if ctx.Config.Git.PrereleaseSuffix != "" {
-		args = []string{
-			"-c",
-			"versionsort.suffix=" + ctx.Config.Git.PrereleaseSuffix,
-			"tag",
-			"--points-at",
-			ref,
-			"--sort",
-			ctx.Config.Git.TagSort,
-		}
-	}
+	)
 	return git.CleanAllLines(git.Run(ctx, args...))
 }
 

--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -28,9 +28,6 @@ func setDefaults(ctx *context.Context) {
 	if ctx.Config.Git.TagSort == "" {
 		ctx.Config.Git.TagSort = "-version:refname"
 	}
-	if ctx.Config.Git.PrereleaseSuffix == "" {
-		ctx.Config.Git.PrereleaseSuffix = "-"
-	}
 }
 
 // Run the pipe.
@@ -291,16 +288,25 @@ func getPreviousTag(ctx *context.Context, current string) (string, error) {
 }
 
 func gitTagsPointingAt(ctx *context.Context, ref string) ([]string, error) {
-	return git.CleanAllLines(git.Run(
-		ctx,
-		"-c",
-		"versionsort.suffix="+ctx.Config.Git.PrereleaseSuffix,
+	args := []string{
 		"tag",
 		"--points-at",
 		ref,
 		"--sort",
 		ctx.Config.Git.TagSort,
-	))
+	}
+	if ctx.Config.Git.PrereleaseSuffix != "" {
+		args = []string{
+			"-c",
+			"versionsort.suffix=" + ctx.Config.Git.PrereleaseSuffix,
+			"tag",
+			"--points-at",
+			ref,
+			"--sort",
+			ctx.Config.Git.TagSort,
+		}
+	}
+	return git.CleanAllLines(git.Run(ctx, args...))
 }
 
 func gitDescribe(ctx *context.Context, ref string) (string, error) {

--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -28,6 +28,9 @@ func setDefaults(ctx *context.Context) {
 	if ctx.Config.Git.TagSort == "" {
 		ctx.Config.Git.TagSort = "-version:refname"
 	}
+	if ctx.Config.Git.PrereleaseSuffix == "" {
+		ctx.Config.Git.PrereleaseSuffix = "-"
+	}
 }
 
 // Run the pipe.
@@ -290,6 +293,8 @@ func getPreviousTag(ctx *context.Context, current string) (string, error) {
 func gitTagsPointingAt(ctx *context.Context, ref string) ([]string, error) {
 	return git.CleanAllLines(git.Run(
 		ctx,
+		"-c",
+		"versionsort.suffix="+ctx.Config.Git.PrereleaseSuffix,
 		"tag",
 		"--points-at",
 		ref,

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -176,11 +176,30 @@ func TestTagSortOrder(t *testing.T) {
 	testlib.GitCommit(t, "commit1")
 	testlib.GitCommit(t, "commit2")
 	testlib.GitCommit(t, "commit3")
-	testlib.GitTag(t, "v0.0.1-rc.2")
+	testlib.GitTag(t, "v0.0.2")
 	testlib.GitTag(t, "v0.0.1")
 	ctx := testctx.NewWithCfg(config.Project{
 		Git: config.Git{
 			TagSort: "-version:refname",
+		},
+	})
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, "v0.0.2", ctx.Git.CurrentTag)
+}
+
+func TestTagSortOrderPrerelease(t *testing.T) {
+	testlib.Mktmp(t)
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
+	testlib.GitCommit(t, "commit1")
+	testlib.GitCommit(t, "commit2")
+	testlib.GitCommit(t, "commit3")
+	testlib.GitTag(t, "v0.0.1-rc.2")
+	testlib.GitTag(t, "v0.0.1")
+	ctx := testctx.NewWithCfg(config.Project{
+		Git: config.Git{
+			TagSort:          "-version:refname",
+			PrereleaseSuffix: "-",
 		},
 	})
 	require.NoError(t, Pipe{}.Run(ctx))

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -180,7 +180,7 @@ func TestTagSortOrder(t *testing.T) {
 	testlib.GitTag(t, "v0.0.1")
 	ctx := testctx.NewWithCfg(config.Project{
 		Git: config.Git{
-			TagSort: "-version:creatordate",
+			TagSort: "-version:refname",
 		},
 	})
 	require.NoError(t, Pipe{}.Run(ctx))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,7 +18,8 @@ import (
 
 // Git configs.
 type Git struct {
-	TagSort string `yaml:"tag_sort,omitempty" json:"tag_sort,omitempty"`
+	TagSort          string `yaml:"tag_sort,omitempty" json:"tag_sort,omitempty"`
+	PrereleaseSuffix string `yaml:"prerelease_suffix,omitempty" json:"prerelease_suffix,omitempty"`
 }
 
 // GitHubURLs holds the URLs to be used when using github enterprise.

--- a/www/docs/customization/git.md
+++ b/www/docs/customization/git.md
@@ -12,4 +12,9 @@ git:
   #
   # Default: `-version:refname`
   tag_sort: -version:creatordate
+  # What should be used to specify prerelease suffix while sorting tags when gathering
+  # the current and previous tags if there are more than one tag in the same commit.
+  #
+  # Default: `-`
+  prerelease_suffix: +
 ```

--- a/www/docs/customization/git.md
+++ b/www/docs/customization/git.md
@@ -12,6 +12,7 @@ git:
   #
   # Default: `-version:refname`
   tag_sort: -version:creatordate
+
   # What should be used to specify prerelease suffix while sorting tags when gathering
   # the current and previous tags if there are more than one tag in the same commit.
   #

--- a/www/docs/customization/git.md
+++ b/www/docs/customization/git.md
@@ -16,6 +16,5 @@ git:
   # What should be used to specify prerelease suffix while sorting tags when gathering
   # the current and previous tags if there are more than one tag in the same commit.
   #
-  # Default: `-`
-  prerelease_suffix: +
+  prerelease_suffix: "-"
 ```

--- a/www/docs/static/schema-pro.json
+++ b/www/docs/static/schema-pro.json
@@ -1077,6 +1077,9 @@
 				"properties": {
 					"tag_sort": {
 						"type": "string"
+					},
+					"prerelease_suffix": {
+						"type": "string"
 					}
 				},
 				"additionalProperties": false,

--- a/www/docs/static/schema.json
+++ b/www/docs/static/schema.json
@@ -979,6 +979,9 @@
 				"properties": {
 					"tag_sort": {
 						"type": "string"
+					},
+					"prerelease_suffix": {
+						"type": "string"
 					}
 				},
 				"additionalProperties": false,


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

This commit will fix bad version tag sort if there is a prerelease on the same commit as a release tag. Current output is shown below
```
❯ git tag --points-at HEAD --sort=-version:refname --format='%(creatordate)%09%(refname)'
Thu Mar 2 21:38:51 2023 +0300   refs/tags/v1.13.0-rc3
Thu Mar 2 21:38:51 2023 +0300   refs/tags/v1.13.0
```
Test is changed to match current default value so it will fail without this fix.

Default value `-` is set to the one that is described inside [docs](https://goreleaser.com/how-it-works/?h=prerelease#how-it-works), but people are still allowed to change it.

Output with fix applied
```
❯ git -c versionsort.suffix=- tag --points-at HEAD --sort -version:refname --format='%(creatordate)%09%(refname)'
Thu Mar 2 21:38:51 2023 +0300   refs/tags/v1.13.0
Thu Mar 2 21:38:51 2023 +0300   refs/tags/v1.13.0-rc3
```

<!-- # Provide links to any relevant tickets, URLs or other resources -->
More info about `versionsort.suffix` can be found [here](https://github.com/git/git/blob/master/Documentation/config/versionsort.txt#L5)

Docs as well both schemas are updated as well.

I am not sure if users should be allowed to change this option at all.
