### PR TITLE
fix(gpg sign): issue #3890

### DIFF
--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -337,3 +337,15 @@ func getFromEnv(s string) func() ([]string, error) {
 		return nil, nil
 	}
 }
+
+// GetGPGProgram returns the user set GPG path or "gpg" if nothing is set
+func GetGPGProgram(ctx *context.Context) (string, error) {
+	path, err := git.Clean(git.Run(ctx, "config", "gpg.program"))
+
+	// if config not set assume default
+	if len(path) == 0 {
+		path = "gpg"
+	}
+
+	return path, err
+}

--- a/internal/pipe/sign/sign.go
+++ b/internal/pipe/sign/sign.go
@@ -15,6 +15,7 @@ import (
 	"github.com/goreleaser/goreleaser/internal/ids"
 	"github.com/goreleaser/goreleaser/internal/logext"
 	"github.com/goreleaser/goreleaser/internal/pipe"
+	"github.com/goreleaser/goreleaser/internal/pipe/git"
 	"github.com/goreleaser/goreleaser/internal/semerrgroup"
 	"github.com/goreleaser/goreleaser/internal/tmpl"
 	"github.com/goreleaser/goreleaser/pkg/config"
@@ -37,11 +38,17 @@ func (Pipe) Dependencies(ctx *context.Context) []string {
 
 // Default sets the Pipes defaults.
 func (Pipe) Default(ctx *context.Context) error {
+	gpgPath, err := git.GetGPGProgram(ctx)
+	if err != nil {
+		return err
+	}
+
 	ids := ids.New("signs")
 	for i := range ctx.Config.Signs {
 		cfg := &ctx.Config.Signs[i]
 		if cfg.Cmd == "" {
-			cfg.Cmd = "gpg"
+			// gpgPath is either "gpg" (default) or the user's git config gpg.program value
+			cfg.Cmd = gpgPath
 		}
 		if cfg.Signature == "" {
 			cfg.Signature = "${artifact}.sig"

--- a/internal/pipe/sign/sign_test.go
+++ b/internal/pipe/sign/sign_test.go
@@ -56,7 +56,7 @@ func TestSignDefault(t *testing.T) {
 	})
 	err := Pipe{}.Default(ctx)
 	require.NoError(t, err)
-	require.Equal(t, ctx.Config.Signs[0].Cmd, "gpg")
+	require.Equal(t, ctx.Config.Signs[0].Cmd, "gpg") // assumes git config gpg.program is not set
 	require.Equal(t, ctx.Config.Signs[0].Signature, "${artifact}.sig")
 	require.Equal(t, ctx.Config.Signs[0].Args, []string{"--output", "$signature", "--detach-sig", "$artifact"})
 	require.Equal(t, ctx.Config.Signs[0].Artifacts, "none")


### PR DESCRIPTION
Fixes issue #3890 by checking the user's git `gpg.program` configuration. If the user didn't set this value it will use the default "gpg", just like before this PR.

No need to add a additional unit test as your existing tests cover it (mostly); however, a comment has been added to that check, informing the reader that the test environment assumes `git config gpg.program` is not be set.