### PR TITLE
docs: standarizing docs defaults, since, etc 

### DIFF
--- a/www/docs/customization/announce/discord.md
+++ b/www/docs/customization/announce/discord.md
@@ -17,19 +17,24 @@ announce:
     enabled: true
 
     # Message template to use while publishing.
+    #
     # Default: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'
+    # Templates: allowed
     message_template: 'Awesome project {{.Tag}} is out!'
 
     # Set author of the embed.
+    #
     # Default: 'GoReleaser'
     author: ''
 
     # Color code of the embed. You have to use decimal numeral system, not hexadecimal.
+    #
     # Default: '3888754' (the grey-ish from GoReleaser)
     color: ''
 
     # URL to an image to use as the icon for the embed.
-    # Defaults to `https://goreleaser.com/static/avatar.png`
+    #
+    # Default: 'https://goreleaser.com/static/avatar.png'
     icon_url: ''
 ```
 

--- a/www/docs/customization/announce/discord.md
+++ b/www/docs/customization/announce/discord.md
@@ -14,19 +14,18 @@ After this, you can add following section to your `.goreleaser.yaml` config:
 announce:
   discord:
     # Whether its enabled or not.
-    # Defaults to false.
     enabled: true
 
     # Message template to use while publishing.
-    # Defaults to `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}`
+    # Default: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'
     message_template: 'Awesome project {{.Tag}} is out!'
 
     # Set author of the embed.
-    # Defaults to `GoReleaser`
+    # Default: 'GoReleaser'
     author: ''
 
     # Color code of the embed. You have to use decimal numeral system, not hexadecimal.
-    # Defaults to `3888754` - the grey-ish from goreleaser
+    # Default: '3888754' (the grey-ish from GoReleaser)
     color: ''
 
     # URL to an image to use as the icon for the embed.

--- a/www/docs/customization/announce/index.md
+++ b/www/docs/customization/announce/index.md
@@ -15,7 +15,6 @@ announce:
   #
   # Any value different from 'true' is evaluated to false.
   #
-  # Default: ""
   # Templates: allowed
   skip: "{{gt .Patch 0}}"
 ```

--- a/www/docs/customization/announce/index.md
+++ b/www/docs/customization/announce/index.md
@@ -1,14 +1,21 @@
 # Announce
 
-GoReleaser can also announce new releases on social networks, chat rooms and via email!
+GoReleaser can also announce new releases on social networks, chat rooms and via
+email!
 
-It runs at the very end of the pipeline and can be skipped with the `--skip-announce` flag of the [`release`](/cmd/goreleaser_release/) command, or via the skip property:
+It runs at the very end of the pipeline and can be skipped with the
+`--skip-announce` flag of the [`release`](/cmd/goreleaser_release/) command, or
+via the skip property:
 
 ```yaml
 # .goreleaser.yaml
 announce:
-  # Skip the announcing feature in some conditions, for instance, when publishing patch releases.
-  # Valid options are `true`, `false`, empty, or a template that evaluates to a boolean (`true` or `false`).
-  # Defaults to empty (which means false).
+  # Skip the announcing feature in some conditions, for instance, when
+  # publishing patch releases.
+  #
+  # Any value different from 'true' is evaluated to false.
+  #
+  # Default: ""
+  # Templates: allowed
   skip: "{{gt .Patch 0}}"
 ```

--- a/www/docs/customization/announce/linkedin.md
+++ b/www/docs/customization/announce/linkedin.md
@@ -14,11 +14,10 @@ Then, you can add something like the following to your `.goreleaser.yaml` config
 announce:
   linkedin:
     # Whether its enabled or not.
-    # Defaults to false.
     enabled: true
 
     # Message template to use while publishing.
-    # Defaults to `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}`
+    # Default: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'
     message_template: 'Awesome project {{.Tag}} is out!'
 ```
 

--- a/www/docs/customization/announce/linkedin.md
+++ b/www/docs/customization/announce/linkedin.md
@@ -16,7 +16,8 @@ announce:
     # Whether its enabled or not.
     enabled: true
 
-    # Message template to use while publishing.
+    # Message to use while publishing.
+    #
     # Default: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'
     message_template: 'Awesome project {{.Tag}} is out!'
 ```

--- a/www/docs/customization/announce/mastodon.md
+++ b/www/docs/customization/announce/mastodon.md
@@ -20,9 +20,10 @@ announce:
     # Whether its enabled or not.
     enabled: true
 
-    # Message template to use while publishing.
+    # Message to use while publishing.
     #
     # Default: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'
+    # Templates: allowed
     message_template: 'Awesome project {{.Tag}} is out!'
 
     # Mastodon server URL.

--- a/www/docs/customization/announce/mastodon.md
+++ b/www/docs/customization/announce/mastodon.md
@@ -1,6 +1,6 @@
 # Mastodon
 
-> Since: v1.13.0
+> Since: v1.13
 
 For it to work, you'll need to create a new Mastodon app
 `https://social.yourdomain.tld/settings/applications/new` with `write:statuses`
@@ -18,15 +18,14 @@ configuration file:
 announce:
   mastodon:
     # Whether its enabled or not.
-    # Defaults to false.
     enabled: true
 
     # Message template to use while publishing.
-    # Defaults to `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}`
+    #
+    # Default: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'
     message_template: 'Awesome project {{.Tag}} is out!'
 
     # Mastodon server URL.
-    # Defaults to empty.
     server: https://mastodon.social
 ```
 

--- a/www/docs/customization/announce/mattermost.md
+++ b/www/docs/customization/announce/mattermost.md
@@ -14,13 +14,16 @@ announce:
     # Whether its enabled or not.
     enabled: true
 
-    # Title template to use while publishing.
+    # Title to use while publishing.
     #
     # Default: '{{ .ProjectName }} {{ .Tag }} is out!'
+    # Templates: allowed
     title_template: 'GoReleaser {{ .Tag }} was just released!'
 
-    # Message template to use while publishing.
+    # Message to use while publishing.
+    #
     # Default: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'
+    # Templates: allowed
     message_template: 'Awesome project {{.Tag}} is out!'
 
     # Color code of the message. You have to use hexadecimal.

--- a/www/docs/customization/announce/mattermost.md
+++ b/www/docs/customization/announce/mattermost.md
@@ -12,19 +12,19 @@ Then, you can add something like the following to your `.goreleaser.yaml` config
 announce:
   mattermost:
     # Whether its enabled or not.
-    # Defaults to false.
     enabled: true
 
     # Title template to use while publishing.
-    # Defaults to `{{ .ProjectName }} {{ .Tag }} is out!`
+    #
+    # Default: '{{ .ProjectName }} {{ .Tag }} is out!'
     title_template: 'GoReleaser {{ .Tag }} was just released!'
 
     # Message template to use while publishing.
-    # Defaults to `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}`
+    # Default: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'
     message_template: 'Awesome project {{.Tag}} is out!'
 
     # Color code of the message. You have to use hexadecimal.
-    # Defaults to `#2D313E` - the grey-ish from goreleaser
+    # Default: '#2D313E' (the grey-ish from GoReleaser)
     color: ''
 
     # The name of the channel that the user selected as a destination for webhook messages.

--- a/www/docs/customization/announce/opencollective.md
+++ b/www/docs/customization/announce/opencollective.md
@@ -18,10 +18,14 @@ announce:
     slug: 'goreleaser'
 
     # Title for the update
+    #
     # Default: '{{ .Tag }}'
+    # Templates: allowed
     title_template: 'Release of {{ .Tag }}'
 
-    # Message template to use while publishing. It can be HTML!
+    # Message to use while publishing. It can be HTML!
+    #
     # Default: '{{ .ProjectName }} {{ .Tag }} is out!<br/>Check it out at <a href="{{ .ReleaseURL }}">{{ .ReleaseURL }}</a>'
+    # Templates: allowed
     message_template: 'Awesome project {{.Tag}} is out!'
 ```

--- a/www/docs/customization/announce/opencollective.md
+++ b/www/docs/customization/announce/opencollective.md
@@ -11,7 +11,6 @@ Then, you can add something like the following to your `.goreleaser.yaml` config
 announce:
   opencollective:
     # Whether its enabled or not.
-    # Defaults to false.
     enabled: true
 
     # Collective slug
@@ -19,10 +18,10 @@ announce:
     slug: 'goreleaser'
 
     # Title for the update
-    # Defaults to `{{ .Tag }}`
+    # Default: '{{ .Tag }}'
     title_template: 'Release of {{ .Tag }}'
 
     # Message template to use while publishing. It can be HTML!
-    # Defaults to `{{ .ProjectName }} {{ .Tag }} is out!<br/>Check it out at <a href="{{ .ReleaseURL }}">{{ .ReleaseURL }}</a>`
+    # Default: '{{ .ProjectName }} {{ .Tag }} is out!<br/>Check it out at <a href="{{ .ReleaseURL }}">{{ .ReleaseURL }}</a>'
     message_template: 'Awesome project {{.Tag}} is out!'
 ```

--- a/www/docs/customization/announce/reddit.md
+++ b/www/docs/customization/announce/reddit.md
@@ -13,7 +13,6 @@ Then, you can add something like the following to your `.goreleaser.yaml` config
 announce:
   reddit:
     # Whether its enabled or not.
-    # Defaults to false.
     enabled: true
 
     # Application ID for Reddit Application
@@ -23,11 +22,11 @@ announce:
     username: ""
 
     # URL template to use while publishing.
-    # Defaults to `{{ .ReleaseURL }}`
+    # Default: '{{ .ReleaseURL }}'
     url_template: 'https://github.com/goreleaser/goreleaser/releases/tag/{{ .Tag }}'
 
     # Title template to use while publishing.
-    # Defaults to `{{ .ProjectName }} {{ .Tag }} is out!`
+    # Default: '{{ .ProjectName }} {{ .Tag }} is out!'
     title_template: ''GoReleaser {{ .Tag }} was just released!''
 ```
 

--- a/www/docs/customization/announce/reddit.md
+++ b/www/docs/customization/announce/reddit.md
@@ -22,11 +22,15 @@ announce:
     username: ""
 
     # URL template to use while publishing.
+    #
     # Default: '{{ .ReleaseURL }}'
+    # Templates: allowed
     url_template: 'https://github.com/goreleaser/goreleaser/releases/tag/{{ .Tag }}'
 
     # Title template to use while publishing.
+    #
     # Default: '{{ .ProjectName }} {{ .Tag }} is out!'
+    # Templates: allowed
     title_template: ''GoReleaser {{ .Tag }} was just released!''
 ```
 

--- a/www/docs/customization/announce/slack.md
+++ b/www/docs/customization/announce/slack.md
@@ -15,7 +15,9 @@ announce:
     enabled: true
 
     # Message template to use while publishing.
+    #
     # Default: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'
+    # Templates: allowed
     message_template: 'Awesome project {{.Tag}} is out!'
 
     # The name of the channel that the user selected as a destination for webhook messages.
@@ -33,18 +35,18 @@ announce:
     # Blocks for advanced formatting, see: https://api.slack.com/messaging/webhooks#advanced_message_formatting
     # and https://api.slack.com/messaging/composing/layouts#adding-blocks.
     #
-    # Templating is possible inside this structure.
-    #
     # Attention: goreleaser doesn't check the full structure of the Slack API: please make sure that
     # your configuration for advanced message formatting abides by this API.
+    #
+    # Templates: allowed
     blocks: []
 
     # Attachments, see: https://api.slack.com/reference/messaging/attachments
     #
-    # Templating is possible inside this structure.
-    #
     # Attention: goreleaser doesn't check the full structure of the Slack API: please make sure that
     # your configuration for advanced message formatting abides by this API.
+    #
+    # Templates: allowed
     attachments: []
 ```
 

--- a/www/docs/customization/announce/slack.md
+++ b/www/docs/customization/announce/slack.md
@@ -12,11 +12,10 @@ Then, you can add something like the following to your `.goreleaser.yaml` config
 announce:
   slack:
     # Whether its enabled or not.
-    # Defaults to false.
     enabled: true
 
     # Message template to use while publishing.
-    # Defaults to `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}`
+    # Default: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'
     message_template: 'Awesome project {{.Tag}} is out!'
 
     # The name of the channel that the user selected as a destination for webhook messages.

--- a/www/docs/customization/announce/smtp.md
+++ b/www/docs/customization/announce/smtp.md
@@ -14,10 +14,12 @@ announce:
     enabled: true
 
     # SMTP Host.
+    #
     # Default: $SMTP_HOST
     host: "smtp.gmail.com"
 
     # SMTP Port
+    #
     # Default: $SMTP_PORT
     port: 587
 
@@ -30,15 +32,20 @@ announce:
       - ""
 
     # Owner of the email
+    #
     # Default: $SMTP_USERNAME
     username: ""
 
-    # Body template to use within the email.
+    # Body to use within the email.
+    #
     # Default: 'You can view details from: {{ .ReleaseURL }}'
+    # Templates: allowed
     body_template: 'https://github.com/goreleaser/goreleaser/releases/tag/{{ .Tag }}'
 
     # Subject template to use within the email subject.
+    #
     # Default: '{{ .ProjectName }} {{ .Tag }} is out!'
+    # Templates: allowed
     subject_template: ''GoReleaser {{ .Tag }} was just released!''
 ```
 

--- a/www/docs/customization/announce/smtp.md
+++ b/www/docs/customization/announce/smtp.md
@@ -11,15 +11,14 @@ Then, you can add something like the following to your `.goreleaser.yaml` config
 announce:
   smtp:
     # Whether its enabled or not.
-    # Defaults to false.
     enabled: true
 
     # SMTP Host.
-    # Default from $SMTP_HOST.
+    # Default: $SMTP_HOST
     host: "smtp.gmail.com"
 
     # SMTP Port
-    # Default from $SMTP_PORT.
+    # Default: $SMTP_PORT
     port: 587
 
     # Sender of the email
@@ -31,15 +30,15 @@ announce:
       - ""
 
     # Owner of the email
-    # Default from $SMTP_USERNAME.
+    # Default: $SMTP_USERNAME
     username: ""
 
     # Body template to use within the email.
-    # Defaults to `You can view details from: {{ .ReleaseURL }}`
+    # Default: 'You can view details from: {{ .ReleaseURL }}'
     body_template: 'https://github.com/goreleaser/goreleaser/releases/tag/{{ .Tag }}'
 
     # Subject template to use within the email subject.
-    # Defaults to `{{ .ProjectName }} {{ .Tag }} is out!`
+    # Default: '{{ .ProjectName }} {{ .Tag }} is out!'
     subject_template: ''GoReleaser {{ .Tag }} was just released!''
 ```
 

--- a/www/docs/customization/announce/teams.md
+++ b/www/docs/customization/announce/teams.md
@@ -13,23 +13,22 @@ After this, you can add following section to your `.goreleaser.yaml` config:
 announce:
   teams:
     # Whether its enabled or not.
-    # Defaults to false.
     enabled: true
 
     # Title template to use while publishing.
-    # Defaults to `{{ .ProjectName }} {{ .Tag }} is out!`
+    # Default: '{{ .ProjectName }} {{ .Tag }} is out!'
     title_template: 'GoReleaser {{ .Tag }} was just released!'
 
     # Message template to use while publishing.
-    # Defaults to `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}`
+    # Default: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'
     message_template: 'Awesome project {{.Tag}} is out!'
 
     # Color code of the message. You have to use hexadecimal.
-    # Defaults to `#2D313E` - the grey-ish from goreleaser
+    # Default: '#2D313E' (the grey-ish from GoReleaser)
     color: ''
 
     # URL to an image to use as the icon for the message.
-    # Defaults to `https://goreleaser.com/static/avatar.png`
+    # Default: 'https://goreleaser.com/static/avatar.png'
     icon_url: ''
 ```
 

--- a/www/docs/customization/announce/teams.md
+++ b/www/docs/customization/announce/teams.md
@@ -16,18 +16,24 @@ announce:
     enabled: true
 
     # Title template to use while publishing.
+    #
     # Default: '{{ .ProjectName }} {{ .Tag }} is out!'
+    # Templates: allowed
     title_template: 'GoReleaser {{ .Tag }} was just released!'
 
     # Message template to use while publishing.
+    #
     # Default: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'
+    # Templates: allowed
     message_template: 'Awesome project {{.Tag}} is out!'
 
     # Color code of the message. You have to use hexadecimal.
+    #
     # Default: '#2D313E' (the grey-ish from GoReleaser)
     color: ''
 
     # URL to an image to use as the icon for the message.
+    #
     # Default: 'https://goreleaser.com/static/avatar.png'
     icon_url: ''
 ```

--- a/www/docs/customization/announce/telegram.md
+++ b/www/docs/customization/announce/telegram.md
@@ -20,12 +20,13 @@ announce:
 
     # Integer representation of your channel
     #
-    # Templateable. (since v1.15)
+    # Templates: allowed (since v1.15)
     chat_id: 123456
 
     # Message template to use while publishing.
     #
     # Default: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'
+    # Templates: allowed
     message_template: 'Awesome project {{.Tag}} is out!'
 ```
 

--- a/www/docs/customization/announce/telegram.md
+++ b/www/docs/customization/announce/telegram.md
@@ -16,8 +16,6 @@ config:
 announce:
   telegram:
     # Whether its enabled or not.
-    #
-    # Defaults to false.
     enabled: true
 
     # Integer representation of your channel
@@ -27,7 +25,7 @@ announce:
 
     # Message template to use while publishing.
     #
-    # Defaults to `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}`
+    # Default: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'
     message_template: 'Awesome project {{.Tag}} is out!'
 ```
 

--- a/www/docs/customization/announce/twitter.md
+++ b/www/docs/customization/announce/twitter.md
@@ -21,11 +21,10 @@ Then, you can add something like the following to your `.goreleaser.yaml` config
 announce:
   twitter:
     # Whether its enabled or not.
-    # Defaults to false.
     enabled: true
 
     # Message template to use while publishing.
-    # Defaults to `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}`
+    # Default: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'
     message_template: 'Awesome project {{.Tag}} is out!'
 ```
 

--- a/www/docs/customization/announce/twitter.md
+++ b/www/docs/customization/announce/twitter.md
@@ -24,7 +24,9 @@ announce:
     enabled: true
 
     # Message template to use while publishing.
+    #
     # Default: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'
+    # Templates: allowed
     message_template: 'Awesome project {{.Tag}} is out!'
 ```
 

--- a/www/docs/customization/announce/webhook.md
+++ b/www/docs/customization/announce/webhook.md
@@ -23,10 +23,13 @@ announce:
     skip_tls_verify: true
 
     # Message template to use while publishing.
+    #
     # Default: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'
+    # Templates: allowed
     message_template: '{ "title": "Awesome project {{.Tag}} is out!"}'
 
     # Content type to use.
+    #
     # Default: 'application/json; charset=utf-8'
     content_type: "application/json"
 

--- a/www/docs/customization/announce/webhook.md
+++ b/www/docs/customization/announce/webhook.md
@@ -1,6 +1,6 @@
 # Webhook
 
-Since: v1.3.
+> Since: v1.3
 
 Webhooks are a way to receive notifications. With this `Goreleaser` functionality, you can send events to any server
 exposing a webhook.
@@ -17,18 +17,17 @@ Add following to your `.goreleaser.yaml` config to enable the webhook functional
 announce:
   webhook:
     # Whether its enabled or not.
-    # Defaults to false.
     enabled: true
 
-    # Check the certificate of the webhook. Defaults to false.
+    # Check the certificate of the webhook.
     skip_tls_verify: true
 
     # Message template to use while publishing.
-    # Defaults to `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}`
+    # Default: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'
     message_template: '{ "title": "Awesome project {{.Tag}} is out!"}'
 
     # Content type to use.
-    # Defaults to `"application/json; charset=utf-8"`
+    # Default: 'application/json; charset=utf-8'
     content_type: "application/json"
 
     # Endpoint to send the webhook to.

--- a/www/docs/customization/archive.md
+++ b/www/docs/customization/archive.md
@@ -30,15 +30,17 @@ archives:
     # The name template must not contain any references to `Os`, `Arch` and etc, since the archive will be meta.
     #
     # Since: v1.9
+    # Templates: allowed
     meta: true
 
-    # Archive name template.
+    # Archive name.
     #
-    # Defaults:
+    # Default:
     # - if format is `tar.gz`, `tar.xz`, `gz` or `zip`:
     #   - `{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}`
     # - if format is `binary`:
     #   - `{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}`
+    # Templates: allowed
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
     # Sets the given file info to all the binaries included from the `builds`.
@@ -82,9 +84,10 @@ archives:
       - goos: windows
         format: zip
 
-    # Additional files/template/globs you want to add to the archive.
+    # Additional files/globs you want to add to the archive.
     #
     # Default: [ 'LICENSE*', 'README*', 'CHANGELOG', 'license*', 'readme*', 'changelog']
+    # Templates: allowed
     files:
       - LICENSE.txt
       - README_{{.Os}}.md
@@ -104,14 +107,15 @@ archives:
         #
         # Default: copied from the source file
         info:
-          # Templateable (since v1.14.0)
+          # Templates: allowed (since v1.14)
           owner: root
 
-          # Templateable (since v1.14.0)
+          # Templates: allowed (since v1.14)
           group: root
 
           # Must be in time.RFC3339Nano format.
-          # Templateable (since v1.14.0)
+          #
+          # Templates: allowed (since v1.14)
           mtime: '{{ .CommitDate }}'
 
           # File mode.
@@ -124,6 +128,7 @@ archives:
     #
     # Since: v1.17 (pro)
     # This feature is only available in GoReleaser Pro.
+    # Templates: allowed
     files:
       # a more complete example, check the globbing deep dive below
       - src: 'LICENSE.md.tpl'
@@ -134,17 +139,10 @@ archives:
         #
         # Default: copied from the source file
         info:
-          # Templateable (since v1.14.0)
           owner: root
-
-          # Templateable (since v1.14.0)
           group: root
-
           # Must be in time.RFC3339Nano format.
-          # Templateable (since v1.14.0)
           mtime: '{{ .CommitDate }}'
-
-          # File mode.
           mode: 0644
 
     # Before and after hooks for each archive.

--- a/www/docs/customization/archive.md
+++ b/www/docs/customization/archive.md
@@ -11,28 +11,29 @@ Here is a commented `archives` section with all fields specified:
 archives:
   -
     # ID of this archive.
-    # Defaults to `default`.
+    #
+    # Default: 'default'
     id: my-archive
 
     # Builds reference which build instances should be archived in this archive.
-    # Default is empty, which includes all builds.
     builds:
     - default
 
     # Archive format. Valid options are `tar.gz`, `tar.xz`, `tar`, `gz`, `zip` and `binary`.
     # If format is `binary`, no archives are created and the binaries are instead
     # uploaded directly.
-    # Default is `tar.gz`.
+    #
+    # Default: 'tar.gz'
     format: zip
 
     # This will create an archive without any binaries, only the files are there.
     # The name template must not contain any references to `Os`, `Arch` and etc, since the archive will be meta.
     #
-    # Default: false.
-    # Since: v1.9.
+    # Since: v1.9
     meta: true
 
     # Archive name template.
+    #
     # Defaults:
     # - if format is `tar.gz`, `tar.xz`, `gz` or `zip`:
     #   - `{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}`
@@ -42,9 +43,8 @@ archives:
 
     # Sets the given file info to all the binaries included from the `builds`.
     #
-    # Default is to use the actual binary properties.
-    #
-    # Since: v1.14.0.
+    # Default: copied from the source binary.
+    # Since: v1.14
     builds_info:
       group: root
       owner: root
@@ -58,15 +58,13 @@ archives:
     # you'll get a folder 'goreleaser_Linux_arm64'.
     # If set to false, all files are extracted separately.
     # You can also set it to a custom folder name (templating is supported).
-    # Default is false.
     wrap_in_directory: true
 
     # If set to true, will strip the parent directories away from binary files.
     #
     # This might be useful if you have your binary be built with a subdir for some reason, but do no want that subdir inside the archive.
     #
-    # Default: false.
-    # Since: v1.11.
+    # Since: v1.11
     strip_parent_binary_folder: true
 
 
@@ -75,20 +73,18 @@ archives:
     # Enabling this essentially mimic the behavior of nfpm's contents section.
     # It will be the default by June 2023.
     #
-    # Default: false
-    # Since: v1.14.
+    # Since: v1.14
     rlcp: true
 
     # Can be used to change the archive formats for specific GOOSs.
     # Most common use case is to archive as zip on Windows.
-    # Default is empty.
     format_overrides:
       - goos: windows
         format: zip
 
     # Additional files/template/globs you want to add to the archive.
-    # Defaults are any files matching `LICENSE*`, `README*`, `CHANGELOG*`,
-    #  `license*`, `readme*` and `changelog*`.
+    #
+    # Default: [ 'LICENSE*', 'README*', 'CHANGELOG', 'license*', 'readme*', 'changelog']
     files:
       - LICENSE.txt
       - README_{{.Os}}.md
@@ -101,12 +97,12 @@ archives:
         dst: docs
 
         # Strip parent folders when adding files to the archive.
-        # Default: false
         strip_parent: true
 
         # File info.
         # Not all fields are supported by all formats available formats.
-        # Defaults to the file info of the actual file if not provided.
+        #
+        # Default: copied from the source file
         info:
           # Templateable (since v1.14.0)
           owner: root
@@ -126,7 +122,6 @@ archives:
     # Those files will have their contents pass through the template engine,
     # and its results will be added to the archive.
     #
-    # Default: empty
     # Since: v1.17 (pro)
     # This feature is only available in GoReleaser Pro.
     files:
@@ -136,7 +131,8 @@ archives:
 
         # File info.
         # Not all fields are supported by all formats available formats.
-        # Defaults to the file info of the actual file if not provided.
+        #
+        # Default: copied from the source file
         info:
           # Templateable (since v1.14.0)
           owner: root
@@ -174,7 +170,6 @@ archives:
         - 'RELEASE_DONE=something-{{ .ProjectName }}' # specify hook level environment variables
 
     # Disables the binary count check.
-    # Default: false
     allow_different_binary_count: true
 ```
 

--- a/www/docs/customization/artifactory.md
+++ b/www/docs/customization/artifactory.md
@@ -146,8 +146,7 @@ artifactories:
     # extensions with the same ID, and need to upload each extension to
     # a different place (e.g. nFPM packages).
     #
-    # Default: empty.
-    # Since: v1.7.
+    # Since: v1.7
     exts:
     - deb
     - rpm
@@ -155,7 +154,7 @@ artifactories:
     # Upload mode. Valid options are `binary` and `archive`.
     # If mode is `archive`, variables _Os_, _Arch_ and _Arm_ for target name are not supported.
     # In that case these variables are empty.
-    # Default is `archive`.
+    # Default: 'archive'
     mode: archive
 
     # URL of your Artifactory instance + path to deploy to
@@ -165,14 +164,15 @@ artifactories:
     username: deployuser
 
     # Client certificate and key (when provided, added as client cert to TLS connections)
-    # Since: v1.11.
+    #
+    # Since: v1.11
     client_x509_cert: /path/to/client.cert.pem
     client_x509_key: /path/to/client.key.pem
 
-    # Upload checksums (defaults to false)
+    # Upload checksums.
     checksum: true
 
-    # Upload signatures (defaults to false)
+    # Upload signatures.
     signature: true
 
     # Certificate chain used to validate server certificates

--- a/www/docs/customization/artifactory.md
+++ b/www/docs/customization/artifactory.md
@@ -154,6 +154,7 @@ artifactories:
     # Upload mode. Valid options are `binary` and `archive`.
     # If mode is `archive`, variables _Os_, _Arch_ and _Arm_ for target name are not supported.
     # In that case these variables are empty.
+    #
     # Default: 'archive'
     mode: archive
 

--- a/www/docs/customization/aur.md
+++ b/www/docs/customization/aur.md
@@ -1,6 +1,6 @@
 # Arch User Repositories
 
-Since: v1.4.
+> Since: v1.4
 
 After releasing to GitHub, GitLab, or Gitea, GoReleaser can generate and publish
 a `PKGBUILD` to an _Arch User Repository_.
@@ -17,40 +17,34 @@ aurs:
   -
     # The package name.
     #
-    # Defaults to the Project Name with a -bin suffix.
-    #
     # Note that since this integration does not create a PKGBUILD to build from
     # source, per Arch's guidelines.
     # That said, GoReleaser will enforce a `-bin` suffix if its not present.
+    #
+    # Default: ProjectName with a -bin suffix.
     name: package-bin
 
     # Artifact IDs to filter for.
-    #
-    # Defaults to empty, which includes all artifacts.
+    # Empty means all IDs (no filter).
     ids:
       - foo
       - bar
 
     # Your app's homepage.
-    # Default is empty.
     homepage: "https://example.com/"
 
     # Template of your app's description.
-    # Default is empty.
     description: "Software to create fast and easy drum rolls."
 
     # The maintainers of the package.
-    # Defaults to empty.
     maintainers:
       - 'Foo Bar <foo at bar dot com>'
 
     # The contributors of the package.
-    # Defaults to empty.
     contributors:
       - 'Foo Zaz <foo at zaz dot com>'
 
     # SPDX identifier of your app's license.
-    # Default is empty.
     license: "MIT"
 
     # The SSH private key that should be used to commit to the Git repository.
@@ -62,7 +56,6 @@ aurs:
     private_key: '{{ .Env.AUR_KEY }}'
 
     # The AUR Git URL for this package.
-    # Defaults to empty
     # Publish is skipped if empty.
     git_url: 'ssh://aur@aur.archlinux.org/mypackage-bin.git'
 
@@ -72,25 +65,21 @@ aurs:
     #
     # If set to auto, the release will not be uploaded to the AUR repo
     # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1.
-    #
-    # Default is false.
     skip_upload: true
 
     # List of additional packages that the software provides the features of.
     #
-    # Defaults to the project name.
+    # Default: ProjectName
     provides:
       - mybin
 
     # List of packages that conflict with, or cause problems with the package.
     #
-    # Defaults to the project name.
+    # Default: ProjectName
     conflicts:
       - mybin
 
     # List of packages that must be installed to install this.
-    #
-    # Defaults to empty.
     depends:
       - curl
 
@@ -98,26 +87,23 @@ aurs:
     # but provide additional features.
     #
     # Must be in the format `package: short description of the extra functionality`.
-    #
-    # Defaults to empty.
     optdepends:
       - 'wget: for downloading things'
 
     # List of files that can contain user-made changes and should be preserved
     # during package upgrades and removals.
     #
-    # Default: empty.
     # Since: v1.12
     backup:
       - /etc/foo.conf
 
     # Custom package instructions.
-    #
-    # Defaults to `install -Dm755 "./PROJECT_NAME" "${pkgdir}/usr/bin/PROJECT_NAME",
     # which is not always correct.
     #
     # We recommend you override this, installing the binary, license and
     # everything else your package needs.
+    #
+    # Default: 'install -Dm755 "./PROJECT_NAME" "${pkgdir}/usr/bin/PROJECT_NAME"'
     package: |-
       # bin
       install -Dm755 "./mybin" "${pkgdir}/usr/bin/mybin"
@@ -137,30 +123,29 @@ aurs:
       install -Dm644 "./manpages/mybin.1.gz" "${pkgdir}/usr/share/man/man1/mybin.1.gz"
 
     # Git author used to commit to the repository.
-    # Defaults are shown below.
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com
 
     # Commit message template.
-    # Defaults to `Update to {{ .Tag }}`.
+    # Default: 'Update to {{ .Tag }}'
     commit_msg_template: "pkgbuild updates"
 
     # If you build for multiple GOAMD64 versions, you may use this to choose which one to use.
-    # Defaults to `v1`.
+    # Default: 'v1'.
     goamd64: v2
 
     # The value to be passed to `GIT_SSH_COMMAND`.
     # This is mainly used to specify the SSH private key used to pull/push to
     # the Git URL.
     #
-    # Defaults to `ssh -i {{ .KeyPath }} -o StrictHostKeyChecking=accept-new -F /dev/null`.
+    # Default: 'ssh -i {{ .KeyPath }} -o StrictHostKeyChecking=accept-new -F /dev/null'
     git_ssh_command: 'ssh -i {{ .Env.KEY }} -o SomeOption=yes'
 
     # Template for the url which is determined by the given Token
     # (github, gitlab or gitea).
     #
-    # Default depends on the client.
+    # Default: depends on the client
     url_template: "http://github.mycompany.com/foo/bar/releases/{{ .Tag }}/{{ .ArtifactName }}"
 ```
 

--- a/www/docs/customization/aur.md
+++ b/www/docs/customization/aur.md
@@ -33,7 +33,9 @@ aurs:
     # Your app's homepage.
     homepage: "https://example.com/"
 
-    # Template of your app's description.
+    # Your app's description.
+    #
+    # Templates: allowed
     description: "Software to create fast and easy drum rolls."
 
     # The maintainers of the package.
@@ -127,11 +129,14 @@ aurs:
       name: goreleaserbot
       email: bot@goreleaser.com
 
-    # Commit message template.
+    # Commit message.
+    #
     # Default: 'Update to {{ .Tag }}'
+    # Templates: allowed
     commit_msg_template: "pkgbuild updates"
 
     # If you build for multiple GOAMD64 versions, you may use this to choose which one to use.
+    #
     # Default: 'v1'.
     goamd64: v2
 
@@ -142,10 +147,11 @@ aurs:
     # Default: 'ssh -i {{ .KeyPath }} -o StrictHostKeyChecking=accept-new -F /dev/null'
     git_ssh_command: 'ssh -i {{ .Env.KEY }} -o SomeOption=yes'
 
-    # Template for the url which is determined by the given Token
+    # URL which is determined by the given Token
     # (github, gitlab or gitea).
     #
     # Default: depends on the client
+    # Templates: allowed
     url_template: "http://github.mycompany.com/foo/bar/releases/{{ .Tag }}/{{ .ArtifactName }}"
 ```
 

--- a/www/docs/customization/blob.md
+++ b/www/docs/customization/blob.md
@@ -28,14 +28,12 @@ blobs:
 
     # Sets the bucket region.
     # Requires provider to be `s3`
-    # Defaults to empty.
     #
-    # Templateable.
+    # Templates: allowed
     region: us-west-1
 
     # Disables SSL
     # Requires provider to be `s3`
-    # Defaults to false
     disableSSL: true
 
     # Template for the bucket name
@@ -49,21 +47,18 @@ blobs:
     - bar
 
     # Template for the path/name inside the bucket.
-    # Default is `{{ .ProjectName }}/{{ .Tag }}`
+    # Default: '{{ .ProjectName }}/{{ .Tag }}'
     folder: "foo/bar/{{.Version}}"
 
     # Template to disable this particular upload configuration.
     #
     # Since: v1.17
-    # Default: false
     disable: '{{ neq .BLOB_UPLOAD_ONLY "foo" }}'
 
     # You can add extra pre-existing files to the bucket.
     # The filename on the release will be the last part of the path (base).
     # If another file with the same name exists, the last one found will be used.
     # These globs can also include templates.
-    #
-    # Defaults to empty.
     extra_files:
       - glob: ./path/to/file.txt
       - glob: ./glob/**/to/**/file/**/*
@@ -76,7 +71,6 @@ blobs:
     # Those files will have their contents pass through the template engine,
     # and its results will be uploaded.
     #
-    # Default: empty
     # Since: v1.17 (pro)
     # This feature is only available in GoReleaser Pro.
     templated_extra_files:

--- a/www/docs/customization/blob.md
+++ b/www/docs/customization/blob.md
@@ -15,7 +15,7 @@ blobs:
     # - azblob for Azure Blob Storage
     # - gs for Google Cloud Storage
     #
-    # Templateable.
+    # Templates: allowed
     provider: azblob
 
     # Set a custom endpoint, useful if you're using a minio backend or
@@ -23,7 +23,7 @@ blobs:
     #
     # Implies s3ForcePathStyle and requires provider to be `s3`
     #
-    # Templateable.
+    # Templates: allowed
     endpoint: https://minio.foo.bar
 
     # Sets the bucket region.
@@ -36,9 +36,9 @@ blobs:
     # Requires provider to be `s3`
     disableSSL: true
 
-    # Template for the bucket name
+    # Bucket name.
     #
-    # Templateable.
+    # Templates: allowed
     bucket: goreleaser-bucket
 
     # IDs of the artifacts you want to upload.
@@ -46,13 +46,16 @@ blobs:
     - foo
     - bar
 
-    # Template for the path/name inside the bucket.
+    # Path/name inside the bucket.
+    #
     # Default: '{{ .ProjectName }}/{{ .Tag }}'
+    # Templates: allowed
     folder: "foo/bar/{{.Version}}"
 
-    # Template to disable this particular upload configuration.
+    # Whether to disable this particular upload configuration.
     #
     # Since: v1.17
+    # Templates: allowed
     disable: '{{ neq .BLOB_UPLOAD_ONLY "foo" }}'
 
     # You can add extra pre-existing files to the bucket.
@@ -64,6 +67,7 @@ blobs:
       - glob: ./glob/**/to/**/file/**/*
       - glob: ./glob/foo/to/bar/file/foobar/override_from_previous
       - glob: ./single_file.txt
+        # Templates: allowed
         name_template: file.txt # note that this only works if glob matches 1 file only
 
 
@@ -73,6 +77,7 @@ blobs:
     #
     # Since: v1.17 (pro)
     # This feature is only available in GoReleaser Pro.
+    # Templates: allowed
     templated_extra_files:
       - src: LICENSE.tpl
         dst: LICENSE.txt

--- a/www/docs/customization/builds.md
+++ b/www/docs/customization/builds.md
@@ -170,7 +170,7 @@ builds:
     # It is safe to ignore this option in most cases.
     #
     # Default: build.
-    # Since: v1.9.
+    # Since: v1.9
     command: test
 
     # Set the modified timestamp on the output binary, typically
@@ -211,7 +211,7 @@ builds:
     # example.
     #
     # Default: false.
-    # Since: v1.9.
+    # Since: v1.9
     no_main_check: true
 
     # Path to project's (sub)directory containing Go code.
@@ -232,8 +232,8 @@ builds:
     # This can be specially useful when using CGO.
     # Note: it'll only match if the full target matches.
     #
-    # Default: empty.
-    # Since: v1.5.
+    # Default: []
+    # Since: v1.5
     overrides:
       - goos: darwin
         goarch: arm64

--- a/www/docs/customization/builds.md
+++ b/www/docs/customization/builds.md
@@ -13,7 +13,8 @@ builds:
   # You can have multiple builds defined as a yaml list
   -
     # ID of the build.
-    # Defaults to the binary name.
+    #
+    # Default: Binary name
     id: "my-build"
 
     # Path to main.go file or main package.
@@ -24,29 +25,35 @@ builds:
 
     # Binary name.
     # Can be a path (e.g. `bin/app`) to wrap the binary in a directory.
-    # Default is the name of the project directory.
+    #
+    # Default: Project directory name
     binary: program
 
-    # Custom flags templates.
-    # Default is empty.
+    # Custom flags.
+    #
+    # Templates: allowed
     flags:
       - -tags=dev
       - -v
 
-    # Custom asmflags templates.
-    # Default is empty.
+    # Custom asmflags.
+    #
+    # Templates: allowed
     asmflags:
       - -D mysymbol
       - all=-trimpath={{.Env.GOPATH}}
 
-    # Custom gcflags templates.
-    # Default is empty.
+    # Custom gcflags.
+    #
+    # Templates: allowed
     gcflags:
       - all=-trimpath={{.Env.GOPATH}}
       - ./dontoptimizeme=-N
 
-    # Custom ldflags templates.
-    # Default is `-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser`.
+    # Custom ldflags.
+    #
+    # Default: 's -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser'
+    # Templates: allowed
     ldflags:
       - -s -w -X main.build={{.Version}}
       - ./usemsan=-msan
@@ -57,12 +64,10 @@ builds:
     # - `c-shared`
     # - `c-archive`
     #
-    # Since GoReleaser v1.13.
-    # Default is empty.
+    # Since: v1.13
     buildmode: c-shared
 
     # Custom build tags templates.
-    # Default is empty.
     tags:
       - osusergo
       - netgo
@@ -70,12 +75,10 @@ builds:
       - feature
 
     # Custom environment variables to be set during the builds.
-    #
-    # This field is templateable. Since v1.14.
-    #
     # Invalid environment variables will be ignored.
     #
-    # Default: `os.Environ()` merged with what you set the root `env` section.
+    # Default: os.Environ() ++ env config section
+    # Templates: allowed (since v1.14)
     env:
       - CGO_ENABLED=0
       # complex, templated envs (v1.14+):
@@ -90,14 +93,16 @@ builds:
 
     # GOOS list to build for.
     # For more info refer to: https://golang.org/doc/install/source#environment
-    # Defaults are darwin, linux, and windows.
+    #
+    # Default: [ 'darwin', 'linux', 'windows' ]
     goos:
       - freebsd
       - windows
 
     # GOARCH to build for.
     # For more info refer to: https://golang.org/doc/install/source#environment
-    # Defaults are 386, amd64 and arm64.
+    #
+    # Default: [ '386', 'amd64', 'arm64' ]
     goarch:
       - amd64
       - arm
@@ -105,27 +110,29 @@ builds:
 
     # GOARM to build for when GOARCH is arm.
     # For more info refer to: https://golang.org/doc/install/source#environment
-    # Default is only 6.
+    #
+    # Default: [ 6 ]
     goarm:
       - 6
       - 7
 
     # GOAMD64 to build when GOARCH is amd64.
     # For more info refer to: https://golang.org/doc/install/source#environment
-    # Default is only v1.
+    #
+    # Default: [ 'v1' ]
     goamd64:
       - v2
       - v3
 
     # GOMIPS and GOMIPS64 to build when GOARCH is mips, mips64, mipsle or mips64le.
     # For more info refer to: https://golang.org/doc/install/source#environment
-    # Default is only hardfloat.
+    #
+    # Default: [ 'hardfloat' ]
     gomips:
       - hardfloat
       - softfloat
 
     # List of combinations of GOOS + GOARCH + GOARM to ignore.
-    # Default is empty.
     ignore:
       - goos: darwin
         goarch: 386
@@ -144,15 +151,15 @@ builds:
     #
     # Special values:
     # - go_118_first_class: evaluates to the first-class ports of go1.18.
-    #   Since GoReleaser v1.9.
     # - go_first_class: evaluates to latest stable go first-class ports,
     #   currently same as 1.18.
-    #   Since GoReleaser v1.9.
     #
     # This overrides `goos`, `goarch`, `goarm`, `gomips`, `goamd64` and
     # `ignores`.
     targets:
+      # Since: v1.9
       - go_first_class
+      # Since: v1.9
       - go_118_first_class
       - linux_amd64_v1
       - darwin_arm64
@@ -176,20 +183,18 @@ builds:
     # Set the modified timestamp on the output binary, typically
     # you would do this to ensure a build was reproducible. Pass
     # empty string to skip modifying the output.
-    # Default is empty string, which will be the compile time.
     mod_timestamp: '{{ .CommitTimestamp }}'
 
     # Hooks can be used to customize the final binary,
     # for example, to run generators.
-    # Those fields allow templates.
-    # Default is both hooks empty.
+    #
+    # Templates: allowed
     hooks:
       pre: rice embed-go
       post: ./script.sh {{ .Path }}
 
     # If true, skip the build.
     # Useful for library projects.
-    # Default is false
     skip: false
 
     # By default, GoReleaser will create your binaries inside
@@ -201,8 +206,6 @@ builds:
     # created, you can set this property.
     # If you do, you are responsible for keeping different builds from
     # overriding each other.
-    #
-    # Defaults to `false`.
     no_unique_dist_dir: true
 
     # By default, GoReleaser will check if the main filepath has a main
@@ -210,7 +213,6 @@ builds:
     # This can be used to skip that check, in case you're building tests, for
     # example.
     #
-    # Default: false.
     # Since: v1.9
     no_main_check: true
 
@@ -219,20 +221,21 @@ builds:
     # If dir does not contain a `go.mod` file, and you are using `gomod.proxy`,
     # produced binaries will be invalid.
     # You would likely want to use `main` instead of this.
-    # Default is `.`.
+    #
+    # Default: '.'
     dir: go
 
     # Builder allows you to use a different build implementation.
     # This is a GoReleaser Pro feature.
     # Valid options are: `go` and `prebuilt`.
-    # Defaults to `go`.
+    #
+    # Default: 'go'
     builder: prebuilt
 
     # Overrides allows to override some fields for specific targets.
     # This can be specially useful when using CGO.
     # Note: it'll only match if the full target matches.
     #
-    # Default: []
     # Since: v1.5
     overrides:
       - goos: darwin
@@ -364,7 +367,9 @@ builds:
       pre:
        - cmd: first-script.sh
          dir: "{{ dir .Dist}}"
-         output: true # always print command output, otherwise only visible in debug mode. Since GoReleaser v1.5.
+          # Always print command output, otherwise only visible in debug mode.
+          # Since: v1.5
+         output: true
          env:
           - HOOK_SPECIFIC_VAR={{ .Env.GLOBAL_VAR }}
        - second-script.sh
@@ -439,8 +444,7 @@ GoReleaser:
 !!! success "GoReleaser Pro"
     The prebuilt builder is a [GoReleaser Pro feature](/pro/).
 
-Since GoReleaser Pro v0.179.0, it is possible to import pre-built binaries into
-the GoReleaser lifecycle.
+It is also possible to import pre-built binaries into the GoReleaser lifecycle.
 
 Reasons you might want to do that include:
 
@@ -544,7 +548,7 @@ You can read more about it
 
 ## Building shared or static libraries
 
-> Since: v1.13.0
+> Since: v1.13
 
 GoReleaser supports compiling and releasing C shared or static libraries, by
 configuring the [Go build mode](https://pkg.go.dev/cmd/go#hdr-Build_modes).
@@ -573,7 +577,7 @@ builds:
 
 ## Complex templated environment variables
 
-> Since v1.14.0.
+> Since v1.14
 
 Builds environment variables are templateable.
 

--- a/www/docs/customization/builds.md
+++ b/www/docs/customization/builds.md
@@ -575,11 +575,11 @@ builds:
     buildmode: "c-shared"  # or "c-archive" for a static library
 ```
 
-## Complex templated environment variables
+## Complex template environment variables
 
 > Since v1.14
 
-Builds environment variables are templateable.
+Builds environment variables accept templates.
 
 You can leverage that to have a single build configuration with different
 environment variables for each platform, for example.

--- a/www/docs/customization/changelog.md
+++ b/www/docs/customization/changelog.md
@@ -12,8 +12,7 @@ changelog:
   #
   # This may result in an empty release notes on GitHub/GitLab/Gitea.
   #
-  # Templateable since v1.16.0.
-  # Must evaluate to either true or false.
+  # Templates: allowed
   skip: '{{ .Env.CREATE_CHANGELOG }}'
 
   # Changelog generation implementation to use.
@@ -91,7 +90,6 @@ changelog:
 
   # Divider to use between groups.
   #
-  # Default: ''
   # Since: v1.16 (pro)
   # This feature is only available in GoReleaser Pro.
   divider: '---'
@@ -99,7 +97,6 @@ changelog:
   filters:
     # Commit messages matching the regexp listed here will be removed from
     # the changelog
-    # Default is empty
     exclude:
       - '^docs:'
       - typo

--- a/www/docs/customization/changelog.md
+++ b/www/docs/customization/changelog.md
@@ -14,8 +14,6 @@ changelog:
   #
   # Templateable since v1.16.0.
   # Must evaluate to either true or false.
-  #
-  # Defaults to false.
   skip: '{{ .Env.CREATE_CHANGELOG }}'
 
   # Changelog generation implementation to use.
@@ -26,12 +24,11 @@ changelog:
   # - `gitlab`: uses the compare GitLab API, appending the author name and email to the changelog.
   # - `github-native`: uses the GitHub release notes generation API, disables the groups feature.
   #
-  # Defaults to `git`.
+  # Default: 'git'
   use: github
 
   # Sorts the changelog by the commit's messages.
   # Could either be asc, desc or empty
-  # Default is empty
   sort: asc
 
   # Max commit hash length to use in the changelog.
@@ -40,7 +37,6 @@ changelog:
   # -1: remove the commit hash from the changelog
   # any other number: max length.
   #
-  # Default: 0.
   # Since: v1.11.2
   abbrev: -1
 
@@ -48,8 +44,9 @@ changelog:
   # Only works when `use: git`, otherwise ignored.
   # Only on GoReleaser Pro.
   #
-  # Default: monorepo.dir value, or empty if no monorepo.
-  # Since: v1.12.0-pro
+  # Default: monorepo.dir value, or empty if no monorepo
+  # Since: v1.12 (pro)
+  # This feature is only available in GoReleaser Pro.
   paths:
   - foo/
   - bar/
@@ -60,8 +57,6 @@ changelog:
   # Groups are disabled when using github-native, as it already groups things by itself.
   # Matches are performed against strings of the form: "<abbrev-commit>[:] <title-commit>".
   # Regex use RE2 syntax as defined here: https://github.com/google/re2/wiki/Syntax.
-  #
-  # Default is no groups.
   groups:
     - title: Features
       regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
@@ -84,7 +79,8 @@ changelog:
       #
       # This feature is only available in GoReleaser Pro.
       #
-      # Since: v1.15.0-pro
+      # Since: v1.15 (pro)
+      # This feature is only available in GoReleaser Pro.
       subgroups:
         - title: 'Docs'
           regex: '.*docs.*'
@@ -95,11 +91,9 @@ changelog:
 
   # Divider to use between groups.
   #
-  # Defaults to empty.
-  #
+  # Default: ''
+  # Since: v1.16 (pro)
   # This feature is only available in GoReleaser Pro.
-  #
-  # Since: v1.16.0-pro
   divider: '---'
 
   filters:

--- a/www/docs/customization/checksum.md
+++ b/www/docs/customization/checksum.md
@@ -11,6 +11,7 @@ checksum:
   # You can change the name of the checksums file.
   #
   # Default: {{ .ProjectName }}_{{ .Version }}_checksums.txt
+  # Templates: allowed
   name_template: "{{ .ProjectName }}_checksums.txt"
 
   # Algorithm to be used.
@@ -33,7 +34,8 @@ checksum:
   # You can add extra pre-existing files to the checksums file.
   # The filename on the checksum will be the last part of the path (base).
   # If another file with the same name exists, the last one found will be used.
-  # These globs can also include templates.
+  #
+  # Templates: allowed
   extra_files:
     - glob: ./path/to/file.txt
     - glob: ./glob/**/to/**/file/**/*
@@ -48,6 +50,7 @@ checksum:
   #
   # Since: v1.17 (pro)
   # This feature is only available in GoReleaser Pro.
+  # Templates: allowed
   templated_extra_files:
     - src: LICENSE.tpl
       dst: LICENSE.txt

--- a/www/docs/customization/checksum.md
+++ b/www/docs/customization/checksum.md
@@ -9,32 +9,31 @@ The `checksum` section allows customizations of the filename:
 # .goreleaser.yaml
 checksum:
   # You can change the name of the checksums file.
-  # Default is `{{ .ProjectName }}_{{ .Version }}_checksums.txt`.
+  #
+  # Default: {{ .ProjectName }}_{{ .Version }}_checksums.txt
   name_template: "{{ .ProjectName }}_checksums.txt"
 
   # Algorithm to be used.
   # Accepted options are sha256, sha512, sha1, crc32, md5, sha224 and sha384.
-  # Default is sha256.
+  #
+  # Default: sha256.
   algorithm: sha256
 
   # IDs of artifacts to include in the checksums file.
+  #
   # If left empty, all published binaries, archives, linux packages and source archives
   # are included in the checksums file.
-  # Default is an empty list.
   ids:
     - foo
     - bar
 
   # Disable the generation/upload of the checksum file.
-  # Default is false.
   disable: true
 
   # You can add extra pre-existing files to the checksums file.
   # The filename on the checksum will be the last part of the path (base).
   # If another file with the same name exists, the last one found will be used.
   # These globs can also include templates.
-  #
-  # Defaults to empty.
   extra_files:
     - glob: ./path/to/file.txt
     - glob: ./glob/**/to/**/file/**/*
@@ -47,7 +46,6 @@ checksum:
   # Those files will have their contents pass through the template engine,
   # and its results will be added to the checksum.
   #
-  # Default: empty
   # Since: v1.17 (pro)
   # This feature is only available in GoReleaser Pro.
   templated_extra_files:

--- a/www/docs/customization/chocolatey.md
+++ b/www/docs/customization/chocolatey.md
@@ -45,10 +45,11 @@ chocolateys:
     # It is a required field.
     project_url: https://example.com/
 
-    # Template for the url which is determined by the given Token (github,
+    # URL which is determined by the given Token (github,
     # gitlab or gitea).
     #
     # Default: depends on the git remote
+    # Templates: allowed
     url_template: "https://github.com/foo/bar/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
 
     # App's icon.

--- a/www/docs/customization/chocolatey.md
+++ b/www/docs/customization/chocolatey.md
@@ -1,6 +1,6 @@
 # Chocolatey Packages
 
-> Since: v1.13.0
+> Since: v1.13
 
 GoReleaser can also generate `nupkg` packages.
 [Chocolatey](http://chocolatey.org/) are packages based on `nupkg` format, that
@@ -19,27 +19,26 @@ chocolateys:
     # The value may not contain spaces or character that are not valid for a URL.
     # If you want a good separator for words, use '-', not  '.'.
     #
-    # Defaults to `ProjectName`.
+    # Default: ProjectName
     name: foo
 
     # IDs of the archives to use.
-    # Defaults to empty, which includes all artifacts.
+    # Empty means all IDs.
     ids:
       - foo
       - bar
 
     # Your app's owner.
     # It basically means your.
-    # Defaults empty.
     owners: Drum Roll Inc
 
     # The app's title.
     # A human-friendly title of the package.
-    # Defaults to `ProjectName`.
+    #
+    # Default: ProjectName
     title: Foo Bar
 
     # Your app's authors (probably you).
-    # Defaults are shown below.
     authors: Drummer
 
     # Your app's project url.
@@ -47,16 +46,15 @@ chocolateys:
     project_url: https://example.com/
 
     # Template for the url which is determined by the given Token (github,
-    # gitlab or gitea)
-    # Default depends on the client.
+    # gitlab or gitea).
+    #
+    # Default: depends on the git remote
     url_template: "https://github.com/foo/bar/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
 
     # App's icon.
-    # Default is empty.
     icon_url: 'https://rawcdn.githack.com/foo/bar/efbdc760-395b-43f1-bf69-ba25c374d473/icon.png'
 
     # Your app's copyright details.
-    # Default is empty.
     copyright: 2022 Drummer Roll Inc
 
     # App's license information url.
@@ -65,23 +63,18 @@ chocolateys:
     # Your apps's require license acceptance:
     # Specify whether the client must prompt the consumer to accept the package
     # license before installing.
-    # Default is false.
     require_license_acceptance: false
 
     # Your app's source url.
-    # Default is empty.
     project_source_url: https://github.com/foo/bar
 
     # Your app's documentation url.
-    # Default is empty.
     docs_url: https://github.com/foo/bar/blob/main/README.md
 
     # App's bugtracker url.
-    # Default is empty.
     bug_tracker_url: https://github.com/foo/barr/issues
 
     # Your app's tag list.
-    # Default is empty.
     tags: "foo bar baz"
 
     # Your app's summary:
@@ -98,11 +91,10 @@ chocolateys:
     # Supports markdown. To prevent the need to continually update this field,
     # providing a URL to an external list of Release Notes is perfectly
     # acceptable.
-    # Default is empty.
     release_notes: "https://github.com/foo/bar/releases/tag/v{{ .Version }}"
 
     # App's dependencies
-    # Default is empty. Version is not required.
+    # The version is not required.
     dependencies:
       - id: nfpm
         version: 2.20.0
@@ -113,8 +105,6 @@ chocolateys:
     api_key: '{{ .Env.CHOCOLATEY_API_KEY }}'
 
     # The source repository that will push the package to.
-    #
-    # Defaults are shown below.
     source_repo: "https://push.chocolatey.org/"
 
     # Setting this will prevent goreleaser to actually try to push the package
@@ -124,7 +114,8 @@ chocolateys:
 
     # GOAMD64 to specify which amd64 version to use if there are multiple
     # versions from the build section.
-    # Default is v1.
+    #
+    # Default: 'v1'
     goamd64: v1
 ```
 

--- a/www/docs/customization/dist.md
+++ b/www/docs/customization/dist.md
@@ -5,5 +5,9 @@ If you must, you can change it by setting it in the `.goreleaser.yaml` file:
 
 ```yaml
 # .goreleaser.yaml
+#
+# Default: './dist'
 dist: another-folder-that-is-not-dist
 ```
+
+More often than not, you won't need to change this.

--- a/www/docs/customization/docker.md
+++ b/www/docs/customization/docker.md
@@ -50,23 +50,22 @@ dockers:
     id: myimg
 
     # GOOS of the built binaries/packages that should be used.
-    # Default: `linux`.
+    # Default: 'linux'
     goos: linux
 
     # GOARCH of the built binaries/packages that should be used.
-    # Default: `amd64`.
+    # Default: 'amd64'
     goarch: amd64
 
     # GOARM of the built binaries/packages that should be used.
-    # Default: `6`.
+    # Default: '6'
     goarm: ''
 
     # GOAMD64 of the built binaries/packages that should be used.
-    # Default: `v1`.
+    # Default: 'v1'
     goamd64: 'v2'
 
     # IDs to filter the binaries/packages.
-    # Default: `empty`.
     ids:
     - mybuild
     - mynfpm
@@ -84,11 +83,9 @@ dockers:
     # Could be useful if you want to skip building the windows docker image on
     # linux, for example.
     #
-    # This field allows templates.
-    # Since: v1.14.0-pro.
+    # Templates: allowed
+    # Since: v1.14 (pro)
     # This option is only available on GoReleaser Pro.
-    #
-    # Defaults to false.
     skip_build: false
 
     # Skips the docker push.
@@ -96,13 +93,11 @@ dockers:
     #
     # If set to auto, the release will not be pushed to the Docker repository
     #  in case there is an indicator of a prerelease in the tag, e.g. v1.0.0-rc1.
-    #
-    # Defaults to false.
     skip_push: false
 
     # Path to the Dockerfile (from the project root).
     #
-    # Defaults to `Dockerfile`.
+    # Default: 'Dockerfile'
     dockerfile: '{{ .Env.DOCKERFILE }}'
 
     # Set the "backend" for the Docker pipe.
@@ -111,7 +106,7 @@ dockers:
     #
     # Podman is a GoReleaser Pro feature and is only available on Linux.
     #
-    # Defaults to docker.
+    # Default: 'docker'
     use: docker
 
     # Template of the docker build flags.
@@ -125,7 +120,6 @@ dockers:
     - "--platform=linux/arm64"
 
     # Extra flags to be passed down to the push command.
-    # Defaults to empty.
     push_flags:
     - --tls-verify=false
 
@@ -147,7 +141,6 @@ dockers:
     # and its results will be added to the build context the same way as the
     # extra_files field above.
     #
-    # Default: empty
     # Since: v1.17 (pro)
     # This feature is only available in GoReleaser Pro.
     templated_extra_files:

--- a/www/docs/customization/docker.md
+++ b/www/docs/customization/docker.md
@@ -71,6 +71,8 @@ dockers:
     - mynfpm
 
     # Templates of the Docker image names.
+    #
+    # Templates: allowed
     image_templates:
     - "myuser/myimage:latest"
     - "myuser/myimage:{{ .Tag }}"
@@ -109,7 +111,9 @@ dockers:
     # Default: 'docker'
     use: docker
 
-    # Template of the docker build flags.
+    # Docker build flags.
+    #
+    # Templates: allowed
     build_flag_templates:
     - "--pull"
     - "--label=org.opencontainers.image.created={{.Date}}"
@@ -143,6 +147,7 @@ dockers:
     #
     # Since: v1.17 (pro)
     # This feature is only available in GoReleaser Pro.
+    # Templates: allowed
     templated_extra_files:
       - src: LICENSE.tpl
         dst: LICENSE.txt

--- a/www/docs/customization/docker_manifest.md
+++ b/www/docs/customization/docker_manifest.md
@@ -33,22 +33,18 @@ docker_manifests:
   id: myimg
 
   # Name template for the manifest.
-  # Defaults to empty.
   name_template: "foo/bar:{{ .Version }}"
 
   # Image name templates to be added to this manifest.
-  # Defaults to empty.
   image_templates:
   - "foo/bar:{{ .Version }}-amd64"
   - "foo/bar:{{ .Version }}-arm64v8"
 
   # Extra flags to be passed down to the manifest create command.
-  # Defaults to empty.
   create_flags:
   - --insecure
 
   # Extra flags to be passed down to the manifest push command.
-  # Defaults to empty.
   push_flags:
   - --insecure
 
@@ -58,8 +54,6 @@ docker_manifests:
   #
   # If set to `auto`, the manifest will not be created in case there is an
   #  indicator of a prerelease in the tag, e.g. v1.0.0-rc1.
-  #
-  # Defaults to false.
   skip_push: false
 
   # Set the "backend" for the Docker manifest pipe.
@@ -70,7 +64,7 @@ docker_manifests:
   # 2. if you set podman here, the respective docker configs need to use podman
   #    too.
   #
-  # Defaults to docker.
+  # Default: 'docker'
   use: docker
 ```
 

--- a/www/docs/customization/docker_manifest.md
+++ b/www/docs/customization/docker_manifest.md
@@ -32,10 +32,14 @@ docker_manifests:
   # custom publishers).
   id: myimg
 
-  # Name template for the manifest.
+  # Name for the manifest.
+  #
+  # Templates: allowed
   name_template: "foo/bar:{{ .Version }}"
 
-  # Image name templates to be added to this manifest.
+  # Image name to be added to this manifest.
+  #
+  # Templates: allowed
   image_templates:
   - "foo/bar:{{ .Version }}-amd64"
   - "foo/bar:{{ .Version }}-arm64v8"

--- a/www/docs/customization/docker_sign.md
+++ b/www/docs/customization/docker_sign.md
@@ -26,8 +26,9 @@ docker_signs:
     # Default: 'cosign'
     cmd: cosign
 
-    # Command line templateable arguments for the command
+    # Command line arguments for the command
     #
+    # Templates: allowed
     # Default: ["sign", "--key=cosign.key", "${artifact}@${digest}", "--yes"]
     args:
     - "sign"
@@ -52,17 +53,15 @@ docker_signs:
       - foo
       - bar
 
-    # Stdin data template to be given to the signature command as stdin.
-    # Defaults to empty
+    # Stdin data to be given to the signature command as stdin.
+    #
+    # Templates: allowed
     stdin: '{{ .Env.COSIGN_PWD }}'
 
     # StdinFile file to be given to the signature command as stdin.
-    # Defaults to empty
     stdin_file: ./.password
 
     # List of environment variables that will be passed to the signing command as well as the templates.
-    #
-    # Defaults to empty
     env:
     - FOO=bar
     - HONK=honkhonk
@@ -70,7 +69,6 @@ docker_signs:
     # By default, the stdout and stderr of the signing cmd are discarded unless GoReleaser is running with `--debug` set.
     # You can set this to true if you want them to be displayed regardless.
     #
-    # Default: false
     # Since: v1.2
     output: true
 ```

--- a/www/docs/customization/docker_sign.md
+++ b/www/docs/customization/docker_sign.md
@@ -18,17 +18,17 @@ docker_signs:
     # ID of the sign config, must be unique.
     # Only relevant if you want to produce some sort of signature file.
     #
-    # Defaults to "default".
+    # Default: 'default'
     id: foo
 
     # Path to the signature command
     #
-    # Defaults to `cosign`
+    # Default: 'cosign'
     cmd: cosign
 
     # Command line templateable arguments for the command
     #
-    # defaults to `["sign", "--key=cosign.key", "${artifact}@${digest}", "--yes"]`
+    # Default: ["sign", "--key=cosign.key", "${artifact}@${digest}", "--yes"]
     args:
     - "sign"
     - "--key=cosign.key"
@@ -44,12 +44,10 @@ docker_signs:
     #   images:    only docker images
     #   manifests: only docker manifests
     #
-    # defaults to `none`
+    # Default: 'none'
     artifacts: all
 
     # IDs of the artifacts to sign.
-    #
-    # Defaults to empty (which implies no ID filtering).
     ids:
       - foo
       - bar
@@ -72,8 +70,8 @@ docker_signs:
     # By default, the stdout and stderr of the signing cmd are discarded unless GoReleaser is running with `--debug` set.
     # You can set this to true if you want them to be displayed regardless.
     #
-    # Default: false.
-    # Since: v1.2.
+    # Default: false
+    # Since: v1.2
     output: true
 ```
 

--- a/www/docs/customization/fury.md
+++ b/www/docs/customization/fury.md
@@ -37,8 +37,9 @@ furies:
 
     # Skip the announcing feature in some conditions, for instance, when
     # publishing patch releases.
-    # Valid options are `true`, `false`, empty, or a
-    # template that evaluates to a boolean (`true` or `false`).
+    # Any value different of 'true' will be considered 'false'.
+    #
+    # Templates: allowed
     skip: "{{gt .Patch 0}}"
 
     # Environment variable name to get the push token from.
@@ -55,6 +56,7 @@ furies:
 
     # Formats to upload.
     # Available options are `deb` and `rpm`.
+    #
     # Default: ['deb', 'rpm']
     formats:
       - deb

--- a/www/docs/customization/fury.md
+++ b/www/docs/customization/fury.md
@@ -39,27 +39,23 @@ furies:
     # publishing patch releases.
     # Valid options are `true`, `false`, empty, or a
     # template that evaluates to a boolean (`true` or `false`).
-    #
-    # Defaults to empty - which means false.
     skip: "{{gt .Patch 0}}"
 
     # Environment variable name to get the push token from.
     # You might want to change it if you have multiple fury configurations for
     # some reason.
     #
-    # Defaults to empty - which means false.
-    # Defaults to `FURY_TOKEN`.
+    # Default: 'FURY_TOKEN'
     secret_name: MY_ACCOUNT_FURY_TOKEN
 
     # IDs to filter by.
-    # Defaults to empty, which means all packages created by all nfpm
     # configurations get uploaded.
     ids:
       - packages
 
     # Formats to upload.
     # Available options are `deb` and `rpm`.
-    # Defaults to `deb` and `rpm`.
+    # Default: ['deb', 'rpm']
     formats:
       - deb
 ```

--- a/www/docs/customization/git.md
+++ b/www/docs/customization/git.md
@@ -10,13 +10,12 @@ git:
   # What should be used to sort tags when gathering the current and previous
   # tags if there are more than one tag in the same commit.
   #
-  # Default: `-version:refname`
+  # Default: '-version:refname'
   tag_sort: -version:creatordate
 
   # What should be used to specify prerelease suffix while sorting tags when gathering
   # the current and previous tags if there are more than one tag in the same commit.
   #
   # Since: v1.17
-  # Default: ''
   prerelease_suffix: "-"
 ```

--- a/www/docs/customization/git.md
+++ b/www/docs/customization/git.md
@@ -16,7 +16,7 @@ git:
   # What should be used to specify prerelease suffix while sorting tags when gathering
   # the current and previous tags if there are more than one tag in the same commit.
   #
-  # Since: v1.17.0.
-  # Default: empty, uses what's defined in the git configuration.
+  # Since: v1.17
+  # Default: ''
   prerelease_suffix: "-"
 ```

--- a/www/docs/customization/homebrew.md
+++ b/www/docs/customization/homebrew.md
@@ -14,14 +14,14 @@ for more details.
 # .goreleaser.yaml
 brews:
   -
-    # Name template of the recipe
-    # Default to project name
+    # Name of the recipe
+    #
+    # Default: ProjectName
+    # Templates: allowed
     name: myproject
 
     # IDs of the archives to use.
     # Empty means all IDs.
-    #
-    # Default: []
     ids:
     - foo
     - bar
@@ -29,13 +29,15 @@ brews:
     # GOARM to specify which 32-bit arm version to use if there are multiple
     # versions from the build section. Brew formulas support only one 32-bit
     # version.
-    # Default is 6 for all artifacts or each id if there a multiple versions.
+    #
+    # Default: 6
     goarm: 6
 
     # GOAMD64 to specify which amd64 version to use if there are multiple
     # versions from the build section.
-    # Default is v1.
-    goamd64: v3
+    #
+    # Default: v1
+    goamd64: v1
 
     # NOTE: make sure the url_template, the token and given repo (github or
     # gitlab) owner and name are from the same kind.
@@ -44,65 +46,67 @@ brews:
 
     # GitHub/GitLab repository to push the formula to
     tap:
-      # Repository owner template. (templateable)
+      # Repository owner.
+      #
+      # Templates: allowed
       owner: user
 
-      # Repository name. (templateable)
+      # Repository name.
+      #
+      # Templates: allowed
       name: homebrew-tap
 
-      # Optionally a branch can be provided. (templateable)
+      # Optionally a branch can be provided.
       #
       # Default: default repository branch.
+      #
+      # Templates: allowed
       branch: main
 
       # Optionally a token can be provided, if it differs from the token
       # provided to GoReleaser
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
 
-    # Template for the url which is determined by the given Token (github,
-    # gitlab or gitea)
+    # URL which is determined by the given Token (github, gitlab or gitea).
     #
     # Default depends on the client.
+    # Templates: allowed
     url_template: "https://github.mycompany.com/foo/bar/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
 
     # Allows you to set a custom download strategy. Note that you'll need
     # to implement the strategy and add it to your tap repository.
     # Example: https://docs.brew.sh/Formula-Cookbook#specifying-the-download-strategy-explicitly
-    # Default is empty.
     download_strategy: CurlDownloadStrategy
 
     # Allows you to add a custom require_relative at the top of the formula
     # template.
-    # Default is empty
     custom_require: custom_download_strategy
 
     # Git author used to commit to the repository.
-    # Defaults are shown.
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com
 
     # The project name and current git tag are used in the format string.
+    #
+    # Templates: allowed
     commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
 
     # Folder inside the repository to put the formula.
-    # Default is the root folder.
     folder: Formula
 
     # Caveats for the user of your binary.
-    # Default is empty.
     caveats: "How to use this binary"
 
     # Your app's homepage.
-    # Default is empty.
     homepage: "https://example.com/"
 
-    # Template of your app's description.
-    # Default is empty.
+    # Your app's description.
+    #
+    # Templates: allowed
     description: "Software to create fast and easy drum rolls."
 
     # SPDX identifier of your app's license.
-    # Default is empty.
     license: "MIT"
 
     # Setting this will prevent goreleaser to actually try to commit the updated
@@ -110,12 +114,10 @@ brews:
     # leaving the responsibility of publishing it to the user.
     # If set to auto, the release will not be uploaded to the homebrew tap
     # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
-    # Default is false.
     skip_upload: true
 
     # Custom block for brew.
     # Can be used to specify alternate downloads for devel or head releases.
-    # Default is empty.
     custom_block: |
       head "https://github.com/some/package.git"
       ...
@@ -140,7 +142,6 @@ brews:
       - bash
 
     # Specify for packages that run as a service.
-    # Default is empty.
     plist: |
       <?xml version="1.0" encoding="UTF-8"?>
       # ...
@@ -153,13 +154,12 @@ brews:
       # ...
 
     # So you can `brew test` your formula.
-    # Default is empty.
     test: |
       system "#{bin}/foo --version"
       # ...
 
     # Custom install script for brew.
-    # Default is 'bin.install "the binary name"'.
+    # Default: 'bin.install "BinaryName"'
     install: |
       bin.install "some_other_name"
       bash_completion.install "completions/foo.bash" => "foo"
@@ -167,7 +167,6 @@ brews:
 
     # Custom post_install script for brew.
     # Could be used to do any additional work after the "install" script
-    # Default is empty.
     post_install: |
     	etc.install "app-config.conf"
     	...

--- a/www/docs/customization/homebrew.md
+++ b/www/docs/customization/homebrew.md
@@ -19,7 +19,9 @@ brews:
     name: myproject
 
     # IDs of the archives to use.
-    # Defaults to all.
+    # Empty means all IDs.
+    #
+    # Default: []
     ids:
     - foo
     - bar
@@ -50,7 +52,7 @@ brews:
 
       # Optionally a branch can be provided. (templateable)
       #
-      # Defaults to the default repository branch.
+      # Default: default repository branch.
       branch: main
 
       # Optionally a token can be provided, if it differs from the token
@@ -145,7 +147,7 @@ brews:
 
     # Service block.
     #
-    # Since: v1.7.
+    # Since: v1.7
     service: |
       run: foo/bar
       # ...

--- a/www/docs/customization/hooks.md
+++ b/www/docs/customization/hooks.md
@@ -38,12 +38,17 @@ GoReleaser allows this with the global hooks feature.
     # .goreleaser.yaml
     # global before hooks
     before:
-      # Templates for the commands to be ran.
+      # Commands to be ran.
+      #
+      # Templates: allowed
       hooks:
       - make clean # simple string
       - cmd: go generate ./... # specify cmd
       - cmd: go mod tidy
-        output: true # always prints command output. Since GoReleaser v1.5.
+        # Always prints command output.
+        #
+        # Since: v1.5
+        output: true
         dir: ./submodule # specify command working directory
       - cmd: touch {{ .Env.FILE_TO_TOUCH }}
         env:
@@ -51,7 +56,9 @@ GoReleaser allows this with the global hooks feature.
 
     # global after hooks
     after:
-      # Templates for the commands to be ran.
+      # Commands to be ran.
+      #
+      # Templates: allowed
       hooks:
       - make clean
       - cmd: cat *.yaml

--- a/www/docs/customization/ko.md
+++ b/www/docs/customization/ko.md
@@ -26,41 +26,40 @@ kos:
 
   # Main path to build.
   #
-  # Defaults to the build's main.
+  # Default: build.main
   main: ./cmd/...
 
   # Working directory used to build.
   #
-  # Defaults to the build's dir.
+  # Default: build.dir
   working_dir: .
 
   # Base image to publish to use.
   #
-  # Defaults to cgr.dev/chainguard/static.
+  # Default: 'cgr.dev/chainguard/static'
   base_image: alpine
 
   # Labels for the image.
   #
-  # Defaults to null.
   # Since v1.17.
   labels:
     foo: bar
 
   # Repository to push to.
   #
-  # Defaults to the value of $KO_DOCKER_REPO.
+  # Default: $KO_DOCKER_REPO
   repository: ghcr.io/foo/bar
 
   # Platforms to build and publish.
   #
-  # Defaults to linux/amd64.
+  # Default: 'linux/amd64'
   platforms:
   - linux/amd64
   - linux/arm64
 
   # Tag templates to build and push.
   #
-  # Defaults to `latest`.
+  # Default: 'latest'
   tags:
   - latest
   - '{{.Tag}}'
@@ -68,58 +67,49 @@ kos:
   # Creation time given to the image
   # in seconds since the Unix epoch as a string.
   #
-  # Defaults to empty string.
   # Since v1.17.
   creation_time: '{{.CommitTimestamp}}'
 
   # Creation time given to the files in the kodata directory
   # in seconds since the Unix epoch as a string.
   #
-  # Defaults to empty string.
   # Since v1.17.
   ko_data_creation_time: '{{.CommitTimestamp}}'
 
   # SBOM format to use.
   #
-  # Defaults to spdx.
   # Valid options are: spdx, cyclonedx, go.version-m and none.
   sbom: none
 
   # Ldflags to use on build.
   #
-  # Defaults to the build's ldflags.
+  # Default: build.ldflags
   ldflags:
   - foo
   - bar
 
   # Flags to use on build.
   #
-  # Defaults to the build's flags.
+  # Default: build.flags
   flags:
   - foo
   - bar
 
   # Env to use on build.
   #
-  # Defaults to the build's env.
+  # Default: build.env
   env:
   - FOO=bar
   - SOMETHING=value
 
 
   # Bare uses a tag on the KO_DOCKER_REPO without anything additional.
-  #
-  # Defaults to false.
   bare: true
 
   # Whether to preserve the full import path after the repository name.
-  #
-  # Defaults to false.
   preserve_import_paths: true
 
   # Whether to use the base path without the MD5 hash after the repository name.
-  #
-  # Defaults to false.
   base_import_paths: true
 ```
 

--- a/www/docs/customization/ko.md
+++ b/www/docs/customization/ko.md
@@ -1,6 +1,6 @@
 # Docker Images with Ko
 
-> Since v1.15.0.
+> Since v1.15
 
 You can also use [ko][] to build and publish Docker container images.
 
@@ -41,7 +41,7 @@ kos:
 
   # Labels for the image.
   #
-  # Since v1.17.
+  # Since: v1.17
   labels:
     foo: bar
 
@@ -57,9 +57,10 @@ kos:
   - linux/amd64
   - linux/arm64
 
-  # Tag templates to build and push.
+  # Tag to build and push.
   #
   # Default: 'latest'
+  # Templates: allowed
   tags:
   - latest
   - '{{.Tag}}'
@@ -67,17 +68,20 @@ kos:
   # Creation time given to the image
   # in seconds since the Unix epoch as a string.
   #
-  # Since v1.17.
+  # Since: v1.17
+  # Templates: allowed
   creation_time: '{{.CommitTimestamp}}'
 
   # Creation time given to the files in the kodata directory
   # in seconds since the Unix epoch as a string.
   #
-  # Since v1.17.
+  # Since: v1.17
+  # Templates: allowed
   ko_data_creation_time: '{{.CommitTimestamp}}'
 
   # SBOM format to use.
   #
+  # Default: 'spdx'
   # Valid options are: spdx, cyclonedx, go.version-m and none.
   sbom: none
 
@@ -103,7 +107,7 @@ kos:
   - SOMETHING=value
 
 
-  # Bare uses a tag on the KO_DOCKER_REPO without anything additional.
+  # Bare uses a tag on the $KO_DOCKER_REPO without anything additional.
   bare: true
 
   # Whether to preserve the full import path after the repository name.

--- a/www/docs/customization/krew.md
+++ b/www/docs/customization/krew.md
@@ -11,7 +11,8 @@ The `krews` section specifies how the plugins should be created:
 # .goreleaser.yaml
 krews:
   -
-    # Name template of the recipe
+    # Name of the recipe
+    #
     # Default: ProjectName
     name: myproject
 
@@ -23,11 +24,13 @@ krews:
     # GOARM to specify which 32-bit arm version to use if there are multiple
     # versions from the build section. Krew plugin supports at this moment only
     # one 32-bit version.
+    #
     # Default: 6
     goarm: 6
 
     # GOAMD64 to specify which amd64 version to use if there are multiple
     # versions from the build section.
+    #
     # Default: 'v1'
     goamd64: v3
 
@@ -38,26 +41,32 @@ krews:
     # GitHub/GitLab repository to push the Krew plugin to
     # Gitea is not supported yet, but the support coming
     index:
-      # Repository owner template. (templateable)
+      # Repository owner.
+      #
+      # Templates: allowed
       owner: user
 
-      # Repository name. (templateable)
+      # Repository name.
+      #
+      # Templates: allowed
       name: krew-plugins
 
-      # Optionally a branch can be provided. (templateable)
+      # Optionally a branch can be provided.
       #
       # Default: default repository branch
+      # Templates: allowed
       branch: main
 
       # Optionally a token can be provided, if it differs from the token
       # provided to GoReleaser
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
 
-    # Template for the url which is determined by the given Token (github or
+    # URL which is determined by the given Token (github or
     # gitlab)
-    # Default for GitHub: 'https://github.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}'
-    # Default for GitLab: 'https://gitlab.com/<repo_owner>/<repo_name>/-/releases/{{ .Tag }}/downloads/{{ .ArtifactName }}'
-    # Default for Gitea: 'https://gitea.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}'
+    # Default:
+    #   GitHub: 'https://github.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}'
+    #   GitLab: 'https://gitlab.com/<repo_owner>/<repo_name>/-/releases/{{ .Tag }}/downloads/{{ .ArtifactName }}'
+    #   Gitea: 'https://gitea.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}'
     url_template: "http://github.mycompany.com/foo/bar/releases/{{ .Tag }}/{{ .ArtifactName }}"
 
     # Git author used to commit to the repository.
@@ -71,12 +80,16 @@ krews:
     # Your app's homepage.
     homepage: "https://example.com/"
 
-    # Template of your app's description.
+    # Your app's description.
     # The usual guideline for this is to wrap the line at 80 chars.
+    #
+    # Templates: allowed
     description: "Software to create fast and easy drum rolls."
 
-    # Template of your app's short description.
+    # Your app's short description.
     # The usual guideline for this is to be at most 50 chars long.
+    #
+    # Templates: allowed
     short_description: "Software to create fast and easy drum rolls."
 
     # Caveats for the user of your binary.

--- a/www/docs/customization/krew.md
+++ b/www/docs/customization/krew.md
@@ -12,11 +12,10 @@ The `krews` section specifies how the plugins should be created:
 krews:
   -
     # Name template of the recipe
-    # Default to project name
+    # Default: ProjectName
     name: myproject
 
     # IDs of the archives to use.
-    # Defaults to all.
     ids:
     - foo
     - bar
@@ -24,12 +23,12 @@ krews:
     # GOARM to specify which 32-bit arm version to use if there are multiple
     # versions from the build section. Krew plugin supports at this moment only
     # one 32-bit version.
-    # Default is 6 for all artifacts or each id if there a multiple versions.
+    # Default: 6
     goarm: 6
 
     # GOAMD64 to specify which amd64 version to use if there are multiple
     # versions from the build section.
-    # Default is v1.
+    # Default: 'v1'
     goamd64: v3
 
     # NOTE: make sure the url_template, the token and given repo (github or
@@ -47,7 +46,7 @@ krews:
 
       # Optionally a branch can be provided. (templateable)
       #
-      # Defaults to the default repository branch.
+      # Default: default repository branch
       branch: main
 
       # Optionally a token can be provided, if it differs from the token
@@ -56,13 +55,12 @@ krews:
 
     # Template for the url which is determined by the given Token (github or
     # gitlab)
-    # Default for github is "https://github.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-    # Default for gitlab is "https://gitlab.com/<repo_owner>/<repo_name>/-/releases/{{ .Tag }}/downloads/{{ .ArtifactName }}"
-    # Default for gitea is "https://gitea.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    # Default for GitHub: 'https://github.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}'
+    # Default for GitLab: 'https://gitlab.com/<repo_owner>/<repo_name>/-/releases/{{ .Tag }}/downloads/{{ .ArtifactName }}'
+    # Default for Gitea: 'https://gitea.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}'
     url_template: "http://github.mycompany.com/foo/bar/releases/{{ .Tag }}/{{ .ArtifactName }}"
 
     # Git author used to commit to the repository.
-    # Defaults are shown.
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com
@@ -71,25 +69,18 @@ krews:
     commit_msg_template: "Krew plugin update for {{ .ProjectName }} version {{ .Tag }}"
 
     # Your app's homepage.
-    # Default is empty.
     homepage: "https://example.com/"
 
     # Template of your app's description.
     # The usual guideline for this is to wrap the line at 80 chars.
-    #
-    # Default is empty.
     description: "Software to create fast and easy drum rolls."
 
     # Template of your app's short description.
     # The usual guideline for this is to be at most 50 chars long.
-    #
-    # Default is empty.
     short_description: "Software to create fast and easy drum rolls."
 
     # Caveats for the user of your binary.
     # The usual guideline for this is to wrap the line at 80 chars.
-    #
-    # Default is empty.
     caveats: "How to use this binary"
 
     # Setting this will prevent goreleaser to actually try to commit the updated
@@ -97,7 +88,6 @@ krews:
     # only, leaving the responsibility of publishing it to the user.
     # If set to auto, the release will not be uploaded to the Krew plugin
     # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
-    # Default is false.
     skip_upload: true
 ```
 

--- a/www/docs/customization/milestone.md
+++ b/www/docs/customization/milestone.md
@@ -17,15 +17,14 @@ milestones:
       name: repo
 
     # Whether to close the milestone
-    # Default is false
     close: true
 
     # Fail release on errors, such as missing milestone.
-    # Default is false
     fail_on_error: true
 
     # Name of the milestone
-    # Default is `{{ .Tag }}`
+    #
+    # Default: '{{ .Tag }}'
     name_template: "Current Release"
 ```
 

--- a/www/docs/customization/nfpm.md
+++ b/www/docs/customization/nfpm.md
@@ -65,7 +65,8 @@ nfpms:
       - zsh
 
     # Packages it provides. (overridable)
-    # Since: v1.11.
+    #
+    # Since: v1.11
     provides:
       - bar
 
@@ -129,8 +130,8 @@ nfpms:
     # formats (deb and rpm at the moment).
     #
     # Experimental.
-    # Default: empty.
-    # Since: v1.11.
+    # Default: ''
+    # Since: v1.11
     changelog: ./foo.yml
 
     # Contents to add to the package.

--- a/www/docs/customization/nfpm.md
+++ b/www/docs/customization/nfpm.md
@@ -11,16 +11,18 @@ nfpms:
   # note that this is an array of nfpm configs
   -
     # ID of the nfpm config, must be unique.
-    # Defaults to "default".
+    #
+    # Defaults: 'default'
     id: foo
 
     # Name of the package.
-    # Defaults to `ProjectName`.
+    # Defaults: ProjectName
     package_name: foo
 
     # You can change the file name of the package.
     #
-    # Default:`{{ .PackageName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}`
+    # Default: '{{ .PackageName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
+    # Templates: allowed
     file_name_template: "{{ .ConventionalFileName }}"
 
     # Build IDs for the builds you want to create NFPM packages for.
@@ -30,25 +32,20 @@ nfpms:
       - bar
 
     # Your app's vendor.
-    # Default is empty.
     vendor: Drum Roll Inc.
 
-    # Template to your app's homepage.
-    # Default is empty.
+    # Your app's homepage.
     homepage: https://example.com/
 
     # Your app's maintainer (probably you).
-    # Default is empty.
     maintainer: Drummer <drum-roll@example.com>
 
-    # Template to your app's description.
-    # Default is empty.
+    # Your app's description.
     description: |-
       Drum rolls installer package.
       Software to create fast and easy drum rolls.
 
     # Your app's license.
-    # Default is empty.
     license: Apache 2.0
 
     # Formats to be generated.
@@ -56,8 +53,8 @@ nfpms:
       - apk
       - deb
       - rpm
-      - termux.deb # Since GoReleaser v1.11.
-      - archlinux  # Since GoReleaser v1.13.
+      - termux.deb # Since: v1.11
+      - archlinux  # Since: v1.13
 
     # Packages your package depends on. (overridable)
     dependencies:
@@ -89,22 +86,23 @@ nfpms:
     replaces:
       - fish
 
-    # Template to the path that the binaries should be installed.
-    # Defaults to `/usr/bin`.
+    # Path that the binaries should be installed.
+    # Default: '/usr/bin'
     bindir: /usr/bin
 
     # Version Epoch.
-    # Default is extracted from `version` if it is semver compatible.
+    # Default: extracted from `version` if it is semver compatible
     epoch: 2
 
     # Version Prerelease.
-    # Default is extracted from `version` if it is semver compatible.
+    # Default: extracted from `version` if it is semver compatible
     prerelease: beta1
 
     # Version Metadata (previously deb.metadata).
-    # Default is extracted from `version` if it is semver compatible.
     # Setting metadata might interfere with version comparisons depending on the
     # packager.
+    #
+    # Default: extracted from `version` if it is semver compatible
     version_metadata: git
 
     # Version Release.
@@ -119,7 +117,8 @@ nfpms:
     # Makes a meta package - an empty package that contains only supporting
     # files and dependencies.
     # When set to `true`, the `builds` option is ignored.
-    # Defaults to false.
+    #
+    # Default: false
     meta: true
 
     # Changelog YAML file, see: https://github.com/goreleaser/chglog
@@ -130,7 +129,6 @@ nfpms:
     # formats (deb and rpm at the moment).
     #
     # Experimental.
-    # Default: ''
     # Since: v1.11
     changelog: ./foo.yml
 
@@ -150,7 +148,8 @@ nfpms:
       # This will replicate the directory structure under some/directory at
       # /etc, using the "tree" type.
       #
-      # Since v1.17.0.
+      # Since: v1.17
+      # Templates: allowed
       - src: some/directory/
         dst: /etc
         type: tree
@@ -181,9 +180,9 @@ nfpms:
     # Those files will have their contents pass through the template engine,
     # and its results will be added to the package.
     #
-    # Default: empty
     # Since: v1.17 (pro)
     # This feature is only available in GoReleaser Pro.
+    # Templates: allowed
     files:
       # a more complete example, check the globbing deep dive below
       - src: 'LICENSE.md.tpl'
@@ -290,13 +289,14 @@ nfpms:
         # The posttrans script runs after all RPM package transactions / stages.
         posttrans: ./scripts/posttrans.sh
 
-      # The package summary. This is, by default, the first line of the
-      # description, but can be explicitly provided here.
-      # Defaults to the first line of the description.
+      # The package summary.
+      #
+      # Default: first line of the description
       summary: Explicit Summary for Sample Package
 
-      # The package group. This option is deprecated by most distros
-      # but required by old distros like CentOS 5 / EL 5 and earlier.
+      # The package group.
+      # This option is deprecated by most distros but required by old distros
+      # like CentOS 5 / EL 5 and earlier.
       group: Unspecified
 
       # The packager is used to identify the organization that actually packaged
@@ -310,13 +310,15 @@ nfpms:
 
       # The package is signed if a key_file is set
       signature:
-        # Template to the PGP secret key file path (can also be ASCII-armored).
+        # PGP secret key file path (can also be ASCII-armored).
         # The passphrase is taken from the environment variable
         # `$NFPM_ID_RPM_PASSPHRASE` with a fallback to `$NFPM_ID_PASSPHRASE`,
         # where ID is the id of the current nfpm config.
         # The id will be transformed to uppercase.
         # E.g. If your nfpm id is 'default' then the rpm-specific passphrase
         # should be set as `$NFPM_DEFAULT_RPM_PASSPHRASE`
+        #
+        # Templates: allowed
         key_file: '{{ .Env.GPG_KEY_PATH }}'
 
     # Custom configuration applied only to the Deb packager.
@@ -352,17 +354,21 @@ nfpms:
 
       # The package is signed if a key_file is set
       signature:
-        # Template to the PGP secret key file path (can also be ASCII-armored).
+        # PGP secret key file path (can also be ASCII-armored).
         # The passphrase is taken from the environment variable
         # `$NFPM_ID_DEB_PASSPHRASE` with a fallback to `$NFPM_ID_PASSPHRASE`,
         # where ID is the id of the current nfpm config.
         # The id will be transformed to uppercase.
         # E.g. If your nfpm id is 'default' then the deb-specific passphrase
         # should be set as `$NFPM_DEFAULT_DEB_PASSPHRASE`
+        #
+        # Templates: allowed
         key_file: '{{ .Env.GPG_KEY_PATH }}'
 
         # The type describes the signers role, possible values are "origin",
-        # "maint" and "archive". If unset, the type defaults to "origin".
+        # "maint" and "archive".
+        #
+        # Default: 'origin'
         type: origin
 
     apk:
@@ -375,20 +381,22 @@ nfpms:
 
       # The package is signed if a key_file is set
       signature:
-        # Template to the PGP secret key file path (can also be ASCII-armored).
+        # PGP secret key file path (can also be ASCII-armored).
         # The passphrase is taken from the environment variable
         # `$NFPM_ID_APK_PASSPHRASE` with a fallback to `$NFPM_ID_PASSPHRASE`,
         # where ID is the id of the current nfpm config.
         # The id will be transformed to uppercase.
         # E.g. If your nfpm id is 'default' then the apk-specific passphrase
         # should be set as `$NFPM_DEFAULT_APK_PASSPHRASE`
+        #
+        # Templates: allowed
         key_file: '{{ .Env.GPG_KEY_PATH }}'
 
         # The name of the signing key. When verifying a package, the signature
         # is matched to the public key store in /etc/apk/keys/<key_name>.rsa.pub.
-        # If unset, it defaults to the maintainer email address.
         #
-        # Templateable. (since v1.15)
+        # Default: maintainer's email address
+        # Templates: allowed (since v1.15)
         key_name: origin
 
     archlinux:

--- a/www/docs/customization/nfpm.md
+++ b/www/docs/customization/nfpm.md
@@ -12,11 +12,11 @@ nfpms:
   -
     # ID of the nfpm config, must be unique.
     #
-    # Defaults: 'default'
+    # Default: 'default'
     id: foo
 
     # Name of the package.
-    # Defaults: ProjectName
+    # Default: ProjectName
     package_name: foo
 
     # You can change the file name of the package.

--- a/www/docs/customization/nightlies.md
+++ b/www/docs/customization/nightlies.md
@@ -19,24 +19,19 @@ nightly:
   # for example).
   #
   # Default is `{{ incpatch .Version }}-{{ .ShortCommit }}-nightly`.
+  # Templates: allowed
   name_template: '{{ incpatch .Version }}-devel'
 
   # Tag name to create if publish_release is enabled.
-  #
-  # Default is `nightly`
   tag_name: devel
 
   # Whether to publish a release or not.
   # Only works on GitHub.
-  #
-  # Default is `false`.
   publish_release: true
 
   # Whether to delete previous pre-releases for the same `tag_name` when
   # releasing.
   # This allows you to keep a single pre-release.
-  #
-  # Default is `false`.
   keep_single_release: true
 ```
 

--- a/www/docs/customization/partial.md
+++ b/www/docs/customization/partial.md
@@ -2,7 +2,7 @@
 
 GoReleaser can also split and merge builds.
 
-> Since: v1.12.0-pro.
+> Since: v1.12 (pro)
 
 !!! success "GoReleaser Pro"
     This subcommand is a [GoReleaser Pro feature](https://goreleaser.com/pro/).

--- a/www/docs/customization/publishers.md
+++ b/www/docs/customization/publishers.md
@@ -125,7 +125,8 @@ publishers:
     # You can publish extra pre-existing files.
     # The filename published will be the last part of the path (base).
     # If another file with the same name exists, the last one found will be used.
-    # These globs can also include templates.
+    #
+    # Templates: allowed
     extra_files:
       - glob: ./path/to/file.txt
       - glob: ./glob/**/to/**/file/**/*
@@ -140,6 +141,7 @@ publishers:
     #
     # Since: v1.17 (pro)
     # This feature is only available in GoReleaser Pro.
+    # Templates: allowed
     templated_extra_files:
       - src: LICENSE.tpl
         dst: LICENSE.txt

--- a/www/docs/customization/publishers.md
+++ b/www/docs/customization/publishers.md
@@ -106,10 +106,10 @@ publishers:
      - foo
      - bar
 
-    # Publish checksums (defaults to false)
+    # Publish checksums.
     checksum: true
 
-    # Publish signatures (defaults to false)
+    # Publish signatures.
     signature: true
 
     # Working directory in which to execute the command
@@ -126,8 +126,6 @@ publishers:
     # The filename published will be the last part of the path (base).
     # If another file with the same name exists, the last one found will be used.
     # These globs can also include templates.
-    #
-    # Defaults to empty.
     extra_files:
       - glob: ./path/to/file.txt
       - glob: ./glob/**/to/**/file/**/*
@@ -140,7 +138,6 @@ publishers:
     # Those files will have their contents pass through the template engine,
     # and its results will be published.
     #
-    # Default: empty
     # Since: v1.17 (pro)
     # This feature is only available in GoReleaser Pro.
     templated_extra_files:

--- a/www/docs/customization/release.md
+++ b/www/docs/customization/release.md
@@ -18,7 +18,9 @@ release:
     name: repo
 
   # IDs of the archives to use.
-  # Defaults to all.
+  # Empty means all IDs.
+  #
+  # Default: []
   ids:
     - foo
     - bar
@@ -26,7 +28,7 @@ release:
   # If set to true, will not auto-publish the release.
   # Available only for GitHub and Gitea.
   #
-  # Default is false.
+  # Default: false
   draft: true
 
   # Whether to remove existing draft releases with the same name before creating
@@ -34,8 +36,8 @@ release:
   # Only effective if `draft` is set to true.
   # Available only for GitHub.
   #
-  # Default: false.
-  # Since: v1.11.
+  # Default: false
+  # Since: v1.11
   replace_existing_draft: true
 
   # Useful if you want to delay the creation of the tag in the remote.
@@ -44,8 +46,8 @@ release:
   # value of this field.
   # Only works on GitHub.
   #
-  # Default: empty.
-  # Since: v1.11.
+  # Default: ''
+  # Since: v1.11
   target_commitish: '{{ .Commit }}'
 
   # If set, will create a release discussion in the category specified.
@@ -74,46 +76,40 @@ release:
   mode: append
 
   # Header template for the release body.
-  # Defaults to empty.
   header: |
     ## Some title ({{ .Date }})
 
     Welcome to this new release!
 
   # Footer template for the release body.
-  # Defaults to empty.
   footer: |
     ## Thanks!
 
     Those were the changes on {{ .Tag }}!
 
   # You can change the name of the release.
-  # Default is `{{.Tag}}` on OSS and `{{.PrefixedTag}}` on Pro.
+  # Default: '{{.Tag}}' ('{{.PrefixedTag}}' on Pro)
   name_template: "{{.ProjectName}}-v{{.Version}} {{.Env.USER}}"
 
   # You can disable this pipe in order to not create the release on any SCM.
   # Keep in mind that this might also break things that depend on the release
   # URL, for instance, homebrew taps.
   #
-  # Defaults to false.
-  # Templateable since: v1.15.
+  # Templates: allowed (since v1.15)
   disable: true
 
   # Set this to true if you want to disable just the artifact upload to the SCM.
   # If this is true, GoReleaser will still create the release with the
   # changelog, but won't upload anything to it.
   #
-  # Default: false.
-  # Since: v1.11.
-  # Templateable since: v1.15.
+  # Since: v1.11
+  # Templates: allowed (since v1.15)
   skip_upload: true
 
   # You can add extra pre-existing files to the release.
   # The filename on the release will be the last part of the path (base).
   # If another file with the same name exists, the last one found will be used.
   # These globs can also include templates.
-  #
-  # Defaults to empty.
   extra_files:
     - glob: ./path/to/file.txt
     - glob: ./glob/**/to/**/file/**/*
@@ -126,7 +122,6 @@ release:
   # Those files will have their contents pass through the template engine,
   # and its results will be added to the release.
   #
-  # Default: empty
   # Since: v1.17 (pro)
   # This feature is only available in GoReleaser Pro.
   templated_extra_files:
@@ -154,17 +149,15 @@ release:
     name: repo
 
   # IDs of the archives to use.
-  # Defaults to all.
   ids:
     - foo
     - bar
 
   # You can change the name of the release.
-  # Default is `{{.Tag}}` on OSS and `{{.PrefixedTag}}` on Pro.
+  # Default: '{{.Tag}}' ('{{.PrefixedTag}}' on Pro)
   name_template: "{{.ProjectName}}-v{{.Version}} {{.Env.USER}}"
 
   # You can disable this pipe in order to not upload any artifacts.
-  # Defaults to false.
   disable: true
 
   # What to do with the release notes in case there the release already exists.
@@ -175,15 +168,13 @@ release:
   # - `prepend`: prepend the current release notes to the existing notes
   # - `replace`: replace existing notes
   #
-  # Default is `keep-existing`.
+  # Default: 'keep-existing'
   mode: append
 
   # You can add extra pre-existing files to the release.
   # The filename on the release will be the last part of the path (base).
   # If another file with the same name exists, the last one found will be used.
   # These globs can also include templates.
-  #
-  # Defaults to empty.
   extra_files:
     - glob: ./path/to/file.txt
     - glob: ./glob/**/to/**/file/**/*
@@ -209,23 +200,21 @@ You can also configure the `release` section to upload to a [Gitea](https://gite
 ```yaml
 # .goreleaser.yaml
 release:
-  # Default is empty.
   gitea:
     owner: user
     name: repo
 
   # IDs of the artifacts to use.
-  # Defaults to all.
   ids:
     - foo
     - bar
 
   # You can change the name of the release.
-  # Default is `{{.Tag}}` on OSS and `{{.PrefixedTag}}` on Pro.
+  #
+  # Default: '{{.Tag}}' ('{{.PrefixedTag}}' on Pro)
   name_template: "{{.ProjectName}}-v{{.Version}} {{.Env.USER}}"
 
   # You can disable this pipe in order to not upload any artifacts.
-  # Defaults to false.
   disable: true
 
   # What to do with the release notes in case there the release already exists.
@@ -236,15 +225,13 @@ release:
   # - `prepend`: prepend the current release notes to the existing notes
   # - `replace`: replace existing notes
   #
-  # Default is `keep-existing`.
+  # Default: 'keep-existing'
   mode: append
 
   # You can add extra pre-existing files to the release.
   # The filename on the release will be the last part of the path (base).
   # If another file with the same name exists, the last one found will be used.
   # These globs can also include templates.
-  #
-  # Defaults to empty.
   extra_files:
     - glob: ./path/to/file.txt
     - glob: ./glob/**/to/**/file/**/*

--- a/www/docs/customization/release.md
+++ b/www/docs/customization/release.md
@@ -75,20 +75,26 @@ release:
   # Default is `keep-existing`.
   mode: append
 
-  # Header template for the release body.
+  # Header for the release body.
+  #
+  # Templates: allowed
   header: |
     ## Some title ({{ .Date }})
 
     Welcome to this new release!
 
-  # Footer template for the release body.
+  # Footer for the release body.
+  #
+  # Templates: allowed
   footer: |
     ## Thanks!
 
     Those were the changes on {{ .Tag }}!
 
   # You can change the name of the release.
+  #
   # Default: '{{.Tag}}' ('{{.PrefixedTag}}' on Pro)
+  # Templates: allowed
   name_template: "{{.ProjectName}}-v{{.Version}} {{.Env.USER}}"
 
   # You can disable this pipe in order to not create the release on any SCM.
@@ -109,7 +115,8 @@ release:
   # You can add extra pre-existing files to the release.
   # The filename on the release will be the last part of the path (base).
   # If another file with the same name exists, the last one found will be used.
-  # These globs can also include templates.
+  #
+  # Templates: allowed
   extra_files:
     - glob: ./path/to/file.txt
     - glob: ./glob/**/to/**/file/**/*
@@ -124,6 +131,7 @@ release:
   #
   # Since: v1.17 (pro)
   # This feature is only available in GoReleaser Pro.
+  # Templates: allowed
   templated_extra_files:
     - src: LICENSE.tpl
       dst: LICENSE.txt
@@ -154,7 +162,9 @@ release:
     - bar
 
   # You can change the name of the release.
+  #
   # Default: '{{.Tag}}' ('{{.PrefixedTag}}' on Pro)
+  # Templates: allowed
   name_template: "{{.ProjectName}}-v{{.Version}} {{.Env.USER}}"
 
   # You can disable this pipe in order to not upload any artifacts.
@@ -174,7 +184,8 @@ release:
   # You can add extra pre-existing files to the release.
   # The filename on the release will be the last part of the path (base).
   # If another file with the same name exists, the last one found will be used.
-  # These globs can also include templates.
+  #
+  # Templates: allowed
   extra_files:
     - glob: ./path/to/file.txt
     - glob: ./glob/**/to/**/file/**/*
@@ -212,6 +223,7 @@ release:
   # You can change the name of the release.
   #
   # Default: '{{.Tag}}' ('{{.PrefixedTag}}' on Pro)
+  # Templates: allowed
   name_template: "{{.ProjectName}}-v{{.Version}} {{.Env.USER}}"
 
   # You can disable this pipe in order to not upload any artifacts.
@@ -231,7 +243,8 @@ release:
   # You can add extra pre-existing files to the release.
   # The filename on the release will be the last part of the path (base).
   # If another file with the same name exists, the last one found will be used.
-  # These globs can also include templates.
+  #
+  # Templates: allowed
   extra_files:
     - glob: ./path/to/file.txt
     - glob: ./glob/**/to/**/file/**/*

--- a/www/docs/customization/sbom.md
+++ b/www/docs/customization/sbom.md
@@ -33,7 +33,7 @@ sboms:
     # Default: 'default'
     id: foo
 
-    # List of Names/templates of the SBOM documents created at this step
+    # List of names of the SBOM documents created at this step
     # (relative to the dist dir).
     #
     # Each element configured is made available as variables. For example:
@@ -43,13 +43,14 @@ sboms:
     #   document0: "foo"
     #   document1: "bar"
     #
-    # Default value is conditional based on the value of "artifacts":
-    #   - "binary":   ["{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}.sbom"]
-    #   - "any":      []
-    #   - otherwise:  ["{{ .ArtifactName }}.sbom"]
-    #
     # Note that multiple sbom values are only allowed if the value of
     # "artifacts" is "any".
+    #
+    # Default:
+    #   When "binary":   ["{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}.sbom"]
+    #   When "any":      []
+    #   Otherwise:       ["{{ .ArtifactName }}.sbom"]
+    # Templates: allowed
     documents:
       - "${artifact}.spdx.sbom"
 
@@ -60,9 +61,10 @@ sboms:
     # Default: 'syft'
     cmd: syft
 
-    # Command line templateable arguments for the command
+    # Command line arguments for the command
     #
     # Default: ["$artifact", "--file", "$document", "--output", "spdx-json"]
+    # Templates: allowed
     args: ["$artifact", "--file", "$sbom", "--output", "spdx-json"]
 
     # List of environment variables that will be passed to the SBOM command as
@@ -95,8 +97,8 @@ sboms:
 
 ### Available variable names
 
-These environment variables might be available in the fields that are
-templateable:
+These environment variables might be available in the fields that are accept
+templates:
 
 - `${artifact}`: the path to the artifact that will be cataloged (unless
   "artifacts" config item is "any")

--- a/www/docs/customization/sbom.md
+++ b/www/docs/customization/sbom.md
@@ -1,6 +1,6 @@
 # Cataloging artifacts
 
-Since: v1.2.
+> Since: v1.2
 
 A Software Bill of Materials (SBOM) is a description of the components that make
 up a software artifact.
@@ -30,7 +30,7 @@ sboms:
   -
     # ID of the sbom config, must be unique.
     #
-    # Defaults to "default".
+    # Default: 'default'
     id: foo
 
     # List of Names/templates of the SBOM documents created at this step
@@ -43,7 +43,7 @@ sboms:
     #   document0: "foo"
     #   document1: "bar"
     #
-    # Default value is conditional based on the value of "artifacts"
+    # Default value is conditional based on the value of "artifacts":
     #   - "binary":   ["{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}.sbom"]
     #   - "any":      []
     #   - otherwise:  ["{{ .ArtifactName }}.sbom"]
@@ -57,18 +57,18 @@ sboms:
     #
     # Note: the process CWD will be set to the same location as "dist"
     #
-    # Defaults to `syft`
+    # Default: 'syft'
     cmd: syft
 
     # Command line templateable arguments for the command
     #
-    # Defaults to `["$artifact", "--file", "$document", "--output", "spdx-json"]`
+    # Default: ["$artifact", "--file", "$document", "--output", "spdx-json"]
     args: ["$artifact", "--file", "$sbom", "--output", "spdx-json"]
 
     # List of environment variables that will be passed to the SBOM command as
     # well as the templates.
     #
-    # Defaults to [ "SYFT_FILE_METADATA_CATALOGER_ENABLED=true" ]
+    # Default: [ "SYFT_FILE_METADATA_CATALOGER_ENABLED=true" ]
     env:
       - FOO=bar
       - HONK=honkhonk
@@ -82,14 +82,12 @@ sboms:
     #   archive:  archives from archive pipe
     #   binary:   binaries output from the build stage
     #
-    # Defaults to `archive`
+    # Default: 'archive'
     artifacts: archive
 
     # IDs of the artifacts to catalog.
     #
     # If `artifacts` is "source" or "any" then this fields has no effect.
-    #
-    # Defaults to empty (which implies no filtering).
     ids:
       - foo
       - bar

--- a/www/docs/customization/scoop.md
+++ b/www/docs/customization/scoop.md
@@ -25,7 +25,7 @@ scoop:
 
     # Optionally a branch can be provided. (templateable)
     #
-    # Defaults to the default repository branch.
+    # Default: the repository default branch
     branch: main
 
     # Optionally a token can be provided, if it differs from the token provided
@@ -33,11 +33,9 @@ scoop:
     token: "{{ .Env.SCOOP_TAP_GITHUB_TOKEN }}"
 
   # Folder inside the repository to put the scoop.
-  # Default is the root folder.
   folder: Scoops
 
   # Git author used to commit to the repository.
-  # Defaults are shown.
   commit_author:
     name: goreleaserbot
     email: bot@goreleaser.com
@@ -46,22 +44,18 @@ scoop:
   commit_msg_template: "Scoop update for {{ .ProjectName }} version {{ .Tag }}"
 
   # Your app's homepage.
-  # Default is empty.
   homepage: "https://example.com/"
 
   # Your app's description.
-  # Default is empty.
   description: "Software to create fast and easy drum rolls."
 
   # Your app's license
-  # Default is empty.
   license: MIT
 
   # Setting this will prevent goreleaser to actually try to commit the updated
   # manifest leaving the responsibility of publishing it to the user.
   # If set to auto, the release will not be uploaded to the scoop bucket
   # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
-  # Default is false.
   skip_upload: true
 
   # Persist data between application updates
@@ -70,28 +64,27 @@ scoop:
   - "config.toml"
 
   # An array of commands to be executed before an application is installed.
-  # Default is empty.
   pre_install: ["Write-Host 'Running preinstall command'"]
 
   # An array of commands to be executed after an application is installed.
-  # Default is empty.
   post_install: ["Write-Host 'Running postinstall command'"]
 
   # An array of dependencies.
-  # Defaults to empty.
-  # Since GoReleaser v1.16.0.
+  #
+  # Since GoReleaser v1.16
   depends: ["git", "foo"]
 
 
   # A two-dimensional array of string, specifies the shortcut values to make available in the startmenu.
   # The array has to contain a executable/label pair. The third and fourth element are optional.
-  # Defaults to empty.
+  #
   # Since GoReleaser v1.17.0.
   shortcuts: [["drumroll.exe", "drumroll"]]
 
   # GOAMD64 to specify which amd64 version to use if there are multiple versions
   # from the build section.
-  # Default is v1.
+  #
+  # Default: v1
   goamd64: v3
 ```
 

--- a/www/docs/customization/scoop.md
+++ b/www/docs/customization/scoop.md
@@ -9,23 +9,31 @@ commented example below:
 ```yaml
 # .goreleaser.yaml
 scoop:
-  # Template for the url which is determined by the given Token (github or gitlab)
-  # Default for github is "https://github.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-  # Default for gitlab is "https://gitlab.com/<repo_owner>/<repo_name>/-/releases/{{ .Tag }}/downloads/{{ .ArtifactName }}"
-  # Default for gitea is "https://gitea.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+  # URL which is determined by the given Token (github or gitlab)
+  #
+  # Default:
+  #   GitHub: 'https://github.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}'
+  #   GitLab: 'https://gitlab.com/<repo_owner>/<repo_name>/-/releases/{{ .Tag }}/downloads/{{ .ArtifactName }}'
+  #   Gitea: 'https://gitea.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}'
+  # Templates: allowed
   url_template: "http://github.mycompany.com/foo/bar/releases/{{ .Tag }}/{{ .ArtifactName }}"
 
   # Repository to push the app manifest to.
   bucket:
-    # Repository owner template. (templateable)
+    # Repository owner.
+    #
+    # Templates: allowed
     owner: user
 
-    # Repository name. (templateable)
+    # Repository name.
+    #
+    # Templates: allowed
     name: scoop-bucket
 
-    # Optionally a branch can be provided. (templateable)
+    # Optionally a branch can be provided.
     #
     # Default: the repository default branch
+    # Templates: allowed
     branch: main
 
     # Optionally a token can be provided, if it differs from the token provided
@@ -41,6 +49,8 @@ scoop:
     email: bot@goreleaser.com
 
   # The project name and current git tag are used in the format string.
+  #
+  # Templates: allowed
   commit_msg_template: "Scoop update for {{ .ProjectName }} version {{ .Tag }}"
 
   # Your app's homepage.
@@ -84,7 +94,7 @@ scoop:
   # GOAMD64 to specify which amd64 version to use if there are multiple versions
   # from the build section.
   #
-  # Default: v1
+  # Default: 'v1'
   goamd64: v3
 ```
 

--- a/www/docs/customization/sign.md
+++ b/www/docs/customization/sign.md
@@ -32,9 +32,10 @@ signs:
     # Default: 'default'
     id: foo
 
-    # Name/template of the signature file.
+    # Name of the signature file.
     #
     # Default: '${artifact}.sig'
+    # Templates: allowed
     signature: "${artifact}_sig"
 
     # Path to the signature command
@@ -42,12 +43,13 @@ signs:
     # Default: 'gpg'
     cmd: gpg2
 
-    # Command line templateable arguments for the command
+    # Command line arguments for the command
     #
     # to sign with a specific key use
     # args: ["-u", "<key id, fingerprint, email, ...>", "--output", "${signature}", "--detach-sign", "${artifact}"]
     #
     # Default: ["--output", "${signature}", "--detach-sign", "${artifact}"]
+    # Templates: allowed
     args: ["--output", "${signature}", "${artifact}", "{{ .ProjectName }}"]
 
     # Which artifacts to sign
@@ -71,7 +73,9 @@ signs:
       - foo
       - bar
 
-    # Stdin data template to be given to the signature command as stdin.
+    # Stdin data to be given to the signature command as stdin.
+    #
+    # Templates: allowed
     stdin: '{{ .Env.GPG_PASSWORD }}'
 
     # StdinFile file to be given to the signature command as stdin.
@@ -83,7 +87,8 @@ signs:
     # Note that this should be a name, not a path.
     certificate: '{{ trimsuffix .Env.artifact ".tar.gz" }}.pem'
 
-    # List of environment variables that will be passed to the signing command as well as the templates.
+    # List of environment variables that will be passed to the signing command
+    # as well as the templates.
     env:
     - FOO=bar
     - HONK=honkhonk
@@ -98,8 +103,8 @@ signs:
 
 ### Available variable names
 
-These environment variables might be available in the fields that are
-templateable:
+These environment variables might be available in the fields that accept
+templates:
 
 - `${artifact}`: the path to the artifact that will be signed
 - `${artifactID}`: the ID of the artifact that will be signed

--- a/www/docs/customization/sign.md
+++ b/www/docs/customization/sign.md
@@ -29,17 +29,17 @@ signs:
   -
     # ID of the sign config, must be unique.
     #
-    # Defaults to "default".
+    # Default: 'default'
     id: foo
 
     # Name/template of the signature file.
     #
-    # Defaults to `${artifact}.sig`.
+    # Default: '${artifact}.sig'
     signature: "${artifact}_sig"
 
     # Path to the signature command
     #
-    # Defaults to `gpg`
+    # Default: 'gpg'
     cmd: gpg2
 
     # Command line templateable arguments for the command
@@ -47,7 +47,7 @@ signs:
     # to sign with a specific key use
     # args: ["-u", "<key id, fingerprint, email, ...>", "--output", "${signature}", "--detach-sign", "${artifact}"]
     #
-    # Defaults to `["--output", "${signature}", "--detach-sign", "${artifact}"]`
+    # Default: ["--output", "${signature}", "--detach-sign", "${artifact}"]
     args: ["--output", "${signature}", "${artifact}", "{{ .ProjectName }}"]
 
     # Which artifacts to sign
@@ -61,39 +61,29 @@ signs:
     #   binary:   binaries if archiving format is set to binary
     #   sbom:     any Software Bill of Materials generated for other artifacts
     #
-    # Defaults to `none`
+    # Default: 'none'
     artifacts: all
 
     # IDs of the artifacts to sign.
     #
     # If `artifacts` is checksum or source, this fields has no effect.
-    #
-    # Defaults to empty (which implies no filtering).
     ids:
       - foo
       - bar
 
     # Stdin data template to be given to the signature command as stdin.
-    #
-    # Defaults to empty
     stdin: '{{ .Env.GPG_PASSWORD }}'
 
     # StdinFile file to be given to the signature command as stdin.
-    #
-    # Defaults to empty
     stdin_file: ./.password
 
     # Sets a certificate that your signing command should write to.
     # You can later use `${certificate}` or `.Env.certificate` in the `args` section.
     # This is particularly useful for keyless signing (for instance, with cosign).
     # Note that this should be a name, not a path.
-    #
-    # Defaults to empty.
     certificate: '{{ trimsuffix .Env.artifact ".tar.gz" }}.pem'
 
     # List of environment variables that will be passed to the signing command as well as the templates.
-    #
-    # Defaults to empty
     env:
     - FOO=bar
     - HONK=honkhonk
@@ -102,8 +92,7 @@ signs:
     # GoReleaser is running with `--debug` set.
     # You can set this to true if you want them to be displayed regardless.
     #
-    # Default: false.
-    # Since: v1.2.
+    # Since: v1.2
     output: true
 ```
 

--- a/www/docs/customization/snapcraft.md
+++ b/www/docs/customization/snapcraft.md
@@ -26,10 +26,13 @@ snapcrafts:
     - bar
 
     # You can change the name of the package.
+    #
     # Default: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
+    # Templates: allowed
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
     # The name of the snap. This is optional.
+    #
     # Default: ProjectName
     name: drumroll
 
@@ -49,12 +52,12 @@ snapcrafts:
 
     # Channels in store where snap will be pushed.
     #
-    # Default: depends on grade:
-    # * `stable` = ["edge", "beta", "candidate", "stable"]
-    # * `devel` = ["edge", "beta"]
     # More info about channels here:
     # https://snapcraft.io/docs/reference/channels
     #
+    # Default:
+    #   grade is 'stable': ["edge", "beta", "candidate", "stable"]
+    #   grade is 'devel': ["edge", "beta"]
     # Templates: allowed (since v1.15)
     channel_templates:
       - edge
@@ -107,6 +110,7 @@ snapcrafts:
     #
     # Since: v1.17 (pro)
     # This feature is only available in GoReleaser Pro.
+    # Templates: allowed
     templated_extra_files:
       - source: LICENSE.tpl
         destination: LICENSE.txt
@@ -208,6 +212,7 @@ snapcrafts:
         completer: drumroll-completion.bash
 
         # You can override the command name.
+        #
         # Default: AppName
         command: bin/drumroll.wrapper
 

--- a/www/docs/customization/snapcraft.md
+++ b/www/docs/customization/snapcraft.md
@@ -16,26 +16,25 @@ Available options:
 snapcrafts:
   -
     # ID of the snapcraft config, must be unique.
-    # Defaults to "default".
+    #
+    # Default: 'default'
     id: foo
 
     # Build IDs for the builds you want to create snapcraft packages for.
-    # Defaults to all builds.
     builds:
     - foo
     - bar
 
     # You can change the name of the package.
-    # Default: `{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}`
+    # Default: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
     # The name of the snap. This is optional.
-    # Default is project name.
+    # Default: ProjectName
     name: drumroll
 
     # Whether to publish the snap to the snapcraft store.
     # Remember you need to `snapcraft login` first.
-    # Defaults to false.
     publish: true
 
     # Single-line elevator pitch for your amazing snap.
@@ -49,13 +48,14 @@ snapcrafts:
     description: This is the best drum roll application out there. Install it and awe!
 
     # Channels in store where snap will be pushed.
-    # Default depends on grade:
+    #
+    # Default: depends on grade:
     # * `stable` = ["edge", "beta", "candidate", "stable"]
     # * `devel` = ["edge", "beta"]
     # More info about channels here:
     # https://snapcraft.io/docs/reference/channels
     #
-    # Templateable since v1.15.
+    # Templates: allowed (since v1.15)
     channel_templates:
       - edge
       - beta
@@ -83,7 +83,6 @@ snapcrafts:
 
     # Your app's license, based on SPDX license expressions:
     # https://spdx.org/licenses
-    # Default is empty.
     license: MIT
 
     # A snap of type base to be used as the execution environment for this snap.
@@ -91,14 +90,12 @@ snapcrafts:
     # * bare - Empty base snap;
     # * core - Ubuntu Core 16;
     # * core18 - Ubuntu Core 18.
-    # Default is empty.
     base: core18
 
     # Add extra files on the resulting snap. Useful for including wrapper
     # scripts or other useful static files. Source filenames are relative to the
     # project directory. Destination filenames are relative to the snap prime
     # directory.
-    # Default is empty.
     extra_files:
       - source: drumroll.wrapper
         destination: bin/drumroll.wrapper
@@ -108,7 +105,6 @@ snapcrafts:
     # Those files will have their contents pass through the template engine,
     # and its results will be added to the package.
     #
-    # Default: empty
     # Since: v1.17 (pro)
     # This feature is only available in GoReleaser Pro.
     templated_extra_files:
@@ -136,7 +132,6 @@ snapcrafts:
     # * SNAP_VERSION: snap version (from snap.yaml)
     # More info about layout here:
     # https://snapcraft.io/docs/snap-layouts
-    # Default is empty.
     layout:
       # The path you want to access in sandbox.
       /etc/drumroll:
@@ -163,84 +158,71 @@ snapcrafts:
 
         # The kind of wrapper to generate for the given command.
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         adapter: none
 
         # List of applications that are ordered to be started after the current
         # one.
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         after: ["postdrum"]
 
         # Aliases for the app command.
         # https://snapcraft.io/docs/commands-and-aliases#heading--aliases
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         aliases: ["droll"]
 
         # Defines the name of the .desktop file used to start an application
         # with the desktop session.
         # https://snapcraft.io/docs/snap-format#heading--autostart
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         autostart: drumroll.desktop
 
         # List of applications that are ordered to be started before the current
         # one.
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         before: ["predrum"]
 
         # D-Bus name this service is reachable as. Mandatory if daemon=dbus.
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         bus_name: drumbus
 
         # A list of commands to be executed in order before the command of this
         # app.
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         command_chain: ["foo", "bar", "baz"]
 
         # An identifier to a desktop-id within an external appstream file.
         # https://snapcraft.io/docs/using-external-metadata
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         common_id: "com.example.drumroll"
 
         # Bash completion snippet. More information about completion here:
         # https://docs.snapcraft.io/tab-completion-for-snaps.
-        #
-        # Default: empty.
         completer: drumroll-completion.bash
 
         # You can override the command name.
-        # Default is the app name.
+        # Default: AppName
         command: bin/drumroll.wrapper
 
         # If you want your app to be autostarted and to always run in the
         # background, you can make it a simple daemon.
-        # Defaults to empty.
         daemon: simple
 
         # Location of the .desktop file.
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         desktop: usr/share/applications/drumroll.desktop
 
         # A set of key-value pairs specifying environment variables.
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         environment:
           foo: bar
           baz: quo
@@ -248,24 +230,21 @@ snapcrafts:
         # A list of Snapcraft extensions this app depends on.
         # https://snapcraft.io/docs/snapcraft-extensions
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         extensions: ["gnome-3-38"]
 
         # Defines whether a freshly installed daemon is started automatically,
         # or whether startup control is deferred to the snap.
         # Requires `daemon` to be set.
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         install_mode: "disable"
 
         # A set of key-value attributes passed through to snap.yaml without
         # snapcraft validation.
         # https://snapcraft.io/docs/using-in-development-features
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         passthrough:
           foo: bar
 
@@ -278,40 +257,33 @@ snapcrafts:
 
         # Sets a command to run from inside the snap after a service stops.
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         post_stop_command: foo
 
         # Controls whether the daemon should be restarted during a snap refresh.
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         refresh_mode: endure
 
         # Command to use to ask the service to reload its configuration.
         # Requires `daemon` to be set.
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         reload_command: foo
 
         # Restart condition of the snap.
         # https://snapcraft.io/docs/snapcraft-yaml-reference
-        #
-        # Default: empty.
         restart_condition: "always"
 
         # List of slots for interfaces to connect to.
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         slots: ["foo", "bar", "baz"]
 
         # Maps a daemon’s sockets to services and activates them.
         # Requires `plugs` to contain `network-bind`.
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         sockets:
           sock:
             listen-stream: $SNAP_COMMON/socket
@@ -320,48 +292,41 @@ snapcrafts:
 
         # Time to wait for daemon to start.
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         start_timeout: 42ms
 
         # Command to use to stop the service.
         # Requires `daemon` to be set.
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         stop_command: foo
 
         # Controls how the daemon should be stopped.
         # Requires `daemon` to be set.
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         stop_mode: sigterm
 
         # Time to wait for daemon to stop.
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         stop_timeout: 42ms
 
         # Schedules when, or how often, to run a service or command.
         # Requires `daemon` to be set.
         # https://snapcraft.io/docs/services-and-daemons
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         timer: "00:00-24:00/24"
 
         # Declares the service watchdog timeout.
         # Requires `plugs` to contain `daemon-notify`.
         #
-        # Default: empty.
-        # Since: v1.6.
+        # Since: v1.6
         watchdog_timeout: 42ms
 
     # Allows plugs to be configured. Plugs like system-files and personal-files
     # require this.
-    # Default is empty.
     plugs:
       personal-files:
         read:

--- a/www/docs/customization/snapshots.md
+++ b/www/docs/customization/snapshots.md
@@ -15,6 +15,7 @@ snapshot:
   # for example).
   #
   # Default is `{{ .Version }}-SNAPSHOT-{{.ShortCommit}}`.
+  # Templates: allowed
   name_template: '{{ incpatch .Version }}-devel'
 ```
 

--- a/www/docs/customization/source.md
+++ b/www/docs/customization/source.md
@@ -7,21 +7,19 @@ particularly useful if you want to sign it, for example.
 # .goreleaser.yaml
 source:
   # Whether this pipe is enabled or not.
-  # Defaults to `false`
   enabled: true
 
   # Name template of the final archive.
-  # Defaults to `{{ .ProjectName }}-{{ .Version }}`
+  # Default: '{{ .ProjectName }}-{{ .Version }}'
   name_template: '{{ .ProjectName }}'
 
   # Format of the archive.
   # Any format git-archive supports, this supports too.
-  # Defaults to `tar.gz`
+  # Default: 'tar.gz'
   format: 'tar'
 
   # Prefix template.
   # String to prepend to each filename in the archive.
-  # Defaults to empty
   prefix_template: '{{ .ProjectName }}-{{ .Version }}/'
 
   # This will make the destination paths be relative to the longest common
@@ -29,14 +27,12 @@ source:
   # Enabling this essentially mimic the behavior of nfpm's contents section.
   # It will be the default by June 2023.
   #
-  # Default: false
-  # Since: v1.14.
+  # Since: v1.14
   rlcp: true
 
   # Additional files/template/globs you want to add to the source archive.
   #
-  # Default: empty.
-  # Since: v1.11.
+  # Since: v1.11
   files:
     - LICENSE.txt
     - README_{{.Os}}.md
@@ -49,12 +45,11 @@ source:
       dst: docs
 
       # Strip parent folders when adding files to the archive.
-      # Default: false
       strip_parent: true
 
       # File info.
       # Not all fields are supported by all formats available formats.
-      # Defaults to the file info of the actual file if not provided.
+      # Default: file info of the source file
       info:
         owner: root
         group: root
@@ -67,7 +62,6 @@ source:
   # Those files will have their contents pass through the template engine,
   # and its results will be added to the source archive.
   #
-  # Default: empty
   # Since: v1.17 (pro)
   # This feature is only available in GoReleaser Pro.
   files:

--- a/www/docs/customization/source.md
+++ b/www/docs/customization/source.md
@@ -10,16 +10,21 @@ source:
   enabled: true
 
   # Name template of the final archive.
+  #
   # Default: '{{ .ProjectName }}-{{ .Version }}'
+  # Templates: allowed
   name_template: '{{ .ProjectName }}'
 
   # Format of the archive.
   # Any format git-archive supports, this supports too.
+  #
   # Default: 'tar.gz'
   format: 'tar'
 
-  # Prefix template.
+  # Prefix.
   # String to prepend to each filename in the archive.
+  #
+  # Templates: allowed
   prefix_template: '{{ .ProjectName }}-{{ .Version }}/'
 
   # This will make the destination paths be relative to the longest common
@@ -30,9 +35,10 @@ source:
   # Since: v1.14
   rlcp: true
 
-  # Additional files/template/globs you want to add to the source archive.
+  # Additional files/globs you want to add to the source archive.
   #
   # Since: v1.11
+  # Templates: allowed
   files:
     - LICENSE.txt
     - README_{{.Os}}.md
@@ -64,6 +70,7 @@ source:
   #
   # Since: v1.17 (pro)
   # This feature is only available in GoReleaser Pro.
+  # Templates: allowed
   files:
     # a more complete example, check the globbing deep dive below
     - src: 'LICENSE.md.tpl'

--- a/www/docs/customization/templatefiles.md
+++ b/www/docs/customization/templatefiles.md
@@ -17,7 +17,7 @@ All the templated files are uploaded to the release by default.
 template_files:
 -
   # ID of this particular file.
-  # Defaults to `default`.
+  # Default: 'default'
   id: default
 
   # Source path of the template file.
@@ -30,7 +30,7 @@ template_files:
   dst: foo.sh
 
   # File mode.
-  # Defaults to 0655.
+  # Default: 0655.
   mode: 0755
 ```
 

--- a/www/docs/customization/templatefiles.md
+++ b/www/docs/customization/templatefiles.md
@@ -1,6 +1,6 @@
 # Template Files
 
-> Since v1.16.0-pro
+> Since v1.16 (pro)
 
 !!! success "GoReleaser Pro"
     Template Files is a [GoReleaser Pro feature](/pro/).
@@ -17,19 +17,25 @@ All the templated files are uploaded to the release by default.
 template_files:
 -
   # ID of this particular file.
+  #
   # Default: 'default'
   id: default
 
   # Source path of the template file.
   # Ignored if empty.
+  #
+  # Templates: allowed
   src: foo.tpl.sh
 
   # Destination path of the file.
   # Will be prefixed with the `dist` folder.
   # Ignored if empty.
+  #
+  # Templates: allowed
   dst: foo.sh
 
   # File mode.
+  #
   # Default: 0655.
   mode: 0755
 ```

--- a/www/docs/customization/universalbinaries.md
+++ b/www/docs/customization/universalbinaries.md
@@ -12,13 +12,13 @@ universal_binaries:
 -
   # ID of resulting universal binary.
   #
-  # Defaults to the project name.
+  # Default: the project name
   id: foo
 
   # IDs to use to filter the built binaries.
   #
-  # Defaults to the `id` field.
-  # Since: v1.3.
+  # Default: the value of the id field
+  # Since: v1.3
   ids:
   - build1
   - build2
@@ -27,21 +27,17 @@ universal_binaries:
   #
   # You will want to change this if you have multiple builds!
   #
-  # Defaults to '{{ .ProjectName }}'
+  # Default: '{{ .ProjectName }}'
   name_template: '{{.ProjectName}}_{{.Version}}'
 
   # Whether to remove the previous single-arch binaries from the artifact list.
   # If left as false, your end release might have both several macOS archives:
   # amd64, arm64 and all.
-  #
-  # Defaults to false.
   replace: true
 
   # Hooks can be used to customize the final binary,
   # for example, to run generators.
   # Those fields allow templates.
-  #
-  # Default is both hooks empty.
   hooks:
     pre: rice embed-go
     post: ./script.sh {{ .Path }}

--- a/www/docs/customization/universalbinaries.md
+++ b/www/docs/customization/universalbinaries.md
@@ -23,11 +23,12 @@ universal_binaries:
   - build1
   - build2
 
-  # Universal binary name template.
+  # Universal binary name.
   #
   # You will want to change this if you have multiple builds!
   #
   # Default: '{{ .ProjectName }}'
+  # Templates: allowed
   name_template: '{{.ProjectName}}_{{.Version}}'
 
   # Whether to remove the previous single-arch binaries from the artifact list.
@@ -37,7 +38,8 @@ universal_binaries:
 
   # Hooks can be used to customize the final binary,
   # for example, to run generators.
-  # Those fields allow templates.
+  #
+  # Templates: allowed
   hooks:
     pre: rice embed-go
     post: ./script.sh {{ .Path }}

--- a/www/docs/customization/upload.md
+++ b/www/docs/customization/upload.md
@@ -153,7 +153,8 @@ uploads:
     name: production
 
     # HTTP method to use.
-    # Default: PUT
+    #
+    # Default: 'PUT'
     method: POST
 
     # IDs of the artifacts you want to upload.
@@ -166,8 +167,7 @@ uploads:
     # extensions with the same ID, and need to upload each extension to
     # a different place (e.g. nFPM packages).
     #
-    # Default: empty.
-    # Since: v1.7.
+    # Since: v1.7
     exts:
     - deb
     - rpm
@@ -175,13 +175,14 @@ uploads:
     # Upload mode. Valid options are `binary` and `archive`.
     # If mode is `archive`, variables _Os_, _Arch_ and _Arm_ for target name are not supported.
     # In that case these variables are empty.
-    # Default is `archive`.
+    #
+    # Default: 'archive'
     mode: archive
 
     # Template of the URL to be used as target of the HTTP request
     target: https://some.server/some/path/example-repo-local/{{ .ProjectName }}/{{ .Version }}/
 
-    # Custom artifact name (defaults to false)
+    # Custom artifact name.
     # If enable, you must supply the name of the Artifact as part of the Target
     # URL as it will not be automatically append to the end of the URL, its
     # pre-computed name is available as _ArtifactName_ for example
@@ -192,24 +193,22 @@ uploads:
     username: deployuser
 
     # Client certificate and key (when provided, added as client cert to TLS connections)
-    # Since: v1.11.
+    # Since: v1.11
     client_x509_cert: /path/to/client.cert.pem
     client_x509_key: /path/to/client.key.pem
 
     # An optional header you can use to tell GoReleaser to pass the artifact's
     # SHA256 checksum within the upload request.
-    # Default is empty.
     checksum_header: -X-SHA256-Sum
 
     # A map of custom headers e.g. to support required content types or auth schemes.
-    # Default is empty.
     custom_headers:
       JOB-TOKEN: "{{ .Env.CI_JOB_TOKEN }}"
 
-    # Upload checksums (defaults to false)
+    # Upload checksums.
     checksum: true
 
-    # Upload signatures (defaults to false)
+    # Upload signatures.
     signature: true
 
    # Certificate chain used to validate server certificates

--- a/www/docs/customization/upload.md
+++ b/www/docs/customization/upload.md
@@ -179,7 +179,9 @@ uploads:
     # Default: 'archive'
     mode: archive
 
-    # Template of the URL to be used as target of the HTTP request
+    # URL to be used as target of the HTTP request
+    #
+    # Templates: allowed
     target: https://some.server/some/path/example-repo-local/{{ .ProjectName }}/{{ .Version }}/
 
     # Custom artifact name.
@@ -193,6 +195,7 @@ uploads:
     username: deployuser
 
     # Client certificate and key (when provided, added as client cert to TLS connections)
+    #
     # Since: v1.11
     client_x509_cert: /path/to/client.cert.pem
     client_x509_key: /path/to/client.key.pem

--- a/www/docs/customization/verifiable_builds.md
+++ b/www/docs/customization/verifiable_builds.md
@@ -32,8 +32,8 @@ gomod:
 
   # Sets the `-mod` flag value.
   #
-  # Default: empty.
-  # Since: v1.7.
+  # Default: ''
+  # Since: v1.7
   mod: mod
 
   # Which Go binary to use.

--- a/www/docs/customization/verifiable_builds.md
+++ b/www/docs/customization/verifiable_builds.md
@@ -17,8 +17,6 @@ gomod:
   # This will only be effective if running against a tag. Snapshots will ignore
   # this setting.
   # Notice: for this to work your `build.main` must be a package, not a `.go` file.
-  #
-  # Default: false.
   proxy: true
 
   # If proxy is true, use these environment variables when running `go mod`
@@ -32,7 +30,6 @@ gomod:
 
   # Sets the `-mod` flag value.
   #
-  # Default: ''
   # Since: v1.7
   mod: mod
 

--- a/www/docs/scm/gitlab.md
+++ b/www/docs/scm/gitlab.md
@@ -43,12 +43,14 @@ gitlab_urls:
 
   # set to true if you want to upload to the Package Registry rather than attachments
   # Only works with GitLab 13.5+
-  # Since: v1.3.
+  #
+  # Since: v1.3
   use_package_registry: false
 
   # Set this if you set GITLAB_TOKEN to the value of CI_JOB_TOKEN.
+  #
   # Default: false
-  # Since: v1.11.
+  # Since: v1.11
   use_job_token: true
 ```
 


### PR DESCRIPTION
- [x] if the default is the zero-value for the field, do not specify
  - [ ] TODO: add a "how to read this docs" section somewhere explaining that
- [x] if the change was introduced in a v1.x.0, say only v1.x
- [x] drop trail ending `.` from Since, Default, etc
- [x] wording: always use `Default: ` instead of `Defaults to` and others
- [x] add a note to templateable fields
- [x] default value of a field, if its a string, always between single quotes `'`