### PR TITLE
feat: add context info to docker build errors

### DIFF
--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -436,6 +436,20 @@ func TestRunPipe(t *testing.T) {
 			pubAssertError:      shouldNotErr,
 			manifestAssertError: shouldNotErr,
 		},
+		"wrong binary name": {
+			dockers: []config.Docker{
+				{
+					ImageTemplates: []string{
+						registry + "goreleaser/wrong_bin_name:v1",
+					},
+					Goos:       "linux",
+					Goarch:     "amd64",
+					Dockerfile: "testdata/Dockerfile.wrongbin",
+				},
+			},
+			assertError:       shouldErr("seems like you tried to copy a file that is not available in the build context"),
+			assertImageLabels: noLabels,
+		},
 		"templated-dockerfile-invalid": {
 			dockers: []config.Docker{
 				{

--- a/internal/pipe/docker/testdata/Dockerfile.wrongbin
+++ b/internal/pipe/docker/testdata/Dockerfile.wrongbin
@@ -1,0 +1,3 @@
+FROM alpine
+# a typo:
+ADD mybyn /


### PR DESCRIPTION
its too hard to debug docker build issues... sometimes is just a typo in the binary name, and you might end debugging it for way too long...

this prints the full path to the build context (so, locally at least, you can cd into it) and also all the files available there when the error seems to be one of the "file not found" kind.

Hopefully this helps fixing things easier :)

closes #3912