### PR TITLE
fix(jsonschema): add binary to Archive format enum

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -447,7 +447,7 @@ func (bh Hook) JSONSchema() *jsonschema.Schema {
 // FormatOverride is used to specify a custom format for a specific GOOS.
 type FormatOverride struct {
 	Goos   string `yaml:"goos,omitempty" json:"goos,omitempty"`
-	Format string `yaml:"format,omitempty" json:"format,omitempty" jsonschema:"enum=tar,enum=tgz,enum=tar.gz,enum=zip,enum=gz,enum=tar.xz,enum=txz,default=tar.gz"`
+	Format string `yaml:"format,omitempty" json:"format,omitempty" jsonschema:"enum=tar,enum=tgz,enum=tar.gz,enum=zip,enum=gz,enum=tar.xz,enum=txz,enum=binary,default=tar.gz"`
 }
 
 // File is a file inside an archive.
@@ -516,7 +516,7 @@ type Archive struct {
 	BuildsInfo                FileInfo          `yaml:"builds_info,omitempty" json:"builds_info,omitempty"`
 	NameTemplate              string            `yaml:"name_template,omitempty" json:"name_template,omitempty"`
 	Replacements              map[string]string `yaml:"replacements,omitempty" json:"replacements,omitempty"` // Deprecated: use templates instead
-	Format                    string            `yaml:"format,omitempty" json:"format,omitempty" jsonschema:"enum=tar,enum=tgz,enum=tar.gz,enum=zip,enum=gz,enum=tar.xz,enum=txz,default=tar.gz"`
+	Format                    string            `yaml:"format,omitempty" json:"format,omitempty" jsonschema:"enum=tar,enum=tgz,enum=tar.gz,enum=zip,enum=gz,enum=tar.xz,enum=txz,enum=binary,default=tar.gz"`
 	FormatOverrides           []FormatOverride  `yaml:"format_overrides,omitempty" json:"format_overrides,omitempty"`
 	WrapInDirectory           string            `yaml:"wrap_in_directory,omitempty" json:"wrap_in_directory,omitempty" jsonschema:"oneof_type=string;boolean"`
 	StripParentBinaryFolder   bool              `yaml:"strip_parent_binary_folder,omitempty" json:"strip_parent_binary_folder,omitempty"`

--- a/www/docs/static/schema.json
+++ b/www/docs/static/schema.json
@@ -192,7 +192,8 @@
 							"zip",
 							"gz",
 							"tar.xz",
-							"txz"
+							"txz",
+							"binary"
 						],
 						"default": "tar.gz"
 					},
@@ -1005,7 +1006,8 @@
 							"zip",
 							"gz",
 							"tar.xz",
-							"txz"
+							"txz",
+							"binary"
 						],
 						"default": "tar.gz"
 					}


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

Add `binary` to Archive `format` enum in the JSON schema.

<!-- Why is this change being made? -->

JSON schema validation currently fails on `archives[0].format: binary`:

```
Value is not accepted. Valid values: "tar", "tgz", "tar.gz", "zip", "gz", "tar.xz", "txz".
``` 

<!-- # Provide links to any relevant tickets, URLs or other resources -->

Follow up to c41d6de833114f52759e6c6b70349d960a8ae293