### PR TITLE
test: ensure utf-8 sources/archives filenames work properly

### DIFF
--- a/internal/pipe/sourcearchive/source_test.go
+++ b/internal/pipe/sourcearchive/source_test.go
@@ -22,6 +22,8 @@ func TestArchive(t *testing.T) {
 			require.NoError(t, os.WriteFile("code.rb", []byte("not really code"), 0o655))
 			require.NoError(t, os.WriteFile("code.py", []byte("print 1"), 0o655))
 			require.NoError(t, os.WriteFile("README.md", []byte("# my dope fake project"), 0o655))
+			require.NoError(t, os.WriteFile("ملف.go", []byte("محتوى عربي"), 0o655))
+			require.NoError(t, os.WriteFile("🤔", []byte("thinking"), 0o655))
 			require.NoError(t, os.WriteFile(".gitignore", []byte(`
 added-later.txt
 ignored.txt
@@ -39,6 +41,8 @@ subfolder/
 			require.NoError(t, os.WriteFile("added-later.txt", []byte("this file was added later"), 0o655))
 			require.NoError(t, os.WriteFile("ignored.md", []byte("never added"), 0o655))
 			require.NoError(t, os.WriteFile("code.txt", []byte("not really code"), 0o655))
+			require.NoError(t, os.WriteFile("ملف.txt", []byte("محتوى عربي"), 0o655))
+			require.NoError(t, os.WriteFile("🤝", []byte("it works"), 0o655))
 			require.NoError(t, os.MkdirAll("subfolder", 0o755))
 			require.NoError(t, os.WriteFile("subfolder/file.md", []byte("a file within a folder, added later"), 0o655))
 
@@ -88,6 +92,8 @@ subfolder/
 				"foo-1.0.0/code.py",
 				"foo-1.0.0/code.rb",
 				"foo-1.0.0/code.txt",
+				"foo-1.0.0/ملف.go",
+				"foo-1.0.0/ملف.txt",
 				"foo-1.0.0/added-later.txt",
 				"foo-1.0.0/subfolder/file.md",
 			}

--- a/internal/testlib/archive.go
+++ b/internal/testlib/archive.go
@@ -136,7 +136,7 @@ func doLsTar(f io.Reader) []string {
 		if h == nil || err == io.EOF {
 			break
 		}
-		if h.Format == tar.FormatPAX {
+		if h.Name == "pax_global_header" {
 			continue
 		}
 		paths = append(paths, h.Name)

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -50,18 +50,28 @@ func TestArchive(t *testing.T) {
 
 			a, err := Copying(f1, f2, format)
 			require.NoError(t, err)
+			require.NoError(t, f1.Close())
+
 			require.NoError(t, a.Add(config.File{
 				Source:      empty.Name(),
 				Destination: "added_later.txt",
 			}))
+			require.NoError(t, a.Add(config.File{
+				Source:      empty.Name(),
+				Destination: "ملف.txt",
+			}))
 			require.NoError(t, a.Close())
-			require.NoError(t, f1.Close())
 			require.NoError(t, f2.Close())
 
-			require.Equal(t, []string{"empty.txt", "added_later.txt"}, testlib.LsArchive(t, f2.Name(), format))
+			require.ElementsMatch(
+				t,
+				[]string{"empty.txt", "added_later.txt", "ملف.txt"},
+				testlib.LsArchive(t, f2.Name(), format),
+			)
 		})
 	}
 
+	// unsupported format...
 	t.Run("7z", func(t *testing.T) {
 		_, err := New(io.Discard, "7z")
 		require.EqualError(t, err, "invalid archive format: 7z")

--- a/pkg/archive/tar/tar.go
+++ b/pkg/archive/tar/tar.go
@@ -34,9 +34,8 @@ func Copying(source io.Reader, target io.Writer) (Archive, error) {
 		if err == io.EOF || header == nil {
 			break
 		}
-		// needed for git archive
-		if len(header.PAXRecords) == 0 {
-			header.Format = tar.FormatGNU
+		if err != nil {
+			return Archive{}, err
 		}
 		w.files[header.Name] = true
 		if err := w.tw.WriteHeader(header); err != nil {
@@ -76,8 +75,6 @@ func (a Archive) Add(f config.File) error {
 		return fmt.Errorf("%s: %w", f.Source, err)
 	}
 	header.Name = f.Destination
-	// https://pkg.go.dev/archive/tar#Format
-	header.Format = tar.FormatGNU
 	if !f.Info.ParsedMTime.IsZero() {
 		header.ModTime = f.Info.ParsedMTime
 	}

--- a/pkg/archive/tar/tar.go
+++ b/pkg/archive/tar/tar.go
@@ -30,13 +30,16 @@ func Copying(source io.Reader, target io.Writer) (Archive, error) {
 	w := New(target)
 	r := tar.NewReader(source)
 	for {
-		h, err := r.Next()
-		if err == io.EOF || h == nil {
+		header, err := r.Next()
+		if err == io.EOF || header == nil {
 			break
 		}
-
-		w.files[h.Name] = true
-		if err := w.tw.WriteHeader(h); err != nil {
+		// needed for git archive
+		if len(header.PAXRecords) == 0 {
+			header.Format = tar.FormatGNU
+		}
+		w.files[header.Name] = true
+		if err := w.tw.WriteHeader(header); err != nil {
 			return w, err
 		}
 		if _, err := io.Copy(w.tw, r); err != nil {

--- a/pkg/archive/tar/tar.go
+++ b/pkg/archive/tar/tar.go
@@ -73,6 +73,8 @@ func (a Archive) Add(f config.File) error {
 		return fmt.Errorf("%s: %w", f.Source, err)
 	}
 	header.Name = f.Destination
+	// https://pkg.go.dev/archive/tar#Format
+	header.Format = tar.FormatGNU
 	if !f.Info.ParsedMTime.IsZero() {
 		header.ModTime = f.Info.ParsedMTime
 	}

--- a/pkg/archive/tar/tar_test.go
+++ b/pkg/archive/tar/tar_test.go
@@ -176,6 +176,10 @@ func TestCopying(t *testing.T) {
 		Source:      "../testdata/foo.txt",
 		Destination: "foo.txt",
 	}))
+	require.NoError(t, t1.Add(config.File{
+		Source:      "../testdata/foo.txt",
+		Destination: "ملف.txt",
+	}))
 	require.NoError(t, t1.Close())
 	require.NoError(t, f1.Close())
 
@@ -188,10 +192,14 @@ func TestCopying(t *testing.T) {
 		Source:      "../testdata/sub1/executable",
 		Destination: "executable",
 	}))
+	require.NoError(t, t2.Add(config.File{
+		Source:      "../testdata/sub1/executable",
+		Destination: "ملف.exe",
+	}))
 	require.NoError(t, t2.Close())
 	require.NoError(t, f2.Close())
 	require.NoError(t, f1.Close())
 
-	require.Equal(t, []string{"foo.txt"}, testlib.LsArchive(t, f1.Name(), "tar"))
-	require.Equal(t, []string{"foo.txt", "executable"}, testlib.LsArchive(t, f2.Name(), "tar"))
+	require.Equal(t, []string{"foo.txt", "ملف.txt"}, testlib.LsArchive(t, f1.Name(), "tar"))
+	require.Equal(t, []string{"foo.txt", "ملف.txt", "executable", "ملف.exe"}, testlib.LsArchive(t, f2.Name(), "tar"))
 }


### PR DESCRIPTION
This now works for files added to the source archive **after** the `git archive` command is run. During the `git archive`, it seems that the `tar` is still using some format that doesn't support utf-8 by default.

Tomorrow I'll look more into it.

see https://pkg.go.dev/archive/tar#Format

closes #3812