### PR TITLE
fix(nfpm): Add extension to produced artifacts

### DIFF
--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -443,6 +443,7 @@ func create(ctx *context.Context, fpm config.NFPM, format string, binaries []*ar
 			artifact.ExtraBuilds: binaries,
 			artifact.ExtraID:     fpm.ID,
 			artifact.ExtraFormat: format,
+			artifact.ExtraExt:    format,
 			extraFiles:           contents,
 		},
 	})

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -281,6 +281,7 @@ func TestRunPipe(t *testing.T) {
 	for _, pkg := range packages {
 		format := pkg.Format()
 		require.NotEmpty(t, format)
+		require.Equal(t, pkg.Format(), artifact.ExtraOr(*pkg, artifact.ExtraExt, ""))
 		arch := pkg.Goarch
 		if pkg.Goarm != "" {
 			arch += "v" + pkg.Goarm


### PR DESCRIPTION
Add extension to produced artifacts so that they can be filtered in later steps

Fixes #3933

---

I tried running the tests before raising this, but I get an unrelated error with docker (I get the same error on `main`). I'm not sure about if you value a test specifically around this? If so, lmk and I'll try to add one