### PR TITLE
fix: do not fatal on automaxprocs error

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,7 +29,8 @@ func init() {
 	// automatically set GOMAXPROCS to match available CPUs.
 	// GOMAXPROCS will be used as the default value for the --parallelism flag.
 	if _, err := maxprocs.Set(); err != nil {
-		log.WithError(err).Fatal("failed to set GOMAXPROCS")
+		// might fail on WSL...
+		log.WithError(err).Error("failed to set GOMAXPROCS")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func init() {
 	// GOMAXPROCS will be used as the default value for the --parallelism flag.
 	if _, err := maxprocs.Set(); err != nil {
 		// might fail on WSL...
-		log.WithError(err).Error("failed to set GOMAXPROCS")
+		log.WithError(err).Warn("failed to set GOMAXPROCS")
 	}
 }
 


### PR DESCRIPTION
This might fail on windows/wsl (see https://github.com/uber-go/automaxprocs/issues/65), and its not too bad if it fails, actually, so, let's just warn the error instead of exiting 1

closes #3945



Signed-off-by: Carlos Alexandro Becker <caarlos0@users.noreply.github.com>