### PR TITLE
feat(artifactory): Support matrix parameters in upload

### DIFF
--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -243,6 +243,18 @@ func uploadAsset(ctx *context.Context, upload *config.Upload, artifact *artifact
 		}
 		targetURL += artifact.Name
 	}
+
+	// Add any matrix parameters
+	for k, templatedVal := range upload.Properties {
+		// nolint:staticcheck
+		val, err := tmpl.New(ctx).WithArtifact(artifact).Apply(templatedVal)
+		if err != nil {
+			msg := fmt.Sprintf("%s: error while applying matrix parameters", kind)
+			log.WithField("instance", upload.Name).WithError(err).Error(msg)
+			return fmt.Errorf("%s: %w", msg, err)
+		}
+		targetURL += (";" + k + "=" + val)
+	}
 	log.Debugf("generated target url: %s", targetURL)
 
 	headers := map[string]string{}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,9 +11,10 @@ import (
 	"time"
 
 	"github.com/caarlos0/log"
-	"github.com/goreleaser/goreleaser/internal/yaml"
 	"github.com/goreleaser/nfpm/v2/files"
 	"github.com/invopop/jsonschema"
+
+	"github.com/goreleaser/goreleaser/internal/yaml"
 )
 
 // Git configs.
@@ -916,6 +917,7 @@ type Upload struct {
 	Signature          bool              `yaml:"signature,omitempty" json:"signature,omitempty"`
 	CustomArtifactName bool              `yaml:"custom_artifact_name,omitempty" json:"custom_artifact_name,omitempty"`
 	CustomHeaders      map[string]string `yaml:"custom_headers,omitempty" json:"custom_headers,omitempty"`
+	Properties         map[string]string `yaml:"properties,omitempty" json:"properties,omitempty"`
 }
 
 // Publisher configuration.

--- a/www/docs/customization/artifactory.md
+++ b/www/docs/customization/artifactory.md
@@ -183,6 +183,10 @@ artifactories:
       ...(edited content)...
       TyzMJasj5BPZrmKjJb6O/tOtEIJ66xPSBTxPShkEYHnB7A==
       -----END CERTIFICATE-----
+
+    # Additional properties supplied as matrix parameters
+    properties:
+        propertyName: propertyValue
 ```
 
 These settings should allow you to push your artifacts into multiple Artifactories.


### PR DESCRIPTION
Support matrix parameters when uploading to artifactory, which allows setting properties on uploaded artifacts

Fixes #3951