### PR TITLE
docs(artifactory): Add details on custom_artifact_name

### DIFF
--- a/www/docs/customization/artifactory.md
+++ b/www/docs/customization/artifactory.md
@@ -161,6 +161,9 @@ artifactories:
     # URL of your Artifactory instance + path to deploy to
     target: http://artifacts.company.com:8081/artifactory/example-repo-local/{{ .ProjectName }}/{{ .Version }}/
 
+    # Tells goreleaer not to append the artifact name to the target URL. You must do this manually
+    custom_artifact_name: true
+
     # User that will be used for the deployment
     username: deployuser
 


### PR DESCRIPTION
This property can be used to omit the artifact name from the target URL, which indirectly adds support for matrix parameters.

Fixes #3951