### PR TITLE
feat: IsGitDirty template variable

### DIFF
--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -164,6 +164,7 @@ func getGitInfo(ctx *context.Context) (context.GitInfo, error) {
 		TagSubject:  subject,
 		TagContents: contents,
 		TagBody:     body,
+		Dirty:       CheckDirty(ctx) != nil,
 	}, nil
 }
 

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -114,10 +114,12 @@ func TestDirty(t *testing.T) {
 	t.Run("skip validate is set", func(t *testing.T) {
 		ctx := testctx.New(testctx.SkipValidate)
 		testlib.AssertSkipped(t, Pipe{}.Run(ctx))
+		require.True(t, ctx.Git.Dirty)
 	})
 	t.Run("snapshot", func(t *testing.T) {
 		ctx := testctx.New(testctx.Snapshot)
 		testlib.AssertSkipped(t, Pipe{}.Run(ctx))
+		require.True(t, ctx.Git.Dirty)
 	})
 }
 
@@ -235,6 +237,7 @@ func TestValidState(t *testing.T) {
 	require.Equal(t, "v0.0.3", ctx.Git.CurrentTag)
 	require.Equal(t, "git@github.com:foo/bar.git", ctx.Git.URL)
 	require.NotEmpty(t, ctx.Git.FirstCommit)
+	require.False(t, ctx.Git.Dirty)
 }
 
 func TestSnapshotNoTags(t *testing.T) {

--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -45,6 +45,7 @@ const (
 	tagContents     = "TagContents"
 	tagBody         = "TagBody"
 	releaseURL      = "ReleaseURL"
+	isGitDirty      = "IsGitDirty"
 	major           = "Major"
 	minor           = "Minor"
 	patch           = "Patch"
@@ -98,6 +99,7 @@ func New(ctx *context.Context) *Template {
 		commitDate:      ctx.Git.CommitDate.UTC().Format(time.RFC3339),
 		commitTimestamp: ctx.Git.CommitDate.UTC().Unix(),
 		gitURL:          ctx.Git.URL,
+		isGitDirty:      ctx.Git.Dirty,
 		env:             ctx.Env,
 		date:            ctx.Date.UTC().Format(time.RFC3339),
 		timestamp:       ctx.Date.UTC().Unix(),

--- a/internal/tmpl/tmpl_test.go
+++ b/internal/tmpl/tmpl_test.go
@@ -35,6 +35,7 @@ func TestWithArtifact(t *testing.T) {
 			TagSubject:  "awesome release",
 			TagContents: "awesome release\n\nanother line",
 			TagBody:     "another line",
+			Dirty:       true,
 		}),
 		testctx.WithEnv(map[string]string{
 			"FOO":       "bar",
@@ -88,6 +89,7 @@ func TestWithArtifact(t *testing.T) {
 		"1678327562":                       `{{ .Timestamp }}`,
 		"snapshot true":                    `snapshot {{.IsSnapshot}}`,
 		"draft true":                       `draft {{.IsDraft}}`,
+		"dirty true":                       `dirty {{.IsGitDirty}}`,
 
 		"remove this": "{{ filter .Env.MULTILINE \".*remove.*\" }}",
 		"something with\nmultiple lines\nto test things": "{{ reverseFilter .Env.MULTILINE \".*remove.*\" }}",

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -32,6 +32,7 @@ type GitInfo struct {
 	TagSubject  string
 	TagContents string
 	TagBody     string
+	Dirty       bool
 }
 
 // Env is the environment variables.

--- a/www/docs/customization/templates.md
+++ b/www/docs/customization/templates.md
@@ -27,6 +27,7 @@ Key                   |Description
 `.CommitDate`         |the UTC commit date in RFC 3339 format
 `.CommitTimestamp`    |the UTC commit date in Unix format
 `.GitURL`             |the git remote url
+`.IsGitDirty`         |whether or not current git state is dirty. Since v1.19.
 `.Major`              |the major part of the version[^tag-is-semver]
 `.Minor`              |the minor part of the version[^tag-is-semver]
 `.Patch`              |the patch part of the version[^tag-is-semver]


### PR DESCRIPTION
will only ever be true on snapshots or when ran with `--skip-validate`. This should be useful as a ldflag, for example.