### PR TITLE
fix: goreleaser build index out of range

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -178,6 +178,7 @@ func setupBuildSingleTarget(ctx *context.Context) {
 		build.Goamd64 = nil
 		build.Targets = nil
 	}
+	ctx.Config.UniversalBinaries = nil
 }
 
 func setupBuildID(ctx *context.Context, ids []string) error {
@@ -214,7 +215,11 @@ func (w withOutputPipe) String() string {
 }
 
 func (w withOutputPipe) Run(ctx *context.Context) error {
-	path := ctx.Artifacts.Filter(artifact.ByType(artifact.Binary)).List()[0].Path
+	bins := ctx.Artifacts.Filter(artifact.ByType(artifact.Binary)).List()
+	if len(bins) == 0 {
+		return fmt.Errorf("no binary found")
+	}
+	path := bins[0].Path
 	out := w.output
 	if out == "." {
 		out = filepath.Base(path)

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -292,15 +292,19 @@ func TestBuildSingleTargetWithSpecificTargets(t *testing.T) {
 				},
 			},
 		},
+		UniversalBinaries: []config.UniversalBinary{
+			{Replace: true},
+		},
 	})
 
-	t.Setenv("GOOS", "linux")
+	t.Setenv("GOOS", "darwin")
 	t.Setenv("GOARCH", "amd64")
 	setupBuildSingleTarget(ctx)
 	require.Equal(t, config.Build{
-		Goos:   []string{"linux"},
+		Goos:   []string{"darwin"},
 		Goarch: []string{"amd64"},
 	}, ctx.Config.Builds[0])
+	require.Nil(t, ctx.Config.UniversalBinaries)
 }
 
 func TestBuildSingleTargetRemoveOtherOptions(t *testing.T) {


### PR DESCRIPTION
If you run `goreleaser build --single-target` with `universalbinaries[*].replace = true` on a mac, it'll break.

This fixes it by disabling universal binaries when building a single target.

It isn't useful anyway.

Closes #4004
