### PR TITLE
fix(archive): warn only for non-default globs with no matches

### DIFF
--- a/internal/archivefiles/archivefiles.go
+++ b/internal/archivefiles/archivefiles.go
@@ -31,7 +31,11 @@ func Eval(template *tmpl.Template, rlcp bool, files []config.File) ([]config.Fil
 		}
 
 		if len(files) == 0 {
-			log.WithField("glob", f.Source).Warn("no files matched")
+			if !f.Default {
+				// only log if its not a default glob, as those are usually
+				// very generic and are not really warnings for the user.
+				log.WithField("glob", f.Source).Warn("no files matched")
+			}
 			continue
 		}
 

--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -64,12 +64,12 @@ func (Pipe) Default(ctx *context.Context) error {
 		}
 		if len(archive.Files) == 0 {
 			archive.Files = []config.File{
-				{Source: "license*"},
-				{Source: "LICENSE*"},
-				{Source: "readme*"},
-				{Source: "README*"},
-				{Source: "changelog*"},
-				{Source: "CHANGELOG*"},
+				{Source: "license*", Default: true},
+				{Source: "LICENSE*", Default: true},
+				{Source: "readme*", Default: true},
+				{Source: "README*", Default: true},
+				{Source: "changelog*", Default: true},
+				{Source: "CHANGELOG*", Default: true},
 			}
 		}
 		if archive.NameTemplate == "" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -464,6 +464,7 @@ type File struct {
 	Destination string   `yaml:"dst,omitempty" json:"dst,omitempty"`
 	StripParent bool     `yaml:"strip_parent,omitempty" json:"strip_parent,omitempty"`
 	Info        FileInfo `yaml:"info,omitempty" json:"info,omitempty"`
+	Default     bool     `yaml:"-" json:"-"`
 }
 
 // FileInfo is the file info of a file.


### PR DESCRIPTION
Adjust the logging of warnings for unmatched globs to only show when the glob is not a default. No warning will be output for the default globs when there are no matching files.

These are defaults, by design, very generic.
We should not warn the user about them not finding anything, as that is their expected behavior most of the time.
