### PR TITLE
feat: improve verbose output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,9 +45,10 @@ func (cmd *rootCmd) Execute(args []string) {
 }
 
 type rootCmd struct {
-	cmd   *cobra.Command
-	debug bool
-	exit  func(int)
+	cmd     *cobra.Command
+	verbose bool
+	debug   bool // deprecated
+	exit    func(int)
 }
 
 func newRootCmd(version goversion.Info, exit func(int)) *rootCmd {
@@ -71,9 +72,9 @@ Check out our website for more information, examples and documentation: https://
 		SilenceErrors: true,
 		Args:          cobra.NoArgs,
 		PersistentPreRun: func(_ *cobra.Command, _ []string) {
-			if root.debug {
+			if root.verbose || root.debug {
 				log.SetLevel(log.DebugLevel)
-				log.Debug("debug logs enabled")
+				log.Debug("verbose output enabled")
 			}
 		},
 		PersistentPostRun: func(_ *cobra.Command, _ []string) {
@@ -82,7 +83,10 @@ Check out our website for more information, examples and documentation: https://
 	}
 	cmd.SetVersionTemplate("{{.Version}}")
 
-	cmd.PersistentFlags().BoolVar(&root.debug, "debug", false, "Enable debug mode")
+	cmd.PersistentFlags().BoolVar(&root.debug, "debug", false, "Enable verbose mode")
+	cmd.PersistentFlags().BoolVar(&root.verbose, "verbose", false, "Enable verbose mode")
+	_ = cmd.Flags().MarkDeprecated("debug", "please use --verbose instead")
+	_ = cmd.Flags().MarkHidden("debug")
 	cmd.AddCommand(
 		newBuildCmd().cmd,
 		newReleaseCmd().cmd,

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -32,12 +32,12 @@ func RunWithEnv(ctx context.Context, env []string, args ...string) (string, erro
 	cmd.Stderr = &stderr
 	cmd.Env = append(cmd.Env, env...)
 
-	log.WithField("args", args).Debug("running git")
 	err := cmd.Run()
 
-	log.WithField("stdout", stdout.String()).
-		WithField("stderr", stderr.String()).
-		Debug("git result")
+	log.WithField("args", args).
+		WithField("stdout", strings.TrimSpace(stdout.String())).
+		WithField("stderr", strings.TrimSpace(stderr.String())).
+		Debug("git command result")
 
 	if err != nil {
 		return "", errors.New(stderr.String())

--- a/www/docs/ci/codefresh.md
+++ b/www/docs/ci/codefresh.md
@@ -31,7 +31,7 @@ steps:
     stage: release
     image: 'goreleaser/goreleaser'
     commands:
-      - goreleaser --clean
+      - goreleaser release --clean
 ```
 
 You need to pass the variable `GITHUB_TOKEN` in the Codefresh UI that

--- a/www/docs/cookbooks/semantic-release.md
+++ b/www/docs/cookbooks/semantic-release.md
@@ -10,7 +10,7 @@ You can, though, leverage other tools to do the work for you, like for example
 ```bash
 git tag "$(svu next)"
 git push --tags
-goreleaser --clean
+goreleaser release --clean
 ```
 
 ## Example: semantic-release

--- a/www/docs/customization/release.md
+++ b/www/docs/customization/release.md
@@ -298,7 +298,7 @@ list all commits since the last tag, but skip ones starting with `Merge` or
 `docs`, you could run this command:
 
 ```sh
-goreleaser --release-notes <(some_changelog_generator)
+goreleaser release --release-notes <(some_changelog_generator)
 ```
 
 Some changelog generators you can use:

--- a/www/docs/deprecations.md
+++ b/www/docs/deprecations.md
@@ -37,6 +37,24 @@ Description.
 -->
 
 
+### --debug
+
+> since 2023-05-16 (v1.19.0)
+
+`--debug` has been deprecated in favor of `--verbose`.
+
+=== "Before"
+
+    ```bash
+    goreleaser release --debug
+    ```
+
+=== "After"
+
+    ```bash
+    goreleaser release --verbose
+    ```
+
 ### scoop
 
 > since 2023-04-30 (v1.18.0)
@@ -91,13 +109,13 @@ Simply use the pluralized form, `builds`, according to the
 === "Before"
 
     ```bash
-    goreleaser --rm-dist
+    goreleaser release --rm-dist
     ```
 
 === "After"
 
     ```bash
-    goreleaser --clean
+    goreleaser release --clean
     ```
 
 ### archives.rlcp


### PR DESCRIPTION
- deprecates `--debug` in favor of `--verbose` which is clearer 
- improved some debug log outputs
- docs: update documentation to always use the `release` subcommand (when it makes sense)

