### PR TITLE
feat(telegram): ability to choose msg format, mdv2escape

### DIFF
--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -232,6 +232,7 @@ func (t *Template) Apply(s string) (string, error) {
 			"incpatch":      incPatch,
 			"filter":        filter(false),
 			"reverseFilter": filter(true),
+			"mdv2escape":    mdv2Escape,
 		}).
 		Parse(s)
 	if err != nil {
@@ -321,4 +322,27 @@ func filter(reverse bool) func(content, exp string) string {
 
 		return strings.Join(lines, "\n")
 	}
+}
+
+func mdv2Escape(s string) string {
+	return strings.NewReplacer(
+		"_", "\\_",
+		"*", "\\*",
+		"[", "\\[",
+		"]", "\\]",
+		"(", "\\(",
+		")", "\\)",
+		"~", "\\~",
+		"`", "\\`",
+		">", "\\>",
+		"#", "\\#",
+		"+", "\\+",
+		"-", "\\-",
+		"=", "\\=",
+		"|", "\\|",
+		"{", "\\{",
+		"}", "\\}",
+		".", "\\.",
+		"!", "\\!",
+	).Replace(s)
 }

--- a/internal/tmpl/tmpl_test.go
+++ b/internal/tmpl/tmpl_test.go
@@ -410,3 +410,10 @@ func TestBool(t *testing.T) {
 		}
 	})
 }
+
+func TestMdv2Escape(t *testing.T) {
+	require.Equal(
+		t,
+		"aaa\\_\\*\\[\\]\\(\\)\\~\\`\\>\\#\\+\\-\\=\\|\\{\\}\\.\\!",
+		mdv2Escape("aaa_*[]()~`>#+-=|{}.!"))
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1145,6 +1145,7 @@ type Telegram struct {
 	Enabled         bool   `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	MessageTemplate string `yaml:"message_template,omitempty" json:"message_template,omitempty"`
 	ChatID          string `yaml:"chat_id,omitempty" json:"chat_id,omitempty" jsonschema:"oneof_type=string;integer"`
+	ParseMode       string `yaml:"parse_mode,omitempty" json:"parse_mode,omitempty" jsonschema:"enum=MarkdownV2,enum=HTML,default=MarkdownV2"`
 }
 
 type OpenCollective struct {

--- a/www/docs/customization/announce/telegram.md
+++ b/www/docs/customization/announce/telegram.md
@@ -25,9 +25,17 @@ announce:
 
     # Message template to use while publishing.
     #
-    # Default: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'
+    # Default: '{{ .ProjectName }} {{ mdv2escape .Tag }} is out! Check it out at {{ mdv2escape .ReleaseURL }}'
     # Templates: allowed
     message_template: 'Awesome project {{.Tag}} is out!'
+
+    # Parse mode.
+    #
+    # Valid options are MarkdownV2 and HTML.
+    #
+    # Default: MarkdownV2
+    # Since: v1.19
+    parse_mode: HTML
 ```
 
 You can format your message using `MarkdownV2`, for reference, see the
@@ -35,3 +43,5 @@ You can format your message using `MarkdownV2`, for reference, see the
 
 !!! tip
     Learn more about the [name template engine](/customization/templates/).
+    In the specific case of `MarkdownV2`, you'll probably need the `mdv2escape`
+    function.

--- a/www/docs/customization/templates.md
+++ b/www/docs/customization/templates.md
@@ -143,6 +143,7 @@ Usage                         |Description
 `filter "text" "regex"`       |keeps only the lines matching the given regex, analogous to `grep -E`. Since v1.6.
 `reverseFilter "text" "regex"`|keeps only the lines **not** matching the given regex, analogous to `grep -vE`. Since v1.6.
 `title "foo"`                 |"titlenize" the string using english as language. See [Title](https://pkg.go.dev/golang.org/x/text/cases#Title). Since v1.14.
+`mdv2escape "foo"`            |escape characteres according to MarkdownV2, especially useful in the Telegram integration. Since v1.19.
 
 With all those fields, you may be able to compose the name of your artifacts
 pretty much the way you want:


### PR DESCRIPTION
this allows to choose parse mode between `HTML` and `Markdownv2`, and adds a new template function, `mdv2escape`, to escape the characters according to telegram docs: https://core.telegram.org/bots/api#formatting-options


closes #4021