### PR TITLE
feat: allow to sign KO manifests

### DIFF
--- a/internal/pipe/ko/ko.go
+++ b/internal/pipe/ko/ko.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/ko/pkg/build"
 	"github.com/google/ko/pkg/commands/options"
 	"github.com/google/ko/pkg/publish"
+	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/internal/ids"
 	"github.com/goreleaser/goreleaser/internal/semerrgroup"
 	"github.com/goreleaser/goreleaser/internal/tmpl"
@@ -251,12 +252,27 @@ func doBuild(ctx *context.Context, ko config.Ko) func() error {
 			return fmt.Errorf("newDefault: %w", err)
 		}
 		defer func() { _ = p.Close() }()
-		if _, err = p.Publish(ctx, r, opts.importPath); err != nil {
+		ref, err := p.Publish(ctx, r, opts.importPath)
+		if err != nil {
 			return fmt.Errorf("publish: %w", err)
 		}
 		if err := p.Close(); err != nil {
 			return fmt.Errorf("close: %w", err)
 		}
+
+		art := &artifact.Artifact{
+			Type:  artifact.DockerManifest,
+			Name:  ref.Name(),
+			Path:  ref.Name(),
+			Extra: map[string]interface{}{},
+		}
+		if ko.ID != "" {
+			art.Extra[artifact.ExtraID] = ko.ID
+		}
+		if digest := ref.Context().Digest(ref.Identifier()).DigestStr(); digest != "" {
+			art.Extra[artifact.ExtraDigest] = digest
+		}
+		ctx.Artifacts.Add(art)
 		return nil
 	}
 }

--- a/internal/pipe/ko/ko_test.go
+++ b/internal/pipe/ko/ko_test.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/internal/testctx"
 	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/goreleaser/goreleaser/pkg/config"
@@ -210,6 +211,13 @@ func TestPublishPipeSuccess(t *testing.T) {
 
 			require.NoError(t, Pipe{}.Default(ctx))
 			require.NoError(t, Pipe{}.Publish(ctx))
+
+			manifests := ctx.Artifacts.Filter(artifact.ByType(artifact.DockerManifest)).List()
+			require.Len(t, manifests, 1)
+			require.NotEmpty(t, manifests[0].Name)
+			require.Equal(t, manifests[0].Name, manifests[0].Path)
+			require.NotEmpty(t, manifests[0].Extra[artifact.ExtraDigest])
+			require.Equal(t, "default", manifests[0].Extra[artifact.ExtraID])
 
 			ref, err := name.ParseReference(
 				fmt.Sprintf("%s:%s", repository, table.Name),

--- a/www/docs/customization/ko.md
+++ b/www/docs/customization/ko.md
@@ -155,5 +155,17 @@ kos:
 This will build the binaries for `linux/arm64`, `linux/amd64`, `darwin/amd64`
 and `darwin/arm64`, as well as the Docker images and manifest for Linux.
 
+# Signing KO manifests
+
+KO will add the built manifest to the artifact list, so you can sign them with
+`docker_signs`:
+
+```yaml
+# .goreleaser.yml
+docker_signs:
+  -
+    artifacts: manifests
+```
+
 [ko]: https://ko.build
 [build]: /customization/build/


### PR DESCRIPTION
add ko-generated manifests to the artifact list, this way they can be signed later.

closes #4027
