### PR TITLE
feat: envOrDefault template function

### DIFF
--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -219,6 +219,7 @@ func (t *Template) Apply(s string) (string, error) {
 			"filter":        filter(false),
 			"reverseFilter": filter(true),
 			"mdv2escape":    mdv2Escape,
+			"envOrDefault":  t.envOrDefault,
 		}).
 		Parse(s)
 	if err != nil {
@@ -227,6 +228,14 @@ func (t *Template) Apply(s string) (string, error) {
 
 	err = tmpl.Execute(&out, t.fields)
 	return out.String(), err
+}
+
+func (t *Template) envOrDefault(name, value string) string {
+	s, ok := t.fields[env].(context.Env)[name]
+	if !ok {
+		return value
+	}
+	return s
 }
 
 type ExpectedSingleEnvErr struct{}

--- a/internal/tmpl/tmpl_test.go
+++ b/internal/tmpl/tmpl_test.go
@@ -91,6 +91,8 @@ func TestWithArtifact(t *testing.T) {
 		"nightly false":                    `nightly {{.IsNightly}}`,
 		"draft true":                       `draft {{.IsDraft}}`,
 		"dirty true":                       `dirty {{.IsGitDirty}}`,
+		"env bar: barrrrr":                 `env bar: {{ envOrDefault "BAR" "barrrrr" }}`,
+		"env foo: bar":                     `env foo: {{ envOrDefault "FOO" "barrrrr" }}`,
 
 		"remove this": "{{ filter .Env.MULTILINE \".*remove.*\" }}",
 		"something with\nmultiple lines\nto test things": "{{ reverseFilter .Env.MULTILINE \".*remove.*\" }}",

--- a/www/docs/customization/templates.md
+++ b/www/docs/customization/templates.md
@@ -155,6 +155,7 @@ On all fields, you have these available functions:
 | `reverseFilter "text" "regex"` | keeps only the lines **not** matching the given regex, analogous to `grep -vE`. Since v1.6.                                     |
 | `title "foo"`                  | "titlenize" the string using english as language. See [Title](https://pkg.go.dev/golang.org/x/text/cases#Title). Since v1.14.   |
 | `mdv2escape "foo"`             | escape characters according to MarkdownV2, especially useful in the Telegram integration. Since v1.19.                          |
+| `envOrDefault "NAME" "value"`  | either gets the value of the given environment variable, or the given default. Since v1.19.                                     |
 
 With all those fields, you may be able to compose the name of your artifacts
 pretty much the way you want:


### PR DESCRIPTION
You can achieve the same with `{{ with (index .Env "NAME") }}etc`, but this looks cleaner.

refs #4096