### PR TITLE
fix: runner tarball download URL

### DIFF
--- a/www/docs/static/run
+++ b/www/docs/static/run
@@ -31,7 +31,7 @@ TAR_FILE="${FILE_BASENAME}_${OS}_${ARCH}.tar.gz"
 (
 	cd "$TMP_DIR"
 	echo "Downloading GoReleaser $VERSION..."
-	curl -sfLO "$RELEASES_URL/download/$VERSION/$TAR_FILE.tar.gz"
+	curl -sfLO "$RELEASES_URL/download/$VERSION/$TAR_FILE"
 	curl -sfLO "$RELEASES_URL/download/$VERSION/checksums.txt"
 	echo "Verifying checksums..."
 	sha256sum --ignore-missing --quiet --check checksums.txt


### PR DESCRIPTION
Regression in 4b7827829298c2f4a23dfcdc79bd4fcb685ac1bf, .tar.gz twice. Sorry :(