### PR TITLE
fix: runner tarball extract path

### DIFF
--- a/www/docs/static/run
+++ b/www/docs/static/run
@@ -48,5 +48,5 @@ TAR_FILE="${FILE_BASENAME}_${OS}_${ARCH}.tar.gz"
 	fi
 )
 
-tar -xf "$TAR_FILE" -C "$TMP_DIR"
+tar -xf "$TMP_DIR/$TAR_FILE" -C "$TMP_DIR"
 "$TMP_DIR/goreleaser" "$@"


### PR DESCRIPTION
Sigh, yet another regression from 4b7827829298c2f4a23dfcdc79bd4fcb685ac1bf. I actually _did_ test already with 10a627c1967a09810473c182d6e1c1dcb8748f33, but for some reason failed to notice the error. Tested better now :/