### PR TITLE
fix: archives should always use forward slash

### DIFF
--- a/internal/archivefiles/archivefiles.go
+++ b/internal/archivefiles/archivefiles.go
@@ -55,8 +55,8 @@ func Eval(template *tmpl.Template, files []config.File) ([]config.File, error) {
 				return nil, err
 			}
 			result = append(result, config.File{
-				Source:      file,
-				Destination: dst,
+				Source:      filepath.ToSlash(file),
+				Destination: filepath.ToSlash(dst),
 				Info:        f.Info,
 			})
 		}


### PR DESCRIPTION
extracted from #3795 