### PR TITLE
fix: artifact.Path should filepath.ToSlash

### DIFF
--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -358,6 +358,7 @@ func (artifacts *Artifacts) Add(a *Artifact) {
 			a.Path = rel
 		}
 	}
+	a.Path = filepath.ToSlash(a.Path)
 	log.WithField("name", a.Name).
 		WithField("type", a.Type).
 		WithField("path", a.Path).

--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -20,10 +20,12 @@ var _ fmt.Stringer = Type(0)
 func TestAdd(t *testing.T) {
 	var g errgroup.Group
 	artifacts := New()
+	wd, _ := os.Getwd()
 	for _, a := range []*Artifact{
 		{
 			Name: "foo",
 			Type: UploadableArchive,
+			Path: filepath.Join(wd, "/foo/bar.tgz"),
 		},
 		{
 			Name: "bar",
@@ -46,6 +48,8 @@ func TestAdd(t *testing.T) {
 	}
 	require.NoError(t, g.Wait())
 	require.Len(t, artifacts.List(), 4)
+	archives := artifacts.Filter(ByType(UploadableArchive)).List()
+	require.Len(t, archives, 1)
 }
 
 func TestFilter(t *testing.T) {


### PR DESCRIPTION
this is needed when we run part of the pipeline on windows, and the rest on linux, for example, the split build pro feature.

extracted from https://github.com/goreleaser/goreleaser/pull/3795 

+ added tests for relative path thing