### PR TITLE
fix: do runner cleanups also on `SIGINT` and `SIGTERM`

### DIFF
--- a/www/docs/static/run
+++ b/www/docs/static/run
@@ -22,7 +22,7 @@ test -z "$VERSION" && {
 
 TMP_DIR="$(mktemp -d)"
 # shellcheck disable=SC2064 # intentionally expands here
-trap "rm -rf \"$TMP_DIR\"" EXIT
+trap "rm -rf \"$TMP_DIR\"" EXIT INT TERM
 OS="$(uname -s)"
 ARCH="$(uname -m)"
 test "$ARCH" = "aarch64" && ARCH="arm64"


### PR DESCRIPTION
Behavior of the `EXIT` condition is not consistent between shells with regards to abnormal exits and signals. This cleanup should occur always.

https://austingroupbugs.net/view.php?id=621