### PR TITLE
fix(snapcraft): title and icon are optional

### DIFF
--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -37,11 +37,11 @@ var ErrNoSummary = errors.New("no summary provided for snapcraft")
 // Metadata to generate the snap package.
 type Metadata struct {
 	Name          string
-	Title         string
+	Title         string `yaml:",omitempty"`
 	Version       string
 	Summary       string
 	Description   string
-	Icon          string
+	Icon          string `yaml:",omitempty"`
 	Base          string `yaml:",omitempty"`
 	License       string `yaml:",omitempty"`
 	Grade         string `yaml:",omitempty"`


### PR DESCRIPTION
It will otherwise create the empty fields in the yaml, and snapcraft then complains they are empty and fail.