### PR TITLE
test: use `t.Setenv` to set env vars

### DIFF
--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"os"
 	"runtime"
 	"testing"
 
@@ -181,12 +180,8 @@ func TestBuildFlags(t *testing.T) {
 		})
 
 		t.Run("from env", func(t *testing.T) {
-			os.Setenv("GOOS", "linux")
-			os.Setenv("GOARCH", "arm64")
-			t.Cleanup(func() {
-				os.Unsetenv("GOOS")
-				os.Unsetenv("GOARCH")
-			})
+			t.Setenv("GOOS", "linux")
+			t.Setenv("GOARCH", "arm64")
 			result := setup(opts)
 			require.Equal(t, []string{"linux"}, result.Config.Builds[0].Goos)
 			require.Equal(t, []string{"arm64"}, result.Config.Builds[0].Goarch)

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -281,12 +281,9 @@ func createFakeGoBinaryWithVersion(tb testing.TB, name, version string) {
 	))
 
 	currentPath := os.Getenv("PATH")
-	tb.Cleanup(func() {
-		require.NoError(tb, os.Setenv("PATH", currentPath))
-	})
 
 	path := fmt.Sprintf("%s%c%s", d, os.PathListSeparator, currentPath)
-	require.NoError(tb, os.Setenv("PATH", path))
+	tb.Setenv("PATH", path)
 }
 
 func TestInvalidTargets(t *testing.T) {

--- a/internal/pipe/blob/blob_minio_test.go
+++ b/internal/pipe/blob/blob_minio_test.go
@@ -168,7 +168,7 @@ func TestMinioUploadCustomBucketID(t *testing.T) {
 	require.NoError(t, os.WriteFile(tgzpath, []byte("fake\ntargz"), 0o744))
 	require.NoError(t, os.WriteFile(debpath, []byte("fake\ndeb"), 0o744))
 	// Set custom BUCKET_ID env variable.
-	require.NoError(t, os.Setenv("BUCKET_ID", name))
+	t.Setenv("BUCKET_ID", name)
 	ctx := testctx.NewWithCfg(config.Project{
 		Dist:        folder,
 		ProjectName: "testupload",

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -246,7 +246,7 @@ func TestDefaultFail(t *testing.T) {
 }
 
 func TestDefaultExpandEnv(t *testing.T) {
-	require.NoError(t, os.Setenv("XBAR", "FOOBAR"))
+	t.Setenv("XBAR", "FOOBAR")
 	ctx := testctx.NewWithCfg(config.Project{
 		Builds: []config.Build{
 			{

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -283,11 +283,7 @@ func TestSnapshotDirty(t *testing.T) {
 }
 
 func TestGitNotInPath(t *testing.T) {
-	path := os.Getenv("PATH")
-	defer func() {
-		require.NoError(t, os.Setenv("PATH", path))
-	}()
-	require.NoError(t, os.Setenv("PATH", ""))
+	t.Setenv("PATH", "")
 	require.EqualError(t, Pipe{}.Run(testctx.New()), ErrNoGit.Error())
 }
 
@@ -310,16 +306,12 @@ func TestTagFromCI(t *testing.T) {
 		},
 	} {
 		for name, value := range tc.envs {
-			require.NoError(t, os.Setenv(name, value))
+			t.Setenv(name, value)
 		}
 
 		ctx := testctx.New()
 		require.NoError(t, Pipe{}.Run(ctx))
 		require.Equal(t, tc.expected, ctx.Git.CurrentTag)
-
-		for name := range tc.envs {
-			require.NoError(t, os.Setenv(name, ""))
-		}
 	}
 }
 
@@ -357,16 +349,12 @@ func TestPreviousTagFromCI(t *testing.T) {
 	} {
 		t.Run(tc.expected, func(t *testing.T) {
 			for name, value := range tc.envs {
-				require.NoError(t, os.Setenv(name, value))
+				t.Setenv(name, value)
 			}
 
 			ctx := testctx.New()
 			require.NoError(t, Pipe{}.Run(ctx))
 			require.Equal(t, tc.expected, ctx.Git.PreviousTag)
-
-			for name := range tc.envs {
-				require.NoError(t, os.Setenv(name, ""))
-			}
 		})
 	}
 }

--- a/internal/pipe/slack/slack_test.go
+++ b/internal/pipe/slack/slack_test.go
@@ -97,7 +97,6 @@ func TestParseRichText(t *testing.T) {
 }
 
 func TestRichText(t *testing.T) {
-	t.Parallel()
 	t.Setenv("SLACK_WEBHOOK", slackTestHook())
 
 	t.Run("e2e - full slack config with blocks and attachments", func(t *testing.T) {

--- a/internal/pipe/slack/slack_test.go
+++ b/internal/pipe/slack/slack_test.go
@@ -2,7 +2,6 @@ package slack
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/internal/testctx"
@@ -99,7 +98,7 @@ func TestParseRichText(t *testing.T) {
 
 func TestRichText(t *testing.T) {
 	t.Parallel()
-	os.Setenv("SLACK_WEBHOOK", slackTestHook())
+	t.Setenv("SLACK_WEBHOOK", slackTestHook())
 
 	t.Run("e2e - full slack config with blocks and attachments", func(t *testing.T) {
 		t.SkipNow() // requires a valid webhook for integration testing

--- a/internal/pipe/snapcraft/snapcraft_test.go
+++ b/internal/pipe/snapcraft/snapcraft_test.go
@@ -319,11 +319,7 @@ func TestRunPipeMetadata(t *testing.T) {
 }
 
 func TestNoSnapcraftInPath(t *testing.T) {
-	path := os.Getenv("PATH")
-	defer func() {
-		require.NoError(t, os.Setenv("PATH", path))
-	}()
-	require.NoError(t, os.Setenv("PATH", ""))
+	t.Setenv("PATH", "")
 	ctx := testctx.NewWithCfg(config.Project{
 		Snapcrafts: []config.Snapcraft{
 			{

--- a/internal/testlib/path_test.go
+++ b/internal/testlib/path_test.go
@@ -1,7 +1,6 @@
 package testlib
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,17 +14,8 @@ func TestCheckPath(t *testing.T) {
 		})
 	}
 
-	setupEnv := func(tb testing.TB, value string) {
-		tb.Helper()
-		previous := os.Getenv("CI")
-		require.NoError(tb, os.Setenv("CI", value))
-		tb.Cleanup(func() {
-			require.NoError(tb, os.Setenv("CI", previous))
-		})
-	}
-
 	t.Run("local", func(t *testing.T) {
-		setupEnv(t, "false")
+		t.Setenv("CI", "false")
 
 		t.Run("in path", func(t *testing.T) {
 			requireSkipped(t, false)
@@ -39,7 +29,7 @@ func TestCheckPath(t *testing.T) {
 	})
 
 	t.Run("CI", func(t *testing.T) {
-		setupEnv(t, "true")
+		t.Setenv("CI", "true")
 
 		t.Run("in path on CI", func(t *testing.T) {
 			requireSkipped(t, false)

--- a/pkg/context/context_test.go
+++ b/pkg/context/context_test.go
@@ -1,7 +1,6 @@
 package context
 
 import (
-	"os"
 	"runtime"
 	"testing"
 	"time"
@@ -11,8 +10,8 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	require.NoError(t, os.Setenv("FOO", "NOT BAR"))
-	require.NoError(t, os.Setenv("BAR", "1"))
+	t.Setenv("FOO", "NOT BAR")
+	t.Setenv("BAR", "1")
 	ctx := New(config.Project{
 		Env: []string{
 			"FOO=BAR",


### PR DESCRIPTION
We have been using `t.Setenv` is most of our tests. This PR replaces the remaining `os.Setenv` with `t.Setenv`.

Reference: https://pkg.go.dev/testing#T.Setenv

```go
func TestFoo(t *testing.T) {
	// before
	os.Setenv(key, "new value")
	defer os.Unsetenv(key)
	
	// after
	t.Setenv(key, "new value")
}
```