### PR TITLE
fix: Scoop releases being skipped via disabled SCM releases

### DIFF
--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -241,14 +241,6 @@ func doPublish(ctx *context.Context, manifest *artifact.Artifact, cl client.Clie
 		return pipe.Skip("release is prerelease")
 	}
 
-	relDisabled, err := tmpl.New(ctx).Bool(ctx.Config.Release.Disable)
-	if err != nil {
-		return err
-	}
-	if relDisabled {
-		return pipe.Skip("release is disabled")
-	}
-
 	commitMessage, err := tmpl.New(ctx).Apply(scoop.CommitMessageTemplate)
 	if err != nil {
 		return err

--- a/internal/pipe/scoop/scoop_test.go
+++ b/internal/pipe/scoop/scoop_test.go
@@ -515,38 +515,6 @@ func Test_doRun(t *testing.T) {
 			noAssertions,
 		},
 		{
-			"release is disabled",
-			args{
-				testctx.NewWithCfg(
-					config.Project{
-						ProjectName: "run-pipe",
-						Release: config.Release{
-							Disable: "true",
-						},
-						Scoop: config.Scoop{
-							Repository: config.RepoRef{
-								Owner: "test",
-								Name:  "test",
-							},
-							Description: "A run pipe test formula",
-							Homepage:    "https://github.com/goreleaser",
-						},
-					},
-					testctx.GitHubTokenType,
-					testctx.WithCurrentTag("v1.0.1"),
-					testctx.WithVersion("1.0.1"),
-				),
-				client.NewMock(),
-			},
-			[]artifact.Artifact{
-				{Name: "foo_1.0.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64", Goamd64: "v1", Path: file},
-				{Name: "foo_1.0.1_windows_386.tar.gz", Goos: "windows", Goarch: "386", Path: file},
-			},
-			shouldNotErr,
-			shouldErr("release is disabled"),
-			noAssertions,
-		},
-		{
 			"no archive",
 			args{
 				testctx.NewWithCfg(


### PR DESCRIPTION
The check to skip Scoop releases when SCM ones are disabled seems to be the only place where this is happening and in conflict to Brew releases. These two need not be linked as users can configure the `url_template` to point elsewhere.

--- 

Consider the following use case:

```
 * goreleaser/my-app.yml
   - builds: spec for building a Go binary for my-app
   - dockers: spec for packaging my-app in a container and pushing to Artifactory & GCP
   - archives: spec for zipping up my-app binary
   - artifactories: spec for pushing archives of my-app to a private jfrog artifactory
   - brews: spec for publishing my-app through brew on macOS with URLs from artifactory
   - scoop: spec for publishing my-app through scoop on Windows with URLs from artifactory
   - release: disabled SCM (e.g. GitHub) release
```

Running `goreleaser release -f goreleaser/my-app.yml` with the above setup results in the correct artifacts (archives & containers) being published to Artifactory, GCP, Brew, but no Scoop.

Given that Scoop's `skip_upload` cannot be templated in 1.18 and I do not wish to have SCM releases & tags on every release, one can be rather stuck.