### PR TITLE
build(nix): fix goreleaser config path

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -197,6 +197,7 @@ nix:
       name: nur
     homepage: https://goreleaser.com
     description: Deliver Go binaries as fast and easily as possible
+    path: pkgs/goreleaser/default.nix
     license: mit
     install: |-
       mkdir -p $out/bin


### PR DESCRIPTION
default is `goreleaser.nix`