### PR TITLE
Support `make_latest` for GitHub release

### DIFF
--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -349,6 +349,7 @@ func (c *githubClient) CreateRelease(ctx *context.Context, body string) (string,
 		Body:       github.String(body),
 		Draft:      github.Bool(ctx.Config.Release.Draft),
 		Prerelease: github.Bool(ctx.PreRelease),
+		MakeLatest: github.String("true"),
 	}
 
 	if ctx.Config.Release.DiscussionCategoryName != "" {
@@ -363,6 +364,10 @@ func (c *githubClient) CreateRelease(ctx *context.Context, body string) (string,
 		if target != "" {
 			data.TargetCommitish = github.String(target)
 		}
+	}
+
+	if latest := strings.TrimSpace(ctx.Config.Release.MakeLatest); latest == "false" {
+		data.MakeLatest = github.String(latest)
 	}
 
 	release, err := c.createOrUpdateRelease(ctx, data, body)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -658,6 +658,7 @@ type Release struct {
 	Disable                string      `yaml:"disable,omitempty" json:"disable,omitempty" jsonschema:"oneof_type=string;boolean"`
 	SkipUpload             string      `yaml:"skip_upload,omitempty" json:"skip_upload,omitempty" jsonschema:"oneof_type=string;boolean"`
 	Prerelease             string      `yaml:"prerelease,omitempty" json:"prerelease,omitempty"`
+	MakeLatest             string      `yaml:"make_latest,omitempty" json:"make_latest,omitempty" jsonschema:"oneof_type=string;boolean"`
 	NameTemplate           string      `yaml:"name_template,omitempty" json:"name_template,omitempty"`
 	IDs                    []string    `yaml:"ids,omitempty" json:"ids,omitempty"`
 	ExtraFiles             []ExtraFile `yaml:"extra_files,omitempty" json:"extra_files,omitempty"`

--- a/www/docs/customization/release.md
+++ b/www/docs/customization/release.md
@@ -75,6 +75,15 @@ release:
   # Default is false.
   prerelease: auto
 
+  # If set to false, will NOT mark the release as "latest".
+  # This prevents it from being shown at the top of the release list,
+  # and from being returned when calling https://api.github.com/repos/OWNER/REPO/releases/latest.
+  #
+  # Available only for GitHub.
+  #
+  # Default is true.
+  make_latest: true
+
   # What to do with the release notes in case there the release already exists.
   #
   # Valid options are:


### PR DESCRIPTION
This commit adds a `make_latest` boolean to the release configuration,
to allow signaling to GitHub if the release should be marked as latest.

Albeit being a boolean, the internal Go type is a string to allow
to distinguish an empty string (default behavior: `true`) from an
explicit `false`.

For more information around the GitHub API field, see
https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release

I did not include the `legacy` option, to not adopt something which
appears to be scheduled for removal in the future.

In addition, I opted for `make_latest` over `latest` because the
option is only available for GitHub. Which keeps the latter key
reserved for e.g. future use of a config option which is used across
Git providers.

Fixes #4159 