### PR TITLE
docs: fix yaml formatting on scoop deprecations

### DIFF
--- a/www/docs/deprecations.md
+++ b/www/docs/deprecations.md
@@ -197,10 +197,11 @@ GoReleaser now allows many `scoop` configurations, so it should be pluralized
     ```
 
 === "After"
-`yaml
+
+    ``` yaml
     scoops:
     - # ...
-   `
+    ```
 
 ### build
 


### PR DESCRIPTION
docs: fix yaml formatting on scoop deprecations

right now, the formatting at 
https://goreleaser.com/deprecations#scoop
is slightly broken when you click 'after'