### PR TITLE
fix: Delete temporary dir used for docker build

### DIFF
--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -157,6 +157,7 @@ func process(ctx *context.Context, docker config.Docker, artifacts []*artifact.A
 	if err != nil {
 		return fmt.Errorf("failed to create temporary dir: %w", err)
 	}
+	defer os.RemoveAll(tmp)
 
 	images, err := processImageTemplates(ctx, docker)
 	if err != nil {


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

Delete the temporary directory used for building Docker images.

<!-- Why is this change being made? -->

Leaving the temporary directory leads to wasted disk space.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

