### PR TITLE
feat: adds syft to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ RUN apk add --no-cache bash \
 # install cosign
 COPY --from=gcr.io/projectsigstore/cosign:v1.12.1@sha256:ac8e08a2141e093f4fd7d1d0b05448804eb3771b66574b13ad73e31b460af64d /ko-app/cosign /usr/bin/cosign
 
+# install syft
+RUN curl -sSfL https://raw.githubusercontent.com/anchore/syft/v0.84.1/install.sh | sh -s -- -b /usr/local/bin
+
 ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]
 CMD [ "-h" ]
 


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

As discussed in #4176, this PR adds syft to the Docker image.

<!-- Why is this change being made? -->

As mentioned in #4176, it simplifies CI when SBOM generation is needed.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

I tried to test by running `task goreleaser` in my dev environment. The amd64 image has been built properly and syft is available:
```
docker run --rm -it --entrypoint="" goreleaser/goreleaser:v1.19.2-amd64 sh
/go # syft --version
syft 0.84.1
```

However I couldn't test other platforms since I got unrelated errors when it tried to build the arm64 image. 