### PR TITLE
docs: fix links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@ By participating in this project, you agree to abide our
 
 Prerequisites:
 
-- [Task](https://taskfile.dev/#/installation)
-- [Go 1.20+](https://golang.org/doc/install)
+- [Task](https://taskfile.dev/installation)
+- [Go 1.20+](https://go.dev/doc/install)
 
 Other things you might need to run the tests:
 


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

This PR fixes the links to Go and Task installation pages.

<!-- Why is this change being made? -->

Official go site is now https://go.dev where the old link was automatically redicting.
Task's website has been changed and the installation procedure is now on its own page.

<!-- # Provide links to any relevant tickets, URLs or other resources -->
