### PR TITLE
ci: append envs when calling docker instead of overriding

### DIFF
--- a/internal/pipe/docker/api.go
+++ b/internal/pipe/docker/api.go
@@ -48,7 +48,7 @@ func runCommand(ctx *context.Context, dir, binary string, args ...string) error 
 	/* #nosec */
 	cmd := exec.CommandContext(ctx, binary, args...)
 	cmd.Dir = dir
-	cmd.Env = ctx.Env.Strings()
+	cmd.Env = append(cmd.Env, ctx.Env.Strings()...)
 
 	var b bytes.Buffer
 	w := gio.Safe(&b)
@@ -69,7 +69,7 @@ func runCommandWithOutput(ctx *context.Context, dir, binary string, args ...stri
 	/* #nosec */
 	cmd := exec.CommandContext(ctx, binary, args...)
 	cmd.Dir = dir
-	cmd.Env = ctx.Env.Strings()
+	cmd.Env = append(cmd.Env, ctx.Env.Strings()...)
 
 	var b bytes.Buffer
 	w := gio.Safe(&b)


### PR DESCRIPTION
This is causing issues when trying to run tests in Dagger.
ref: https://github.com/goreleaser/goreleaser/pull/4186#discussion_r1262977616

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
