### PR TITLE
fix(winget): replace forward slashes in Winget `RelativeFilePath`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 )
 
 require (
+	github.com/google/rpmpack v0.5.0 // indirect
 	cloud.google.com/go v0.110.2 // indirect
 	cloud.google.com/go/compute v1.20.1 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
@@ -160,7 +161,6 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/google/rpmpack v0.5.0 // indirect
 	github.com/google/s2a-go v0.1.4 // indirect
 	github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,6 @@ require (
 )
 
 require (
-	github.com/google/rpmpack v0.5.0 // indirect
 	cloud.google.com/go v0.110.2 // indirect
 	cloud.google.com/go/compute v1.20.1 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
@@ -161,6 +160,7 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/google/rpmpack v0.5.0 // indirect
 	github.com/google/s2a-go v0.1.4 // indirect
 	github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect

--- a/internal/pipe/winget/testdata/TestRunPipe/wrapped-in-dir/wrapped-in-dir.installer.yaml.golden
+++ b/internal/pipe/winget/testdata/TestRunPipe/wrapped-in-dir/wrapped-in-dir.installer.yaml.golden
@@ -9,21 +9,21 @@ Installers:
   - Architecture: x64
     NestedInstallerType: portable
     NestedInstallerFiles:
-      - RelativeFilePath: foo\foo.exe
+      - RelativeFilePath: foo\bin\foo.exe
     InstallerUrl: https://dummyhost/download/v1.2.1/foo_windows_amd64v1.zip
     InstallerSha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     UpgradeBehavior: uninstallPrevious
   - Architecture: x86
     NestedInstallerType: portable
     NestedInstallerFiles:
-      - RelativeFilePath: foo\foo.exe
+      - RelativeFilePath: foo\bin\foo.exe
     InstallerUrl: https://dummyhost/download/v1.2.1/foo_windows_386.zip
     InstallerSha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     UpgradeBehavior: uninstallPrevious
   - Architecture: arm64
     NestedInstallerType: portable
     NestedInstallerFiles:
-      - RelativeFilePath: foo\foo.exe
+      - RelativeFilePath: foo\bin\foo.exe
     InstallerUrl: https://dummyhost/download/v1.2.1/foo_windows_arm64.zip
     InstallerSha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     UpgradeBehavior: uninstallPrevious

--- a/internal/pipe/winget/winget.go
+++ b/internal/pipe/winget/winget.go
@@ -224,7 +224,7 @@ func (p Pipe) doRun(ctx *context.Context, winget config.Winget, cl client.Releas
 		folder := artifact.ExtraOr(*archive, artifact.ExtraWrappedIn, ".")
 		for _, bin := range artifact.ExtraOr(*archive, artifact.ExtraBinaries, []string{}) {
 			files = append(files, InstallerItemFile{
-				RelativeFilePath: windowsJoin([2]string{folder, bin}),
+				RelativeFilePath: strings.ReplaceAll(filepath.Join(folder, bin), "/", "\\"),
 			})
 		}
 		url, err := tmpl.New(ctx).WithArtifact(archive).Apply(winget.URLTemplate)
@@ -396,11 +396,4 @@ func extFor(tp artifact.Type) string {
 		// should never happen
 		return ""
 	}
-}
-
-func windowsJoin(elem [2]string) string {
-	if elem[0] == "" {
-		return elem[1]
-	}
-	return elem[0] + "\\" + elem[1]
 }

--- a/internal/pipe/winget/winget_test.go
+++ b/internal/pipe/winget/winget_test.go
@@ -602,18 +602,24 @@ func TestRunPipe(t *testing.T) {
 			goarch := "amd64"
 			createFakeArtifact("partial", goos, goarch, "v1", "", nil)
 			createFakeArtifact("foo", goos, goarch, "v1", "", nil)
-			createFakeArtifact("wrapped-in-dir", goos, goarch, "v1", "", map[string]any{artifact.ExtraWrappedIn: "foo",
-																						artifact.ExtraBinaries: []string{"bin/foo.exe"}})
+			createFakeArtifact("wrapped-in-dir", goos, goarch, "v1", "", map[string]any{
+				artifact.ExtraWrappedIn: "foo",
+				artifact.ExtraBinaries:  []string{"bin/foo.exe"},
+			})
 
 			goarch = "386"
 			createFakeArtifact("foo", goos, goarch, "", "", nil)
-			createFakeArtifact("wrapped-in-dir", goos, goarch, "", "", map[string]any{artifact.ExtraWrappedIn: "foo",
-																					  artifact.ExtraBinaries: []string{"bin/foo.exe"}})
+			createFakeArtifact("wrapped-in-dir", goos, goarch, "", "", map[string]any{
+				artifact.ExtraWrappedIn: "foo",
+				artifact.ExtraBinaries:  []string{"bin/foo.exe"},
+			})
 
 			goarch = "arm64"
 			createFakeArtifact("foo", goos, goarch, "", "", nil)
-			createFakeArtifact("wrapped-in-dir", goos, goarch, "", "", map[string]any{artifact.ExtraWrappedIn: "foo",
-																					  artifact.ExtraBinaries: []string{"bin/foo.exe"}})
+			createFakeArtifact("wrapped-in-dir", goos, goarch, "", "", map[string]any{
+				artifact.ExtraWrappedIn: "foo",
+				artifact.ExtraBinaries:  []string{"bin/foo.exe"},
+			})
 
 			client := client.NewMock()
 			pipe := Pipe{}

--- a/internal/pipe/winget/winget_test.go
+++ b/internal/pipe/winget/winget_test.go
@@ -602,15 +602,18 @@ func TestRunPipe(t *testing.T) {
 			goarch := "amd64"
 			createFakeArtifact("partial", goos, goarch, "v1", "", nil)
 			createFakeArtifact("foo", goos, goarch, "v1", "", nil)
-			createFakeArtifact("wrapped-in-dir", goos, goarch, "v1", "", map[string]any{artifact.ExtraWrappedIn: "foo"})
+			createFakeArtifact("wrapped-in-dir", goos, goarch, "v1", "", map[string]any{artifact.ExtraWrappedIn: "foo",
+																						artifact.ExtraBinaries: []string{"bin/foo.exe"}})
 
 			goarch = "386"
 			createFakeArtifact("foo", goos, goarch, "", "", nil)
-			createFakeArtifact("wrapped-in-dir", goos, goarch, "", "", map[string]any{artifact.ExtraWrappedIn: "foo"})
+			createFakeArtifact("wrapped-in-dir", goos, goarch, "", "", map[string]any{artifact.ExtraWrappedIn: "foo",
+																					  artifact.ExtraBinaries: []string{"bin/foo.exe"}})
 
 			goarch = "arm64"
 			createFakeArtifact("foo", goos, goarch, "", "", nil)
-			createFakeArtifact("wrapped-in-dir", goos, goarch, "", "", map[string]any{artifact.ExtraWrappedIn: "foo"})
+			createFakeArtifact("wrapped-in-dir", goos, goarch, "", "", map[string]any{artifact.ExtraWrappedIn: "foo",
+																					  artifact.ExtraBinaries: []string{"bin/foo.exe"}})
 
 			client := client.NewMock()
 			pipe := Pipe{}


### PR DESCRIPTION
If an archive filename contains `/` characters, they can sneak into Winget's `RelativeFilePath`.
In this PR, I make sure that `RelativeFilePath` only uses `\` directory separators.
