### PR TITLE
chore: remove comment about WSL failure

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,7 +30,6 @@ func init() {
 	// automatically set GOMAXPROCS to match available CPUs.
 	// GOMAXPROCS will be used as the default value for the --parallelism flag.
 	if _, err := maxprocs.Set(); err != nil {
-		// might fail on WSL...
 		log.WithError(err).Warn("failed to set GOMAXPROCS")
 	}
 }


### PR DESCRIPTION
Remove the comment about WSL failing to set max procs as this was fixed by v1.5.3 of automaxprocs.