### PR TITLE
feat: improve output

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/caarlos0/log"
+	"github.com/goreleaser/goreleaser/internal/logext"
 	"github.com/goreleaser/goreleaser/pkg/config"
 )
 
@@ -38,6 +39,6 @@ func loadConfigCheck(path string) (config.Project, string, error) {
 	}
 	// the user didn't specify a config file and the known possible file names
 	// don't exist, so, return an empty config and a nil err.
-	log.Warn("could not find a configuration file, using defaults...")
+	log.Warn(logext.Warning("could not find a configuration file, using defaults..."))
 	return config.Project{}, "", nil
 }

--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -123,7 +123,7 @@ func warnIfTargetsAndOtherOptionTogether(build config.Build) bool {
 		if v == 0 {
 			continue
 		}
-		log.Warnf(logext.Keyword("builds."+k) + " is ignored when " + logext.Keyword("targets") + " is set")
+		log.Warnf(logext.Keyword("builds."+k) + " is ignored when " + logext.Keyword("builds.targets") + " is set")
 		res = true
 	}
 	return res

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -1373,6 +1373,34 @@ func TestOverrides(t *testing.T) {
 	})
 }
 
+func TestWarnIfTargetsAndOtherOptionsTogether(t *testing.T) {
+	nonEmpty := []string{"foo", "bar"}
+	for name, fn := range map[string]func(*config.Build){
+		"goos":    func(b *config.Build) { b.Goos = nonEmpty },
+		"goarch":  func(b *config.Build) { b.Goarch = nonEmpty },
+		"goarm":   func(b *config.Build) { b.Goarm = nonEmpty },
+		"gomips":  func(b *config.Build) { b.Gomips = nonEmpty },
+		"goamd64": func(b *config.Build) { b.Goamd64 = nonEmpty },
+		"ignores": func(b *config.Build) { b.Ignore = []config.IgnoredBuild{{Goos: "linux"}} },
+		"multiple": func(b *config.Build) {
+			b.Goos = nonEmpty
+			b.Goarch = nonEmpty
+			b.Goarm = nonEmpty
+			b.Gomips = nonEmpty
+			b.Goamd64 = nonEmpty
+			b.Ignore = []config.IgnoredBuild{{Goos: "linux"}}
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			b := config.Build{
+				Targets: nonEmpty,
+			}
+			fn(&b)
+			require.True(t, warnIfTargetsAndOtherOptionTogether(b))
+		})
+	}
+}
+
 //
 // Helpers
 //

--- a/internal/deprecate/deprecate.go
+++ b/internal/deprecate/deprecate.go
@@ -8,24 +8,19 @@ import (
 	"text/template"
 
 	"github.com/caarlos0/log"
-	"github.com/charmbracelet/lipgloss"
+	"github.com/goreleaser/goreleaser/internal/logext"
 	"github.com/goreleaser/goreleaser/pkg/context"
 )
 
 const baseURL = "https://goreleaser.com/deprecations#"
 
-var warnStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("11")).Bold(true)
-
 // Notice warns the user about the deprecation of the given property.
 func Notice(ctx *context.Context, property string) {
-	NoticeCustom(ctx, property, "`{{ .Property }}` should not be used anymore, check {{ .URL }} for more info")
+	NoticeCustom(ctx, property, "{{ .Property }} should not be used anymore, check {{ .URL }} for more info")
 }
 
 // NoticeCustom warns the user about the deprecation of the given property.
 func NoticeCustom(ctx *context.Context, property, tmpl string) {
-	log.IncreasePadding()
-	defer log.DecreasePadding()
-
 	// replaces . and _ with -
 	url := baseURL + strings.NewReplacer(
 		".", "",
@@ -37,14 +32,14 @@ func NoticeCustom(ctx *context.Context, property, tmpl string) {
 	if err := template.
 		Must(template.New("deprecation").Parse("DEPRECATED: "+tmpl)).
 		Execute(&out, templateData{
-			URL:      url,
-			Property: property,
+			URL:      logext.URL(url),
+			Property: logext.Keyword(property),
 		}); err != nil {
 		panic(err) // this should never happen
 	}
 
 	ctx.Deprecated = true
-	log.Warn(warnStyle.Render(out.String()))
+	log.Warn(logext.Warning(out.String()))
 }
 
 type templateData struct {

--- a/internal/deprecate/testdata/TestNotice.txt.golden
+++ b/internal/deprecate/testdata/TestNotice.txt.golden
@@ -1,3 +1,3 @@
   • first
-    • DEPRECATED: `foo.bar.whatever: foobar` should not be used anymore, check https://goreleaser.com/deprecations#foobarwhatever-foobar for more info
+  • DEPRECATED:  foo.bar.whatever: foobar  should not be used anymore, check https://goreleaser.com/deprecations#foobarwhatever-foobar for more info
   • last

--- a/internal/deprecate/testdata/TestNoticeCustom.txt.golden
+++ b/internal/deprecate/testdata/TestNoticeCustom.txt.golden
@@ -1,3 +1,3 @@
   • first
-    • DEPRECATED: some custom template with a url https://goreleaser.com/deprecations#something-else
+  • DEPRECATED: some custom template with a url https://goreleaser.com/deprecations#something-else
   • last

--- a/internal/logext/styles.go
+++ b/internal/logext/styles.go
@@ -1,0 +1,18 @@
+package logext
+
+import "github.com/charmbracelet/lipgloss"
+
+// Keyword should be used to highlight code.
+var Keyword = lipgloss.NewStyle().
+	Padding(0, 1).
+	Foreground(lipgloss.AdaptiveColor{Light: "#FF4672", Dark: "#ED567A"}).
+	Background(lipgloss.AdaptiveColor{Light: "#DDDADA", Dark: "#242424"}).
+	Render
+
+var (
+	// URL is used to style URLs.
+	URL = lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Render
+
+	// Warning is used to style warnings for the user.
+	Warning = lipgloss.NewStyle().Foreground(lipgloss.Color("11")).Bold(true).Render
+)

--- a/internal/pipe/env/env.go
+++ b/internal/pipe/env/env.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/caarlos0/log"
+	"github.com/goreleaser/goreleaser/internal/logext"
 	"github.com/goreleaser/goreleaser/internal/tmpl"
 	"github.com/goreleaser/goreleaser/pkg/context"
 	homedir "github.com/mitchellh/go-homedir"
@@ -159,7 +160,7 @@ func checkErrors(ctx *context.Context, noTokens, noTokenErrs bool, gitlabTokenEr
 func loadEnv(env, path string) (string, error) {
 	val := os.Getenv(env)
 	if val != "" {
-		log.Infof("using token from %q", "$"+env)
+		log.Infof("using token from %q", logext.Keyword("$"+env))
 		return val, nil
 	}
 	path, err := homedir.Expand(path)
@@ -174,7 +175,7 @@ func loadEnv(env, path string) (string, error) {
 		return "", err
 	}
 	defer f.Close()
-	log.Infof("using token from %q", path)
+	log.Infof("using token from %q", logext.Keyword(path))
 	bts, _, err := bufio.NewReader(f).ReadLine()
 	return string(bts), err
 }


### PR DESCRIPTION
- improves deprecation warning styles a bit so they caught the readers eye faster and are easier to read 
- warns if the user uses `builds.target` in conjunction with other options which are ignored in that case
- improved env output
- improved no configuration found warning

some of the changes:

<img width="1263" alt="CleanShot 2023-07-24 at 21 38 41@2x" src="https://github.com/goreleaser/goreleaser/assets/245435/40465853-7177-44d6-b07b-61b67590669a">
