### PR TITLE
make docker build stage files same as archive

### DIFF
--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -192,7 +192,12 @@ func process(ctx *context.Context, docker config.Docker, artifacts []*artifact.A
 		}
 	}
 	for _, art := range artifacts {
-		if err := gio.Copy(art.Path, filepath.Join(tmp, filepath.Base(art.Path))); err != nil {
+		target := filepath.Join(tmp, art.Name)
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return fmt.Errorf("failed to make dir for artifact: %w", err)
+		}
+
+		if err := gio.Copy(art.Path, target); err != nil {
 			return fmt.Errorf("failed to copy artifact: %w", err)
 		}
 	}

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -908,7 +908,7 @@ func TestRunPipe(t *testing.T) {
 					ImageTemplates: []string{registry + "goreleaser/multiple:latest"},
 					Goos:           "darwin",
 					Goarch:         "amd64",
-					IDs:            []string{"mybin", "anotherbin"},
+					IDs:            []string{"mybin", "anotherbin", "subdir/subbin"},
 					Dockerfile:     "testdata/Dockerfile.multiple",
 				},
 			},
@@ -965,12 +965,14 @@ func TestRunPipe(t *testing.T) {
 			t.Run(name+" on "+imager, func(t *testing.T) {
 				folder := t.TempDir()
 				dist := filepath.Join(folder, "dist")
-				require.NoError(t, os.Mkdir(dist, 0o755))
-				require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0o755))
+				require.NoError(t, os.MkdirAll(filepath.Join(dist, "mybin", "subdir"), 0o755))
 				f, err := os.Create(filepath.Join(dist, "mybin", "mybin"))
 				require.NoError(t, err)
 				require.NoError(t, f.Close())
 				f, err = os.Create(filepath.Join(dist, "mybin", "anotherbin"))
+				require.NoError(t, err)
+				require.NoError(t, f.Close())
+				f, err = os.Create(filepath.Join(dist, "mybin", "subdir", "subbin"))
 				require.NoError(t, err)
 				require.NoError(t, f.Close())
 				f, err = os.Create(filepath.Join(dist, "mynfpm.apk"))
@@ -997,7 +999,7 @@ func TestRunPipe(t *testing.T) {
 				)
 				for _, os := range []string{"linux", "darwin"} {
 					for _, arch := range []string{"amd64", "386", "arm64"} {
-						for _, bin := range []string{"mybin", "anotherbin"} {
+						for _, bin := range []string{"mybin", "anotherbin", "subdir/subbin"} {
 							ctx.Artifacts.Add(&artifact.Artifact{
 								Name:   bin,
 								Path:   filepath.Join(dist, "mybin", bin),

--- a/internal/pipe/docker/testdata/Dockerfile.multiple
+++ b/internal/pipe/docker/testdata/Dockerfile.multiple
@@ -1,3 +1,4 @@
 FROM scratch
 ADD mybin /
 ADD anotherbin /
+ADD subdir/subbin /


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->

`docker` packaging does not honor the path structure defined in builds/binary
it copies all binaries to temp docker build folder

this PR fixes the behavior and make it same as `archive` 

for example

```
builds:
- id: xxx 
  binary: plugins/xxx
```

before:

```
/tmp/goreleaserdocker2210262014/xxx
```

after:

```
/tmp/goreleaserdocker2210262014/plugins/xxx
```


<!-- If applied, this commit will... -->



<!-- Why is this change being made? -->



<!-- # Provide links to any relevant tickets, URLs or other resources -->


