### PR TITLE
feat: support WASI

### DIFF
--- a/internal/builders/buildtarget/targets.go
+++ b/internal/builders/buildtarget/targets.go
@@ -157,6 +157,7 @@ var (
 		"illumosamd64",
 		"iosarm64",
 		"jswasm",
+		"wasip1wasm",
 		"linux386",
 		"linuxamd64",
 		"linuxarm",
@@ -202,6 +203,7 @@ var (
 		"plan9",
 		"solaris",
 		"windows",
+		"wasip1",
 	}
 
 	validGoarch = []string{

--- a/internal/builders/buildtarget/targets_test.go
+++ b/internal/builders/buildtarget/targets_test.go
@@ -19,6 +19,7 @@ func TestAllBuildTargets(t *testing.T) {
 			"windows",
 			"js",
 			"ios",
+			"wasip1",
 		},
 		Goarch: []string{
 			"386",
@@ -111,6 +112,7 @@ func TestAllBuildTargets(t *testing.T) {
 			"windows_arm64",
 			"js_wasm",
 			"ios_arm64",
+			"wasip1_wasm",
 		}, result)
 	})
 


### PR DESCRIPTION
`wasip1` is a valid `GOOS` value in the upcoming go 1.21.
