### PR TITLE
fix: failing when pull_request.base is empty

### DIFF
--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -196,6 +196,8 @@ func (c *githubClient) OpenPullRequest(
 	draft bool,
 ) error {
 	c.checkRateLimit(ctx)
+	base.Owner = firstNonEmpty(base.Owner, head.Owner)
+	base.Name = firstNonEmpty(base.Name, head.Name)
 	if base.Branch == "" {
 		def, err := c.getDefaultBranch(ctx, base)
 		if err != nil {
@@ -217,8 +219,8 @@ func (c *githubClient) OpenPullRequest(
 	log.Info("opening pull request")
 	pr, res, err := c.client.PullRequests.Create(
 		ctx,
-		firstNonEmpty(base.Owner, head.Owner),
-		firstNonEmpty(base.Name, head.Name),
+		base.Owner,
+		base.Name,
 		&github.NewPullRequest{
 			Title: github.String(title),
 			Base:  github.String(base.Branch),

--- a/internal/client/github_test.go
+++ b/internal/client/github_test.go
@@ -661,6 +661,55 @@ func TestGitHubOpenPullRequestBaseEmpty(t *testing.T) {
 	repo := Repo{
 		Owner:  "someone",
 		Name:   "something",
+		Branch: "foo",
+	}
+
+	require.NoError(t, client.OpenPullRequest(ctx, Repo{}, repo, "some title", false))
+}
+
+func TestGitHubOpenPullRequestHeadEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		if r.URL.Path == "/repos/someone/something/contents/.github/PULL_REQUEST_TEMPLATE.md" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		if r.URL.Path == "/repos/someone/something/pulls" {
+			r, err := os.Open("testdata/github/pull.json")
+			require.NoError(t, err)
+			_, err = io.Copy(w, r)
+			require.NoError(t, err)
+			return
+		}
+
+		if r.URL.Path == "/repos/someone/something" {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"default_branch": "main"}`)
+			return
+		}
+
+		if r.URL.Path == "/rate_limit" {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"resources":{"core":{"remaining":120}}}`)
+			return
+		}
+
+		t.Error("unhandled request: " + r.URL.Path)
+	}))
+	defer srv.Close()
+
+	ctx := testctx.NewWithCfg(config.Project{
+		GitHubURLs: config.GitHubURLs{
+			API: srv.URL + "/",
+		},
+	})
+	client, err := newGitHub(ctx, "test-token")
+	require.NoError(t, err)
+	repo := Repo{
+		Owner:  "someone",
+		Name:   "something",
 		Branch: "main",
 	}
 


### PR DESCRIPTION
if the base branch is empty, it'll try to fetch the default branch, which would fail if base repo name/owner are also empty.

the default behavior when base owner/name are missing is to using head's, so I changed it do that before trying to get the default branch, which should fix the issue.