### PR TITLE
feat: allow goreleaser to run in gerrit, soft-serve and others

### DIFF
--- a/internal/pipe/aur/aur.go
+++ b/internal/pipe/aur/aur.go
@@ -67,7 +67,7 @@ func (Pipe) Default(ctx *context.Context) error {
 }
 
 func (Pipe) Run(ctx *context.Context) error {
-	cli, err := client.New(ctx)
+	cli, err := client.NewReleaseClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func (Pipe) Run(ctx *context.Context) error {
 	return runAll(ctx, cli)
 }
 
-func runAll(ctx *context.Context, cli client.Client) error {
+func runAll(ctx *context.Context, cli client.ReleaseURLTemplater) error {
 	for _, aur := range ctx.Config.AURs {
 		err := doRun(ctx, aur, cli)
 		if err != nil {
@@ -85,7 +85,7 @@ func runAll(ctx *context.Context, cli client.Client) error {
 	return nil
 }
 
-func doRun(ctx *context.Context, aur config.AUR, cl client.Client) error {
+func doRun(ctx *context.Context, aur config.AUR, cl client.ReleaseURLTemplater) error {
 	name, err := tmpl.New(ctx).Apply(aur.Name)
 	if err != nil {
 		return err
@@ -189,7 +189,7 @@ func doRun(ctx *context.Context, aur config.AUR, cl client.Client) error {
 	return nil
 }
 
-func buildPkgFile(ctx *context.Context, pkg config.AUR, client client.Client, artifacts []*artifact.Artifact, tpl string) (string, error) {
+func buildPkgFile(ctx *context.Context, pkg config.AUR, client client.ReleaseURLTemplater, artifacts []*artifact.Artifact, tpl string) (string, error) {
 	data, err := dataFor(ctx, pkg, client, artifacts)
 	if err != nil {
 		return "", err
@@ -274,7 +274,7 @@ func toPkgBuildArch(arch string) string {
 	}
 }
 
-func dataFor(ctx *context.Context, cfg config.AUR, cl client.Client, artifacts []*artifact.Artifact) (templateData, error) {
+func dataFor(ctx *context.Context, cfg config.AUR, cl client.ReleaseURLTemplater, artifacts []*artifact.Artifact) (templateData, error) {
 	result := templateData{
 		Name:         cfg.Name,
 		Desc:         cfg.Description,

--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -79,7 +79,7 @@ func (Pipe) Default(ctx *context.Context) error {
 }
 
 func (Pipe) Run(ctx *context.Context) error {
-	cli, err := client.New(ctx)
+	cli, err := client.NewReleaseClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func (Pipe) Publish(ctx *context.Context) error {
 	return publishAll(ctx, cli)
 }
 
-func runAll(ctx *context.Context, cli client.Client) error {
+func runAll(ctx *context.Context, cli client.ReleaseURLTemplater) error {
 	for _, brew := range ctx.Config.Brews {
 		err := doRun(ctx, brew, cli)
 		if err != nil {
@@ -187,7 +187,7 @@ func doPublish(ctx *context.Context, formula *artifact.Artifact, cl client.Clien
 	}, repo, msg, brew.Repository.PullRequest.Draft)
 }
 
-func doRun(ctx *context.Context, brew config.Homebrew, cl client.ReleaserURLTemplater) error {
+func doRun(ctx *context.Context, brew config.Homebrew, cl client.ReleaseURLTemplater) error {
 	if brew.Repository.Name == "" {
 		return pipe.Skip("brew.repository.name is not set")
 	}
@@ -281,7 +281,7 @@ func buildFormulaPath(folder, filename string) string {
 	return path.Join(folder, filename)
 }
 
-func buildFormula(ctx *context.Context, brew config.Homebrew, client client.ReleaserURLTemplater, artifacts []*artifact.Artifact) (string, error) {
+func buildFormula(ctx *context.Context, brew config.Homebrew, client client.ReleaseURLTemplater, artifacts []*artifact.Artifact) (string, error) {
 	data, err := dataFor(ctx, brew, client, artifacts)
 	if err != nil {
 		return "", err
@@ -367,7 +367,7 @@ func keys(m map[string]bool) []string {
 	return keys
 }
 
-func dataFor(ctx *context.Context, cfg config.Homebrew, cl client.ReleaserURLTemplater, artifacts []*artifact.Artifact) (templateData, error) {
+func dataFor(ctx *context.Context, cfg config.Homebrew, cl client.ReleaseURLTemplater, artifacts []*artifact.Artifact) (templateData, error) {
 	sort.Slice(cfg.Dependencies, func(i, j int) bool {
 		return cfg.Dependencies[i].Name < cfg.Dependencies[j].Name
 	})

--- a/internal/pipe/chocolatey/chocolatey.go
+++ b/internal/pipe/chocolatey/chocolatey.go
@@ -62,13 +62,13 @@ func (Pipe) Default(ctx *context.Context) error {
 
 // Run the pipe.
 func (Pipe) Run(ctx *context.Context) error {
-	client, err := client.New(ctx)
+	cli, err := client.NewReleaseClient(ctx)
 	if err != nil {
 		return err
 	}
 
 	for _, choco := range ctx.Config.Chocolateys {
-		if err := doRun(ctx, client, choco); err != nil {
+		if err := doRun(ctx, cli, choco); err != nil {
 			return err
 		}
 	}
@@ -95,7 +95,7 @@ func (Pipe) Publish(ctx *context.Context) error {
 	return nil
 }
 
-func doRun(ctx *context.Context, cl client.Client, choco config.Chocolatey) error {
+func doRun(ctx *context.Context, cl client.ReleaseURLTemplater, choco config.Chocolatey) error {
 	filters := []artifact.Filter{
 		artifact.ByGoos("windows"),
 		artifact.ByType(artifact.UploadableArchive),
@@ -280,7 +280,7 @@ func buildTemplate(name string, text string, data templateData) ([]byte, error) 
 	return out.Bytes(), nil
 }
 
-func dataFor(ctx *context.Context, cl client.Client, choco config.Chocolatey, artifacts []*artifact.Artifact) (templateData, error) {
+func dataFor(ctx *context.Context, cl client.ReleaseURLTemplater, choco config.Chocolatey, artifacts []*artifact.Artifact) (templateData, error) {
 	result := templateData{}
 
 	if choco.URLTemplate == "" {

--- a/internal/pipe/krew/krew.go
+++ b/internal/pipe/krew/krew.go
@@ -66,7 +66,7 @@ func (Pipe) Default(ctx *context.Context) error {
 }
 
 func (Pipe) Run(ctx *context.Context) error {
-	cli, err := client.New(ctx)
+	cli, err := client.NewReleaseClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func (Pipe) Run(ctx *context.Context) error {
 	return runAll(ctx, cli)
 }
 
-func runAll(ctx *context.Context, cli client.Client) error {
+func runAll(ctx *context.Context, cli client.ReleaseURLTemplater) error {
 	for _, krew := range ctx.Config.Krews {
 		err := doRun(ctx, krew, cli)
 		if err != nil {
@@ -84,7 +84,7 @@ func runAll(ctx *context.Context, cli client.Client) error {
 	return nil
 }
 
-func doRun(ctx *context.Context, krew config.Krew, cl client.ReleaserURLTemplater) error {
+func doRun(ctx *context.Context, krew config.Krew, cl client.ReleaseURLTemplater) error {
 	if krew.Name == "" {
 		return pipe.Skip("krew: manifest name is not set")
 	}
@@ -176,7 +176,7 @@ func templateFields(ctx *context.Context, krew config.Krew) (config.Krew, error)
 func buildmanifest(
 	ctx *context.Context,
 	krew config.Krew,
-	client client.ReleaserURLTemplater,
+	client client.ReleaseURLTemplater,
 	artifacts []*artifact.Artifact,
 ) (string, error) {
 	data, err := manifestFor(ctx, krew, client, artifacts)
@@ -197,7 +197,7 @@ func doBuildManifest(data Manifest) (string, error) {
 func manifestFor(
 	ctx *context.Context,
 	cfg config.Krew,
-	cl client.ReleaserURLTemplater,
+	cl client.ReleaseURLTemplater,
 	artifacts []*artifact.Artifact,
 ) (Manifest, error) {
 	result := Manifest{

--- a/internal/pipe/nix/nix.go
+++ b/internal/pipe/nix/nix.go
@@ -88,7 +88,7 @@ func (Pipe) Default(ctx *context.Context) error {
 }
 
 func (p Pipe) Run(ctx *context.Context) error {
-	cli, err := client.New(ctx)
+	cli, err := client.NewReleaseClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func (p Pipe) Publish(ctx *context.Context) error {
 	return p.publishAll(ctx, cli)
 }
 
-func (p Pipe) runAll(ctx *context.Context, cli client.Client) error {
+func (p Pipe) runAll(ctx *context.Context, cli client.ReleaseURLTemplater) error {
 	for _, nix := range ctx.Config.Nix {
 		err := p.doRun(ctx, nix, cli)
 		if err != nil {
@@ -130,7 +130,7 @@ func (p Pipe) publishAll(ctx *context.Context, cli client.Client) error {
 	return skips.Evaluate()
 }
 
-func (p Pipe) doRun(ctx *context.Context, nix config.Nix, cl client.ReleaserURLTemplater) error {
+func (p Pipe) doRun(ctx *context.Context, nix config.Nix, cl client.ReleaseURLTemplater) error {
 	if nix.Repository.Name == "" {
 		return errNoRepoName
 	}
@@ -187,7 +187,7 @@ func (p Pipe) doRun(ctx *context.Context, nix config.Nix, cl client.ReleaserURLT
 func preparePkg(
 	ctx *context.Context,
 	nix config.Nix,
-	cli client.ReleaserURLTemplater,
+	cli client.ReleaseURLTemplater,
 	prefetcher shaPrefetcher,
 ) (string, error) {
 	filters := []artifact.Filter{

--- a/internal/pipe/release/release.go
+++ b/internal/pipe/release/release.go
@@ -33,7 +33,10 @@ func (Pipe) Skip(ctx *context.Context) (bool, error) {
 }
 
 // Default sets the pipe defaults.
-func (Pipe) Default(ctx *context.Context) error {
+func (p Pipe) Default(ctx *context.Context) error {
+	if b, _ := p.Skip(ctx); b {
+		return pipe.Skip("release is disabled")
+	}
 	numOfReleases := 0
 	if ctx.Config.Release.GitHub.String() != "" {
 		numOfReleases++

--- a/internal/pipe/release/release_test.go
+++ b/internal/pipe/release/release_test.go
@@ -534,9 +534,9 @@ func TestDefaultPipeDisabled(t *testing.T) {
 		},
 	})
 	ctx.TokenType = context.TokenTypeGitHub
-	require.NoError(t, Pipe{}.Default(ctx))
-	require.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Name)
-	require.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Owner)
+	testlib.AssertSkipped(t, Pipe{}.Default(ctx))
+	require.Empty(t, ctx.Config.Release.GitHub.Name)
+	require.Empty(t, ctx.Config.Release.GitHub.Owner)
 }
 
 func TestDefaultFilled(t *testing.T) {

--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -67,11 +67,11 @@ func (Pipe) Skip(ctx *context.Context) bool {
 
 // Run creates the scoop manifest locally.
 func (Pipe) Run(ctx *context.Context) error {
-	client, err := client.New(ctx)
+	cli, err := client.NewReleaseClient(ctx)
 	if err != nil {
 		return err
 	}
-	return runAll(ctx, client)
+	return runAll(ctx, cli)
 }
 
 // Publish scoop manifest.
@@ -90,6 +90,7 @@ func (Pipe) Default(ctx *context.Context) error {
 		deprecate.Notice(ctx, "scoop")
 		ctx.Config.Scoops = append(ctx.Config.Scoops, ctx.Config.Scoop)
 	}
+
 	for i := range ctx.Config.Scoops {
 		scoop := &ctx.Config.Scoops[i]
 		if scoop.Name == "" {
@@ -110,7 +111,7 @@ func (Pipe) Default(ctx *context.Context) error {
 	return nil
 }
 
-func runAll(ctx *context.Context, cl client.ReleaserURLTemplater) error {
+func runAll(ctx *context.Context, cl client.ReleaseURLTemplater) error {
 	for _, scoop := range ctx.Config.Scoops {
 		err := doRun(ctx, scoop, cl)
 		if err != nil {
@@ -120,7 +121,7 @@ func runAll(ctx *context.Context, cl client.ReleaserURLTemplater) error {
 	return nil
 }
 
-func doRun(ctx *context.Context, scoop config.Scoop, cl client.ReleaserURLTemplater) error {
+func doRun(ctx *context.Context, scoop config.Scoop, cl client.ReleaseURLTemplater) error {
 	filters := []artifact.Filter{
 		artifact.ByGoos("windows"),
 		artifact.ByType(artifact.UploadableArchive),
@@ -310,7 +311,7 @@ func doBuildManifest(manifest Manifest) (bytes.Buffer, error) {
 	return result, err
 }
 
-func dataFor(ctx *context.Context, scoop config.Scoop, cl client.ReleaserURLTemplater, artifacts []*artifact.Artifact) (Manifest, error) {
+func dataFor(ctx *context.Context, scoop config.Scoop, cl client.ReleaseURLTemplater, artifacts []*artifact.Artifact) (Manifest, error) {
 	manifest := Manifest{
 		Version:      ctx.Version,
 		Architecture: map[string]Resource{},

--- a/internal/pipe/winget/winget.go
+++ b/internal/pipe/winget/winget.go
@@ -70,7 +70,7 @@ func (Pipe) Default(ctx *context.Context) error {
 }
 
 func (p Pipe) Run(ctx *context.Context) error {
-	cli, err := client.New(ctx)
+	cli, err := client.NewReleaseClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func (p Pipe) Publish(ctx *context.Context) error {
 	return p.publishAll(ctx, cli)
 }
 
-func (p Pipe) runAll(ctx *context.Context, cli client.Client) error {
+func (p Pipe) runAll(ctx *context.Context, cli client.ReleaseURLTemplater) error {
 	for _, winget := range ctx.Config.Winget {
 		err := p.doRun(ctx, winget, cli)
 		if err != nil {
@@ -97,7 +97,7 @@ func (p Pipe) runAll(ctx *context.Context, cli client.Client) error {
 	return nil
 }
 
-func (p Pipe) doRun(ctx *context.Context, winget config.Winget, cl client.ReleaserURLTemplater) error {
+func (p Pipe) doRun(ctx *context.Context, winget config.Winget, cl client.ReleaseURLTemplater) error {
 	if winget.Repository.Name == "" {
 		return errNoRepoName
 	}


### PR DESCRIPTION
Currently, GoReleaser will assume you're running against github, gitea or gitlab.

You could set `release.disable: true`, but it would still set and try to use some defaults that could break things up.

Now, if you disable the release, goreleaser will not set these defaults. It'll also hard error in some cases in which it would happily produce invalid resources before, namely, if `release.disable` is set, and, for example, `brews.url_template` is empty (in which case it would try to use the one from the release, usually github).

closes #4208
