### PR TITLE
fix(chocolatey): skip publish is check by publish pipe

### DIFF
--- a/internal/pipe/chocolatey/chocolatey.go
+++ b/internal/pipe/chocolatey/chocolatey.go
@@ -12,7 +12,6 @@ import (
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/internal/client"
-	"github.com/goreleaser/goreleaser/internal/pipe"
 	"github.com/goreleaser/goreleaser/internal/tmpl"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
@@ -78,10 +77,6 @@ func (Pipe) Run(ctx *context.Context) error {
 
 // Publish packages.
 func (Pipe) Publish(ctx *context.Context) error {
-	if ctx.SkipPublish {
-		return pipe.ErrSkipPublishEnabled
-	}
-
 	artifacts := ctx.Artifacts.Filter(
 		artifact.ByType(artifact.PublishableChocolatey),
 	).List()

--- a/internal/pipe/chocolatey/chocolatey_test.go
+++ b/internal/pipe/chocolatey/chocolatey_test.go
@@ -221,11 +221,6 @@ func TestPublish(t *testing.T) {
 		err       string
 	}{
 		{
-			name: "skip publish",
-			skip: true,
-			err:  "publishing is disabled",
-		},
-		{
 			name: "no artifacts",
 		},
 		{
@@ -287,7 +282,7 @@ func TestPublish(t *testing.T) {
 				cmd = stdCmd{}
 			})
 
-			ctx := testctx.New(func(ctx *context.Context) { ctx.SkipPublish = tt.skip })
+			ctx := testctx.New()
 			for _, artifact := range tt.artifacts {
 				ctx.Artifacts.Add(&artifact)
 			}


### PR DESCRIPTION
the publish pipe, which runs all publishers, already skips all publishers if skip publish is set, so this check is not needed here.