### PR TITLE
fix(custom_publishers): skip publish is check by publish pipe

### DIFF
--- a/internal/pipe/custompublishers/custompublishers.go
+++ b/internal/pipe/custompublishers/custompublishers.go
@@ -9,14 +9,6 @@ import (
 // Pipe for custom publisher.
 type Pipe struct{}
 
-// String returns the description of the pipe.
-func (Pipe) String() string { return "custom publisher" }
-
-func (Pipe) Skip(ctx *context.Context) bool {
-	return len(ctx.Config.Publishers) == 0 || ctx.SkipPublish
-}
-
-// Publish artifacts.
-func (Pipe) Publish(ctx *context.Context) error {
-	return exec.Execute(ctx, ctx.Config.Publishers)
-}
+func (Pipe) String() string                     { return "custom publisher" }
+func (Pipe) Skip(ctx *context.Context) bool     { return len(ctx.Config.Publishers) == 0 }
+func (Pipe) Publish(ctx *context.Context) error { return exec.Execute(ctx, ctx.Config.Publishers) }

--- a/internal/pipe/custompublishers/custompublishers_test.go
+++ b/internal/pipe/custompublishers/custompublishers_test.go
@@ -17,15 +17,6 @@ func TestSkip(t *testing.T) {
 		require.True(t, Pipe{}.Skip(testctx.New()))
 	})
 
-	t.Run("skip on skip-publish", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
-			Publishers: []config.Publisher{
-				{},
-			},
-		}, testctx.SkipPublish)
-		require.True(t, Pipe{}.Skip(ctx))
-	})
-
 	t.Run("dont skip", func(t *testing.T) {
 		ctx := testctx.NewWithCfg(config.Project{
 			Publishers: []config.Publisher{


### PR DESCRIPTION
the publish pipe, which runs all publishers, already skips all publishers if skip publish is set, so this check is not needed here.