### PR TITLE
feat: skip gomod pipe when Go does not support modules

### DIFF
--- a/internal/pipe/gomod/gomod.go
+++ b/internal/pipe/gomod/gomod.go
@@ -10,6 +10,7 @@ import (
 )
 
 const (
+	goPreModulesError      = "flag provided but not defined: -m"
 	go115NotAGoModuleError = "go list -m: not using modules"
 	go116NotAGoModuleError = "command-line-arguments"
 )
@@ -37,6 +38,9 @@ func (Pipe) Run(ctx *context.Context) error {
 	cmd.Env = append(ctx.Env.Strings(), ctx.Config.GoMod.Env...)
 	out, err := cmd.CombinedOutput()
 	result := strings.TrimSpace(string(out))
+	if strings.HasPrefix(result, goPreModulesError) {
+		return pipe.Skip("go version does not support modules")
+	}
 	if result == go115NotAGoModuleError || result == go116NotAGoModuleError {
 		return pipe.Skip("not a go module")
 	}


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

The gomod pipe will skip if the Go version does not support modules.

<!-- Why is this change being made? -->

I tried to use goreleaser to build a project with Go v1.8.7 and it failed on `loading go mod information` step. The Go version used doesn't support `go list -m`.

The build failed with the following error:
```
  • loading go mod information
  ⨯ release failed after 0s                          error=failed to get module path: exit status 2: flag provided but not defined: -m
usage: list [-e] [-f format] [-json] [build flags] [packages]

List lists the packages named by the import paths, one per line.
...
```

<!-- # Provide links to any relevant tickets, URLs or other resources -->

...
