### PR TITLE
fix(sbom): Add LOCALAPPDATA to passthroughEnvVars

### DIFF
--- a/internal/pipe/sbom/sbom.go
+++ b/internal/pipe/sbom/sbom.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Environment variables to pass through to exec
-var passthroughEnvVars = []string{"HOME", "USER", "USERPROFILE", "TMPDIR", "TMP", "TEMP", "PATH"}
+var passthroughEnvVars = []string{"HOME", "USER", "USERPROFILE", "TMPDIR", "TMP", "TEMP", "PATH", "LOCALAPPDATA"}
 
 // Pipe that catalogs common artifacts as an SBOM.
 type Pipe struct{}


### PR DESCRIPTION
Adds windows-specific `LOCALAPPDATA` to the list of passed through environment variables.  

closes #4290 