### PR TITLE
fix: chocolatey push failing 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 bin/
 coverage.txt
 goreleaser
+gorelaser.exe
 debug.test
 snap.login
 site/

--- a/internal/pipe/chocolatey/chocolatey.go
+++ b/internal/pipe/chocolatey/chocolatey.go
@@ -199,7 +199,7 @@ func doPush(ctx *context.Context, art *artifact.Artifact) error {
 		choco.SourceRepo,
 		"--api-key",
 		key,
-		art.Path,
+		filepath.Clean(art.Path),
 	}
 
 	if out, err := cmd.Exec(ctx, "choco", args...); err != nil {
@@ -325,5 +325,8 @@ type stdCmd struct{}
 var _ cmder = &stdCmd{}
 
 func (stdCmd) Exec(ctx *context.Context, name string, args ...string) ([]byte, error) {
+	log.WithField("cmd", name).
+		WithField("args", args).
+		Debug("running")
 	return exec.CommandContext(ctx, name, args...).CombinedOutput()
 }

--- a/www/docs/customization/chocolatey.md
+++ b/www/docs/customization/chocolatey.md
@@ -29,7 +29,7 @@ chocolateys:
       - bar
 
     # Your app's owner.
-    # It basically means your.
+    # It basically means you.
     owners: Drum Roll Inc
 
     # The app's title.


### PR DESCRIPTION
tested this on a fake repo, and it seems to fix the problem...

seems like choco does not like when the path has `/` in it, so passing it through `filepath.Clean` fixes it.

also improved tests a bit, and made a small docs fix.


closes https://github.com/goreleaser/goreleaser/issues/4292