### PR TITLE
fix(sbom): syft might fail on windows

### DIFF
--- a/internal/pipe/sbom/sbom.go
+++ b/internal/pipe/sbom/sbom.go
@@ -148,6 +148,8 @@ func catalog(ctx *context.Context, cfg config.SBOM, artifacts []*artifact.Artifa
 }
 
 func subprocessDistPath(distDir string, pathRelativeToCwd string) (string, error) {
+	distDir = filepath.Clean(distDir)
+	pathRelativeToCwd = filepath.Clean(pathRelativeToCwd)
 	cwd, err := os.Getwd()
 	if err != nil {
 		return "", err
@@ -194,6 +196,11 @@ func catalogArtifact(ctx *context.Context, cfg config.SBOM, a *artifact.Artifact
 	}
 	cmd.Env = append(cmd.Env, envs...)
 	cmd.Dir = ctx.Config.Dist
+
+	log.WithField("env", cmd.Env).
+		WithField("dir", cmd.Dir).
+		WithField("cmd", cmd.Args).
+		Debug("running")
 
 	var b bytes.Buffer
 	w := gio.Safe(&b)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -905,7 +905,7 @@ type SBOM struct {
 	Env       []string `yaml:"env,omitempty" json:"env,omitempty"`
 	Args      []string `yaml:"args,omitempty" json:"args,omitempty"`
 	Documents []string `yaml:"documents,omitempty" json:"documents,omitempty"`
-	Artifacts string   `yaml:"artifacts,omitempty" json:"artifacts,omitempty"`
+	Artifacts string   `yaml:"artifacts,omitempty" json:"artifacts,omitempty" jsonschema:"enum=source,enum=package,enum=archive,enum=binary,enum=any,enum=any,default=archive"`
 	IDs       []string `yaml:"ids,omitempty" json:"ids,omitempty"`
 }
 


### PR DESCRIPTION
the paths of the artifacts always use forward slashes, and the logic to handle the relative path stuff inside the sbom pipe did not account for that.

running the paths through `filepath.Clean` beforehand fixes it.

also improved yamlschema a little bit :) 

closes #4289
