### PR TITLE
feat: add cache-control arg to blob

### DIFF
--- a/internal/pipe/blob/upload.go
+++ b/internal/pipe/blob/upload.go
@@ -144,7 +144,7 @@ func uploadData(ctx *context.Context, conf config.Blob, up uploader, dataFile, u
 		return err
 	}
 
-	if err := up.Upload(ctx, uploadFile, data); err != nil {
+	if err := up.Upload(ctx, uploadFile, data, conf.CacheControl); err != nil {
 		return handleError(err, bucketURL)
 	}
 	return nil
@@ -205,7 +205,7 @@ func getData(ctx *context.Context, conf config.Blob, path string) ([]byte, error
 type uploader interface {
 	io.Closer
 	Open(ctx *context.Context, url string) error
-	Upload(ctx *context.Context, path string, data []byte) error
+	Upload(ctx *context.Context, path string, data []byte, cacheControl []string) error
 }
 
 // productionUploader actually do upload to.
@@ -231,12 +231,17 @@ func (u *productionUploader) Open(ctx *context.Context, bucket string) error {
 	return nil
 }
 
-func (u *productionUploader) Upload(ctx *context.Context, filepath string, data []byte) error {
+func (u *productionUploader) Upload(ctx *context.Context, filepath string, data []byte, cacheControl []string) error {
 	log.WithField("path", filepath).Info("uploading")
 
 	opts := &blob.WriterOptions{
 		ContentDisposition: "attachment; filename=" + path.Base(filepath),
 	}
+
+	if len(cacheControl) > 0 {
+		opts.CacheControl = strings.Join(cacheControl, ", ")
+	}
+
 	w, err := u.bucket.NewWriter(ctx, filepath, opts)
 	if err != nil {
 		return err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1086,16 +1086,17 @@ type Before struct {
 
 // Blob contains config for GO CDK blob.
 type Blob struct {
-	Bucket     string      `yaml:"bucket,omitempty" json:"bucket,omitempty"`
-	Provider   string      `yaml:"provider,omitempty" json:"provider,omitempty"`
-	Region     string      `yaml:"region,omitempty" json:"region,omitempty"`
-	DisableSSL bool        `yaml:"disableSSL,omitempty" json:"disableSSL,omitempty"` // nolint:tagliatelle // TODO(caarlos0): rename to disable_ssl
-	Folder     string      `yaml:"folder,omitempty" json:"folder,omitempty"`
-	KMSKey     string      `yaml:"kmskey,omitempty" json:"kmskey,omitempty"`
-	IDs        []string    `yaml:"ids,omitempty" json:"ids,omitempty"`
-	Endpoint   string      `yaml:"endpoint,omitempty" json:"endpoint,omitempty"` // used for minio for example
-	ExtraFiles []ExtraFile `yaml:"extra_files,omitempty" json:"extra_files,omitempty"`
-	Disable    string      `yaml:"disable,omitempty" json:"disable,omitempty" jsonschema:"oneof_type=string;boolean"`
+	Bucket       string      `yaml:"bucket,omitempty" json:"bucket,omitempty"`
+	CacheControl []string    `yaml:"cache_control,omitempty" json:"cache_control,omitempty"`
+	Provider     string      `yaml:"provider,omitempty" json:"provider,omitempty"`
+	Region       string      `yaml:"region,omitempty" json:"region,omitempty"`
+	DisableSSL   bool        `yaml:"disableSSL,omitempty" json:"disableSSL,omitempty"` // nolint:tagliatelle // TODO(caarlos0): rename to disable_ssl
+	Folder       string      `yaml:"folder,omitempty" json:"folder,omitempty"`
+	KMSKey       string      `yaml:"kmskey,omitempty" json:"kmskey,omitempty"`
+	IDs          []string    `yaml:"ids,omitempty" json:"ids,omitempty"`
+	Endpoint     string      `yaml:"endpoint,omitempty" json:"endpoint,omitempty"` // used for minio for example
+	ExtraFiles   []ExtraFile `yaml:"extra_files,omitempty" json:"extra_files,omitempty"`
+	Disable      string      `yaml:"disable,omitempty" json:"disable,omitempty" jsonschema:"oneof_type=string;boolean"`
 }
 
 // Upload configuration.


### PR DESCRIPTION
<!-- If applied, this commit will... -->
This PR adds cache-control ability when uploading files to Bucket. A new section `cache_control` is added to `blobs` as a global rule for all files pushed. Maybe a more granular configuration might be necessary? I've implemented a more granular configuration [here](https://github.com/gandarez/goreleaser/commit/47b9379bfa7b6c7b1a8d3bcf56cc3c7345f1a656) for your appreciation.

<!-- # Provide links to any relevant tickets, URLs or other resources -->
Closes #4309 