### PR TITLE
fix: decouple project_name guessing from the release pipe

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,7 @@ Only the last stable version at any given point.
 
 ## Reporting a Vulnerability
 
-Vulnerabilies can be disclosed in private using GitHub advisories: https://github.com/goreleaser/goreleaser/security
+Vulnerabilities can be disclosed in private using
+[GitHub advisories](https://github.com/goreleaser/goreleaser/security).
 
 Thanks!

--- a/internal/pipe/project/project.go
+++ b/internal/pipe/project/project.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/goreleaser/goreleaser/internal/git"
 	"github.com/goreleaser/goreleaser/pkg/context"
 )
 
@@ -27,6 +28,7 @@ func (Pipe) Default(ctx *context.Context) error {
 		ctx.Config.Release.GitLab.Name,
 		ctx.Config.Release.Gitea.Name,
 		moduleName(),
+		gitRemote(ctx),
 	} {
 		if candidate == "" {
 			continue
@@ -54,4 +56,15 @@ func moduleName() string {
 
 	parts := strings.Split(mod, "/")
 	return strings.TrimSpace(parts[len(parts)-1])
+}
+
+func gitRemote(ctx *context.Context) string {
+	repo, err := git.ExtractRepoFromConfig(ctx)
+	if err != nil {
+		return ""
+	}
+	if err := repo.CheckSCM(); err != nil {
+		return ""
+	}
+	return repo.Name
 }

--- a/internal/pipe/project/project_test.go
+++ b/internal/pipe/project/project_test.go
@@ -76,6 +76,23 @@ func TestEmptyProjectName_DefaultsToGoModPath(t *testing.T) {
 	require.Equal(t, "bar", ctx.Config.ProjectName)
 }
 
+func TestEmptyProjectName_DefaultsToGitURL(t *testing.T) {
+	_ = testlib.Mktmp(t)
+	ctx := testctx.New()
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, "bar", ctx.Config.ProjectName)
+}
+
+func TestEmptyProjectName_DefaultsToNonSCMGitURL(t *testing.T) {
+	_ = testlib.Mktmp(t)
+	ctx := testctx.New()
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@myhost.local:bar.git")
+	require.EqualError(t, Pipe{}.Default(ctx), "couldn't guess project_name, please add it to your config")
+}
+
 func TestEmptyProjectNameAndRelease(t *testing.T) {
 	_ = testlib.Mktmp(t)
 	ctx := testctx.NewWithCfg(config.Project{


### PR DESCRIPTION
the release's defaults run before the project's does, so, usually the github/gitlab/gitea names are set.

however, in some cases, the release's defaults might be skipped, in which case they'll be empty.

this breaks things like `goreleaser changelog`, especially on non-go repositories.

this pr tries to extract the project name from the git remote url in the project's defaulter.

it might be possible now to move it to run before the release defaulter, even.