### PR TITLE
feat(nix): mark all Nix packages with the right source provenance

### DIFF
--- a/internal/pipe/nix/testdata/TestRunPipe/deps_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/deps_build.nix.golden
@@ -56,6 +56,8 @@ pkgs.stdenv.mkDerivation {
 
   meta = {
 
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/deps_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/deps_publish.nix.golden
@@ -56,6 +56,8 @@ pkgs.stdenv.mkDerivation {
 
   meta = {
 
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/extra-install_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/extra-install_build.nix.golden
@@ -57,6 +57,8 @@ pkgs.stdenv.mkDerivation {
 
   meta = {
 
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/extra-install_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/extra-install_publish.nix.golden
@@ -57,6 +57,8 @@ pkgs.stdenv.mkDerivation {
 
   meta = {
 
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/minimal_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/minimal_build.nix.golden
@@ -49,6 +49,8 @@ pkgs.stdenv.mkDerivation {
 
   meta = {
 
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/minimal_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/minimal_publish.nix.golden
@@ -49,6 +49,8 @@ pkgs.stdenv.mkDerivation {
 
   meta = {
 
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/open-pr_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/open-pr_build.nix.golden
@@ -52,6 +52,8 @@ pkgs.stdenv.mkDerivation {
     homepage = "https://goreleaser.com";
     license = lib.licenses.mit;
 
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/open-pr_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/open-pr_publish.nix.golden
@@ -52,6 +52,8 @@ pkgs.stdenv.mkDerivation {
     homepage = "https://goreleaser.com";
     license = lib.licenses.mit;
 
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/partial_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/partial_build.nix.golden
@@ -39,6 +39,8 @@ pkgs.stdenv.mkDerivation {
 
   meta = {
 
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
     platforms = [
       "x86_64-darwin"
       "x86_64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/partial_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/partial_publish.nix.golden
@@ -39,6 +39,8 @@ pkgs.stdenv.mkDerivation {
 
   meta = {
 
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
     platforms = [
       "x86_64-darwin"
       "x86_64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/skip-upload-auto_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/skip-upload-auto_build.nix.golden
@@ -49,6 +49,8 @@ pkgs.stdenv.mkDerivation {
 
   meta = {
 
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/skip-upload_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/skip-upload_build.nix.golden
@@ -49,6 +49,8 @@ pkgs.stdenv.mkDerivation {
 
   meta = {
 
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/unibin-replaces_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/unibin-replaces_build.nix.golden
@@ -48,6 +48,8 @@ pkgs.stdenv.mkDerivation {
     homepage = "https://goreleaser.com";
     license = lib.licenses.mit;
 
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/unibin-replaces_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/unibin-replaces_publish.nix.golden
@@ -48,6 +48,8 @@ pkgs.stdenv.mkDerivation {
     homepage = "https://goreleaser.com";
     license = lib.licenses.mit;
 
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/wrapped-in-dir_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/wrapped-in-dir_build.nix.golden
@@ -52,6 +52,8 @@ pkgs.stdenv.mkDerivation {
     homepage = "https://goreleaser.com";
     license = lib.licenses.mit;
 
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/wrapped-in-dir_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/wrapped-in-dir_publish.nix.golden
@@ -52,6 +52,8 @@ pkgs.stdenv.mkDerivation {
     homepage = "https://goreleaser.com";
     license = lib.licenses.mit;
 
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/zip-with-dependencies_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip-with-dependencies_build.nix.golden
@@ -53,6 +53,8 @@ pkgs.stdenv.mkDerivation {
     homepage = "https://goreleaser.com";
     license = lib.licenses.mit;
 
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/zip-with-dependencies_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip-with-dependencies_publish.nix.golden
@@ -53,6 +53,8 @@ pkgs.stdenv.mkDerivation {
     homepage = "https://goreleaser.com";
     license = lib.licenses.mit;
 
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/zip_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip_build.nix.golden
@@ -51,6 +51,8 @@ pkgs.stdenv.mkDerivation {
     homepage = "https://goreleaser.com";
     license = lib.licenses.mit;
 
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/zip_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip_publish.nix.golden
@@ -51,6 +51,8 @@ pkgs.stdenv.mkDerivation {
     homepage = "https://goreleaser.com";
     license = lib.licenses.mit;
 
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"

--- a/internal/pipe/nix/tmpl.nix
+++ b/internal/pipe/nix/tmpl.nix
@@ -102,6 +102,8 @@ pkgs.stdenv.mkDerivation {
     license = lib.licenses.{{ . }};
     {{- end }}
 
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+
     platforms = [
       {{- range $index, $plat := .Platforms }}
       "{{ . }}"


### PR DESCRIPTION
As GoReleaser focuses on binary packages wrapped in Nix, it is important to mark their right source provenance, i.e. binary native code.

It came up in https://github.com/dagger/nix/pull/4.

<!-- If applied, this commit will... -->

If applied, this commit will mark every package built via GoReleaser for Nix with a binary source provenance, which is what GoReleaser does.

<!-- Why is this change being made? -->

This change was made because it is impossible to know about the source provenance if the tooling template does not encompass it and downstreams won't apply it after an upgrade.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

https://github.com/dagger/nix/pull/4
