### PR TITLE
feat: version in the yaml file

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=jcroql
+version: 1
+
 env:
   - GO111MODULE=on
 

--- a/internal/static/config.yaml
+++ b/internal/static/config.yaml
@@ -6,6 +6,8 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
+version: 1
+
 before:
   hooks:
     # You may remove this if you don't use go modules.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -71,4 +72,24 @@ func TestInvalidYaml(t *testing.T) {
 func TestConfigWithAnchors(t *testing.T) {
 	_, err := Load("testdata/anchor.yaml")
 	require.NoError(t, err)
+}
+
+func TestVersion(t *testing.T) {
+	t.Run("allow no version", func(t *testing.T) {
+		_, err := LoadReader(bytes.NewReader(nil))
+		require.NoError(t, err)
+	})
+	t.Run("allow v0", func(t *testing.T) {
+		_, err := LoadReader(strings.NewReader("version: 0"))
+		require.NoError(t, err)
+	})
+	t.Run("allow v1", func(t *testing.T) {
+		_, err := LoadReader(strings.NewReader("version: 1"))
+		require.NoError(t, err)
+	})
+	t.Run("do not allow v2", func(t *testing.T) {
+		_, err := LoadReader(strings.NewReader("version: 2"))
+		require.Error(t, err)
+		require.ErrorIs(t, err, VersionError{2})
+	})
 }


### PR DESCRIPTION
this should make it easier later on when we have v2, as goreleaser will refuse to run with the wrong version in the configuration.

no version will still work on v1 though, its more to avoid running fils with `version: 2` later, and avoid files with no version or `version: 1` from running on v2.