### PR TITLE
feat(depot): add depot image builder and pusher

### DIFF
--- a/internal/pipe/docker/api.go
+++ b/internal/pipe/docker/api.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"path"
 	"sync"
 
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/internal/gio"
 	"github.com/goreleaser/goreleaser/internal/logext"
+	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
 )
 
@@ -31,9 +33,25 @@ func registerImager(use string, impl imager) {
 	imagers[use] = impl
 }
 
+type buildConfig struct {
+	RootDir      string   // RootDir is the path Dockerfile directory.
+	Images       []string // Images is the list image names to tag the built image.
+	Flags        []string // Flags is the list of flags to pass to the build command.
+	Platform     platform // Platform is the platform to build for (e.g. linux/arm64).
+	DepotProject string   // DepotProject is the name of the depot.dev project to use.
+}
+
+// platform specifies the docker builder platform.
+type platform string
+
+func newPlatform(conf config.Docker) platform {
+	return platform(path.Join(conf.Goos, conf.Goarch))
+}
+
 // imager is something that can build and push docker images.
 type imager interface {
-	Build(ctx *context.Context, root string, images, flags []string) error
+	// Build creates the docker image. Returns a digest if the image was pushed.
+	Build(ctx *context.Context, config buildConfig) (digest string, err error)
 	Push(ctx *context.Context, image string, flags []string) (digest string, err error)
 }
 

--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -222,7 +222,7 @@ func process(ctx *context.Context, docker config.Docker, artifacts []*artifact.A
 		RootDir:      tmp,
 		Images:       images,
 		Flags:        buildFlags,
-		DepotProject: docker.DepotProject,
+		DepotProject: docker.Depot.Project,
 	}
 	digest, err := imagers[docker.Use].Build(ctx, buildConfig)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1040,6 +1040,7 @@ type Docker struct {
 	BuildFlagTemplates []string `yaml:"build_flag_templates,omitempty" json:"build_flag_templates,omitempty"`
 	PushFlags          []string `yaml:"push_flags,omitempty" json:"push_flags,omitempty"`
 	Use                string   `yaml:"use,omitempty" json:"use,omitempty" jsonschema:"enum=docker,enum=buildx,default=docker"`
+	DepotProject       string   `yaml:"depot_project,omitempty" json:"depot_project,omitempty"`
 }
 
 // DockerManifest config.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1039,8 +1039,12 @@ type Docker struct {
 	Files              []string `yaml:"extra_files,omitempty" json:"extra_files,omitempty"`
 	BuildFlagTemplates []string `yaml:"build_flag_templates,omitempty" json:"build_flag_templates,omitempty"`
 	PushFlags          []string `yaml:"push_flags,omitempty" json:"push_flags,omitempty"`
-	Use                string   `yaml:"use,omitempty" json:"use,omitempty" jsonschema:"enum=docker,enum=buildx,default=docker"`
-	DepotProject       string   `yaml:"depot_project,omitempty" json:"depot_project,omitempty"`
+	Use                string   `yaml:"use,omitempty" json:"use,omitempty" jsonschema:"enum=docker,enum=buildx,enum=depot,default=docker"`
+	Depot              Depot    `yaml:"depot,omitempty" json:"depot,omitempty"`
+}
+
+type Depot struct {
+	Project string `yaml:"project,omitempty" json:"project,omitempty"`
 }
 
 // DockerManifest config.


### PR DESCRIPTION
Depot is a fast way to build and push docker images.

This is my draft to add depot with minimal changes to the docker build and push.
The key difference compared to the existing docker code is that depot can both build
and push multi-platform images in one step.

This PR does some refactoring of the `imager` interface to allow the `build` function to optionally return
a digest that signifies the pushed image.  I'm not sure if this is the right approach; let me know!


<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->

( no tests yet ... I'm not sure yet how to proceed as I think the tests
may need a refactor to accommodate simultaneous build and push)

<!-- If applied, this commit will... -->

So, this commit adds `use: depot` to the docker builder allowing images to be build and pushed using depot.dev.
Additionally, a new optional docker setting, `depot_project`, can explicitly set the project. 
Note that the project can also be set via the env var, `DEPOT_PROJECT_ID` or with a local file, `depot.json`.

<!-- Why is this change being made? -->

depot.dev is a hosted buildkit that is a fast way build and push multi-platform images.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

Here is the ticket about depot: https://github.com/goreleaser/goreleaser/issues/3746
