### PR TITLE
fix: properly handle multi-module projects with a go.work file

### DIFF
--- a/internal/pipe/gomod/gomod.go
+++ b/internal/pipe/gomod/gomod.go
@@ -48,6 +48,9 @@ func (Pipe) Run(ctx *context.Context) error {
 		return fmt.Errorf("failed to get module path: %w: %s", err, string(out))
 	}
 
-	ctx.ModulePath = result
+	// Splits and use the first line in case a `go.work` file exists with multiple modules.
+	// The first module is/should be `.` in the `go.work` file, so this should be correct.
+	// Running `go work sync` also always puts `.` as the first line in `use`.
+	ctx.ModulePath = strings.Split(result, "\n")[0]
 	return nil
 }

--- a/internal/pipe/gomod/gomod_test.go
+++ b/internal/pipe/gomod/gomod_test.go
@@ -23,21 +23,11 @@ func TestRun(t *testing.T) {
 func TestRunGoWork(t *testing.T) {
 	dir := testlib.Mktmp(t)
 	require.NoError(t, os.WriteFile(
-		filepath.Join(dir, "main.go"),
-		[]byte("package main\nfunc main() {println(0)}"),
-		0o666,
-	))
-	require.NoError(t, os.WriteFile(
 		filepath.Join(dir, "go.mod"),
 		[]byte("module a"),
 		0o666,
 	))
 	require.NoError(t, os.Mkdir(filepath.Join(dir, "b"), 0o755))
-	require.NoError(t, os.WriteFile(
-		filepath.Join(dir, "b", "main.go"),
-		[]byte("package main\nfunc main() {println(1)}"),
-		0o666,
-	))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(dir, "b", "go.mod"),
 		[]byte("module a/b"),

--- a/www/docs/customization/verifiable_builds.md
+++ b/www/docs/customization/verifiable_builds.md
@@ -40,11 +40,18 @@ gomod:
 ```
 
 !!! tip
+
     You can use `debug.ReadBuildInfo()` to get the version/checksum/dependencies
     of the module.
 
 !!! warning
+
     VCS Info will not be embedded in the binary, as in practice it is not being
     built from the source, but from the Go Mod Proxy.
+
+!!! warning 
+
+    If you have a `go.work` file, make sure to run `go work sync`, so the main
+    module (`.`) is the first line inside the `use` block.
 
 [vgo]: https://research.swtch.com/vgo-repro


### PR DESCRIPTION
closes #4379
