### PR TITLE
docs: update CONTRIBUTING.md add upx as optional prerequesite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ Other things you might need to run the tests:
 - [Podman](https://podman.io/)
 - [Snapcraft](https://snapcraft.io/)
 - [Syft](https://github.com/anchore/syft)
+- [upx](https://upx.github.io/)
 
 Clone `goreleaser` anywhere:
 


### PR DESCRIPTION
A test failed as I didn't had upx installed:

```
--- FAIL: TestRun (0.58s)
    upx_test.go:119: 
                Error Trace:    /home/cipri/git/goreleaser/internal/pipe/upx/upx_test.go:119
                Error:          Received unexpected error:
                                upx not found in PATH
                Test:           TestRun
FAIL
```


<!-- If applied, this commit will... -->

...

<!-- Why is this change being made? -->

...

<!-- # Provide links to any relevant tickets, URLs or other resources -->

...
