### PR TITLE
feat(git): added git.tag_prefixes for use with multi project git tags

### DIFF
--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -50,7 +50,6 @@ func (Pipe) Run(ctx *context.Context) error {
 		WithField("previous_tag", ordered.First(info.PreviousTag, "<unknown>")).
 		WithField("dirty", info.Dirty).
 		Info("git state")
-	ctx.Version = strings.TrimPrefix(ctx.Git.CurrentTag, "v")
 	return validate(ctx)
 }
 

--- a/internal/pipe/semver/semver.go
+++ b/internal/pipe/semver/semver.go
@@ -2,6 +2,10 @@ package semver
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/goreleaser/goreleaser/internal/tmpl"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/goreleaser/goreleaser/pkg/context"
@@ -17,15 +21,41 @@ func (Pipe) String() string {
 
 // Run executes the hooks.
 func (Pipe) Run(ctx *context.Context) error {
-	sv, err := semver.NewVersion(ctx.Git.CurrentTag)
+	currentVer, err := trimCurrentTag(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to parse tag '%s' as semver: %w", ctx.Git.CurrentTag, err)
+		return err
+	}
+	sv, err := semver.NewVersion(currentVer)
+	if err != nil {
+		return fmt.Errorf("failed to parse tag '%s' as semver: %w", currentVer, err)
 	}
 	ctx.Semver = context.Semver{
 		Major:      sv.Major(),
 		Minor:      sv.Minor(),
 		Patch:      sv.Patch(),
 		Prerelease: sv.Prerelease(),
+		Metadata:   sv.Metadata(),
 	}
+	ctx.Version = sv.String()
 	return nil
+}
+
+func trimCurrentTag(ctx *context.Context) (string, error) {
+	if ctx.Config.Git.TagPrefixes == nil || len(ctx.Config.Git.TagPrefixes) < 1 {
+		return ctx.Git.CurrentTag, nil
+	}
+	tpl := tmpl.New(ctx)
+	prefixes := make([]string, len(ctx.Config.Git.TagPrefixes))
+	for i, prefix := range ctx.Config.Git.TagPrefixes {
+		eval, err := tpl.Apply(prefix)
+		if err != nil {
+			return ctx.Git.CurrentTag, err
+		}
+		prefixes[i] = eval
+	}
+	reg := regexp.MustCompile(strings.Join(prefixes, "|") + "(.+)")
+	if !reg.MatchString(ctx.Git.CurrentTag) {
+		return "", fmt.Errorf("tag '%s' has none of expected prefixes %+v", ctx.Git.CurrentTag, ctx.Config.Git.TagPrefixes)
+	}
+	return reg.ReplaceAllString(ctx.Git.CurrentTag, "${1}"), nil
 }

--- a/internal/pipe/semver/semver_test.go
+++ b/internal/pipe/semver/semver_test.go
@@ -3,6 +3,8 @@ package semver
 import (
 	"testing"
 
+	"github.com/goreleaser/goreleaser/pkg/config"
+
 	"github.com/goreleaser/goreleaser/internal/testctx"
 	"github.com/goreleaser/goreleaser/pkg/context"
 	"github.com/stretchr/testify/require"
@@ -13,19 +15,102 @@ func TestDescription(t *testing.T) {
 }
 
 func TestValidSemver(t *testing.T) {
-	ctx := testctx.New(testctx.WithCurrentTag("v1.5.2-rc1"))
+	ctx := testctx.New(testctx.WithCurrentTag("v1.5.2-rc1+ng"))
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Equal(t, context.Semver{
 		Major:      1,
 		Minor:      5,
 		Patch:      2,
 		Prerelease: "rc1",
+		Metadata:   "ng",
 	}, ctx.Semver)
+	require.Equal(t, "1.5.2-rc1+ng", ctx.Version)
 }
 
-func TestInvalidSemver(t *testing.T) {
-	ctx := testctx.New(testctx.WithCurrentTag("aaaav1.5.2-rc1"))
+func TestValidSemverWithoutV(t *testing.T) {
+	ctx := testctx.New(testctx.WithCurrentTag("1.5.2-rc1+ng"))
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, context.Semver{
+		Major:      1,
+		Minor:      5,
+		Patch:      2,
+		Prerelease: "rc1",
+		Metadata:   "ng",
+	}, ctx.Semver)
+	require.Equal(t, "1.5.2-rc1+ng", ctx.Version)
+}
+
+func TestTagWithPrefix(t *testing.T) {
+	ctx := testctx.New(
+		testctx.WithCurrentTag("component_v1.5.2-rc1+ng"),
+		testctx.WithTagPrefixes([]string{"component_"}),
+	)
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, context.Semver{
+		Major:      1,
+		Minor:      5,
+		Patch:      2,
+		Prerelease: "rc1",
+		Metadata:   "ng",
+	}, ctx.Semver)
+	require.Equal(t, "1.5.2-rc1+ng", ctx.Version)
+}
+
+func TestTagWithPrefixTemplated(t *testing.T) {
+	ctx := testctx.NewWithCfg(
+		config.Project{ProjectName: "component"},
+		testctx.WithCurrentTag("component_v1.5.2-rc1+ng"),
+		testctx.WithTagPrefixes([]string{"{{ .ProjectName }}_"}),
+	)
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, context.Semver{
+		Major:      1,
+		Minor:      5,
+		Patch:      2,
+		Prerelease: "rc1",
+		Metadata:   "ng",
+	}, ctx.Semver)
+	require.Equal(t, "1.5.2-rc1+ng", ctx.Version)
+}
+
+func TestTagWithMultiplePrefixes(t *testing.T) {
+	ctx := testctx.New(
+		testctx.WithCurrentTag("component_v1.5.2-rc1+ng"),
+		testctx.WithTagPrefixes([]string{"component_", "app_"}),
+	)
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, context.Semver{
+		Major:      1,
+		Minor:      5,
+		Patch:      2,
+		Prerelease: "rc1",
+		Metadata:   "ng",
+	}, ctx.Semver)
+	require.Equal(t, "1.5.2-rc1+ng", ctx.Version)
+}
+
+func TestTagWithWrongPrefixes(t *testing.T) {
+	ctx := testctx.New(
+		testctx.WithCurrentTag("component_v1.5.2-rc1+ng"),
+		testctx.WithTagPrefixes([]string{"not_matching_prefix"}),
+	)
 	err := Pipe{}.Run(ctx)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to parse tag 'aaaav1.5.2-rc1' as semver")
+	require.Contains(t, err.Error(), "tag 'component_v1.5.2-rc1+ng' has none of expected prefixes [not_matching_prefix]")
+}
+
+func TestTagWithoutPrefix(t *testing.T) {
+	ctx := testctx.New(testctx.WithCurrentTag("aaaav1.5.2-rc1+ng"))
+	err := Pipe{}.Run(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to parse tag 'aaaav1.5.2-rc1+ng' as semver")
+}
+
+func TestTagPrefixNotMatches(t *testing.T) {
+	ctx := testctx.New(
+		testctx.WithCurrentTag("v1.5.2-rc1+ng"),
+		testctx.WithTagPrefixes([]string{"component_"}),
+	)
+	err := Pipe{}.Run(ctx)
+	require.Contains(t, err.Error(), "tag 'v1.5.2-rc1+ng' has none of expected prefixes [component_]")
 }

--- a/internal/testctx/testctx.go
+++ b/internal/testctx/testctx.go
@@ -68,10 +68,16 @@ func WithCurrentTag(tag string) Opt {
 	}
 }
 
-func WithCommit(commig string) Opt {
+func WithTagPrefixes(prefixes []string) Opt {
 	return func(ctx *context.Context) {
-		ctx.Git.Commit = commig
-		ctx.Git.FullCommit = commig
+		ctx.Config.Git.TagPrefixes = prefixes
+	}
+}
+
+func WithCommit(commit string) Opt {
+	return func(ctx *context.Context) {
+		ctx.Git.Commit = commit
+		ctx.Git.FullCommit = commit
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ type Git struct {
 	TagSort          string   `yaml:"tag_sort,omitempty" json:"tag_sort,omitempty" jsonschema:"enum=-version:refname,enum=-version:creatordate,default=-version:refname"`
 	PrereleaseSuffix string   `yaml:"prerelease_suffix,omitempty" json:"prerelease_suffix,omitempty"`
 	IgnoreTags       []string `yaml:"ignore_tags,omitempty" json:"ignore_tags,omitempty"`
+	TagPrefixes      []string `yaml:"tag_prefixes,omitempty" json:"tag_prefixes,omitempty"`
 }
 
 // GitHubURLs holds the URLs to be used when using github enterprise.

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -112,6 +112,7 @@ type Semver struct {
 	Minor      uint64
 	Patch      uint64
 	Prerelease string
+	Metadata   string
 }
 
 // New context.

--- a/www/docs/customization/git.md
+++ b/www/docs/customization/git.md
@@ -24,10 +24,22 @@ git:
   # provided values as either previous or current tags.
   #
   # Templates: allowed.
-  # Since: v1.21.
+  # Since: v1.21
   ignore_tags:
     - nightly
     - "{{.Env.IGNORE_TAG}}"
+
+  # Tag prefixes to be omitted by GoReleaser.
+  # This means that GoReleaser will trim this prefixes from git current tag and
+  # versioning will be computed from trimmed current tag.
+  # If prefixes are defined current tag MUST match at least one of them or error will be raised.
+  # It is useful for multiple projects in one git repository.
+  #
+  # Templates: allowed
+  # Since: v1.23
+  tag_prefixes:
+    - "componentA_"
+    - "{{ .ProjectName }}_"
 ```
 
 ## Semver sorting


### PR DESCRIPTION
Feature adds option for use git tags vith prefix. It is common for multiple tools in one git repository. 
Example project structure:
```
tools:
  db_checker:
    ... files ...
    .goreleaser.yml
  db_copy:
    ... files ...
    .goreleaser.yml
```
GoReleaser normaly accepts only git tag in pattern `v1.0.0-rc+1` but in multi tools structure (see above) is needed to use some prefix for individual tools e.g. `db_checker_v1.0.0-rc` or `db_copy-v0.3.2`

One restriction is if `git.tag_prefixes` are defined, current git tag have to start with with at least one defined prefix, otherwise error is raised.

I also added Metadata into Semver structure because we are using it for marking some versions.

And last change is moving set of `cxt.Version` from **git** Pipe to **semver** Pipe because it makes better sense to do it in semver pipe.