### PR TITLE
docs(azblob): correct auth to Azure storage service

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -80,6 +80,7 @@ Here's a running list of some organizations using GoReleaser[^1]:
 1. [Zitatel](https://zitadel.com)
 1. [pdfcpu](https://pdfcpu.io)
 1. [prestd](https://prestd.com)
+1. [Rixo](https://www.rixo.cz)
 
 Feel free to [add yours](https://github.com/goreleaser/goreleaser/edit/main/USERS.md)!
 

--- a/www/docs/customization/blob.md
+++ b/www/docs/customization/blob.md
@@ -15,70 +15,70 @@ blobs:
     # - gs for Google Cloud Storage
     #
     # Templates: allowed
-    - provider: azblob
+    provider: azblob
 
-      # Set a custom endpoint, useful if you're using a minio backend or
-      # other s3-compatible backends.
-      #
-      # Implies s3ForcePathStyle and requires provider to be `s3`
-      #
-      # Templates: allowed
-      endpoint: https://minio.foo.bar
+    # Set a custom endpoint, useful if you're using a minio backend or
+    # other s3-compatible backends.
+    #
+    # Implies s3ForcePathStyle and requires provider to be `s3`
+    #
+    # Templates: allowed
+    endpoint: https://minio.foo.bar
 
-      # Sets the bucket region.
-      # Requires provider to be `s3`
-      #
-      # Templates: allowed
-      region: us-west-1
+    # Sets the bucket region.
+    # Requires provider to be `s3`
+    #
+    # Templates: allowed
+    region: us-west-1
 
-      # Disables SSL
-      # Requires provider to be `s3`
-      disableSSL: true
+    # Disables SSL
+    # Requires provider to be `s3`
+    disableSSL: true
 
-      # Bucket name.
-      #
-      # Templates: allowed
-      bucket: goreleaser-bucket
+    # Bucket name.
+    #
+    # Templates: allowed
+    bucket: goreleaser-bucket
 
-      # IDs of the artifacts you want to upload.
-      ids:
-        - foo
-        - bar
+    # IDs of the artifacts you want to upload.
+    ids:
+      - foo
+      - bar
 
-      # Path/name inside the bucket.
-      #
-      # Default: '{{ .ProjectName }}/{{ .Tag }}'
-      # Templates: allowed
-      folder: "foo/bar/{{.Version}}"
+    # Path/name inside the bucket.
+    #
+    # Default: '{{ .ProjectName }}/{{ .Tag }}'
+    # Templates: allowed
+    folder: "foo/bar/{{.Version}}"
 
-      # Whether to disable this particular upload configuration.
-      #
-      # Since: v1.17
-      # Templates: allowed
-      disable: '{{ neq .BLOB_UPLOAD_ONLY "foo" }}'
+    # Whether to disable this particular upload configuration.
+    #
+    # Since: v1.17
+    # Templates: allowed
+    disable: '{{ neq .BLOB_UPLOAD_ONLY "foo" }}'
 
-      # You can add extra pre-existing files to the bucket.
-      # The filename on the release will be the last part of the path (base).
-      # If another file with the same name exists, the last one found will be used.
-      # These globs can also include templates.
-      extra_files:
-        - glob: ./path/to/file.txt
-        - glob: ./glob/**/to/**/file/**/*
-        - glob: ./glob/foo/to/bar/file/foobar/override_from_previous
-        - glob: ./single_file.txt
-          # Templates: allowed
-          name_template: file.txt # note that this only works if glob matches 1 file only
+    # You can add extra pre-existing files to the bucket.
+    # The filename on the release will be the last part of the path (base).
+    # If another file with the same name exists, the last one found will be used.
+    # These globs can also include templates.
+    extra_files:
+      - glob: ./path/to/file.txt
+      - glob: ./glob/**/to/**/file/**/*
+      - glob: ./glob/foo/to/bar/file/foobar/override_from_previous
+      - glob: ./single_file.txt
+        # Templates: allowed
+        name_template: file.txt # note that this only works if glob matches 1 file only
 
-      # Additional templated extra files to uploaded.
-      # Those files will have their contents pass through the template engine,
-      # and its results will be uploaded.
-      #
-      # Since: v1.17 (pro)
-      # This feature is only available in GoReleaser Pro.
-      # Templates: allowed
-      templated_extra_files:
-        - src: LICENSE.tpl
-          dst: LICENSE.txt
+    # Additional templated extra files to uploaded.
+    # Those files will have their contents pass through the template engine,
+    # and its results will be uploaded.
+    #
+    # Since: v1.17 (pro)
+    # This feature is only available in GoReleaser Pro.
+    # Templates: allowed
+    templated_extra_files:
+      - src: LICENSE.tpl
+        dst: LICENSE.txt
 
   - provider: gs
     bucket: goreleaser-bucket

--- a/www/docs/customization/blob.md
+++ b/www/docs/customization/blob.md
@@ -15,70 +15,70 @@ blobs:
     # - gs for Google Cloud Storage
     #
     # Templates: allowed
-    provider: azblob
+    - provider: azblob
 
-    # Set a custom endpoint, useful if you're using a minio backend or
-    # other s3-compatible backends.
-    #
-    # Implies s3ForcePathStyle and requires provider to be `s3`
-    #
-    # Templates: allowed
-    endpoint: https://minio.foo.bar
+      # Set a custom endpoint, useful if you're using a minio backend or
+      # other s3-compatible backends.
+      #
+      # Implies s3ForcePathStyle and requires provider to be `s3`
+      #
+      # Templates: allowed
+      endpoint: https://minio.foo.bar
 
-    # Sets the bucket region.
-    # Requires provider to be `s3`
-    #
-    # Templates: allowed
-    region: us-west-1
+      # Sets the bucket region.
+      # Requires provider to be `s3`
+      #
+      # Templates: allowed
+      region: us-west-1
 
-    # Disables SSL
-    # Requires provider to be `s3`
-    disableSSL: true
+      # Disables SSL
+      # Requires provider to be `s3`
+      disableSSL: true
 
-    # Bucket name.
-    #
-    # Templates: allowed
-    bucket: goreleaser-bucket
+      # Bucket name.
+      #
+      # Templates: allowed
+      bucket: goreleaser-bucket
 
-    # IDs of the artifacts you want to upload.
-    ids:
-      - foo
-      - bar
+      # IDs of the artifacts you want to upload.
+      ids:
+        - foo
+        - bar
 
-    # Path/name inside the bucket.
-    #
-    # Default: '{{ .ProjectName }}/{{ .Tag }}'
-    # Templates: allowed
-    folder: "foo/bar/{{.Version}}"
+      # Path/name inside the bucket.
+      #
+      # Default: '{{ .ProjectName }}/{{ .Tag }}'
+      # Templates: allowed
+      folder: "foo/bar/{{.Version}}"
 
-    # Whether to disable this particular upload configuration.
-    #
-    # Since: v1.17
-    # Templates: allowed
-    disable: '{{ neq .BLOB_UPLOAD_ONLY "foo" }}'
+      # Whether to disable this particular upload configuration.
+      #
+      # Since: v1.17
+      # Templates: allowed
+      disable: '{{ neq .BLOB_UPLOAD_ONLY "foo" }}'
 
-    # You can add extra pre-existing files to the bucket.
-    # The filename on the release will be the last part of the path (base).
-    # If another file with the same name exists, the last one found will be used.
-    # These globs can also include templates.
-    extra_files:
-      - glob: ./path/to/file.txt
-      - glob: ./glob/**/to/**/file/**/*
-      - glob: ./glob/foo/to/bar/file/foobar/override_from_previous
-      - glob: ./single_file.txt
-        # Templates: allowed
-        name_template: file.txt # note that this only works if glob matches 1 file only
+      # You can add extra pre-existing files to the bucket.
+      # The filename on the release will be the last part of the path (base).
+      # If another file with the same name exists, the last one found will be used.
+      # These globs can also include templates.
+      extra_files:
+        - glob: ./path/to/file.txt
+        - glob: ./glob/**/to/**/file/**/*
+        - glob: ./glob/foo/to/bar/file/foobar/override_from_previous
+        - glob: ./single_file.txt
+          # Templates: allowed
+          name_template: file.txt # note that this only works if glob matches 1 file only
 
-    # Additional templated extra files to uploaded.
-    # Those files will have their contents pass through the template engine,
-    # and its results will be uploaded.
-    #
-    # Since: v1.17 (pro)
-    # This feature is only available in GoReleaser Pro.
-    # Templates: allowed
-    templated_extra_files:
-      - src: LICENSE.tpl
-        dst: LICENSE.txt
+      # Additional templated extra files to uploaded.
+      # Those files will have their contents pass through the template engine,
+      # and its results will be uploaded.
+      #
+      # Since: v1.17 (pro)
+      # This feature is only available in GoReleaser Pro.
+      # Templates: allowed
+      templated_extra_files:
+        - src: LICENSE.tpl
+          dst: LICENSE.txt
 
   - provider: gs
     bucket: goreleaser-bucket
@@ -108,11 +108,18 @@ chain in the following order:
 
 ### Azure Blob Provider
 
-It supports authentication only with
-[environment variables](https://docs.microsoft.com/en-us/azure/storage/common/storage-azure-cli#set-default-azure-storage-account-environment-variables):
+```yaml
+blobs:
+  - provider: azblob
+    bucket: releases?storage_account=myazurestorage
+```
 
-- `AZURE_STORAGE_ACCOUNT`
-- `AZURE_STORAGE_KEY` or `AZURE_STORAGE_SAS_TOKEN`
+Storage account is set over URL param `storage_account` in `bucket` or in environment variable `AZURE_STORAGE_ACCOUNT`
+
+It supports authentication with
+- [environment variables](https://docs.microsoft.com/en-us/azure/storage/common/storage-azure-cli#set-default-azure-storage-account-environment-variables):
+  - `AZURE_STORAGE_KEY` or `AZURE_STORAGE_SAS_TOKEN`
+- [default Azure credential](https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication-service-principal)
 
 ### [GCS Provider](https://cloud.google.com/docs/authentication/production)
 


### PR DESCRIPTION
I corected documentation for upload blobs to azure Storage Service from [used library](https://github.com/google/go-cloud/blob/53ccd8db26a14fd2a40bfcb28af1a1ceba4663f4/blob/azureblob/azureblob.go#L30).