### PR TITLE
fix: allow homebrew to use tar.xz format

### DIFF
--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -215,7 +215,7 @@ func doRun(ctx *context.Context, brew config.Homebrew, cl client.ReleaseURLTempl
 		),
 		artifact.Or(
 			artifact.And(
-				artifact.ByFormats("zip", "tar.gz"),
+				artifact.ByFormats("zip", "tar.gz", "tar.xz"),
 				artifact.ByType(artifact.UploadableArchive),
 			),
 			artifact.ByType(artifact.UploadableBinary),


### PR DESCRIPTION
<!-- If applied, this commit will... -->

In a `brews` section, goreleaser will fail when using `format: tar.xz` even though homebrew supports installing binaries bundled in a `.tar.xz` archive.

<!-- Why is this change being made? -->

I use `.tar.xz` instead of `.tar.gz` and would like goreleaser to support this when used in conjunction with `brews` sections.

With this patch, I created a test [homebrew formulae](https://github.com/jftuga/homebrew-tap/blob/main/awswho.rb) and successfully installed it under macOS.

