### PR TITLE
docs: update deprecated `--skip-publish` release flag

### DIFF
--- a/www/docs/quick-start.md
+++ b/www/docs/quick-start.md
@@ -125,10 +125,10 @@ goreleaser build --help
 
 ### Release Flags
 
-Use the `--skip-publish` flag to skip publishing:
+Use the `--skip=publish` flag to skip publishing:
 
 ```sh
-goreleaser release --skip-publish
+goreleaser release --skip=publish
 ```
 
 You can check the other options by running:


### PR DESCRIPTION
Calling `goreleaser release --skip-publish` as according to the [dry run documentation](https://goreleaser.com/quick-start/?h=dry+run#release-flags) gives the following deprecation warning
```
• DEPRECATED: --skip-publish was deprecated in favor of --skip=publish, check https://goreleaser.com/deprecations#-skip for more details
```

This updates the documentation

