### PR TITLE
docs: Removed the duplicate GoReleaser Pro entry

### DIFF
--- a/www/docs/customization/changelog.md
+++ b/www/docs/customization/changelog.md
@@ -78,8 +78,6 @@ changelog:
       # There can only be one level of subgroups, i.e. a subgroup cannot have
       # subgroups.
       #
-      # This feature is only available in GoReleaser Pro.
-      #
       # Since: v1.15 (pro)
       # This feature is only available in GoReleaser Pro.
       subgroups:


### PR DESCRIPTION
Removed the duplicate GoReleaser Pro entry from the changelog.

https://github.com/goreleaser/goreleaser/blob/fdf73bda9e8f3223969b26856b3e976352dfa40b/www/docs/customization/changelog.md?plain=1#L81-L84
