### PR TITLE
fix: add -c flags when building go test

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"dario.cat/mergo"
@@ -283,6 +284,9 @@ func buildGoBuildLine(ctx *context.Context, build config.Build, details config.B
 		return cmd, err
 	}
 	cmd = append(cmd, flags...)
+	if build.Command == "test" && !slices.Contains(flags, "-c") {
+		cmd = append(cmd, "-c")
+	}
 
 	asmflags, err := processFlags(ctx, artifact, env, details.Asmflags, "-asmflags=")
 	if err != nil {

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -1175,7 +1175,7 @@ func TestBuildGoBuildLine(t *testing.T) {
 		}, strings.Fields("go test -c -o foo.test ."))
 	})
 
-	t.Run("build test alwasy as c flags", func(t *testing.T) {
+	t.Run("build test always as c flags", func(t *testing.T) {
 		requireEqualCmd(t, config.Build{
 			Main:     ".",
 			GoBinary: "go",

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -1175,6 +1175,15 @@ func TestBuildGoBuildLine(t *testing.T) {
 		}, strings.Fields("go test -c -o foo.test ."))
 	})
 
+	t.Run("build test alwasy as c flags", func(t *testing.T) {
+		requireEqualCmd(t, config.Build{
+			Main:     ".",
+			GoBinary: "go",
+			Command:  "test",
+			Binary:   "foo.test",
+		}, strings.Fields("go test -c -o foo.test ."))
+	})
+
 	t.Run("ldflags1", func(t *testing.T) {
 		requireEqualCmd(t, config.Build{
 			Main: ".",


### PR DESCRIPTION
when building a go test without the `-c` flag like so:
```yaml
 builds:
- command: test
  binary: env.test
  dir: ./internal/builders/golang
  no_main_check: true
  ```

will result in the error: `exit status 1: fork/exec : exec format error`

adding the -c flags when not present in the flags
adding unit test

https://github.com/goreleaser/goreleaser/issues/4462
