### PR TITLE
fix: prevent having whitespaces in artifact names

### DIFF
--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -354,8 +354,7 @@ func shouldRelPath(a *Artifact) bool {
 func (artifacts *Artifacts) Add(a *Artifact) {
 	artifacts.lock.Lock()
 	defer artifacts.lock.Unlock()
-	ext := filepath.Ext(a.Name)
-	a.Name = strings.TrimSpace(strings.TrimSuffix(a.Name, ext)) + ext
+	a.Name = cleanName(*a)
 	if shouldRelPath(a) {
 		rel, err := relPath(a)
 		if rel != "" && err == nil {
@@ -576,4 +575,18 @@ func (artifacts *Artifacts) Visit(fn VisitFn) error {
 		}
 	}
 	return nil
+}
+
+func cleanName(a Artifact) string {
+	name := a.Name
+	ext := filepath.Ext(name)
+	result := strings.TrimSpace(strings.TrimSuffix(name, ext)) + ext
+	if name != result {
+		log.WithField("name", a.Name).
+			WithField("new name", result).
+			WithField("type", a.Type).
+			WithField("path", a.Path).
+			Warn("removed trailing whitespaces from artifact name")
+	}
+	return result
 }

--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -354,6 +354,8 @@ func shouldRelPath(a *Artifact) bool {
 func (artifacts *Artifacts) Add(a *Artifact) {
 	artifacts.lock.Lock()
 	defer artifacts.lock.Unlock()
+	ext := filepath.Ext(a.Name)
+	a.Name = strings.TrimSpace(strings.TrimSuffix(a.Name, ext)) + ext
 	if shouldRelPath(a) {
 		rel, err := relPath(a)
 		if rel != "" && err == nil {

--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -941,4 +941,8 @@ func TestArtifactTypeStringer(t *testing.T) {
 			require.NotEqual(t, "unknown", Type(i).String())
 		})
 	}
+
+	t.Run("unknown", func(t *testing.T) {
+		require.Equal(t, "unknown", Type(99999).String())
+	})
 }

--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -23,13 +23,17 @@ func TestAdd(t *testing.T) {
 	wd, _ := os.Getwd()
 	for _, a := range []*Artifact{
 		{
-			Name: "foo",
+			Name: " whitespaces .zip",
 			Type: UploadableArchive,
 			Path: filepath.Join(wd, "/foo/bar.tgz"),
 		},
 		{
 			Name: "bar",
 			Type: Binary,
+		},
+		{
+			Name: " whitespaces ",
+			Type: UploadableBinary,
 		},
 		{
 			Name: "foobar",
@@ -47,9 +51,13 @@ func TestAdd(t *testing.T) {
 		})
 	}
 	require.NoError(t, g.Wait())
-	require.Len(t, artifacts.List(), 4)
+	require.Len(t, artifacts.List(), 5)
 	archives := artifacts.Filter(ByType(UploadableArchive)).List()
 	require.Len(t, archives, 1)
+	require.Equal(t, "whitespaces.zip", archives[0].Name)
+	binaries := artifacts.Filter(ByType(UploadableBinary)).List()
+	require.Len(t, binaries, 1)
+	require.Equal(t, "whitespaces", binaries[0].Name)
 }
 
 func TestFilter(t *testing.T) {


### PR DESCRIPTION
refs #4513

this does not prevent the `dist` filepath to have spaces in it, although that's likely less of an issue, but it will remove the spaces from artifact's names.

Ideally, we could add a `tmpl.ApplyTrim` (or similar) that applies and trim spaces, and use it everywhere it makes sense (which is likely a lot of places).

Doing it on regular `Apply` might break things like release footers/headers, which usually rely on empty lines (although maybe its easier to treat those cases differently then).

Anyway, still thinking about it. Opinions are welcome :) 