### PR TITLE
docs: GitHub Actions code example

### DIFF
--- a/www/docs/ci/actions.md
+++ b/www/docs/ci/actions.md
@@ -44,14 +44,13 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
-          # either 'goreleaser' (default) or 'goreleaser-pro':
+          # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
           version: latest
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Your GoReleaser Pro key, if you are using the 'goreleaser-pro'
-          # distribution:
+          # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
           # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 ```
 

--- a/www/docs/ci/actions.md
+++ b/www/docs/ci/actions.md
@@ -31,15 +31,18 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
         with:
           go-version: stable
       # More assembly might be required: Docker logins, GPG, etc.
       # It all depends on your needs.
-      - uses: goreleaser/goreleaser-action@v5
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro':
           distribution: goreleaser

--- a/www/docs/ci/actions.md
+++ b/www/docs/ci/actions.md
@@ -17,6 +17,7 @@ Below is a simple snippet to use this action in your workflow:
 name: goreleaser
 
 on:
+  pull_request:
   push:
     # run only against tags
     tags:

--- a/www/docs/ci/actions.md
+++ b/www/docs/ci/actions.md
@@ -31,10 +31,9 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: git fetch --force --tags
       - uses: actions/setup-go@v4
         with:
           go-version: stable


### PR DESCRIPTION
I've changed the GitHub Action workflow code example to be more inline with the code example on the GitHub repository:

1. https://goreleaser.com/ci/actions/#workflow
2. https://github.com/goreleaser/goreleaser-action?tab=readme-ov-file#workflow

This is done by four commits for better code/git diff:

1. https://github.com/goreleaser/goreleaser/commit/7f6d9eefffe1607e9cc778f10c12c5f491b95b62 Changed the GitHub action workflow from `actions/checkout@v3` to `actions/checkout@v4`.

Copying from the code example on the GitHub repository `goreleaser/goreleaser-action`:

1.  https://github.com/goreleaser/goreleaser/commit/effc880f3d220f16e6acd2f4fe0a1aa28f4b1994 The `name` items 
2. https://github.com/goreleaser/goreleaser/commit/9d7fc2949eb3eb35d6a71f2733b29ee8ea121070 The comments
3. https://github.com/goreleaser/goreleaser/commit/3118f60fb01c8f84454477d95aec9c655736b6b2 The workflow trigger `on`: `pull_request`