### PR TITLE
feat: --skip=chocolately

### DIFF
--- a/internal/pipe/chocolatey/chocolatey.go
+++ b/internal/pipe/chocolatey/chocolatey.go
@@ -12,6 +12,7 @@ import (
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/internal/client"
+	"github.com/goreleaser/goreleaser/internal/skips"
 	"github.com/goreleaser/goreleaser/internal/tmpl"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
@@ -31,9 +32,11 @@ var cmd cmder = stdCmd{}
 // Pipe for chocolatey packaging.
 type Pipe struct{}
 
-func (Pipe) String() string                           { return "chocolatey packages" }
-func (Pipe) ContinueOnError() bool                    { return true }
-func (Pipe) Skip(ctx *context.Context) bool           { return len(ctx.Config.Chocolateys) == 0 }
+func (Pipe) String() string        { return "chocolatey packages" }
+func (Pipe) ContinueOnError() bool { return true }
+func (Pipe) Skip(ctx *context.Context) bool {
+	return skips.Any(ctx, skips.Chocolatey) || len(ctx.Config.Chocolateys) == 0
+}
 func (Pipe) Dependencies(_ *context.Context) []string { return []string{"choco"} }
 
 // Default sets the pipe defaults.

--- a/internal/pipe/chocolatey/chocolatey_test.go
+++ b/internal/pipe/chocolatey/chocolatey_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/goreleaser/goreleaser/internal/artifact"
 	"github.com/goreleaser/goreleaser/internal/client"
 	"github.com/goreleaser/goreleaser/internal/golden"
+	"github.com/goreleaser/goreleaser/internal/skips"
 	"github.com/goreleaser/goreleaser/internal/testctx"
 	"github.com/goreleaser/goreleaser/internal/testlib"
 	"github.com/goreleaser/goreleaser/pkg/config"
@@ -25,8 +26,26 @@ func TestDescription(t *testing.T) {
 }
 
 func TestSkip(t *testing.T) {
-	ctx := testctx.New()
-	require.True(t, Pipe{}.Skip(ctx))
+	t.Run("skip", func(t *testing.T) {
+		require.True(t, Pipe{}.Skip(testctx.New()))
+	})
+	t.Run("skip flag", func(t *testing.T) {
+		ctx := testctx.NewWithCfg(config.Project{
+			Chocolateys: []config.Chocolatey{
+				{},
+			},
+		}, testctx.Skip(skips.Chocolatey))
+		require.True(t, Pipe{}.Skip(ctx))
+	})
+
+	t.Run("dont skip", func(t *testing.T) {
+		ctx := testctx.NewWithCfg(config.Project{
+			Chocolateys: []config.Chocolatey{
+				{},
+			},
+		})
+		require.False(t, Pipe{}.Skip(ctx))
+	})
 }
 
 func TestDefault(t *testing.T) {

--- a/internal/skips/skips.go
+++ b/internal/skips/skips.go
@@ -30,6 +30,7 @@ const (
 	Nix            Key = "nix"
 	AUR            Key = "aur"
 	NFPM           Key = "nfpm"
+	Chocolatey     Key = "chocolatey"
 )
 
 func String(ctx *context.Context) string {
@@ -112,6 +113,7 @@ var Release = Keys{
 	AUR,
 	NFPM,
 	Before,
+	Chocolatey,
 }
 
 var Build = Keys{
@@ -119,4 +121,5 @@ var Build = Keys{
 	PostBuildHooks,
 	Validate,
 	Before,
+	Chocolatey,
 }


### PR DESCRIPTION
If applied, this commit will add `chocolately` as a pipe that can be skipped. 

As Chocolately is only available on Windows machines (and [Linux machines with some effort](https://github.com/twpayne/chezmoi/blob/ff3deb9007ca4cf25e17b1c8665cb8f72fcaeaf9/.github/workflows/main.yml#L167-L171)), it's useful to be able to skip this pipe if you don't have a machine with Chocolately installed.
