### PR TITLE
feat: make scm pre-release a template field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	golang.org/x/oauth2 v0.16.0
 	golang.org/x/sync v0.6.0
 	golang.org/x/text v0.14.0
-	golang.org/x/tools v0.16.1
+	golang.org/x/tools v0.17.0
 	gopkg.in/mail.v2 v2.3.1
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1162,8 +1162,8 @@ golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
-golang.org/x/tools v0.16.1 h1:TLyB3WofjdOEepBHAU20JdNC1Zbg87elYofWYAY5oZA=
-golang.org/x/tools v0.16.1/go.mod h1:kYVVN6I1mBNoB1OX+noeBjbRk4IUEPa7JJ+TJMEooJ0=
+golang.org/x/tools v0.17.0 h1:FvmRgNOcs3kOa+T20R1uhfP9F6HgG2mfxDv1vrx1Htc=
+golang.org/x/tools v0.17.0/go.mod h1:xsh6VxdV005rRVaS6SSAf9oiAqljS7UZUacMZ8Bnsps=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/pipe/release/release.go
+++ b/internal/pipe/release/release.go
@@ -71,8 +71,14 @@ func (p Pipe) Default(ctx *context.Context) error {
 		}
 	}
 
-	// Check if we have to check the git tag for an indicator to mark as pre release
-	switch ctx.Config.Release.Prerelease {
+	// Resolve prerelease template
+	release_is_prerelease, err := tmpl.New(ctx).Apply(ctx.Config.Release.Prerelease)
+	if err != nil {
+		return err
+	}
+
+	// Check if we have to check the git tag for an indicator to mark as pre-release
+	switch release_is_prerelease {
 	case "auto":
 		if ctx.Semver.Prerelease != "" {
 			ctx.PreRelease = true

--- a/internal/pipe/release/release.go
+++ b/internal/pipe/release/release.go
@@ -72,13 +72,13 @@ func (p Pipe) Default(ctx *context.Context) error {
 	}
 
 	// Resolve prerelease template
-	release_is_prerelease, err := tmpl.New(ctx).Apply(ctx.Config.Release.Prerelease)
+	releaseIsPrerelease, err := tmpl.New(ctx).Apply(ctx.Config.Release.Prerelease)
 	if err != nil {
 		return err
 	}
 
 	// Check if we have to check the git tag for an indicator to mark as pre-release
-	switch release_is_prerelease {
+	switch releaseIsPrerelease {
 	case "auto":
 		if ctx.Semver.Prerelease != "" {
 			ctx.PreRelease = true


### PR DESCRIPTION
```yaml
# .goreleaser.yaml
release:
  # If set to auto, will mark the release as not ready for production
  # in case there is an indicator for this in the tag e.g. v1.0.0-rc1
  # If set to true, will mark the release as not ready for production.
  # Templates: allowed (since v1.24.0)
  # Default is false.
  prerelease: auto
```