### PR TITLE
docs: fix typo in link to nightly release installations

### DIFF
--- a/www/docs/install.md
+++ b/www/docs/install.md
@@ -237,11 +237,11 @@ Use it for testing out new features only.
 
 === "OSS"
 
-    Download the pre-compiled binaries from the [nightly release][nighly-releases] and copy them to the desired location.
+    Download the pre-compiled binaries from the [nightly release][nightly-releases] and copy them to the desired location.
 
 === "Pro"
 
-    Download the pre-compiled binaries from the [nightly release][nighly-pro-releases] and copy them to the desired location.
+    Download the pre-compiled binaries from the [nightly release][nightly-pro-releases] and copy them to the desired location.
 
 ### bash script
 


### PR DESCRIPTION
👋 This commit updates links to nightly releases in the installation docs to match [the reference links](https://github.com/goreleaser/goreleaser/blob/29f30b623ef8f0a19607afab22b3f3a2f9f68172/www/docs/install.md?plain=1#L421-L422).

Section in the docs: https://goreleaser.com/install/#manually_1
