### PR TITLE
docs: add instructions for setting up local documentation

### DIFF
--- a/www/README.md
+++ b/www/README.md
@@ -9,6 +9,12 @@ To iterate with documentation, therefore, it is recommended to run the mkdocs se
 
 - [Get Docker](https://docs.docker.com/get-docker/)
 - [Get Task](https://taskfile.dev/installation/)
+- [Get MkDocs](https://www.mkdocs.org/user-guide/installation/)
+  - [Get MkDocs Material](https://squidfunk.github.io/mkdocs-material/getting-started/#installation)
+  - [Get MkDocs Redirect](https://github.com/mkdocs/mkdocs-redirects#installing)
+  - [Get MkDocs Minify](https://github.com/byrnereese/mkdocs-minify-plugin#setup)
+  - [Get MkDocs Include Markdown](https://github.com/mondeja/mkdocs-include-markdown-plugin#installation)
+  - [Get MkDocs RSS](https://github.com/guts/mkdocs-rss-plugin#installation)
 
 ### NOTE to M1/M2 mac owners
 

--- a/www/README.md
+++ b/www/README.md
@@ -18,7 +18,7 @@ To iterate with documentation, therefore, it is recommended to run the mkdocs se
 
 ### NOTE to M1/M2 mac owners
 
-If running on an arm64-based mac (M1 or M2, aka "Applie Silicon"), you may find this method quite slow. Until
+If running on an arm64-based mac (M1 or M2, aka "Apple Silicon"), you may find this method quite slow. Until
 multiarch docker images can be built and made available, you may wish to build your own via:
 
 ```bash

--- a/www/README.md
+++ b/www/README.md
@@ -25,3 +25,13 @@ multiarch docker images can be built and made available, you may wish to build y
 git clone git@github.com:squidfunk/mkdocs-material.git
 docker build -t docker.io/squidfunk/mkdocs-material .
 ```
+
+## Edit the docs
+
+After installing mkdocs and extensions, build and run the documentation locally:
+
+```sh
+task docs:serve
+```
+
+The site will soon be available at http://0.0.0.0:8000 and update after changes.


### PR DESCRIPTION
This PR adds a few notes on installing mkdocs and the extensions needed to run the documentation locally. The list of extensions was added to until build errors went away and the site was served successfully!