### PR TITLE
fix(nix): sourceRoot when using archives.wrap_in_directory

### DIFF
--- a/internal/pipe/nix/nix_test.go
+++ b/internal/pipe/nix/nix_test.go
@@ -489,7 +489,7 @@ func TestRunPipe(t *testing.T) {
 						if goos != "darwin" {
 							createFakeArtifact("unibin-replaces", goos, goarch, "v1", "", "tar.gz", nil)
 						}
-						createFakeArtifact("wrapped-in-dir", goos, goarch, "v1", "", "tar.gz", map[string]any{artifact.ExtraWrappedIn: "./foo"})
+						createFakeArtifact("wrapped-in-dir", goos, goarch, "v1", "", "tar.gz", map[string]any{artifact.ExtraWrappedIn: "./foo_" + goarch})
 						createFakeArtifact("foo-zip", goos, goarch, "v1", "", "zip", nil)
 						continue
 					}
@@ -508,7 +508,7 @@ func TestRunPipe(t *testing.T) {
 					if goos != "darwin" {
 						createFakeArtifact("unibin-replaces", goos, goarch, "", "", "tar.gz", nil)
 					}
-					createFakeArtifact("wrapped-in-dir", goos, goarch, "", "", "tar.gz", map[string]any{artifact.ExtraWrappedIn: "./foo"})
+					createFakeArtifact("wrapped-in-dir", goos, goarch, "", "", "tar.gz", map[string]any{artifact.ExtraWrappedIn: "./foo_" + goarch})
 					createFakeArtifact("foo-zip", goos, goarch, "v1", "", "zip", nil)
 					if goos == "darwin" {
 						createFakeArtifact("zip-and-tar", goos, goarch, "v1", "", "zip", nil)

--- a/internal/pipe/nix/template.go
+++ b/internal/pipe/nix/template.go
@@ -15,6 +15,7 @@ type templateData struct {
 	Install      []string
 	PostInstall  []string
 	SourceRoot   string
+	SourceRoots  map[string]string
 	Archives     map[string]Archive
 	Description  string
 	Homepage     string

--- a/internal/pipe/nix/testdata/TestRunPipe/wrapped-in-dir_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/wrapped-in-dir_build.nix.golden
@@ -23,6 +23,13 @@ let
     x86_64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_amd64v1.tar.gz";
     aarch64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_arm64.tar.gz";
   };
+  sourceRootMap = {
+    i686-linux = "./foo_386";
+    x86_64-linux = "./foo_amd64";
+    aarch64-linux = "./foo_arm64";
+    x86_64-darwin = "./foo_amd64";
+    aarch64-darwin = "./foo_arm64";
+  };
 in
 pkgs.stdenvNoCC.mkDerivation {
   pname = "wrapped-in-dir";
@@ -32,7 +39,7 @@ pkgs.stdenvNoCC.mkDerivation {
     sha256 = shaMap.${system};
   };
 
-  sourceRoot = "./foo";
+  sourceRoot = sourceRootMap.${system};
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/internal/pipe/nix/testdata/TestRunPipe/wrapped-in-dir_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/wrapped-in-dir_publish.nix.golden
@@ -23,6 +23,13 @@ let
     x86_64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_amd64v1.tar.gz";
     aarch64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_arm64.tar.gz";
   };
+  sourceRootMap = {
+    i686-linux = "./foo_386";
+    x86_64-linux = "./foo_amd64";
+    aarch64-linux = "./foo_arm64";
+    x86_64-darwin = "./foo_amd64";
+    aarch64-darwin = "./foo_arm64";
+  };
 in
 pkgs.stdenvNoCC.mkDerivation {
   pname = "wrapped-in-dir";
@@ -32,7 +39,7 @@ pkgs.stdenvNoCC.mkDerivation {
     sha256 = shaMap.${system};
   };
 
-  sourceRoot = "./foo";
+  sourceRoot = sourceRootMap.${system};
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/internal/pipe/nix/tmpl.nix
+++ b/internal/pipe/nix/tmpl.nix
@@ -62,6 +62,32 @@ let
     aarch64-darwin = "{{ . }}";
     {{- end }}
   };
+
+  {{- if not .SourceRoot }}
+  sourceRootMap = {
+    {{- with  .SourceRoots.linux386 }}
+    i686-linux = "{{ . }}";
+    {{- end }}
+    {{- with  .SourceRoots.linuxamd64 }}
+    x86_64-linux = "{{ . }}";
+    {{- end }}
+    {{- with  .SourceRoots.linuxarm6 }}
+    armv6l-linux = "{{ . }}";
+    {{- end }}
+    {{- with  .SourceRoots.linuxarm7 }}
+    armv7l-linux = "{{ . }}";
+    {{- end }}
+    {{- with  .SourceRoots.linuxarm64 }}
+    aarch64-linux = "{{ . }}";
+    {{- end }}
+    {{- with  .SourceRoots.darwinamd64 }}
+    x86_64-darwin = "{{ . }}";
+    {{- end }}
+    {{- with  .SourceRoots.darwinarm64 }}
+    aarch64-darwin = "{{ . }}";
+    {{- end }}
+  };
+  {{- end }}
 in
 pkgs.stdenvNoCC.mkDerivation {
   pname = "{{ .Name }}";
@@ -71,7 +97,7 @@ pkgs.stdenvNoCC.mkDerivation {
     sha256 = shaMap.${system};
   };
 
-  sourceRoot = "{{ .SourceRoot }}";
+  sourceRoot = {{ with .SourceRoot }}"{{ . }}"{{ else }}sourceRootMap.${system}{{ end }};
 
   nativeBuildInputs = [ {{ range $input, $plat := .Inputs }}{{ . }} {{ end }}];
 


### PR DESCRIPTION
If `archives.[*].wrap_in_directory` is set, it'll create a folder inside the archive file, usually something like `app_goos_goarch`.

In those cases, the root of the archive is not constant, so we create a `sourceRootMap` and use it instead.

In cases where the `sourceRoot` is constant, the generated derivation will be the same.

refs https://github.com/orgs/goreleaser/discussions/4549