### PR TITLE
Fix: Allow using double quotes for templates in Slack notifications

### DIFF
--- a/internal/pipe/slack/slack.go
+++ b/internal/pipe/slack/slack.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/caarlos0/env/v9"
 	"github.com/caarlos0/log"
@@ -102,7 +103,11 @@ func unmarshal(ctx *context.Context, in interface{}, target interface{}) error {
 		return fmt.Errorf("failed to marshal input as JSON: %w", err)
 	}
 
-	tplApplied, err := tmpl.New(ctx).Apply(string(jazon))
+	body := string(jazon)
+	// ensure that double quotes that are inside the string get un-escaped so they can be interpreted for templates
+	body = strings.ReplaceAll(body, "\\\"", "\"")
+
+	tplApplied, err := tmpl.New(ctx).Apply(body)
 	if err != nil {
 		return fmt.Errorf("failed to evaluate template: %w", err)
 	}


### PR DESCRIPTION

As noted in #4556, when we're using a double quote, for use with a
template variable or function, we receive a template parse error as the
value needs to be unquoted.

This provides a slightly hacky solution which is to unquote any quoted
quotes.

Closes #4556.

