### PR TITLE
refactor(http): remove redundant `nil` check

### DIFF
--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -238,15 +238,13 @@ func uploadAsset(ctx *context.Context, upload *config.Upload, artifact *artifact
 	}
 	log.Debugf("generated target url: %s", targetURL)
 
-	headers := map[string]string{}
-	if upload.CustomHeaders != nil {
-		for name, value := range upload.CustomHeaders {
-			resolvedValue, err := tmpl.New(ctx).WithArtifact(artifact).Apply(value)
-			if err != nil {
-				return fmt.Errorf("%s: %s: failed to resolve custom_headers template: %w", upload.Name, kind, err)
-			}
-			headers[name] = resolvedValue
+	headers := make(map[string]string, len(upload.CustomHeaders))
+	for name, value := range upload.CustomHeaders {
+		resolvedValue, err := tmpl.New(ctx).WithArtifact(artifact).Apply(value)
+		if err != nil {
+			return fmt.Errorf("%s: %s: failed to resolve custom_headers template: %w", upload.Name, kind, err)
 		}
+		headers[name] = resolvedValue
 	}
 	if upload.ChecksumHeader != "" {
 		sum, err := artifact.Checksum("sha256")


### PR DESCRIPTION
From the Go specification [^1]:

> "3. If the map is nil, the number of iterations is 0."

Therefore, it is not required to do a nil check for the map before the loop.

[^1]: https://go.dev/ref/spec#For_range