### PR TITLE
fix(config): handle relative git repos

### DIFF
--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -2,6 +2,7 @@ package git_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/internal/git"
@@ -20,6 +21,24 @@ func TestNoRemote(t *testing.T) {
 	testlib.GitInit(t)
 	_, err := git.ExtractRepoFromConfig(context.Background())
 	require.EqualError(t, err, `no remote configured to list refs from`)
+}
+
+func TestRelativeRemote(t *testing.T) {
+	ctx := context.Background()
+	testlib.Mktmp(t)
+	testlib.GitInit(t)
+	testlib.GitRemoteAddWithName(t, "upstream", "https://github.com/goreleaser/goreleaser.git")
+	_, err := git.Run(ctx, "pull", "upstream", "main")
+	require.NoError(t, err)
+	_, err = git.Run(ctx, "branch", "--set-upstream-to", "upstream/main")
+	require.NoError(t, err)
+	_, err = git.Run(ctx, "checkout", "--track", "-b", "relative_branch")
+	require.NoError(t, err)
+	gitCfg, err := git.Run(ctx, "config", "--local", "--list")
+	require.True(t, strings.Contains(gitCfg, "branch.relative_branch.remote=."))
+	repo, err := git.ExtractRepoFromConfig(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "goreleaser/goreleaser", repo.String())
 }
 
 func TestRepoName(t *testing.T) {

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -35,6 +35,7 @@ func TestRelativeRemote(t *testing.T) {
 	_, err = git.Run(ctx, "checkout", "--track", "-b", "relative_branch")
 	require.NoError(t, err)
 	gitCfg, err := git.Run(ctx, "config", "--local", "--list")
+	require.NoError(t, err)
 	require.True(t, strings.Contains(gitCfg, "branch.relative_branch.remote=."))
 	repo, err := git.ExtractRepoFromConfig(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
## If applied, this commit will...

If applied this change will allow goreleaser to handle relative remotes when attempting to parse a repo URL from git.

## Why is this change being made? 

To fix the error that I recently came across while trying to test my goreleaser configuration:

```
% goreleaser check
  • checking                                 path=
  ⨯ configuration is invalid                 error=invalid scm url: .
  ⨯ .goreleaser.yml                                  error=configuration is invalid: invalid scm url: .
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have issues
```

This change happened while on a branch doing some development. As part of that development I needed to test a change to my goreleaser config.

My git config at the time looked like (repo obfuscated):

```
% cat .git/config
[core]
        repositoryformatversion = 0
        filemode = true
        bare = false
        logallrefupdates = true
[remote "origin"]
        url = git@gitlab.com:some/repo
        fetch = +refs/heads/*:refs/remotes/origin/*
[branch "main"]
        remote = origin
        merge = refs/heads/main
[branch "release_fixes"]
        remote = .
        merge = refs/heads/main
```

It is fairly common for git to add remotes with a `.` when branch tracking is enabled.

While, in general, there aren't many use cases that require a user to need to release from a non-primary branch, there are cases where the user may want to test their configuration with `goreleaser check` and the error of `invalid scm url: .` isn't very helpful.
