### PR TITLE
chore: Updated the GitHub Code Search syntax

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -95,4 +95,4 @@ If you're going to edit it, please:
 
 [^1]:
     Entries were either added by the companies themselves or by the maintainers after seeing it in the wild.
-    You can see all public repositories using GoReleaser by [searching on GitHub](https://github.com/search?q=path%3A%2Fgoreleaser.*+language%3Ayaml&type=code).
+    You can see all public repositories using GoReleaser by [searching on GitHub](https://github.com/search?q=path%3A.goreleaser.yml+OR+path%3A.goreleaser.yaml+&type=code).

--- a/USERS.md
+++ b/USERS.md
@@ -95,4 +95,4 @@ If you're going to edit it, please:
 
 [^1]:
     Entries were either added by the companies themselves or by the maintainers after seeing it in the wild.
-    You can see all public repositories using GoReleaser by [searching on GitHub](https://github.com/search?q=filename%3Agoreleaser+language%3Ayaml+path%3A%2F).
+    You can see all public repositories using GoReleaser by [searching on GitHub](https://github.com/search?q=path%3A%2Fgoreleaser.*+language%3Ayaml&type=code).


### PR DESCRIPTION
Found that the GitHub Code Search syntax did not work (anymore).

**Before**

![before](https://github.com/goreleaser/goreleaser/assets/1150425/a93a3cc1-d49c-496e-9f70-4c19b534c542)

_https://github.com/search?q=filename%3Agoreleaser+language%3Ayaml+path%3A%2F_

**After**

![after](https://github.com/goreleaser/goreleaser/assets/1150425/29d19c70-22c9-442e-94d3-a5f7fcbc2bd9)

_https://github.com/search?q=path%3A%2Fgoreleaser.*+language%3Ayaml&type=code_
