### PR TITLE
fix(nix): improve generated derivations

### DIFF
--- a/internal/pipe/nix/nix.go
+++ b/internal/pipe/nix/nix.go
@@ -503,10 +503,10 @@ func binInstallFormats(nix config.Nix) []string {
 	var depStrings []string
 
 	if len(darwinDeps) > 0 {
-		depStrings = append(depStrings, fmt.Sprintf("lib.optionals stdenv.isDarwin [ %s ]", strings.Join(darwinDeps, " ")))
+		depStrings = append(depStrings, fmt.Sprintf("lib.optionals stdenvNoCC.isDarwin [ %s ]", strings.Join(darwinDeps, " ")))
 	}
 	if len(linuxDeps) > 0 {
-		depStrings = append(depStrings, fmt.Sprintf("lib.optionals stdenv.isLinux [ %s ]", strings.Join(linuxDeps, " ")))
+		depStrings = append(depStrings, fmt.Sprintf("lib.optionals stdenvNoCC.isLinux [ %s ]", strings.Join(linuxDeps, " ")))
 	}
 	if len(deps) > 0 {
 		depStrings = append(depStrings, fmt.Sprintf("[ %s ]", strings.Join(deps, " ")))

--- a/internal/pipe/nix/testdata/TestBinInstallFormats/darwin-only-deps.golden
+++ b/internal/pipe/nix/testdata/TestBinInstallFormats/darwin-only-deps.golden
@@ -1,2 +1,2 @@
 cp -vr ./%[1]s $out/bin/%[1]s
-wrapProgram $out/bin/%[1]s --prefix PATH : ${lib.makeBinPath (lib.optionals stdenv.isDarwin [ foo bar ])}
+wrapProgram $out/bin/%[1]s --prefix PATH : ${lib.makeBinPath (lib.optionals stdenvNoCC.isDarwin [ foo bar ])}

--- a/internal/pipe/nix/testdata/TestBinInstallFormats/linux-only-deps.golden
+++ b/internal/pipe/nix/testdata/TestBinInstallFormats/linux-only-deps.golden
@@ -1,2 +1,2 @@
 cp -vr ./%[1]s $out/bin/%[1]s
-wrapProgram $out/bin/%[1]s --prefix PATH : ${lib.makeBinPath (lib.optionals stdenv.isLinux [ foo bar ])}
+wrapProgram $out/bin/%[1]s --prefix PATH : ${lib.makeBinPath (lib.optionals stdenvNoCC.isLinux [ foo bar ])}

--- a/internal/pipe/nix/testdata/TestBinInstallFormats/mixed-deps.golden
+++ b/internal/pipe/nix/testdata/TestBinInstallFormats/mixed-deps.golden
@@ -1,2 +1,2 @@
 cp -vr ./%[1]s $out/bin/%[1]s
-wrapProgram $out/bin/%[1]s --prefix PATH : ${lib.makeBinPath (lib.optionals stdenv.isDarwin [ bar ] ++ lib.optionals stdenv.isLinux [ foo ] ++ [ fish ])}
+wrapProgram $out/bin/%[1]s --prefix PATH : ${lib.makeBinPath (lib.optionals stdenvNoCC.isDarwin [ bar ] ++ lib.optionals stdenvNoCC.isLinux [ foo ] ++ [ fish ])}

--- a/internal/pipe/nix/testdata/TestRunPipe/deps_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/deps_build.nix.golden
@@ -2,7 +2,6 @@
 # vim: set ft=nix ts=2 sw=2 sts=2 et sta
 {
 system ? builtins.currentSystem
-, pkgs
 , lib
 , fetchurl
 , installShellFiles
@@ -34,7 +33,7 @@ let
     aarch64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_arm64.tar.gz";
   };
 in
-pkgs.stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "foo";
   version = "1.2.1";
   src = fetchurl {
@@ -49,7 +48,7 @@ pkgs.stdenvNoCC.mkDerivation {
   installPhase = ''
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
-    wrapProgram $out/bin/foo --prefix PATH : ${lib.makeBinPath (lib.optionals stdenv.isDarwin [ chromium ] ++ lib.optionals stdenv.isLinux [ ttyd ] ++ [ fish bash ])}
+    wrapProgram $out/bin/foo --prefix PATH : ${lib.makeBinPath (lib.optionals stdenvNoCC.isDarwin [ chromium ] ++ lib.optionals stdenvNoCC.isLinux [ ttyd ] ++ [ fish bash ])}
   '';
 
   system = system;

--- a/internal/pipe/nix/testdata/TestRunPipe/deps_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/deps_publish.nix.golden
@@ -2,7 +2,6 @@
 # vim: set ft=nix ts=2 sw=2 sts=2 et sta
 {
 system ? builtins.currentSystem
-, pkgs
 , lib
 , fetchurl
 , installShellFiles
@@ -34,7 +33,7 @@ let
     aarch64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_arm64.tar.gz";
   };
 in
-pkgs.stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "foo";
   version = "1.2.1";
   src = fetchurl {
@@ -49,7 +48,7 @@ pkgs.stdenvNoCC.mkDerivation {
   installPhase = ''
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
-    wrapProgram $out/bin/foo --prefix PATH : ${lib.makeBinPath (lib.optionals stdenv.isDarwin [ chromium ] ++ lib.optionals stdenv.isLinux [ ttyd ] ++ [ fish bash ])}
+    wrapProgram $out/bin/foo --prefix PATH : ${lib.makeBinPath (lib.optionals stdenvNoCC.isDarwin [ chromium ] ++ lib.optionals stdenvNoCC.isLinux [ ttyd ] ++ [ fish bash ])}
   '';
 
   system = system;

--- a/internal/pipe/nix/testdata/TestRunPipe/extra-install_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/extra-install_build.nix.golden
@@ -2,7 +2,6 @@
 # vim: set ft=nix ts=2 sw=2 sts=2 et sta
 {
 system ? builtins.currentSystem
-, pkgs
 , lib
 , fetchurl
 , installShellFiles
@@ -34,7 +33,7 @@ let
     aarch64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_arm64.tar.gz";
   };
 in
-pkgs.stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "foo";
   version = "1.2.1";
   src = fetchurl {
@@ -49,7 +48,7 @@ pkgs.stdenvNoCC.mkDerivation {
   installPhase = ''
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
-    wrapProgram $out/bin/foo --prefix PATH : ${lib.makeBinPath (lib.optionals stdenv.isDarwin [ chromium ] ++ lib.optionals stdenv.isLinux [ ttyd ] ++ [ fish bash ])}
+    wrapProgram $out/bin/foo --prefix PATH : ${lib.makeBinPath (lib.optionals stdenvNoCC.isDarwin [ chromium ] ++ lib.optionals stdenvNoCC.isLinux [ ttyd ] ++ [ fish bash ])}
     installManPage ./manpages/foo.1.gz
   '';
 

--- a/internal/pipe/nix/testdata/TestRunPipe/extra-install_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/extra-install_publish.nix.golden
@@ -2,7 +2,6 @@
 # vim: set ft=nix ts=2 sw=2 sts=2 et sta
 {
 system ? builtins.currentSystem
-, pkgs
 , lib
 , fetchurl
 , installShellFiles
@@ -34,7 +33,7 @@ let
     aarch64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_arm64.tar.gz";
   };
 in
-pkgs.stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "foo";
   version = "1.2.1";
   src = fetchurl {
@@ -49,7 +48,7 @@ pkgs.stdenvNoCC.mkDerivation {
   installPhase = ''
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
-    wrapProgram $out/bin/foo --prefix PATH : ${lib.makeBinPath (lib.optionals stdenv.isDarwin [ chromium ] ++ lib.optionals stdenv.isLinux [ ttyd ] ++ [ fish bash ])}
+    wrapProgram $out/bin/foo --prefix PATH : ${lib.makeBinPath (lib.optionals stdenvNoCC.isDarwin [ chromium ] ++ lib.optionals stdenvNoCC.isLinux [ ttyd ] ++ [ fish bash ])}
     installManPage ./manpages/foo.1.gz
   '';
 

--- a/internal/pipe/nix/testdata/TestRunPipe/minimal_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/minimal_build.nix.golden
@@ -2,10 +2,10 @@
 # vim: set ft=nix ts=2 sw=2 sts=2 et sta
 {
 system ? builtins.currentSystem
-, pkgs
 , lib
 , fetchurl
 , installShellFiles
+, stdenvNoCC
 }:
 let
   shaMap = {
@@ -28,7 +28,7 @@ let
     aarch64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_arm64.tar.gz";
   };
 in
-pkgs.stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "foo";
   version = "1.2.1";
   src = fetchurl {

--- a/internal/pipe/nix/testdata/TestRunPipe/minimal_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/minimal_publish.nix.golden
@@ -2,10 +2,10 @@
 # vim: set ft=nix ts=2 sw=2 sts=2 et sta
 {
 system ? builtins.currentSystem
-, pkgs
 , lib
 , fetchurl
 , installShellFiles
+, stdenvNoCC
 }:
 let
   shaMap = {
@@ -28,7 +28,7 @@ let
     aarch64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_arm64.tar.gz";
   };
 in
-pkgs.stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "foo";
   version = "1.2.1";
   src = fetchurl {

--- a/internal/pipe/nix/testdata/TestRunPipe/open-pr_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/open-pr_build.nix.golden
@@ -2,10 +2,10 @@
 # vim: set ft=nix ts=2 sw=2 sts=2 et sta
 {
 system ? builtins.currentSystem
-, pkgs
 , lib
 , fetchurl
 , installShellFiles
+, stdenvNoCC
 }:
 let
   shaMap = {
@@ -28,7 +28,7 @@ let
     aarch64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_arm64.tar.gz";
   };
 in
-pkgs.stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "foo";
   version = "1.2.1";
   src = fetchurl {

--- a/internal/pipe/nix/testdata/TestRunPipe/open-pr_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/open-pr_publish.nix.golden
@@ -2,10 +2,10 @@
 # vim: set ft=nix ts=2 sw=2 sts=2 et sta
 {
 system ? builtins.currentSystem
-, pkgs
 , lib
 , fetchurl
 , installShellFiles
+, stdenvNoCC
 }:
 let
   shaMap = {
@@ -28,7 +28,7 @@ let
     aarch64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_arm64.tar.gz";
   };
 in
-pkgs.stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "foo";
   version = "1.2.1";
   src = fetchurl {

--- a/internal/pipe/nix/testdata/TestRunPipe/partial_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/partial_build.nix.golden
@@ -2,10 +2,10 @@
 # vim: set ft=nix ts=2 sw=2 sts=2 et sta
 {
 system ? builtins.currentSystem
-, pkgs
 , lib
 , fetchurl
 , installShellFiles
+, stdenvNoCC
 }:
 let
   shaMap = {
@@ -18,7 +18,7 @@ let
     x86_64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_amd64v1.tar.gz";
   };
 in
-pkgs.stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "partial";
   version = "1.2.1";
   src = fetchurl {

--- a/internal/pipe/nix/testdata/TestRunPipe/partial_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/partial_publish.nix.golden
@@ -2,10 +2,10 @@
 # vim: set ft=nix ts=2 sw=2 sts=2 et sta
 {
 system ? builtins.currentSystem
-, pkgs
 , lib
 , fetchurl
 , installShellFiles
+, stdenvNoCC
 }:
 let
   shaMap = {
@@ -18,7 +18,7 @@ let
     x86_64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_amd64v1.tar.gz";
   };
 in
-pkgs.stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "partial";
   version = "1.2.1";
   src = fetchurl {

--- a/internal/pipe/nix/testdata/TestRunPipe/skip-upload-auto_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/skip-upload-auto_build.nix.golden
@@ -2,10 +2,10 @@
 # vim: set ft=nix ts=2 sw=2 sts=2 et sta
 {
 system ? builtins.currentSystem
-, pkgs
 , lib
 , fetchurl
 , installShellFiles
+, stdenvNoCC
 }:
 let
   shaMap = {
@@ -28,7 +28,7 @@ let
     aarch64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_arm64.tar.gz";
   };
 in
-pkgs.stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "doesnotmatter";
   version = "1.2.1";
   src = fetchurl {

--- a/internal/pipe/nix/testdata/TestRunPipe/skip-upload_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/skip-upload_build.nix.golden
@@ -2,10 +2,10 @@
 # vim: set ft=nix ts=2 sw=2 sts=2 et sta
 {
 system ? builtins.currentSystem
-, pkgs
 , lib
 , fetchurl
 , installShellFiles
+, stdenvNoCC
 }:
 let
   shaMap = {
@@ -28,7 +28,7 @@ let
     aarch64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_arm64.tar.gz";
   };
 in
-pkgs.stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "doesnotmatter";
   version = "1.2.1";
   src = fetchurl {

--- a/internal/pipe/nix/testdata/TestRunPipe/unibin-replaces_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/unibin-replaces_build.nix.golden
@@ -2,10 +2,10 @@
 # vim: set ft=nix ts=2 sw=2 sts=2 et sta
 {
 system ? builtins.currentSystem
-, pkgs
 , lib
 , fetchurl
 , installShellFiles
+, stdenvNoCC
 }:
 let
   shaMap = {
@@ -24,7 +24,7 @@ let
     aarch64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_all.tar.gz";
   };
 in
-pkgs.stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "unibin-replaces";
   version = "1.2.1";
   src = fetchurl {

--- a/internal/pipe/nix/testdata/TestRunPipe/unibin-replaces_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/unibin-replaces_publish.nix.golden
@@ -2,10 +2,10 @@
 # vim: set ft=nix ts=2 sw=2 sts=2 et sta
 {
 system ? builtins.currentSystem
-, pkgs
 , lib
 , fetchurl
 , installShellFiles
+, stdenvNoCC
 }:
 let
   shaMap = {
@@ -24,7 +24,7 @@ let
     aarch64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_all.tar.gz";
   };
 in
-pkgs.stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "unibin-replaces";
   version = "1.2.1";
   src = fetchurl {

--- a/internal/pipe/nix/testdata/TestRunPipe/wrapped-in-dir_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/wrapped-in-dir_build.nix.golden
@@ -2,10 +2,10 @@
 # vim: set ft=nix ts=2 sw=2 sts=2 et sta
 {
 system ? builtins.currentSystem
-, pkgs
 , lib
 , fetchurl
 , installShellFiles
+, stdenvNoCC
 }:
 let
   shaMap = {
@@ -31,7 +31,7 @@ let
     aarch64-darwin = "./foo_arm64";
   };
 in
-pkgs.stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "wrapped-in-dir";
   version = "1.2.1";
   src = fetchurl {

--- a/internal/pipe/nix/testdata/TestRunPipe/wrapped-in-dir_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/wrapped-in-dir_publish.nix.golden
@@ -2,10 +2,10 @@
 # vim: set ft=nix ts=2 sw=2 sts=2 et sta
 {
 system ? builtins.currentSystem
-, pkgs
 , lib
 , fetchurl
 , installShellFiles
+, stdenvNoCC
 }:
 let
   shaMap = {
@@ -31,7 +31,7 @@ let
     aarch64-darwin = "./foo_arm64";
   };
 in
-pkgs.stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "wrapped-in-dir";
   version = "1.2.1";
   src = fetchurl {

--- a/internal/pipe/nix/testdata/TestRunPipe/zip-and-tar_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip-and-tar_build.nix.golden
@@ -2,7 +2,6 @@
 # vim: set ft=nix ts=2 sw=2 sts=2 et sta
 {
 system ? builtins.currentSystem
-, pkgs
 , lib
 , fetchurl
 , installShellFiles
@@ -23,7 +22,7 @@ let
     aarch64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_arm64.zip";
   };
 in
-pkgs.stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "foozip";
   version = "1.2.1";
   src = fetchurl {

--- a/internal/pipe/nix/testdata/TestRunPipe/zip-and-tar_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip-and-tar_publish.nix.golden
@@ -2,7 +2,6 @@
 # vim: set ft=nix ts=2 sw=2 sts=2 et sta
 {
 system ? builtins.currentSystem
-, pkgs
 , lib
 , fetchurl
 , installShellFiles
@@ -23,7 +22,7 @@ let
     aarch64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_arm64.zip";
   };
 in
-pkgs.stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "foozip";
   version = "1.2.1";
   src = fetchurl {

--- a/internal/pipe/nix/testdata/TestRunPipe/zip-with-dependencies_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip-with-dependencies_build.nix.golden
@@ -2,7 +2,6 @@
 # vim: set ft=nix ts=2 sw=2 sts=2 et sta
 {
 system ? builtins.currentSystem
-, pkgs
 , lib
 , fetchurl
 , installShellFiles
@@ -28,7 +27,7 @@ let
     aarch64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_arm64.zip";
   };
 in
-pkgs.stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "foozip";
   version = "1.2.1";
   src = fetchurl {

--- a/internal/pipe/nix/testdata/TestRunPipe/zip-with-dependencies_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip-with-dependencies_publish.nix.golden
@@ -2,7 +2,6 @@
 # vim: set ft=nix ts=2 sw=2 sts=2 et sta
 {
 system ? builtins.currentSystem
-, pkgs
 , lib
 , fetchurl
 , installShellFiles
@@ -28,7 +27,7 @@ let
     aarch64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_arm64.zip";
   };
 in
-pkgs.stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "foozip";
   version = "1.2.1";
   src = fetchurl {

--- a/internal/pipe/nix/testdata/TestRunPipe/zip_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip_build.nix.golden
@@ -2,7 +2,6 @@
 # vim: set ft=nix ts=2 sw=2 sts=2 et sta
 {
 system ? builtins.currentSystem
-, pkgs
 , lib
 , fetchurl
 , installShellFiles
@@ -27,7 +26,7 @@ let
     aarch64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_arm64.zip";
   };
 in
-pkgs.stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "foozip";
   version = "1.2.1";
   src = fetchurl {

--- a/internal/pipe/nix/testdata/TestRunPipe/zip_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip_publish.nix.golden
@@ -2,7 +2,6 @@
 # vim: set ft=nix ts=2 sw=2 sts=2 et sta
 {
 system ? builtins.currentSystem
-, pkgs
 , lib
 , fetchurl
 , installShellFiles
@@ -27,7 +26,7 @@ let
     aarch64-darwin = "https://dummyhost/download/v1.2.1/foo_darwin_arm64.zip";
   };
 in
-pkgs.stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "foozip";
   version = "1.2.1";
   src = fetchurl {

--- a/internal/pipe/nix/tmpl.nix
+++ b/internal/pipe/nix/tmpl.nix
@@ -2,14 +2,13 @@
 # vim: set ft=nix ts=2 sw=2 sts=2 et sta
 {
 system ? builtins.currentSystem
-, pkgs
 , lib
 , fetchurl
 , installShellFiles
 {{- if .Dependencies }}
 , makeWrapper
+{{- end }}
 , stdenvNoCC
-{{- end -}}
 {{- range $index, $element := .Dependencies }}
 , {{ . -}}
 {{- end }}
@@ -89,7 +88,7 @@ let
   };
   {{- end }}
 in
-pkgs.stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "{{ .Name }}";
   version = "{{ .Version }}";
   src = fetchurl {


### PR DESCRIPTION
- use stdenvNoCC instead of pkgs.stdenvNoCC
- always include stdenvNoCC, even if no deps
- use stdenvNoCC.is(Darwin/Linux) instead of stdenv's

refs #4358
refs 003a8815
