### PR TITLE
Fix sort order of brew artifacts

### DIFF
--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -466,7 +466,7 @@ func dataFor(ctx *context.Context, cfg config.Homebrew, cl client.ReleaseURLTemp
 }
 
 func lessFnFor(list []releasePackage) func(i, j int) bool {
-	return func(i, j int) bool { return list[i].OS > list[j].OS && list[i].Arch > list[j].Arch }
+	return func(i, j int) bool { return list[i].Arch < list[j].Arch }
 }
 
 func split(s string) []string {

--- a/internal/pipe/brew/testdata/TestRunPipeForMultipleAmd64Versions/v1.rb.golden
+++ b/internal/pipe/brew/testdata/TestRunPipeForMultipleAmd64Versions/v1.rb.golden
@@ -20,8 +20,8 @@ class V1 < Formula
   end
 
   on_linux do
-    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
+    if Hardware::CPU.intel?
+      url "https://dummyhost/download/v1.0.1/amd64v2.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
       def install
@@ -29,8 +29,8 @@ class V1 < Formula
         man1.install "./man/foo.1.gz"
       end
     end
-    if Hardware::CPU.intel?
-      url "https://dummyhost/download/v1.0.1/amd64v2.tar.gz"
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
       def install

--- a/internal/pipe/brew/testdata/TestRunPipeForMultipleAmd64Versions/v2.rb.golden
+++ b/internal/pipe/brew/testdata/TestRunPipeForMultipleAmd64Versions/v2.rb.golden
@@ -20,8 +20,8 @@ class V2 < Formula
   end
 
   on_linux do
-    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
+    if Hardware::CPU.intel?
+      url "https://dummyhost/download/v1.0.1/amd64v2.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
       def install
@@ -29,8 +29,8 @@ class V2 < Formula
         man1.install "./man/foo.1.gz"
       end
     end
-    if Hardware::CPU.intel?
-      url "https://dummyhost/download/v1.0.1/amd64v2.tar.gz"
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
       def install

--- a/internal/pipe/brew/testdata/TestRunPipeForMultipleAmd64Versions/v3.rb.golden
+++ b/internal/pipe/brew/testdata/TestRunPipeForMultipleAmd64Versions/v3.rb.golden
@@ -20,8 +20,8 @@ class V3 < Formula
   end
 
   on_linux do
-    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
+    if Hardware::CPU.intel?
+      url "https://dummyhost/download/v1.0.1/amd64v3.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
       def install
@@ -29,8 +29,8 @@ class V3 < Formula
         man1.install "./man/foo.1.gz"
       end
     end
-    if Hardware::CPU.intel?
-      url "https://dummyhost/download/v1.0.1/amd64v3.tar.gz"
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
       def install

--- a/internal/pipe/brew/testdata/TestRunPipeForMultipleAmd64Versions/v4.rb.golden
+++ b/internal/pipe/brew/testdata/TestRunPipeForMultipleAmd64Versions/v4.rb.golden
@@ -20,8 +20,8 @@ class V4 < Formula
   end
 
   on_linux do
-    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
+    if Hardware::CPU.intel?
+      url "https://dummyhost/download/v1.0.1/amd64v3.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
       def install
@@ -29,8 +29,8 @@ class V4 < Formula
         man1.install "./man/foo.1.gz"
       end
     end
-    if Hardware::CPU.intel?
-      url "https://dummyhost/download/v1.0.1/amd64v3.tar.gz"
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
       def install

--- a/internal/pipe/brew/testdata/TestRunPipeForMultipleArmVersions/multiple_armv5.rb.golden
+++ b/internal/pipe/brew/testdata/TestRunPipeForMultipleArmVersions/multiple_armv5.rb.golden
@@ -30,16 +30,16 @@ class MultipleArmv5 < Formula
   end
 
   on_linux do
-    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
+    if Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
+      url "https://dummyhost/download/v1.0.1/armv5.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
       def install
         bin.install "multiple_armv5"
       end
     end
-    if Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-      url "https://dummyhost/download/v1.0.1/armv5.tar.gz"
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
       def install

--- a/internal/pipe/brew/testdata/TestRunPipeForMultipleArmVersions/multiple_armv6.rb.golden
+++ b/internal/pipe/brew/testdata/TestRunPipeForMultipleArmVersions/multiple_armv6.rb.golden
@@ -30,16 +30,16 @@ class MultipleArmv6 < Formula
   end
 
   on_linux do
-    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
+    if Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
+      url "https://dummyhost/download/v1.0.1/armv6.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
       def install
         bin.install "multiple_armv6"
       end
     end
-    if Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-      url "https://dummyhost/download/v1.0.1/armv6.tar.gz"
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
       def install

--- a/internal/pipe/brew/testdata/TestRunPipeForMultipleArmVersions/multiple_armv7.rb.golden
+++ b/internal/pipe/brew/testdata/TestRunPipeForMultipleArmVersions/multiple_armv7.rb.golden
@@ -30,16 +30,16 @@ class MultipleArmv7 < Formula
   end
 
   on_linux do
-    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
+    if Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
+      url "https://dummyhost/download/v1.0.1/armv7.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
       def install
         bin.install "multiple_armv7"
       end
     end
-    if Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-      url "https://dummyhost/download/v1.0.1/armv7.tar.gz"
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
       def install


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

Fix the order in which brew artifacts are sorted.

<!-- Why is this change being made? -->

* The order occasionally switches, which results in a larger diff: https://github.com/confluentinc/homebrew-tap/pull/41
* The artifacts are already grouped by OS before `lessFnFor()` is called, so `list[i].OS > list[j].OS` always evaluates to `false` and the order remains unchanged. This PR removes that statement.
* It looks like a `map` is used earlier, while filtering the artifacts, which might explain why the order occasionally switches.
* Update the remaining statement in `lessFnFor()` to actually use `<` as the function suggests.

<!-- # Provide links to any relevant tickets, URLs or other resources -->
