### PR TITLE
feat(pipe/release): Mark GitHub releases as non-draft only after all artifacts are uploaded.

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -52,7 +52,9 @@ func (r Repo) String() string {
 // Client interface.
 type Client interface {
 	CloseMilestone(ctx *context.Context, repo Repo, title string) (err error)
+	// Creates a release. It's marked as draft if possible (should call PublishRelease to finish publishing).
 	CreateRelease(ctx *context.Context, body string) (releaseID string, err error)
+	PublishRelease(ctx *context.Context, releaseID string) (err error)
 	Upload(ctx *context.Context, releaseID string, artifact *artifact.Artifact, file *os.File) (err error)
 	Changelog(ctx *context.Context, repo Repo, prev, current string) (string, error)
 	ReleaseURLTemplater

--- a/internal/client/gitea.go
+++ b/internal/client/gitea.go
@@ -276,6 +276,11 @@ func (c *giteaClient) CreateRelease(ctx *context.Context, body string) (string, 
 	return strconv.FormatInt(release.ID, 10), nil
 }
 
+func (c *giteaClient) PublishRelease(ctx *context.Context, releaseID string) (err error) {
+	// TODO: Create release as draft while uploading artifacts and only publish it here.
+	return nil
+}
+
 func (c *giteaClient) ReleaseURLTemplate(ctx *context.Context) (string, error) {
 	downloadURL, err := tmpl.New(ctx).Apply(ctx.Config.GiteaURLs.Download)
 	if err != nil {

--- a/internal/client/gitea.go
+++ b/internal/client/gitea.go
@@ -276,7 +276,7 @@ func (c *giteaClient) CreateRelease(ctx *context.Context, body string) (string, 
 	return strconv.FormatInt(release.ID, 10), nil
 }
 
-func (c *giteaClient) PublishRelease(ctx *context.Context, releaseID string) (err error) {
+func (c *giteaClient) PublishRelease(_ *context.Context, _ string /* releaseID */) (err error) {
 	// TODO: Create release as draft while uploading artifacts and only publish it here.
 	return nil
 }

--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -349,6 +349,11 @@ func (c *gitlabClient) CreateRelease(ctx *context.Context, body string) (release
 	return tagName, err // gitlab references a tag in a repo by its name
 }
 
+func (c *gitlabClient) PublishRelease(ctx *context.Context, releaseID string) (err error) {
+	// GitLab doesn't support draft releases. So a created release is already published.
+	return nil
+}
+
 func (c *gitlabClient) ReleaseURLTemplate(ctx *context.Context) (string, error) {
 	var urlTemplate string
 	gitlabName, err := tmpl.New(ctx).Apply(ctx.Config.Release.GitLab.Name)

--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -348,7 +348,7 @@ func (c *gitlabClient) CreateRelease(ctx *context.Context, body string) (release
 	return tagName, err // gitlab references a tag in a repo by its name
 }
 
-func (c *gitlabClient) PublishRelease(ctx *context.Context, releaseID string) (err error) {
+func (c *gitlabClient) PublishRelease(_ *context.Context, _ string /* releaseID */) (err error) {
 	// GitLab doesn't support draft releases. So a created release is already published.
 	return nil
 }

--- a/internal/client/mock.go
+++ b/internal/client/mock.go
@@ -82,7 +82,7 @@ func (c *Mock) CreateRelease(_ *context.Context, _ string) (string, error) {
 	return "", nil
 }
 
-func (c *Mock) PublishRelease(ctx *context.Context, releaseID string) (err error) {
+func (c *Mock) PublishRelease(_ *context.Context, _ string /* releaseID */) (err error) {
 	c.ReleasePublished = true
 	return nil
 }

--- a/internal/client/mock.go
+++ b/internal/client/mock.go
@@ -31,6 +31,7 @@ type Mock struct {
 	FailToUpload         bool
 	CreatedRelease       bool
 	UploadedFile         bool
+	ReleasePublished     bool
 	UploadedFileNames    []string
 	UploadedFilePaths    map[string]string
 	FailFirstUpload      bool
@@ -79,6 +80,11 @@ func (c *Mock) CreateRelease(_ *context.Context, _ string) (string, error) {
 	}
 	c.CreatedRelease = true
 	return "", nil
+}
+
+func (c *Mock) PublishRelease(ctx *context.Context, releaseID string) (err error) {
+	c.ReleasePublished = true
+	return nil
 }
 
 func (c *Mock) ReleaseURLTemplate(_ *context.Context) (string, error) {

--- a/internal/pipe/release/release.go
+++ b/internal/pipe/release/release.go
@@ -171,7 +171,11 @@ func doPublish(ctx *context.Context, client client.Client) error {
 			return upload(ctx, client, releaseID, artifact)
 		})
 	}
-	return g.Wait()
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	return client.PublishRelease(ctx, releaseID)
 }
 
 func upload(ctx *context.Context, cli client.Client, releaseID string, artifact *artifact.Artifact) error {

--- a/internal/pipe/release/release_test.go
+++ b/internal/pipe/release/release_test.go
@@ -117,6 +117,7 @@ func TestRunPipeWithoutIDsThenDoesNotFilter(t *testing.T) {
 	require.NoError(t, doPublish(ctx, client))
 	require.True(t, client.CreatedRelease)
 	require.True(t, client.UploadedFile)
+	require.True(t, client.ReleasePublished)
 	require.Contains(t, client.UploadedFileNames, "source.tar.gz")
 	require.Contains(t, client.UploadedFileNames, "bin.deb")
 	require.Contains(t, client.UploadedFileNames, "bin.tar.gz")
@@ -192,6 +193,7 @@ func TestRunPipeWithIDsThenFilters(t *testing.T) {
 	require.NoError(t, doPublish(ctx, client))
 	require.True(t, client.CreatedRelease)
 	require.True(t, client.UploadedFile)
+	require.True(t, client.ReleasePublished)
 	require.Contains(t, client.UploadedFileNames, "bin.deb")
 	require.Contains(t, client.UploadedFileNames, "bin.tar.gz")
 	require.Contains(t, client.UploadedFileNames, "f1")
@@ -215,6 +217,7 @@ func TestRunPipeReleaseCreationFailed(t *testing.T) {
 	require.Error(t, doPublish(ctx, client))
 	require.False(t, client.CreatedRelease)
 	require.False(t, client.UploadedFile)
+	require.False(t, client.ReleasePublished)
 }
 
 func TestRunPipeWithFileThatDontExist(t *testing.T) {
@@ -262,6 +265,7 @@ func TestRunPipeUploadFailure(t *testing.T) {
 	require.EqualError(t, doPublish(ctx, client), "failed to upload bin.tar.gz after 1 tries: upload failed")
 	require.True(t, client.CreatedRelease)
 	require.False(t, client.UploadedFile)
+	require.False(t, client.ReleasePublished)
 }
 
 func TestRunPipeExtraFileNotFound(t *testing.T) {
@@ -330,6 +334,7 @@ func TestRunPipeUploadRetry(t *testing.T) {
 	require.NoError(t, doPublish(ctx, client))
 	require.True(t, client.CreatedRelease)
 	require.True(t, client.UploadedFile)
+	require.True(t, client.ReleasePublished)
 }
 
 func TestDefault(t *testing.T) {

--- a/www/docs/customization/release.md
+++ b/www/docs/customization/release.md
@@ -290,10 +290,6 @@ release:
   # You can disable this pipe in order to not upload any artifacts.
   disable: true
 
-  # If set to true, will not auto-publish the release.
-  # Available only for GitHub and Gitea.
-  draft: true
-
   # What to do with the release notes in case there the release already exists.
   #
   # Valid options are:

--- a/www/docs/customization/release.md
+++ b/www/docs/customization/release.md
@@ -26,6 +26,7 @@ release:
     - bar
 
   # If set to true, will not auto-publish the release.
+  # Note: all GitHub releases start as drafts while artifacts are uploaded.
   # Available only for GitHub and Gitea.
   draft: true
 
@@ -288,6 +289,10 @@ release:
 
   # You can disable this pipe in order to not upload any artifacts.
   disable: true
+
+  # If set to true, will not auto-publish the release.
+  # Available only for GitHub and Gitea.
+  draft: true
 
   # What to do with the release notes in case there the release already exists.
   #


### PR DESCRIPTION
Previously end-users would see missing artifacts if trying to use latest version while artifacts are being uploaded.

This currently applies only to GitHub releases. GitLab does not support drafts, and I don't dare to make the change for Gitea since I don't use it (and can't test easily).