### PR TITLE
test(pipe): fix tests cleanup

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,6 +15,7 @@ linters:
     - misspell
     - depguard
     - testifylint
+    - gocritic
 linters-settings:
   staticcheck:
     checks:
@@ -35,3 +36,6 @@ linters-settings:
         deny:
           - pkg: "github.com/pkg/errors"
             desc: "use stdlib instead"
+  gocritic:
+    enabled-checks:
+      - exitAfterDefer

--- a/internal/pipe/before/before_test.go
+++ b/internal/pipe/before/before_test.go
@@ -15,8 +15,9 @@ import (
 
 func TestMain(m *testing.M) {
 	log.SetLevel(log.DebugLevel)
-	defer log.SetLevel(log.InfoLevel)
-	os.Exit(m.Run())
+	code := m.Run()
+	log.SetLevel(log.InfoLevel)
+	os.Exit(code)
 }
 
 func TestDescription(t *testing.T) {

--- a/internal/pipe/sign/sign_test.go
+++ b/internal/pipe/sign/sign_test.go
@@ -46,8 +46,9 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	defer os.RemoveAll(keyring)
-	os.Exit(m.Run())
+	code := m.Run()
+	_ = os.RemoveAll(keyring)
+	os.Exit(code)
 }
 
 func TestDescription(t *testing.T) {


### PR DESCRIPTION
This PR fixes cleanup in `TestMain` for `before` and `sign` tests, where`defer` is not called after `os.Exit`. This is [a common gotcha](https://gobyexample.com/exit) in Go, as `os.Exit` does not respect `defer` statements.

Additionally, the PR enables `gocritic` linter with [`exitAfterDefer` check](https://go-critic.com/overview.html#exitafterdefer) to prevent introducing this bug in the future.