### PR TITLE
chore: fix all existing lint issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,4 +26,4 @@ jobs:
         uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v3
         with:
           args: --timeout=5m
-          only-new-issues: true
+          version: v1.56.2

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -39,3 +39,7 @@ linters-settings:
   gocritic:
     enabled-checks:
       - exitAfterDefer
+  testifylint:
+    enable-all: true
+    disable:
+      - error-is-as # false positive

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -69,7 +69,7 @@ When using ` + "`--single-target`" + `, the ` + "`GOOS`" + ` and ` + "`GOARCH`" 
 		SilenceErrors:     true,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
-		RunE: timedRunE("build", func(cmd *cobra.Command, args []string) error {
+		RunE: timedRunE("build", func(_ *cobra.Command, _ []string) error {
 			ctx, err := buildProject(root.opts)
 			if err != nil {
 				return err

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -21,7 +21,7 @@ func newDocsCmd() *docsCmd {
 		Hidden:                true,
 		Args:                  cobra.NoArgs,
 		ValidArgsFunction:     cobra.NoFileCompletions,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			root.cmd.Root().DisableAutoGenTag = true
 			return doc.GenMarkdownTreeCustom(root.cmd.Root(), "www/docs/cmd", func(_ string) string {
 				return ""

--- a/cmd/healthcheck.go
+++ b/cmd/healthcheck.go
@@ -33,7 +33,7 @@ func newHealthcheckCmd() *healthcheckCmd {
 		SilenceErrors:     true,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if root.quiet {
 				log.Log = log.New(io.Discard)
 			}

--- a/cmd/man.go
+++ b/cmd/man.go
@@ -23,7 +23,7 @@ func newManCmd() *manCmd {
 		Hidden:                true,
 		Args:                  cobra.NoArgs,
 		ValidArgsFunction:     cobra.NoFileCompletions,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			manPage, err := mcoral.NewManPage(1, root.cmd.Root())
 			if err != nil {
 				return err

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -26,7 +26,7 @@ func newSchemaCmd() *schemaCmd {
 		SilenceErrors:     true,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			schema := jsonschema.Reflect(&config.Project{})
 			schema.Definitions["FileInfo"] = jsonschema.Reflect(&config.FileInfo{})
 			schema.Description = "goreleaser configuration definition file"

--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -635,7 +635,7 @@ func TestVisit(t *testing.T) {
 	})
 
 	t.Run("nok", func(t *testing.T) {
-		require.EqualError(t, artifacts.Visit(func(a *Artifact) error {
+		require.EqualError(t, artifacts.Visit(func(_ *Artifact) error {
 			return fmt.Errorf("fake err")
 		}), `fake err`)
 	})

--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -322,7 +322,6 @@ func (c *gitlabClient) CreateRelease(ctx *context.Context, body string) (release
 			Ref:         &ref,
 			TagName:     &tagName,
 		})
-
 		if err != nil {
 			log.WithError(err).Debug("error creating release")
 			return "", err

--- a/internal/gio/safe_test.go
+++ b/internal/gio/safe_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,8 +21,8 @@ func TestSafe(t *testing.T) {
 	for i := 0; i < chars; i++ {
 		go func() {
 			s, err := io.WriteString(w, "a")
-			require.Equal(t, 1, s)
-			require.NoError(t, err)
+			assert.Equal(t, 1, s)
+			assert.NoError(t, err)
 			wg.Done()
 		}()
 	}

--- a/internal/http/http_test.go
+++ b/internal/http/http_test.go
@@ -214,7 +214,7 @@ func TestUpload(t *testing.T) {
 		w.WriteHeader(h.StatusCreated)
 		w.Header().Set("Location", r.URL.RequestURI())
 	}))
-	assetOpen = func(k string, a *artifact.Artifact) (*asset, error) {
+	assetOpen = func(_ string, _ *artifact.Artifact) (*asset, error) {
 		return &asset{
 			ReadCloser: io.NopCloser(bytes.NewReader(content)),
 			Size:       int64(len(content)),

--- a/internal/middleware/errhandler/error_test.go
+++ b/internal/middleware/errhandler/error_test.go
@@ -12,19 +12,19 @@ import (
 
 func TestError(t *testing.T) {
 	t.Run("no errors", func(t *testing.T) {
-		require.NoError(t, Handle(func(ctx *context.Context) error {
+		require.NoError(t, Handle(func(_ *context.Context) error {
 			return nil
 		})(nil))
 	})
 
 	t.Run("pipe skipped", func(t *testing.T) {
-		require.NoError(t, Handle(func(ctx *context.Context) error {
+		require.NoError(t, Handle(func(_ *context.Context) error {
 			return pipe.ErrSkipValidateEnabled
 		})(nil))
 	})
 
 	t.Run("some err", func(t *testing.T) {
-		require.Error(t, Handle(func(ctx *context.Context) error {
+		require.Error(t, Handle(func(_ *context.Context) error {
 			return fmt.Errorf("pipe errored")
 		})(nil))
 	})
@@ -33,19 +33,19 @@ func TestError(t *testing.T) {
 func TestErrorMemo(t *testing.T) {
 	memo := Memo{}
 	t.Run("no errors", func(t *testing.T) {
-		require.NoError(t, memo.Wrap(func(ctx *context.Context) error {
+		require.NoError(t, memo.Wrap(func(_ *context.Context) error {
 			return nil
 		})(nil))
 	})
 
 	t.Run("pipe skipped", func(t *testing.T) {
-		require.NoError(t, memo.Wrap(func(ctx *context.Context) error {
+		require.NoError(t, memo.Wrap(func(_ *context.Context) error {
 			return pipe.ErrSkipValidateEnabled
 		})(nil))
 	})
 
 	t.Run("some err", func(t *testing.T) {
-		require.NoError(t, memo.Wrap(func(ctx *context.Context) error {
+		require.NoError(t, memo.Wrap(func(_ *context.Context) error {
 			return fmt.Errorf("pipe errored")
 		})(nil))
 	})

--- a/internal/middleware/logging/logging_test.go
+++ b/internal/middleware/logging/logging_test.go
@@ -9,11 +9,11 @@ import (
 )
 
 func TestLogging(t *testing.T) {
-	require.NoError(t, Log("foo", func(ctx *context.Context) error {
+	require.NoError(t, Log("foo", func(_ *context.Context) error {
 		return nil
 	})(nil))
 
-	require.NoError(t, PadLog("foo", func(ctx *context.Context) error {
+	require.NoError(t, PadLog("foo", func(_ *context.Context) error {
 		log.Info("a")
 		return nil
 	})(nil))

--- a/internal/pipe/chocolatey/chocolatey_test.go
+++ b/internal/pipe/chocolatey/chocolatey_test.go
@@ -274,7 +274,7 @@ func TestPublish(t *testing.T) {
 					},
 				},
 			},
-			exec: func(cmd string, args ...string) ([]byte, error) {
+			exec: func(_ string, _ ...string) ([]byte, error) {
 				return nil, errors.New(`unable to push`)
 			},
 			err: "failed to push chocolatey package: unable to push: ",

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -53,7 +53,7 @@ func TestRunPipe(t *testing.T) {
 	}
 	type imageLabelFinder func(*testing.T, string)
 	shouldFindImagesWithLabels := func(image string, filters ...string) func(*testing.T, string) {
-		return func(t *testing.T, use string) {
+		return func(t *testing.T, _ string) {
 			t.Helper()
 			for _, filter := range filters {
 				cmd := exec.Command("docker", "images", "-q", "--filter", "reference=*/"+image, "--filter", filter)

--- a/internal/pipe/gomod/gomod_proxy_test.go
+++ b/internal/pipe/gomod/gomod_proxy_test.go
@@ -122,8 +122,6 @@ func TestGoModProxy(t *testing.T) {
 		require.Equal(t, ".", ctx.Config.Builds[0].UnproxiedMain)
 		require.Equal(t, filepath.Join(dist, "proxy", "foo"), ctx.Config.Builds[0].Dir)
 		require.Equal(t, ".", ctx.Config.Builds[0].UnproxiedDir)
-
-		require.Equal(t, ctx.ModulePath, ctx.ModulePath)
 	})
 
 	t.Run("nfpm", func(t *testing.T) {
@@ -149,7 +147,6 @@ func TestGoModProxy(t *testing.T) {
 		requireGoMod(t)
 		require.Equal(t, ctx.ModulePath+"/cmd/nfpm", ctx.Config.Builds[0].Main)
 		require.Equal(t, filepath.Join(dist, "proxy", "foo"), ctx.Config.Builds[0].Dir)
-		require.Equal(t, ctx.ModulePath, ctx.ModulePath)
 	})
 
 	// this repo does not have a go.sum file, which is ok, a project might not have any dependencies
@@ -175,7 +172,6 @@ func TestGoModProxy(t *testing.T) {
 		requireGoMod(t)
 		require.Equal(t, ctx.ModulePath, ctx.Config.Builds[0].Main)
 		require.Equal(t, filepath.Join(dist, "proxy", "foo"), ctx.Config.Builds[0].Dir)
-		require.Equal(t, ctx.ModulePath, ctx.ModulePath)
 	})
 
 	t.Run("no perms", func(t *testing.T) {
@@ -236,7 +232,6 @@ func TestGoModProxy(t *testing.T) {
 		requireGoMod(t)
 		require.Equal(t, ctx.ModulePath, ctx.Config.Builds[0].Main)
 		require.Equal(t, filepath.Join(dist, "proxy", "foo"), ctx.Config.Builds[0].Dir)
-		require.Equal(t, ctx.ModulePath, ctx.ModulePath)
 	})
 }
 

--- a/internal/pipe/ko/ko.go
+++ b/internal/pipe/ko/ko.go
@@ -172,7 +172,7 @@ func (o *buildOptions) makeBuilder(ctx *context.Context) (*build.Caching, error)
 			},
 		}),
 		build.WithPlatforms(o.platforms...),
-		build.WithBaseImages(func(ctx stdctx.Context, s string) (name.Reference, build.Result, error) {
+		build.WithBaseImages(func(_ stdctx.Context, _ string) (name.Reference, build.Result, error) {
 			ref, err := name.ParseReference(o.baseImage)
 			if err != nil {
 				return nil, nil, err

--- a/internal/pipe/linkedin/client_test.go
+++ b/internal/pipe/linkedin/client_test.go
@@ -55,7 +55,7 @@ func TestCreateLinkedInClient(t *testing.T) {
 }
 
 func TestClient_Share(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		_, _ = io.WriteString(rw, `
 {
 	"sub": "foo",

--- a/internal/pipe/milestone/milestone.go
+++ b/internal/pipe/milestone/milestone.go
@@ -76,7 +76,6 @@ func doPublish(ctx *context.Context, vcsClient client.Client) error {
 			Info("closing milestone")
 
 		err = vcsClient.CloseMilestone(ctx, repo, name)
-
 		if err != nil {
 			if milestone.FailOnError {
 				return err


### PR DESCRIPTION
The PR fixes lint issues, pins `golangci-lint` to `v1.56.2`, disables `only-new-issues`, and enables `fail-on-issues` in the lint workflow. After this, all new lint issues will fail CI.

The full log of fixed lint issues:
```sh
❯ golangci-lint run
cmd/docs.go:24:14: unused-parameter: parameter 'cmd' seems to be unused, consider removing or renaming it as _ (revive)
                RunE: func(cmd *cobra.Command, args []string) error {
                           ^
cmd/man.go:26:14: unused-parameter: parameter 'cmd' seems to be unused, consider removing or renaming it as _ (revive)
                RunE: func(cmd *cobra.Command, args []string) error {
                           ^
cmd/healthcheck.go:36:14: unused-parameter: parameter 'cmd' seems to be unused, consider removing or renaming it as _ (revive)
                RunE: func(cmd *cobra.Command, args []string) error {
                           ^
cmd/build.go:72:33: unused-parameter: parameter 'cmd' seems to be unused, consider removing or renaming it as _ (revive)
                RunE: timedRunE("build", func(cmd *cobra.Command, args []string) error {
                                              ^
cmd/schema.go:29:14: unused-parameter: parameter 'cmd' seems to be unused, consider removing or renaming it as _ (revive)
                RunE: func(cmd *cobra.Command, args []string) error {
                           ^
internal/pipe/nix/nix_test.go:547:5: error-is-as: second argument to require.ErrorAs should not be *error (testifylint)
                                require.ErrorAs(t, err, &tt.expectDefaultErrorIs)
                                ^
internal/pipe/nix/nix_test.go:556:5: error-is-as: second argument to require.ErrorAs should not be *error (testifylint)
                                require.ErrorAs(t, err, &tt.expectRunErrorIs)
                                ^
internal/pipe/nix/nix_test.go:567:5: error-is-as: second argument to require.ErrorAs should not be *error (testifylint)
                                require.ErrorAs(t, err, &tt.expectPublishErrorIs)
                                ^
internal/pipe/winget/winget_test.go:709:5: error-is-as: second argument to require.ErrorAs should not be *error (testifylint)
                                require.ErrorAs(t, err, &tt.expectPublishErrorIs)
                                ^
internal/pipe/winget/winget_test.go:728:5: error-is-as: second argument to require.ErrorAs should not be *error (testifylint)
                                require.ErrorAs(t, err, &tt.expectPublishErrorIs)
                                ^
internal/pipe/docker/docker_test.go:56:29: unused-parameter: parameter 'use' seems to be unused, consider removing or renaming it as _ (revive)
                return func(t *testing.T, use string) {
                                          ^
internal/gio/safe_test.go:23:4: go-require: require must only be used in the goroutine running the test function (testifylint)
                        require.Equal(t, 1, s)
                        ^
internal/gio/safe_test.go:24:4: go-require: require must only be used in the goroutine running the test function (testifylint)
                        require.NoError(t, err)
                        ^
internal/pipe/gomod/gomod_proxy_test.go:126:3: useless-assert: asserting of the same variable (testifylint)
                require.Equal(t, ctx.ModulePath, ctx.ModulePath)
                ^
internal/pipe/gomod/gomod_proxy_test.go:152:3: useless-assert: asserting of the same variable (testifylint)
                require.Equal(t, ctx.ModulePath, ctx.ModulePath)
                ^
internal/pipe/gomod/gomod_proxy_test.go:178:3: useless-assert: asserting of the same variable (testifylint)
                require.Equal(t, ctx.ModulePath, ctx.ModulePath)
                ^
internal/pipe/gomod/gomod_proxy_test.go:239:3: useless-assert: asserting of the same variable (testifylint)
                require.Equal(t, ctx.ModulePath, ctx.ModulePath)
                ^
internal/artifact/artifact_test.go:638:46: unused-parameter: parameter 'a' seems to be unused, consider removing or renaming it as _ (revive)
                require.EqualError(t, artifacts.Visit(func(a *Artifact) error {
                                                           ^
internal/pipe/milestone/milestone.go:79: File is not `gofumpt`-ed (gofumpt)

internal/http/http_test.go:217:19: unused-parameter: parameter 'k' seems to be unused, consider removing or renaming it as _ (revive)
        assetOpen = func(k string, a *artifact.Artifact) (*asset, error) {
                         ^
internal/middleware/logging/logging_test.go:12:37: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
        require.NoError(t, Log("foo", func(ctx *context.Context) error {
                                           ^
internal/middleware/logging/logging_test.go:16:40: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
        require.NoError(t, PadLog("foo", func(ctx *context.Context) error {
                                              ^
internal/pipe/chocolatey/chocolatey_test.go:277:15: unused-parameter: parameter 'cmd' seems to be unused, consider removing or renaming it as _ (revive)
                        exec: func(cmd string, args ...string) ([]byte, error) {
                                   ^
internal/client/gitlab.go:325: File is not `gofumpt`-ed (gofumpt)

internal/pipe/linkedin/client_test.go:58:77: unused-parameter: parameter 'req' seems to be unused, consider removing or renaming it as _ (revive)
        server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
                                                                                   ^
internal/middleware/errhandler/error_test.go:15:34: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
                require.NoError(t, Handle(func(ctx *context.Context) error {
                                               ^
internal/middleware/errhandler/error_test.go:21:34: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
                require.NoError(t, Handle(func(ctx *context.Context) error {
                                               ^
internal/middleware/errhandler/error_test.go:27:32: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
                require.Error(t, Handle(func(ctx *context.Context) error {
                                             ^
internal/middleware/errhandler/error_test.go:36:37: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
                require.NoError(t, memo.Wrap(func(ctx *context.Context) error {
                                                  ^
internal/middleware/errhandler/error_test.go:42:37: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
                require.NoError(t, memo.Wrap(func(ctx *context.Context) error {
                                                  ^
internal/middleware/errhandler/error_test.go:48:37: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
                require.NoError(t, memo.Wrap(func(ctx *context.Context) error {
                                                  ^
internal/pipe/ko/ko.go:175:29: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
                build.WithBaseImages(func(ctx stdctx.Context, s string) (name.Reference, build.Result, error) {
                                          ^
```