### PR TITLE
test: simplify error asserts with require.ErrorContains

### DIFF
--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -642,7 +642,7 @@ func TestBuildFailed(t *testing.T) {
 	err := Default.Build(ctx, ctx.Config.Builds[0], api.Options{
 		Target: "darwin_amd64",
 	})
-	assertContainsError(t, err, `flag provided but not defined: -flag-that-dont-exists-to-force-failure`)
+	require.ErrorContains(t, err, `flag provided but not defined: -flag-that-dont-exists-to-force-failure`)
 	require.Empty(t, ctx.Artifacts.List())
 }
 
@@ -1444,10 +1444,4 @@ func writeTest(t *testing.T, folder string) {
 		[]byte("module foo\n"),
 		0o666,
 	))
-}
-
-func assertContainsError(t *testing.T, err error, s string) {
-	t.Helper()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), s)
 }

--- a/internal/client/git_test.go
+++ b/internal/client/git_test.go
@@ -162,8 +162,7 @@ func TestGitClient(t *testing.T) {
 			"filename",
 			"msg",
 		)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to clone")
+		require.ErrorContains(t, err, "failed to clone")
 	})
 	t.Run("bad ssh cmd", func(t *testing.T) {
 		ctx := testctx.NewWithCfg(config.Project{

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -17,13 +17,8 @@ func TestGit(t *testing.T) {
 	require.NotEmpty(t, out)
 
 	out, err = git.Run(ctx, "command-that-dont-exist")
-	require.Error(t, err)
+	require.EqualError(t, err, "git: 'command-that-dont-exist' is not a git command. See 'git --help'.\n")
 	require.Empty(t, out)
-	require.Equal(
-		t,
-		"git: 'command-that-dont-exist' is not a git command. See 'git --help'.\n",
-		err.Error(),
-	)
 }
 
 func TestGitWarning(t *testing.T) {
@@ -66,23 +61,13 @@ func TestClean(t *testing.T) {
 
 	t.Run("error", func(t *testing.T) {
 		out, err := git.Clean(git.Run(ctx, "command-that-dont-exist"))
-		require.Error(t, err)
+		require.EqualError(t, err, "git: 'command-that-dont-exist' is not a git command. See 'git --help'.")
 		require.Empty(t, out)
-		require.Equal(
-			t,
-			"git: 'command-that-dont-exist' is not a git command. See 'git --help'.",
-			err.Error(),
-		)
 	})
 
 	t.Run("all lines error", func(t *testing.T) {
 		out, err := git.CleanAllLines(git.Run(ctx, "command-that-dont-exist"))
-		require.Error(t, err)
+		require.EqualError(t, err, "git: 'command-that-dont-exist' is not a git command. See 'git --help'.")
 		require.Empty(t, out)
-		require.Equal(
-			t,
-			"git: 'command-that-dont-exist' is not a git command. See 'git --help'.",
-			err.Error(),
-		)
 	})
 }

--- a/internal/pipe/archive/archive_test.go
+++ b/internal/pipe/archive/archive_test.go
@@ -964,8 +964,7 @@ func TestRunPipeSameArchiveFilename(t *testing.T) {
 	ctx.Version = "0.0.1"
 	ctx.Git.CurrentTag = "v0.0.1"
 	err = Pipe{}.Run(ctx)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "same-filename.tar.gz already exists. Check your archive name template")
+	require.ErrorContains(t, err, "same-filename.tar.gz already exists. Check your archive name template")
 }
 
 func TestDuplicateFilesInsideArchive(t *testing.T) {

--- a/internal/pipe/artifactory/artifactory_test.go
+++ b/internal/pipe/artifactory/artifactory_test.go
@@ -418,8 +418,7 @@ func TestRunPipe_BadCredentials(t *testing.T) {
 
 	require.NoError(t, Pipe{}.Default(ctx))
 	err := Pipe{}.Publish(ctx)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "Bad credentials")
+	require.ErrorContains(t, err, "Bad credentials")
 }
 
 func TestRunPipe_UnparsableErrorResponse(t *testing.T) {

--- a/internal/pipe/before/before_test.go
+++ b/internal/pipe/before/before_test.go
@@ -67,7 +67,7 @@ func TestRunPipeFail(t *testing.T) {
 			},
 		)
 		err := Pipe{}.Run(ctx)
-		require.Contains(t, err.Error(), "hook failed")
+		require.ErrorContains(t, err, "hook failed")
 	}
 }
 

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -214,7 +214,7 @@ func TestRunPipeFailingHooks(t *testing.T) {
 
 		err := Pipe{}.Run(ctx)
 		require.ErrorIs(t, err, exec.ErrNotFound)
-		require.Contains(t, err.Error(), "pre hook failed")
+		require.ErrorContains(t, err, "pre hook failed")
 	})
 	t.Run("post-hook", func(t *testing.T) {
 		ctx := testctx.NewWithCfg(cfg, testctx.WithCurrentTag("2.4.5"))
@@ -222,7 +222,7 @@ func TestRunPipeFailingHooks(t *testing.T) {
 		ctx.Config.Builds[0].Hooks.Post = []config.Hook{{Cmd: "exit 1"}}
 		err := Pipe{}.Run(ctx)
 		require.ErrorIs(t, err, exec.ErrNotFound)
-		require.Contains(t, err.Error(), "post hook failed")
+		require.ErrorContains(t, err, "post hook failed")
 	})
 
 	t.Run("post-hook-skip", func(t *testing.T) {
@@ -766,6 +766,6 @@ func TestRunHookFailWithLogs(t *testing.T) {
 	}
 	ctx := testctx.NewWithCfg(config, testctx.WithCurrentTag("2.4.5"))
 	err := Pipe{}.Run(ctx)
-	require.Contains(t, err.Error(), "pre hook failed")
+	require.ErrorContains(t, err, "pre hook failed")
 	require.Empty(t, ctx.Artifacts.List())
 }

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -39,8 +39,7 @@ func TestRunPipe(t *testing.T) {
 	shouldErr := func(msg string) errChecker {
 		return func(t *testing.T, err error) {
 			t.Helper()
-			require.Error(t, err)
-			require.Contains(t, err.Error(), msg)
+			require.ErrorContains(t, err, msg)
 		}
 	}
 	shouldNotErr := func(t *testing.T, err error) {

--- a/internal/pipe/env/env_test.go
+++ b/internal/pipe/env/env_test.go
@@ -187,7 +187,7 @@ func TestEmptyGithubEnvFile(t *testing.T) {
 	})
 	err = Pipe{}.Run(ctx)
 	require.ErrorIs(t, err, syscall.EACCES)
-	require.Contains(t, err.Error(), "failed to load github token")
+	require.ErrorContains(t, err, "failed to load github token")
 }
 
 func TestEmptyGitlabEnvFile(t *testing.T) {
@@ -202,7 +202,7 @@ func TestEmptyGitlabEnvFile(t *testing.T) {
 	})
 	err = Pipe{}.Run(ctx)
 	require.ErrorIs(t, err, syscall.EACCES)
-	require.Contains(t, err.Error(), "failed to load gitlab token")
+	require.ErrorContains(t, err, "failed to load gitlab token")
 }
 
 func TestEmptyGiteaEnvFile(t *testing.T) {
@@ -217,7 +217,7 @@ func TestEmptyGiteaEnvFile(t *testing.T) {
 	})
 	err = Pipe{}.Run(ctx)
 	require.ErrorIs(t, err, syscall.EACCES)
-	require.Contains(t, err.Error(), "failed to load gitea token")
+	require.ErrorContains(t, err, "failed to load gitea token")
 }
 
 func TestInvalidEnvChecksSkipped(t *testing.T) {

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -109,8 +109,7 @@ func TestDirty(t *testing.T) {
 	require.NoError(t, os.WriteFile(dummy.Name(), []byte("lorem ipsum"), 0o644))
 	t.Run("all checks up", func(t *testing.T) {
 		err := Pipe{}.Run(testctx.New())
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "git is in a dirty state")
+		require.ErrorContains(t, err, "git is in a dirty state")
 	})
 	t.Run("skip validate is set", func(t *testing.T) {
 		ctx := testctx.New(testctx.Skip(skips.Validate))
@@ -218,8 +217,7 @@ func TestTagIsNotLastCommit(t *testing.T) {
 	testlib.GitCommit(t, "commit4")
 	ctx := testctx.New()
 	err := Pipe{}.Run(ctx)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "git tag v0.0.1 was not made against commit")
+	require.ErrorContains(t, err, "git tag v0.0.1 was not made against commit")
 	require.Contains(t, ctx.Git.Summary, "v0.0.1-1-g") // commit not represented because it changes every test
 }
 

--- a/internal/pipe/ko/ko_test.go
+++ b/internal/pipe/ko/ko_test.go
@@ -456,8 +456,7 @@ func TestPublishPipeError(t *testing.T) {
 		ctx.Config.Kos[0].CreationTime = "nope"
 		require.NoError(t, Pipe{}.Default(ctx))
 		err := Pipe{}.Publish(ctx)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), `strconv.ParseInt: parsing "nope": invalid syntax`)
+		require.ErrorContains(t, err, `strconv.ParseInt: parsing "nope": invalid syntax`)
 	})
 
 	t.Run("invalid creation time tmpl", func(t *testing.T) {
@@ -472,8 +471,7 @@ func TestPublishPipeError(t *testing.T) {
 		ctx.Config.Kos[0].KoDataCreationTime = "nope"
 		require.NoError(t, Pipe{}.Default(ctx))
 		err := Pipe{}.Publish(ctx)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), `strconv.ParseInt: parsing "nope": invalid syntax`)
+		require.ErrorContains(t, err, `strconv.ParseInt: parsing "nope": invalid syntax`)
 	})
 
 	t.Run("invalid kodata creation time tmpl", func(t *testing.T) {

--- a/internal/pipe/pipe_test.go
+++ b/internal/pipe/pipe_test.go
@@ -10,8 +10,7 @@ import (
 func TestSkipPipe(t *testing.T) {
 	reason := "this is a test"
 	err := Skip(reason)
-	require.Error(t, err)
-	require.Equal(t, reason, err.Error())
+	require.EqualError(t, err, reason)
 }
 
 func TestIsSkip(t *testing.T) {

--- a/internal/pipe/sbom/sbom_test.go
+++ b/internal/pipe/sbom/sbom_test.go
@@ -525,8 +525,7 @@ func testSBOMCataloging(
 	// run the pipeline
 	if expectedErrMsg != "" {
 		err := Pipe{}.Run(ctx)
-		require.Error(tb, err)
-		require.Contains(tb, err.Error(), expectedErrMsg)
+		require.ErrorContains(tb, err, expectedErrMsg)
 		return
 	}
 	if expectedErrAs != nil {

--- a/internal/pipe/semver/semver_test.go
+++ b/internal/pipe/semver/semver_test.go
@@ -26,6 +26,5 @@ func TestValidSemver(t *testing.T) {
 func TestInvalidSemver(t *testing.T) {
 	ctx := testctx.New(testctx.WithCurrentTag("aaaav1.5.2-rc1"))
 	err := Pipe{}.Run(ctx)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to parse tag 'aaaav1.5.2-rc1' as semver")
+	require.ErrorContains(t, err, "failed to parse tag 'aaaav1.5.2-rc1' as semver")
 }

--- a/internal/pipe/sign/sign_test.go
+++ b/internal/pipe/sign/sign_test.go
@@ -650,8 +650,7 @@ func testSign(
 
 	// run the pipeline
 	if expectedErrMsg != "" {
-		require.Error(tb, err)
-		require.Contains(tb, err.Error(), expectedErrMsg)
+		require.ErrorContains(tb, err, expectedErrMsg)
 		return
 	}
 

--- a/internal/pipe/snapcraft/snapcraft_test.go
+++ b/internal/pipe/snapcraft/snapcraft_test.go
@@ -530,7 +530,7 @@ func TestPublish(t *testing.T) {
 		},
 	})
 	err := Pipe{}.Publish(ctx)
-	require.Contains(t, err.Error(), "failed to push nope.snap package")
+	require.ErrorContains(t, err, "failed to push nope.snap package")
 }
 
 func TestDefaultSet(t *testing.T) {

--- a/internal/pipe/universalbinary/universalbinary_test.go
+++ b/internal/pipe/universalbinary/universalbinary_test.go
@@ -318,7 +318,7 @@ func TestRun(t *testing.T) {
 		ctx.Config.UniversalBinaries[0].Hooks.Post = []config.Hook{{Cmd: "echo post"}}
 		err := Pipe{}.Run(ctx)
 		require.ErrorIs(t, err, exec.ErrNotFound)
-		require.Contains(t, err.Error(), "pre hook failed")
+		require.ErrorContains(t, err, "pre hook failed")
 	})
 
 	t.Run("failing post-hook", func(t *testing.T) {
@@ -327,7 +327,7 @@ func TestRun(t *testing.T) {
 		ctx.Config.UniversalBinaries[0].Hooks.Post = []config.Hook{{Cmd: "exit 1"}}
 		err := Pipe{}.Run(ctx)
 		require.ErrorIs(t, err, exec.ErrNotFound)
-		require.Contains(t, err.Error(), "post hook failed")
+		require.ErrorContains(t, err, "post hook failed")
 	})
 
 	t.Run("skipping post-hook", func(t *testing.T) {

--- a/internal/pipe/upload/upload_test.go
+++ b/internal/pipe/upload/upload_test.go
@@ -442,8 +442,7 @@ func TestRunPipe_BadCredentials(t *testing.T) {
 	})
 
 	err := Pipe{}.Publish(ctx)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "Unauthorized")
+	require.ErrorContains(t, err, "Unauthorized")
 }
 
 func TestRunPipe_FileNotFound(t *testing.T) {


### PR DESCRIPTION
The PR refactors tests:
- change two lines `require.Error + require.Contains` with one `require.ErrorContains`;
- change `require.Error + require.Equal` with `require.EqualError`.