### PR TITLE
DOCS: Sort the GoReleaser configuration YAML code examples

### DIFF
--- a/www/docs/customization/archive.md
+++ b/www/docs/customization/archive.md
@@ -123,8 +123,8 @@ archives:
     # Those files will have their contents pass through the template engine,
     # and its results will be added to the archive.
     #
-    # Since: v1.17 (pro)
     # This feature is only available in GoReleaser Pro.
+    # Since: v1.17 (pro)
     # Templates: allowed
     templated_files:
       # a more complete example, check the globbing deep dive below

--- a/www/docs/customization/aur.md
+++ b/www/docs/customization/aur.md
@@ -159,9 +159,9 @@ aurs:
     # Only useful if you're creating your own AUR with multiple packages in a
     # single repository.
     #
+    # Since: v1.23
     # Default: .
     # Templates: allowed
-    # Since: v1.23
     directory: "."
 ```
 

--- a/www/docs/customization/blob.md
+++ b/www/docs/customization/blob.md
@@ -113,9 +113,9 @@ blobs:
     # If you need different `content_disposition` options for different files,
     # create multiple `blobs` configurations.
     #
+    # Since: v1.24
     # Default: attachment;filename={{.Filename}}
     # Templates: allowed
-    # Since: v1.24
     content_disposition: "inline"
 
   - provider: gs

--- a/www/docs/customization/blob.md
+++ b/www/docs/customization/blob.md
@@ -73,8 +73,8 @@ blobs:
     # Those files will have their contents pass through the template engine,
     # and its results will be uploaded.
     #
-    # Since: v1.17 (pro)
     # This feature is only available in GoReleaser Pro.
+    # Since: v1.17 (pro)
     # Templates: allowed
     templated_extra_files:
       - src: LICENSE.tpl

--- a/www/docs/customization/builds.md
+++ b/www/docs/customization/builds.md
@@ -186,7 +186,7 @@ builds:
     # you would do this to ensure a build was reproducible.
     # Pass an empty string to skip modifying the output.
     #
-    # Templates: allowed.
+    # Templates: allowed
     mod_timestamp: "{{ .CommitTimestamp }}"
 
     # Hooks can be used to customize the final binary,

--- a/www/docs/customization/changelog.md
+++ b/www/docs/customization/changelog.md
@@ -43,8 +43,8 @@ changelog:
   # Only works when `use: git`, otherwise ignored.
   #
   # Default: monorepo.dir value, or empty if no monorepo
-  # Since: v1.12 (pro)
   # This feature is only available in GoReleaser Pro.
+  # Since: v1.12 (pro)
   paths:
     - foo/
     - bar/
@@ -79,8 +79,8 @@ changelog:
       # There can only be one level of subgroups, i.e.: a subgroup can't have
       # subgroups within it.
       #
-      # Since: v1.15 (pro)
       # This feature is only available in GoReleaser Pro.
+      # Since: v1.15 (pro)
       groups:
         - title: "Docs"
           regex: ".*docs.*"
@@ -91,8 +91,8 @@ changelog:
 
   # Divider to use between groups.
   #
-  # Since: v1.16 (pro)
   # This feature is only available in GoReleaser Pro.
+  # Since: v1.16 (pro)
   divider: "---"
 
   filters:

--- a/www/docs/customization/checksum.md
+++ b/www/docs/customization/checksum.md
@@ -47,8 +47,8 @@ checksum:
   # Those files will have their contents pass through the template engine,
   # and its results will be added to the checksum.
   #
-  # Since: v1.17 (pro)
   # This feature is only available in GoReleaser Pro.
+  # Since: v1.17 (pro)
   # Templates: allowed
   templated_extra_files:
     - src: LICENSE.tpl

--- a/www/docs/customization/docker.md
+++ b/www/docs/customization/docker.md
@@ -103,7 +103,7 @@ dockers:
     # Path to the Dockerfile (from the project root).
     #
     # Default: 'Dockerfile'
-    # Templates: allowed.
+    # Templates: allowed
     dockerfile: "{{ .Env.DOCKERFILE }}"
 
     # Use this instead of `dockerfile` if the contents of your Dockerfile are

--- a/www/docs/customization/docker.md
+++ b/www/docs/customization/docker.md
@@ -86,9 +86,9 @@ dockers:
     # Could be useful if you want to skip building the windows docker image on
     # linux, for example.
     #
-    # Templates: allowed
     # This option is only available on GoReleaser Pro.
     # Since: v1.14 (pro)
+    # Templates: allowed
     skip_build: false
 
     # Skips the docker push.

--- a/www/docs/customization/docker.md
+++ b/www/docs/customization/docker.md
@@ -87,8 +87,8 @@ dockers:
     # linux, for example.
     #
     # Templates: allowed
-    # Since: v1.14 (pro)
     # This option is only available on GoReleaser Pro.
+    # Since: v1.14 (pro)
     skip_build: false
 
     # Skips the docker push.
@@ -111,8 +111,8 @@ dockers:
     #
     # `dockerfile` is ignored when this is set.
     #
-    # Since: v1.20 (pro)
     # This feature is only available in GoReleaser Pro.
+    # Since: v1.20 (pro)
     # Templates: allowed
     templated_dockerfile: "{{.Env.DOCKERFILE }}"
 
@@ -158,8 +158,8 @@ dockers:
     # and its results will be added to the build context the same way as the
     # extra_files field above.
     #
-    # Since: v1.17 (pro)
     # This feature is only available in GoReleaser Pro.
+    # Since: v1.17 (pro)
     # Templates: allowed
     templated_extra_files:
       - src: LICENSE.tpl

--- a/www/docs/customization/docker_sign.md
+++ b/www/docs/customization/docker_sign.md
@@ -28,8 +28,8 @@ docker_signs:
 
     # Command line arguments for the command
     #
-    # Templates: allowed
     # Default: ["sign", "--key=cosign.key", "${artifact}@${digest}", "--yes"]
+    # Templates: allowed
     args:
     - "sign"
     - "--key=cosign.key"

--- a/www/docs/customization/git.md
+++ b/www/docs/customization/git.md
@@ -24,7 +24,7 @@ git:
   # provided values as either previous or current tags.
   #
   # Since: v1.21
-  # Templates: allowed.
+  # Templates: allowed
   ignore_tags:
     - nightly
     - "{{.Env.IGNORE_TAG}}"
@@ -33,7 +33,7 @@ git:
   #
   # This feature is only available in GoReleaser Pro.
   # Since: v1.24 (pro)
-  # Templates: allowed.
+  # Templates: allowed
   ignore_tag_prefixes:
     - foo/
     - "{{.Env.IGNORE_TAG_PREFIX}}/bar"

--- a/www/docs/customization/git.md
+++ b/www/docs/customization/git.md
@@ -23,8 +23,8 @@ git:
   # This means that GoReleaser will not pick up tags that match any of the
   # provided values as either previous or current tags.
   #
-  # Templates: allowed.
   # Since: v1.21
+  # Templates: allowed.
   ignore_tags:
     - nightly
     - "{{.Env.IGNORE_TAG}}"
@@ -32,8 +32,8 @@ git:
   # Tags that begin with these prefixes will be ignored.
   #
   # This feature is only available in GoReleaser Pro.
-  # Templates: allowed.
   # Since: v1.24 (pro)
+  # Templates: allowed.
   ignore_tag_prefixes:
     - foo/
     - "{{.Env.IGNORE_TAG_PREFIX}}/bar"

--- a/www/docs/customization/git.md
+++ b/www/docs/customization/git.md
@@ -31,8 +31,8 @@ git:
 
   # Tags that begin with these prefixes will be ignored.
   #
-  # Templates: allowed.
   # This feature is only available in GoReleaser Pro.
+  # Templates: allowed.
   # Since: v1.24 (pro)
   ignore_tag_prefixes:
     - foo/

--- a/www/docs/customization/metadata.md
+++ b/www/docs/customization/metadata.md
@@ -13,6 +13,6 @@ These are the options available:
 metadata:
   # Set the modified timestamp on the metadata files.
   #
-  # Templates: allowed.
+  # Templates: allowed
   mod_timestamp: "{{ .CommitTimestamp }}"
 ```

--- a/www/docs/customization/nfpm.md
+++ b/www/docs/customization/nfpm.md
@@ -17,13 +17,13 @@ nfpms:
 
     # Name of the package.
     # Default: ProjectName
-    # Templates: allowed. (since v1.18)
+    # Templates: allowed (since v1.18)
     package_name: foo
 
     # You can change the file name of the package.
     #
     # Default: '{{ .PackageName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
-    # Templates: allowed.
+    # Templates: allowed
     file_name_template: "{{ .ConventionalFileName }}"
 
     # Build IDs for the builds you want to create NFPM packages for.
@@ -172,7 +172,7 @@ nfpms:
       # /etc, using the "tree" type.
       #
       # Since: v1.17
-      # Templates: allowed.
+      # Templates: allowed
       - src: some/directory/
         dst: /etc
         type: tree
@@ -204,7 +204,7 @@ nfpms:
     #
     # This feature is only available in GoReleaser Pro.
     # Since: v1.17 (pro)
-    # Templates: allowed.
+    # Templates: allowed
     templated_contents:
       # a more complete example, check the globbing deep dive below
       - src: "LICENSE.md.tpl"
@@ -292,7 +292,7 @@ nfpms:
     #
     # This feature is only available in GoReleaser Pro.
     # Since: v1.20 (pro)
-    # Templates: allowed.
+    # Templates: allowed
     templated_scripts:
       preinstall: "scripts/preinstall.sh"
       postinstall: "scripts/postinstall.sh"
@@ -358,7 +358,7 @@ nfpms:
         #
         # See "Signing key passphrases" below for more information.
         #
-        # Templates: allowed.
+        # Templates: allowed
         key_file: "{{ .Env.GPG_KEY_PATH }}"
 
     # Custom configuration applied only to the Deb packager.
@@ -406,7 +406,7 @@ nfpms:
         #
         # See "Signing key passphrases" below for more information.
         #
-        # Templates: allowed.
+        # Templates: allowed
         key_file: "{{ .Env.GPG_KEY_PATH }}"
 
         # The type describes the signers role, possible values are "origin",
@@ -440,14 +440,14 @@ nfpms:
         #
         # See "Signing key passphrases" below for more information.
         #
-        # Templates: allowed.
+        # Templates: allowed
         key_file: "{{ .Env.GPG_KEY_PATH }}"
 
         # The name of the signing key. When verifying a package, the signature
         # is matched to the public key store in /etc/apk/keys/<key_name>.rsa.pub.
         #
         # Default: maintainer's email address
-        # Templates: allowed. (since v1.15)
+        # Templates: allowed (since v1.15)
         key_name: origin
 
     archlinux:

--- a/www/docs/customization/nfpm.md
+++ b/www/docs/customization/nfpm.md
@@ -202,8 +202,8 @@ nfpms:
     # Those files will have their contents pass through the template engine,
     # and its results will be added to the package.
     #
-    # Since: v1.17 (pro)
     # This feature is only available in GoReleaser Pro.
+    # Since: v1.17 (pro)
     # Templates: allowed.
     templated_contents:
       # a more complete example, check the globbing deep dive below
@@ -290,8 +290,8 @@ nfpms:
     # Keys are the possible targets during the installation process
     # Values are the paths to the scripts which will be executed.
     #
-    # Since: v1.20 (pro)
     # This feature is only available in GoReleaser Pro.
+    # Since: v1.20 (pro)
     # Templates: allowed.
     templated_scripts:
       preinstall: "scripts/preinstall.sh"

--- a/www/docs/customization/publishers.md
+++ b/www/docs/customization/publishers.md
@@ -143,8 +143,8 @@ publishers:
     # Those files will have their contents pass through the template engine,
     # and its results will be published.
     #
-    # Since: v1.17 (pro)
     # This feature is only available in GoReleaser Pro.
+    # Since: v1.17 (pro)
     # Templates: allowed
     templated_extra_files:
       - src: LICENSE.tpl

--- a/www/docs/customization/release.md
+++ b/www/docs/customization/release.md
@@ -183,8 +183,8 @@ release:
   # Those files will have their contents pass through the template engine,
   # and its results will be added to the release.
   #
-  # Since: v1.17 (pro)
   # This feature is only available in GoReleaser Pro.
+  # Since: v1.17 (pro)
   # Templates: allowed
   templated_extra_files:
     - src: LICENSE.tpl

--- a/www/docs/customization/release.md
+++ b/www/docs/customization/release.md
@@ -44,8 +44,8 @@ release:
   # value of this field.
   # Only works on GitHub.
   #
-  # Default: ''
   # Since: v1.11
+  # Default: ''
   # Templates: allowed
   target_commitish: "{{ .Commit }}"
 
@@ -54,8 +54,8 @@ release:
   # publish a binary from a monorepo into a public repository somewhere, without
   # the tag prefix.
   #
-  # Default: '{{ .PrefixedCurrentTag }}'
   # Since: v1.19 (pro)
+  # Default: '{{ .PrefixedCurrentTag }}'
   # Templates: allowed
   tag: "{{ .CurrentTag }}"
 

--- a/www/docs/customization/snapcraft.md
+++ b/www/docs/customization/snapcraft.md
@@ -144,8 +144,8 @@ snapcrafts:
     # Those files will have their contents pass through the template engine,
     # and its results will be added to the package.
     #
-    # Since: v1.17 (pro)
     # This feature is only available in GoReleaser Pro.
+    # Since: v1.17 (pro)
     # Templates: allowed
     templated_extra_files:
       - source: LICENSE.tpl

--- a/www/docs/customization/source.md
+++ b/www/docs/customization/source.md
@@ -68,8 +68,8 @@ source:
   # Those files will have their contents pass through the template engine,
   # and its results will be added to the source archive.
   #
-  # Since: v1.17 (pro)
   # This feature is only available in GoReleaser Pro.
+  # Since: v1.17 (pro)
   # Templates: allowed
   templated_files:
     # a more complete example, check the globbing deep dive below

--- a/www/docs/customization/universalbinaries.md
+++ b/www/docs/customization/universalbinaries.md
@@ -42,8 +42,8 @@ universal_binaries:
     # you would do this to ensure a build was reproducible.
     # Pass an empty string to skip modifying the output.
     #
-    # Templates: allowed.
     # Since: v1.20
+    # Templates: allowed.
     mod_timestamp: "{{ .CommitTimestamp }}"
 
     # Hooks can be used to customize the final binary,

--- a/www/docs/customization/universalbinaries.md
+++ b/www/docs/customization/universalbinaries.md
@@ -43,7 +43,7 @@ universal_binaries:
     # Pass an empty string to skip modifying the output.
     #
     # Since: v1.20
-    # Templates: allowed.
+    # Templates: allowed
     mod_timestamp: "{{ .CommitTimestamp }}"
 
     # Hooks can be used to customize the final binary,

--- a/www/docs/customization/winget.md
+++ b/www/docs/customization/winget.md
@@ -20,19 +20,19 @@ winget:
     # Publisher name.
     #
     # Templates: allowed
-    # Required.
+    # Required
     publisher: Foo Inc
 
     # Your app's description.
     #
     # Templates: allowed
-    # Required.
+    # Required
     short_description: "Software to create fast and easy drum rolls."
 
     # License name.
     #
     # Templates: allowed
-    # Required.
+    # Required
     license: "mit"
 
     # Publisher URL.

--- a/www/docs/includes/repository.md
+++ b/www/docs/includes/repository.md
@@ -38,8 +38,8 @@
         # If the pull request template has checkboxes, enabling this will
         # check all of them.
         #
-        # Since: v1.20 (pro)
         # This feature is only available in GoReleaser Pro.
+        # Since: v1.20 (pro)
         check_boxes: true
 
         # Base can also be another repository, in which case the owner and name


### PR DESCRIPTION
I have sorted the GoReleaser configuration YAML code examples as follows:

```yaml
# This feature is only available in GoReleaser Pro.
# Since: v1.17 (pro)
# Default: .
# Templates: allowed
# Required
```
