### PR TITLE
DOCS: Fixed the AUT directory configuration

### DIFF
--- a/www/docs/customization/aur.md
+++ b/www/docs/customization/aur.md
@@ -162,7 +162,7 @@ aurs:
     # Default: .
     # Templates: allowed
     # Since: v1.23
-    url_template: "http://github.mycompany.com/foo/bar/releases/{{ .Tag }}/{{ .ArtifactName }}"
+    directory: "your-directory-choice"
 ```
 
 !!! tip


### PR DESCRIPTION
While working from GitHub pull request https://github.com/goreleaser/goreleaser/pull/4652 I noticed a duplicate `url_template` in the YAML code example. Based on that, I consulted the git history and fixed the AUT directory configuration.

_I hope I got the correct context from the GitHub pull request below. If not, feel free to close this GitHub pull request._

* https://github.com/goreleaser/goreleaser/issues/4482
* https://github.com/goreleaser/goreleaser/pull/4484

