### PR TITLE
fix(pipe): Update metadata pipe order

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -132,10 +132,10 @@ var Pipeline = append(
 	reportsizes.Pipe{},
 	// create and push docker images
 	docker.Pipe{},
-	// publishes artifacts
-	publish.New(),
 	// creates a metadata.json and an artifacts.json files in the dist folder
 	metadata.Pipe{},
+	// publishes artifacts
+	publish.New(),
 	// announce releases
 	announce.Pipe{},
 )


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->

I have recently upgraded goreleaser to 1.24.0 and faced the following issue where metadata.json file didn't get created.

Here's my .goreleaser.yaml file content:

```yaml
project_name: m
builds:
  - id: c
    env: &env
      - CGO_ENABLED=0
    binary: c
    main: ./cmd/c/c.go
    ldflags: &ldflags
      - -s -X gitlab.com/m/r.version={{.Tag}}
    targets: &targets
      - linux_amd64
      - darwin_amd64
      - darwin_arm64
      - windows_amd64
  - id: f
    env: *env
    binary: f
    main: ./cmd/f/f.go
    ldflags: *ldflags
    targets: *targets
archives:
  - id: gcs-nightly
    format: binary
    builds:
      - c
      - f
    name_template: >-
      {{- .Binary }}_
      {{- if eq .Os "darwin" }}macos_
      {{- else }}{{- .Os }}_{{ end -}}
      {{- .Arch }}
release:
  gitlab:
    owner: p
    name: tools
  disable: true
blobs:
  - provider: gs
    bucket: tools
    folder: artifacts/nightly/latest
    extra_files:
      - glob: ./dist/metadata.json
checksum:
  name_template: 'checksums.txt'
snapshot:
  name_template: "{{ incpatch .Version }}-next"
changelog:
  disable: true
announce:
  skip: "true"
metadata:
  mod_timestamp: "{{ .CommitTimestamp }}"
```

When I run this command `goreleaser release --config .goreleaser.yaml --clean`, it fails with the following output:

```
• starting release...
• loading                                          path=.goreleaser.yaml
• loading environment variables
• getting and validating git state
  • git state                                      commit=<7515...> branch=master current_tag=v4.47.0 previous_tag=v4.46.0 dirty=false
• parsing tag
• setting defaults
  • pipe skipped                                   reason=release is disabled
• checking distribution directory
  • cleaning dist
• loading go mod information
• build prerequisites
• writing effective config file
  • writing                                        config=dist/config.yaml
• building binaries
  • building                                       binary=dist/f_linux_amd64_v1/f
  • building                                       binary=dist/f_windows_amd64_v1/f.exe
  • building                                       binary=dist/c_darwin_arm64/c
  • building                                       binary=dist/c_linux_amd64_v1/c
  • building                                       binary=dist/f_darwin_arm64/f
  • building                                       binary=dist/c_darwin_amd64_v1/c
  • building                                       binary=dist/c_windows_amd64_v1/c.exe
  • building                                       binary=dist/f_darwin_amd64_v1/f
  • took: 7s
• archives
  • skip archiving                                 binary=c name=c_macos_arm64
  • skip archiving                                 binary=c name=c_macos_amd64
  • skip archiving                                 binary=c.exe name=c_windows_amd64.exe
  • skip archiving                                 binary=f name=f_macos_arm64
  • skip archiving                                 binary=c name=c_linux_amd64
  • skip archiving                                 binary=f name=f_macos_amd64
  • skip archiving                                 binary=f.exe name=f_windows_amd64.exe
  • skip archiving                                 binary=f name=f_linux_amd64
• calculating checksums
• publishing
  • blobs
    • uploading                                    path=artifacts/nightly/latest/checksums.txt
⨯ release failed after 7s                  error=blobs: failed to publish artifacts: globbing failed for pattern ./dist/metadata.json: matching "./dist/metadata.json": file does not exist
```

I noticed that `storing release metadata` step never runs as it's preceded by `publish` step.

<!-- If applied, this commit will... -->
This PR changes the order of steps in the pipeline allowing metadata.json and artifacts.json files created first before publishing.
...

<!-- Why is this change being made? -->

...

<!-- # Provide links to any relevant tickets, URLs or other resources -->
Here's the output from `goreleaser` built from this PR using `--verbose` output:

```
  • skipped generating changelog
  • archives
    • group linuxamd64v1 has 2 binaries
    • group windowsamd64v1 has 2 binaries
    • group darwinamd64v1 has 2 binaries
    • group darwinarm64 has 2 binaries
    • skip archiving                                 binary=c name=c_macos_arm64
    • skip archiving                                 binary=c name=c_macos_amd64
    • added new artifact                             name=c_macos_arm64 type=Binary path=dist/c_darwin_arm64/c
    • skip archiving                                 binary=c.exe name=c_windows_amd64.exe
    • added new artifact                             name=c_windows_amd64.exe type=Binary path=dist/c_windows_amd64_v1/c.exe
    • skip archiving                                 binary=c name=c_linux_amd64
    • added new artifact                             name=c_macos_amd64 type=Binary path=dist/c_darwin_amd64_v1/c
    • skip archiving                                 binary=f name=f_macos_arm64
    • added new artifact                             name=c_linux_amd64 type=Binary path=dist/c_linux_amd64_v1/c
    • skip archiving                                 binary=f.exe name=f_windows_amd64.exe
    • added new artifact                             name=f_windows_amd64.exe type=Binary path=dist/f_windows_amd64_v1/f.exe
    • skip archiving                                 binary=f name=f_macos_amd64
    • skip archiving                                 binary=f name=f_linux_amd64
    • added new artifact                             name=f_macos_arm64 type=Binary path=dist/f_darwin_arm64/f
    • added new artifact                             name=f_macos_amd64 type=Binary path=dist/f_darwin_amd64_v1/f
    • added new artifact                             name=f_linux_amd64 type=Binary path=dist/f_linux_amd64_v1/f
  • skipped creating source archive
  • skipped linux packages
  • skipped snapcraft packages
  • skipped cataloging artifacts
  • calculating checksums
    • checksumming                                   file=f_linux_amd64
    • calculating checksum for dist/f_linux_amd64_v1/f
    • checksumming                                   file=c_linux_amd64
    • calculating checksum for dist/c_linux_amd64_v1/c
    • checksumming                                   file=c_macos_arm64
    • calculating checksum for dist/c_darwin_arm64/c
    • checksumming                                   file=c_windows_amd64.exe
    • calculating checksum for dist/c_windows_amd64_v1/c.exe
    • checksumming                                   file=c_macos_amd64
    • calculating checksum for dist/c_darwin_amd64_v1/c
    • checksumming                                   file=f_macos_arm64
    • calculating checksum for dist/f_darwin_arm64/f
    • checksumming                                   file=f_windows_amd64.exe
    • calculating checksum for dist/f_windows_amd64_v1/f.exe
    • checksumming                                   file=f_macos_amd64
    • calculating checksum for dist/f_darwin_amd64_v1/f
    • added new artifact                             name=checksums.txt type=Checksum path=dist/checksums.txt
  • skipped signing artifacts
  • skipped arch user repositories
  • skipped nixpkgs
  • skipped winget
  • skipped homebrew tap formula
  • skipped krew plugin manifest
  • skipped scoop manifests
  • skipped chocolatey packages
  • skipped size reports
  • skipped docker images
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • publishing
    • blobs
      • uploading                                    bucket=gs://tools
      • uploading                                    path=artifacts/nightly/latest/metadata.json
      • uploading                                    path=artifacts/nightly/latest/checksums.txt
      • uploading                                    path=artifacts/nightly/latest/c_linux_amd64
      • uploading                                    path=artifacts/nightly/latest/c_windows_amd64.exe
      • uploading                                    path=artifacts/nightly/latest/c_macos_arm64
      • uploading                                    path=artifacts/nightly/latest/f_windows_amd64.exe
      • uploading                                    path=artifacts/nightly/latest/f_linux_amd64
      • uploading                                    path=artifacts/nightly/latest/f_macos_amd64
      • uploading                                    path=artifacts/nightly/latest/f_macos_arm64
      • uploading                                    path=artifacts/nightly/latest/c_macos_amd64
      • took: 2m19s
  • skipped http upload
  • skipped artifactory
  • skipped custom publisher
  • skipped docker images
  • skipped docker manifests
  • skipped ko
  • skipped signing docker images
  • skipped snapcraft packages
  • skipped scm releases
  • skipped nixpkgs
  • skipped winget
  • skipped homebrew tap formula
  • skipped arch user repositories
  • skipped krew plugin manifest
  • skipped scoop manifests
  • skipped chocolatey packages
  • skipped milestones
  • took: 2m19s
  • skipped announcing
  • release succeeded after 2m25s
  • thanks for using goreleaser!
```
...
