### PR TITLE
fix(aur): allow to have multiple AUR configs pointing to the same repo

### DIFF
--- a/internal/pipe/aur/aur.go
+++ b/internal/pipe/aur/aur.go
@@ -3,6 +3,7 @@ package aur
 import (
 	"bufio"
 	"bytes"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"os"
@@ -385,7 +386,7 @@ func doPublish(ctx *context.Context, pkgs []*artifact.Artifact) error {
 			URL:        cfg.GitURL,
 			SSHCommand: cfg.GitSSHCommand,
 		},
-		Name: cfg.Name,
+		Name: fmt.Sprintf("%x", sha256.Sum256([]byte(cfg.GitURL))),
 	})
 
 	files := make([]client.RepoFile, 0, len(pkgs))


### PR DESCRIPTION
- using the sha256 of the git url as repo name so we avoid race conditions 
- actually made the git client have a global lock so it doesn't step over itself

closes #4679
