### PR TITLE
Allow the use of absolute paths in release.extra_files globs

### DIFF
--- a/internal/extrafiles/extra_files.go
+++ b/internal/extrafiles/extra_files.go
@@ -25,7 +25,7 @@ func Find(ctx *context.Context, files []config.ExtraFile) (map[string]string, er
 			log.Warn("ignoring empty glob")
 			continue
 		}
-		files, err := fileglob.Glob(glob)
+		files, err := fileglob.Glob(glob, fileglob.MaybeRootFS)
 		if err != nil {
 			return result, fmt.Errorf("globbing failed for pattern %s: %w", extra.Glob, err)
 		}

--- a/internal/extrafiles/extra_files_test.go
+++ b/internal/extrafiles/extra_files_test.go
@@ -48,6 +48,18 @@ func TestShouldGetSpecificFile(t *testing.T) {
 	require.Equal(t, "testdata/file1.golden", files["file1.golden"])
 }
 
+func TestShouldGetAbsoluteFile(t *testing.T) {
+	globs := []config.ExtraFile{
+		{Glob: "/dev/null"},
+	}
+
+	files, err := Find(testctx.New(), globs)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+
+	require.Equal(t, "/dev/null", files["null"])
+}
+
 func TestFailToGetSpecificFile(t *testing.T) {
 	globs := []config.ExtraFile{
 		{Glob: "./testdata/file453.golden"},


### PR DESCRIPTION
This change allows the `release.extra_files` globs to reference absolute paths.

I want to make this change because I am using the Github [sbom-generator-action](https://github.com/advanced-security/sbom-generator-action) to download the Github SBOM and attach it to the Github release. I'm saving the downloaded SBOM to a location outside the git checkout so that `goreleaser` doesn't fail due to a dirty git state.

As per [this issue](https://github.com/goreleaser/fileglob/issues/36), the `MaybeRootFS` option is needed in the call to `Glob()` for absolute paths, otherwise the prefix defaults to `./`, and so `Glob()` tries to match `.//my/absolute/path` and fails with an error.
