### PR TITLE
feat(git): retry git clone on retriable error

### DIFF
--- a/internal/client/git.go
+++ b/internal/client/git.go
@@ -12,13 +12,12 @@ import (
 
 	"github.com/caarlos0/log"
 	"github.com/charmbracelet/x/exp/ordered"
-	"golang.org/x/crypto/ssh"
-
 	"github.com/goreleaser/goreleaser/internal/git"
 	"github.com/goreleaser/goreleaser/internal/pipe"
 	"github.com/goreleaser/goreleaser/internal/tmpl"
 	"github.com/goreleaser/goreleaser/pkg/config"
 	"github.com/goreleaser/goreleaser/pkg/context"
+	"golang.org/x/crypto/ssh"
 )
 
 var gil sync.Mutex


### PR DESCRIPTION
This PR adds retry logic to the process of cloning a git repository.
Currently, it retries only if the output of the git clone command contains the string `Connection reset`.
Probably, there are more cases where retry is reasonable, but I'm not sure what they are.

The number of retries is hardcoded to 10 with increasing delay between retries — in the same way as it is done in #4265, which served me as an example.

The initial use case is described in #4724.
