### PR TITLE
feat(archives): format override to 'none' to skip certain goos

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -627,7 +627,7 @@ func (bh Hook) JSONSchema() *jsonschema.Schema {
 // FormatOverride is used to specify a custom format for a specific GOOS.
 type FormatOverride struct {
 	Goos   string `yaml:"goos,omitempty" json:"goos,omitempty"`
-	Format string `yaml:"format,omitempty" json:"format,omitempty" jsonschema:"enum=tar,enum=tgz,enum=tar.gz,enum=zip,enum=gz,enum=tar.xz,enum=txz,enum=binary,default=tar.gz"`
+	Format string `yaml:"format,omitempty" json:"format,omitempty" jsonschema:"enum=tar,enum=tgz,enum=tar.gz,enum=zip,enum=gz,enum=tar.xz,enum=txz,enum=binary,enum=none,default=tar.gz"`
 }
 
 // File is a file inside an archive.

--- a/www/docs/customization/archive.md
+++ b/www/docs/customization/archive.md
@@ -19,10 +19,12 @@ archives:
     builds:
       - default
 
-    # Archive format. Valid options are `tar.gz`, `tgz`, `tar.xz`, `txz`, tar`, `gz`, `zip` and `binary`.
+    # Archive format.
+    #
     # If format is `binary`, no archives are created and the binaries are instead
     # uploaded directly.
     #
+    # Valid options are `tar.gz`, `tgz`, `tar.xz`, `txz`, tar`, `gz`, `zip`, and `binary`.
     # Default: 'tar.gz'
     format: zip
 
@@ -79,7 +81,12 @@ archives:
     # Can be used to change the archive formats for specific GOOSs.
     # Most common use case is to archive as zip on Windows.
     format_overrides:
-      - goos: windows
+      - # Which GOOS to override the format for.
+        goos: windows
+
+        # The format to use for the given GOOS.
+        #
+        # Valid options are `tar.gz`, `tgz`, `tar.xz`, `txz`, tar`, `gz`, `zip`, `binary`, and `none`.
         format: zip
 
     # Additional files/globs you want to add to the archive.


### PR DESCRIPTION
closes #4644
