### PR TITLE
fix(docs): update default for `build.id` attribute

### DIFF
--- a/www/docs/customization/builds.md
+++ b/www/docs/customization/builds.md
@@ -14,7 +14,7 @@ builds:
   - #
     # ID of the build.
     #
-    # Default: Binary name
+    # Default: Project directory name
     id: "my-build"
 
     # Path to main.go file or main package.


### PR DESCRIPTION
Fixes #4731 
