### PR TITLE
Convert `run` install script to pure POSIX sh

### DIFF
--- a/www/docs/static/run
+++ b/www/docs/static/run
@@ -1,8 +1,10 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 set -e
 
+is_pro="false"
 if [[ "$VERSION" == *-pro ]]; then
 	DISTRIBUTION="pro"
+	is_pro="true"
 fi
 
 if test "$DISTRIBUTION" = "pro"; then
@@ -24,7 +26,7 @@ test -z "$VERSION" && {
 	exit 1
 }
 
-if test "$DISTRIBUTION" = "pro" && [[ "$VERSION" != *-pro ]]; then
+if test "$DISTRIBUTION" = "pro" && ! test "$is_pro"; then
 	VERSION="$VERSION-pro"
 fi
 


### PR DESCRIPTION
The changes are minimal and the benefit is quite nice – this script can now be used to install GoReleaser on e.g. Alpine Linux without `bash`.


`shellcheck run` and `shfmt run` both report no warnings/errors.