### PR TITLE
fix `run` not being truly POSIX-compliant

### DIFF
--- a/www/docs/static/run
+++ b/www/docs/static/run
@@ -2,10 +2,12 @@
 set -e
 
 is_pro="false"
-if [[ "$VERSION" == *-pro ]]; then
+case "$VERSION" in
+*-pro)
 	DISTRIBUTION="pro"
 	is_pro="true"
-fi
+	;;
+esac
 
 if test "$DISTRIBUTION" = "pro"; then
 	echo "Using Pro distribution..."


### PR DESCRIPTION
I'm sorry, but my previous PR #4736 contained a mistake and the script wasn't truly POSIX compliant.

With this PR I fix that mistake.

See relevant shellcheck warning: https://www.shellcheck.net/wiki/SC3010