### PR TITLE
fix: use correct path variable for logging in check command

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -47,7 +47,7 @@ func newCheckCmd() *checkCmd {
 				ctx.Deprecated = root.deprecated
 
 				if err := ctrlc.Default.Run(ctx, func() error {
-					log.WithField("path", config).
+					log.WithField("path", path).
 						Info(boldStyle.Render("checking"))
 
 					return defaults.Pipe{}.Run(ctx)


### PR DESCRIPTION
This trivial PR fixes a minor cosmetic issue in the `check` command.

Before this fix, GoReleaser would not show the auto-detected config path under check when no args are provided:
```
$ goreleaser check
  • checking                                 path=
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
```

After this check, GoReleaser correctly shows any auto-detected config paths:
```
$ goreleaser check
  • checking                                 path=.goreleaser.yaml
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
```