### PR TITLE
docs: description for chocolateys.package_source_url

### DIFF
--- a/www/docs/customization/chocolatey.md
+++ b/www/docs/customization/chocolatey.md
@@ -28,6 +28,10 @@ chocolateys:
       - foo
       - bar
 
+    # Your chocolatey package's source URL.
+    # It point at the location of where someone can find the packaging files for the package.
+    package_source_url: https://github.com/foo/chocolatey-package
+
     # Your app's owner.
     # It basically means you.
     owners: Drum Roll Inc


### PR DESCRIPTION
Adds missing description for the `package_source_url` option when building Chocolatey packages.

This option is present in the config and nuspec:
- https://github.com/goreleaser/goreleaser/blob/826438b86584ba27c055186bfb544c20646bf667/pkg/config/config.go#L1428
- https://github.com/goreleaser/goreleaser/blob/826438b86584ba27c055186bfb544c20646bf667/internal/pipe/chocolatey/nuspec.go#L25

See also https://docs.chocolatey.org/en-us/guides/create/create-config-package#creating-a-configuration-package and https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0040#reasoning.