### PR TITLE
docs: fix typos

### DIFF
--- a/www/docs/blog/posts/2022-02-05-cloud-native-storage.md
+++ b/www/docs/blog/posts/2022-02-05-cloud-native-storage.md
@@ -10,7 +10,7 @@ authors:
 # How to use GoReleaser with Cloud Native Storage
 
 In this tutorial, I want to describe, how quickly we can deploy our release
-artefacts to a cloud native storage when using GoReleaser.
+artifacts to a cloud native storage when using GoReleaser.
 It’s just a few additional lines in your `.goreleaser.yaml`.
 
 <!-- more -->
@@ -103,7 +103,7 @@ variable "azure_location" {
 }
 
 variable "name" {
-  default = "gorleaser-quickbites"
+  default = "goreleaser-quickbites"
 }
 ```
 
@@ -159,16 +159,16 @@ terraform apply  -var  "gcp_project=xxx"
 
 ```
 ...
-azurerm_storage_container.goreleaser-storage-container: Creation complete after 0s [id=https://gorleaserquickbites.blob.core.windows.net/gorleaser-quickbites]
+azurerm_storage_container.goreleaser-storage-container: Creation complete after 0s [id=https://goreleaserquickbites.blob.core.windows.net/goreleaser-quickbites]
 
 Apply complete! Resources: 6 added, 0 changed, 0 destroyed.
 
 Outputs:
 
-aws-s3-bucket-name = "gorleaser-quickbites"
+aws-s3-bucket-name = "goreleaser-quickbites"
 azure-storage-account-key = <sensitive>
-azure-storage-account-name = "export AZURE_STORAGE_ACCOUNT=gorleaserquickbites"
-gcp-bucket-url = "gs://gorleaser-quickbites"
+azure-storage-account-name = "export AZURE_STORAGE_ACCOUNT=goreleaserquickbites"
+gcp-bucket-url = "gs://goreleaser-quickbites"
 ```
 
 ###### Run this command
@@ -205,11 +205,11 @@ release:
 ---
 blobs:
   - provider: gs
-    bucket: gorleaser-quickbites
+    bucket: goreleaser-quickbites
   - provider: azblob
-    bucket: gorleaser-quickbites
+    bucket: goreleaser-quickbites
   - provider: s3
-    bucket: gorleaser-quickbites
+    bucket: goreleaser-quickbites
     region: eu-central-1
 ```
 
@@ -256,7 +256,7 @@ via the command:
 goreleaser release --rm-dist
 ```
 
-If everything went smooth, you should see a similar output, showing the upload of your artefacts.
+If everything went smooth, you should see a similar output, showing the upload of your artifacts.
 
 ```
   ...

--- a/www/docs/blog/posts/2022-02-20-azure-devops.md
+++ b/www/docs/blog/posts/2022-02-20-azure-devops.md
@@ -181,7 +181,7 @@ container, create the SBoM with syft and sign everything via cosign.
 > Here is one first important steps: you need to disable the **release** step in
 > GoReleaser.
 > Azure DevOps does not work the same way as GitHub what releases concerns.
-> We handle the upload of the artefacts differently.
+> We handle the upload of the artifacts differently.
 
 If you need more infos, for the different settings and possibilities inside
 **GoReleaser**, head over to the official documentation
@@ -323,7 +323,7 @@ The pipeline consist of two different jobs parts:
 During the release job, we download [Anchore
 syft](https://github.com/anchore/syft) and
 [cosign](https://github.com/sigstore/cosign) as we going to need them during the
-**gorleaser** task.
+**goreleaser** task.
 Currently there is no native task for this in **Azure DevOps**. We just use the
 **CmdLine** task and curl the binaries.
 
@@ -351,13 +351,13 @@ variables tag.
 
 ![](https://cdn-images-1.medium.com/max/2000/1*CTox6hgrOCgaTs9AFJWUhQ.png)
 
-In this demo, I am going to publish the release artefacts as build artefacts.
+In this demo, I am going to publish the release artifacts as build artifacts.
 
 ![](https://cdn-images-1.medium.com/max/2244/1*nwH4Ej9GbQ6RdE_MfYMelw.png)
 
 The task **CopyFiles** collects some files from the **dist** folder and the
 cosign public key and **PublishBuildArtifacts** publish them.
-You will find the artefacts on the pipeline detail
+You will find the artifacts on the pipeline detail
 
 ![](https://cdn-images-1.medium.com/max/2000/1*GWCiLGBnHOnCjyRuqrPEEw.png)
 

--- a/www/docs/blog/posts/2023-05-05-goreleaser-v1.18.md
+++ b/www/docs/blog/posts/2023-05-05-goreleaser-v1.18.md
@@ -74,7 +74,7 @@ same `.goreleaser.yaml` file.
 
 [brews]: https://goreleaser.com/customization/homebrew/
 
-### Publish Homebrew taps, Scoop manifests and Krew plugins to plain Git repositores
+### Publish Homebrew taps, Scoop manifests and Krew plugins to plain Git repositories
 
 Historically, you could only publish to GitHub, GitLab and Gitea, which used
 their respective APIs.

--- a/www/docs/blog/posts/2023-10-08-slsa-generation-for-your-artifacts.md
+++ b/www/docs/blog/posts/2023-10-08-slsa-generation-for-your-artifacts.md
@@ -80,7 +80,7 @@ kos:
       - -s -w
 ```
 
-I trimmed the file a bit to make it easier to read. As you can see, we are building our binaries for the `linux`, `windows`, and `darwin` operating systems as we defined in the `builds` section, thanks to the built-in cross-compliation support in Golang. We are also using the [kos](https://goreleaser.com/customization/ko/) integration to build a container image for our project. It is a new way to build container images your project using [ko](https://ko.build). We are also using the `ghcr.io/goreleaser/goreleaser-example-slsa-provenance` repository to push our container image both with the `latest` and the `{{.Tag}}` tag.
+I trimmed the file a bit to make it easier to read. As you can see, we are building our binaries for the `linux`, `windows`, and `darwin` operating systems as we defined in the `builds` section, thanks to the built-in cross-compilation support in Golang. We are also using the [kos](https://goreleaser.com/customization/ko/) integration to build a container image for our project. It is a new way to build container images your project using [ko](https://ko.build). We are also using the `ghcr.io/goreleaser/goreleaser-example-slsa-provenance` repository to push our container image both with the `latest` and the `{{.Tag}}` tag.
 
 > _If you want to learn more about the ko tool, check out our [blog post](https://blog.kubesimplify.com/getting-started-with-ko-a-fast-container-image-builder-for-your-go-applications/)._
 
@@ -184,7 +184,7 @@ In essence, the artifacts output consists of the contents of the artifacts.json 
 
 During the process of generating SLSA (Supply Chain Levels for Software Artifacts) provenances for both our binaries and container images, we utilize specific jq operations to extract the necessary information such as the `hashes` for the binaries and the `image` and `digest` of our container image from the artifacts.json file.
 
-At the end of the day, you will be having a succesfull workflow run like this:
+At the end of the day, you will be having a successful workflow run like this:
 
 ![image](/static/slsa-provenance-generation.png)
 

--- a/www/docs/customization/artifactory.md
+++ b/www/docs/customization/artifactory.md
@@ -181,7 +181,7 @@ artifactories:
     # URL of your Artifactory instance + path to deploy to
     target: http://artifacts.company.com:8081/artifactory/example-repo-local/{{ .ProjectName }}/{{ .Version }}/
 
-    # Tells goreleaer not to append the artifact name to the target URL. You must do this manually
+    # Tells goreleaser not to append the artifact name to the target URL. You must do this manually
     custom_artifact_name: true
 
     # User that will be used for the deployment

--- a/www/docs/errors/docker-build.md
+++ b/www/docs/errors/docker-build.md
@@ -7,7 +7,7 @@ the Docker image build process.
 
 The way GoReleaser works, the correct binary for the platform you're building
 should be already available, so you don't need to build it again and can still
-reuse the `Dockefile`.
+reuse the `Dockerfile`.
 
 Another common misconception is trying to copy the binary as if the context is
 the repository root.


### PR DESCRIPTION
This PR corrects grammar mistakes in documentation:

- artefacts -> artifacts
- Dockefile -> Dockerfile
- compliation -> compilation
- gorleaser -> goreleaser
- repositores -> repositories
- succesfull -> successful


