### PR TITLE
fix: typo in User-Agent header value

### DIFF
--- a/internal/pipe/webhook/webhook.go
+++ b/internal/pipe/webhook/webhook.go
@@ -19,7 +19,7 @@ const (
 	defaultMessageTemplate = `{ "message": "{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}"}`
 	ContentTypeHeaderKey   = "Content-Type"
 	UserAgentHeaderKey     = "User-Agent"
-	UserAgentHeaderValue   = "gorleaser"
+	UserAgentHeaderValue   = "goreleaser"
 	AuthorizationHeaderKey = "Authorization"
 	DefaultContentType     = "application/json; charset=utf-8"
 )


### PR DESCRIPTION
Corrects typo in the value of the `UserAgentHeaderValue` constant.