### PR TITLE
Update dirty.md deprecated syntax

### DIFF
--- a/www/docs/errors/dirty.md
+++ b/www/docs/errors/dirty.md
@@ -23,4 +23,4 @@ From here on, you have a couple of options:
   generated);
 - change your build process to not touch any git tracked files.
 - if you are running `goreleaser build`, you might want to add either the
-  `--snapshot` or `--skip-validate` flags to it
+  `--snapshot` or `--skip=validate` flags to it


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

Change `--skip-validate` in a doc file to `--skip=validate`.

<!-- Why is this change being made? -->

Running the command with `--skip-validate` produces the following warning:

>   • DEPRECATED: --skip-validate was deprecated in favor of --skip=validate, check https://goreleaser.com/deprecations#-skip for more details

<!-- # Provide links to any relevant tickets, URLs or other resources -->