### PR TITLE
feat: always log build output

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -380,7 +380,9 @@ func run(ctx *context.Context, command, env []string, dir string) error {
 	if err != nil {
 		return fmt.Errorf("%w: %s", err, string(out))
 	}
-	log.Debug(string(out))
+	if s := strings.TrimSpace(string(out)); s != "" {
+		log.Info(s)
+	}
 	return nil
 }
 


### PR DESCRIPTION
if the output is not empty, log it with info.

this prevents potentially hiding warnings et al.

on successful builds usually the output is empty anyway.

closes #4782
