### PR TITLE
improve -p help message

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -87,7 +87,7 @@ When using ` + "`--single-target`" + `, the ` + "`GOOS`" + ` and ` + "`GOARCH`" 
 	cmd.Flags().BoolVar(&root.opts.skipPostHooks, "skip-post-hooks", false, "Skips all post-build hooks")
 	cmd.Flags().BoolVar(&root.opts.clean, "clean", false, "Removes the 'dist' directory before building")
 	cmd.Flags().BoolVar(&root.opts.rmDist, "rm-dist", false, "Removes the 'dist' directory before building")
-	cmd.Flags().IntVarP(&root.opts.parallelism, "parallelism", "p", 0, "Amount tasks to run concurrently (default: number of CPUs)")
+	cmd.Flags().IntVarP(&root.opts.parallelism, "parallelism", "p", 0, "Number of tasks to run concurrently (default: number of CPUs)")
 	_ = cmd.RegisterFlagCompletionFunc("parallelism", cobra.NoFileCompletions)
 	cmd.Flags().DurationVar(&root.opts.timeout, "timeout", 30*time.Minute, "Timeout to the entire build process")
 	_ = cmd.RegisterFlagCompletionFunc("timeout", cobra.NoFileCompletions)


### PR DESCRIPTION
I just improved the verbiage of the `build -p` switch:

from: `Amount tasks to run concurrently (default: number of CPUs)`

to: `Number of tasks to run concurrently (default: number of CPUs)`