### PR TITLE
chore(gitea): refactor changelog author info

### DIFF
--- a/internal/client/gitea.go
+++ b/internal/client/gitea.go
@@ -84,10 +84,11 @@ func (c *giteaClient) Changelog(_ *context.Context, repo Repo, prev, current str
 
 	for _, commit := range result.Commits {
 		log = append(log, fmt.Sprintf(
-			"%s: %s (@%s)",
+			"%s: %s (@%s <%s>)",
 			commit.SHA[:7],
 			strings.Split(commit.RepoCommit.Message, "\n")[0],
 			commit.Author.UserName,
+			commit.RepoCommit.Author.Name,
 		))
 	}
 	return strings.Join(log, "\n"), nil

--- a/www/docs/customization/changelog.md
+++ b/www/docs/customization/changelog.md
@@ -21,7 +21,7 @@ changelog:
   # - `git`: uses `git log`;
   # - `github`: uses the compare GitHub API, appending the author username to the changelog.
   # - `gitlab`: uses the compare GitLab API, appending the author name and email to the changelog.
-  # - `gitea`: uses the compare Gitea API, appending the author username to the changelog.
+  # - `gitea`: uses the compare Gitea API, appending the author username and name to the changelog.
   # - `github-native`: uses the GitHub release notes generation API, disables the groups feature.
   #
   # Default: 'git'


### PR DESCRIPTION
- Change author information in Gitea changelog from email to name
- Update documentation to reflect the change in author information for Gitea changelog entries

according to the comment https://github.com/goreleaser/goreleaser/pull/4794#discussion_r1574739632

Due to our company's accounts all starting with `mtk` followed by a five-digit employee number, it is difficult to identify who made contributions in the Changelog. Therefore, we have added the username for easier recognition. Like as the following git log

![image](https://github.com/goreleaser/goreleaser/assets/21979/7eeeb3a6-44aa-42bd-80da-a44a8b0b4cdd)

cc @caarlos0 
