### PR TITLE
feat: custom SCM on brew, nix, krew, winget, scoop

### DIFF
--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -170,7 +170,11 @@ func doPublish(ctx *context.Context, formula *artifact.Artifact, cl client.Clien
 			CreateFile(ctx, author, repo, content, gpath, msg)
 	}
 
-	cl, err = client.NewIfToken(ctx, cl, brew.Repository.Token)
+	tokenType, err := client.TokenTypeFromStringOrDefault(ctx, brew.Repository.TokenType)
+	if err != nil {
+		return err
+	}
+	cl, err = client.NewIfToken(ctx, cl, brew.Repository.Token, tokenType)
 	if err != nil {
 		return err
 	}

--- a/internal/pipe/krew/krew.go
+++ b/internal/pipe/krew/krew.go
@@ -330,7 +330,11 @@ func doPublish(ctx *context.Context, manifest *artifact.Artifact, cl client.Clie
 			CreateFile(ctx, author, repo, content, gpath, msg)
 	}
 
-	cl, err = client.NewIfToken(ctx, cl, cfg.Repository.Token)
+	tokenType, err := client.TokenTypeFromStringOrDefault(ctx, cfg.Repository.TokenType)
+	if err != nil {
+		return err
+	}
+	cl, err = client.NewIfToken(ctx, cl, cfg.Repository.Token, tokenType)
 	if err != nil {
 		return err
 	}

--- a/internal/pipe/nix/nix.go
+++ b/internal/pipe/nix/nix.go
@@ -385,7 +385,11 @@ func doPublish(ctx *context.Context, prefetcher shaPrefetcher, cl client.Client,
 			CreateFile(ctx, author, repo, []byte(content), gpath, msg)
 	}
 
-	cl, err = client.NewIfToken(ctx, cl, nix.Repository.Token)
+	tokenType, err := client.TokenTypeFromStringOrDefault(ctx, nix.Repository.TokenType)
+	if err != nil {
+		return err
+	}
+	cl, err = client.NewIfToken(ctx, cl, nix.Repository.Token, tokenType)
 	if err != nil {
 		return err
 	}

--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -258,7 +258,11 @@ func doPublish(ctx *context.Context, manifest *artifact.Artifact, cl client.Clie
 			CreateFile(ctx, author, repo, content, gpath, commitMessage)
 	}
 
-	cl, err = client.NewIfToken(ctx, cl, scoop.Repository.Token)
+	tokenType, err := client.TokenTypeFromStringOrDefault(ctx, scoop.Repository.TokenType)
+	if err != nil {
+		return err
+	}
+	cl, err = client.NewIfToken(ctx, cl, scoop.Repository.Token, tokenType)
 	if err != nil {
 		return err
 	}

--- a/internal/pipe/winget/winget.go
+++ b/internal/pipe/winget/winget.go
@@ -311,7 +311,11 @@ func doPublish(ctx *context.Context, cl client.Client, wingets []*artifact.Artif
 			CreateFiles(ctx, author, repo, msg, files)
 	}
 
-	cl, err = client.NewIfToken(ctx, cl, winget.Repository.Token)
+	tokenType, err := client.TokenTypeFromStringOrDefault(ctx, winget.Repository.TokenType)
+	if err != nil {
+		return err
+	}
+	cl, err = client.NewIfToken(ctx, cl, winget.Repository.Token, tokenType)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -83,10 +83,11 @@ func (r Repo) isSCM() bool {
 // also require separate authentication
 // e.g. Homebrew Tap, Scoop bucket.
 type RepoRef struct {
-	Owner  string `yaml:"owner,omitempty" json:"owner,omitempty"`
-	Name   string `yaml:"name,omitempty" json:"name,omitempty"`
-	Token  string `yaml:"token,omitempty" json:"token,omitempty"`
-	Branch string `yaml:"branch,omitempty" json:"branch,omitempty"`
+	Owner     string `yaml:"owner,omitempty" json:"owner,omitempty"`
+	Name      string `yaml:"name,omitempty" json:"name,omitempty"`
+	Token     string `yaml:"token,omitempty" json:"token,omitempty"`
+	TokenType string `yaml:"token_type,omitempty" json:"token_type,omitempty" jsonschema:"enum=github,enum=gitlab,enum=gitea"`
+	Branch    string `yaml:"branch,omitempty" json:"branch,omitempty"`
 
 	Git         GitRepoRef  `yaml:"git,omitempty" json:"git,omitempty"`
 	PullRequest PullRequest `yaml:"pull_request,omitempty" json:"pull_request,omitempty"`


### PR DESCRIPTION
allows to publish to a SCM different from the repo itself by specifying both the token type and custom token.

very wip