### PR TITLE
fix termux

### DIFF
--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -196,7 +196,7 @@ func TestRunPipe(t *testing.T) {
 			},
 		},
 	}, testctx.WithVersion("1.0.0"), testctx.WithCurrentTag("v1.0.0"))
-	for _, goos := range []string{"linux", "darwin", "ios"} {
+	for _, goos := range []string{"linux", "darwin", "ios", "android"} {
 		for _, goarch := range []string{"amd64", "386", "arm64", "arm", "mips"} {
 			if goos == "ios" && goarch != "arm64" {
 				continue
@@ -415,9 +415,12 @@ func TestRunPipe(t *testing.T) {
 			}
 		}
 
-		if pkg.Goos == "linux" {
+		switch pkg.Goos {
+		case "linux":
 			require.Equal(t, "foo_1.0.0_linux_"+arch+"-10-20"+ext, pkg.Name)
-		} else {
+		case "android":
+			require.Equal(t, "foo_1.0.0_android_"+arch+"-10-20"+ext, pkg.Name)
+		default:
 			require.Equal(t, "foo_1.0.0_ios_arm64-10-20"+ext, pkg.Name)
 		}
 		require.Equal(t, "someid", pkg.ID())
@@ -961,7 +964,7 @@ func TestDebSpecificConfig(t *testing.T) {
 				},
 			},
 		}, testctx.WithVersion("1.0.0"), testctx.WithCurrentTag("v1.0.0"))
-		for _, goos := range []string{"linux", "darwin"} {
+		for _, goos := range []string{"linux", "darwin", "android"} {
 			for _, goarch := range []string{"amd64", "386"} {
 				ctx.Artifacts.Add(&artifact.Artifact{
 					Name:   "mybin",
@@ -1617,6 +1620,15 @@ func TestTemplateExt(t *testing.T) {
 				Formats:    []string{"deb", "rpm", "termux.deb", "apk", "archlinux"},
 				Builds:     []string{"default"},
 			},
+		},
+	})
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name:   "mybin",
+		Goos:   "android",
+		Goarch: "amd64",
+		Type:   artifact.Binary,
+		Extra: map[string]interface{}{
+			artifact.ExtraID: "default",
 		},
 	})
 	ctx.Artifacts.Add(&artifact.Artifact{

--- a/www/docs/customization/nfpm.md
+++ b/www/docs/customization/nfpm.md
@@ -498,6 +498,7 @@ Termux is the same format as `deb`, the differences are:
 
 - it uses a different `bindir` (prefixed with `/data/data/com.termux/files/`)
 - it uses slightly different architecture names than Debian
+- it will only package binaries built for Android
 
 ## Conventional file names, Debian, and ARMv6
 


### PR DESCRIPTION
Ensure `GOOS` is `android` and patch `infoPlatform`.

fix #4809 