### PR TITLE
blob: permit skipping the configuration of the Content-Disposition header

### DIFF
--- a/internal/pipe/blob/blob.go
+++ b/internal/pipe/blob/blob.go
@@ -33,9 +33,13 @@ func (Pipe) Default(ctx *context.Context) error {
 		if blob.Directory == "" {
 			blob.Directory = "{{ .ProjectName }}/{{ .Tag }}"
 		}
+
 		if blob.ContentDisposition == "" {
 			blob.ContentDisposition = "attachment;filename={{.Filename}}"
+		} else if blob.ContentDisposition == "-" {
+			blob.ContentDisposition = ""
 		}
+
 		if blob.OldDisableSSL {
 			deprecate.Notice(ctx, "blobs.disableSSL")
 			blob.DisableSSL = true

--- a/internal/pipe/blob/blob_test.go
+++ b/internal/pipe/blob/blob_test.go
@@ -75,8 +75,9 @@ func TestDefaults(t *testing.T) {
 				ContentDisposition: "inline",
 			},
 			{
-				Bucket:   "foobar",
-				Provider: "gcs",
+				Bucket:             "foobar",
+				Provider:           "gcs",
+				ContentDisposition: "-",
 			},
 			{
 				Bucket:        "deprecated",
@@ -100,7 +101,7 @@ func TestDefaults(t *testing.T) {
 			Bucket:             "foobar",
 			Provider:           "gcs",
 			Directory:          "{{ .ProjectName }}/{{ .Tag }}",
-			ContentDisposition: "attachment;filename={{.Filename}}",
+			ContentDisposition: "",
 		},
 		{
 			Bucket:             "deprecated",

--- a/www/docs/customization/blob.md
+++ b/www/docs/customization/blob.md
@@ -116,6 +116,7 @@ blobs:
     # Since: v1.24
     # Default: attachment;filename={{.Filename}}
     # Templates: allowed
+    # Disable by setting the value to '-'
     content_disposition: "inline"
 
   - provider: gs


### PR DESCRIPTION
This change would allow users to disable the `Content-Disposition` header that is set for blob storage operations. The application will continue to set a default value for `Content-Disposition` of `attachment; filename={{.Filename}}` if no value was provided by the user. However, with this change, users can now specifically disable this header by setting the value to "-" in the configuration.

We feel this would be a nice solution for this issue: https://github.com/Homebrew/brew/issues/15604
