### PR TITLE
docs: update old Go website links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ By participating in this project, you agree to abide our
 
 ## Set up your machine
 
-`goreleaser` is written in [Go](https://golang.org/).
+`goreleaser` is written in [Go](https://go.dev/).
 
 Prerequisites:
 

--- a/internal/builders/buildtarget/targets.go
+++ b/internal/builders/buildtarget/targets.go
@@ -138,7 +138,7 @@ func contains(s string, ss []string) bool {
 	return false
 }
 
-// lists from https://golang.org/doc/install/source#environment
+// lists from https://go.dev/doc/install/source#environment
 // nolint: gochecknoglobals
 var (
 	validTargets = []string{

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -522,7 +522,7 @@ func TestBuild(t *testing.T) {
 		fi, err := os.Stat(bin.Path)
 		require.NoError(t, err)
 
-		// make this a suitable map key, per docs: https://golang.org/pkg/time/#Time
+		// make this a suitable map key, per docs: https://pkg.go.dev/time#Time
 		modTime := fi.ModTime().UTC().Round(0).Unix()
 
 		if modTimes[modTime] {

--- a/www/docs/contributing.md
+++ b/www/docs/contributing.md
@@ -5,7 +5,7 @@ By participating in this project, you agree to abide our
 
 ## Set up your machine
 
-`goreleaser` is written in [Go](https://golang.org/).
+`goreleaser` is written in [Go](https://go.dev/).
 
 Prerequisites:
 

--- a/www/docs/cookbooks/using-main.version.md
+++ b/www/docs/cookbooks/using-main.version.md
@@ -6,7 +6,7 @@ By default, GoReleaser will set the following 3 _ldflags_:
   the snapshot, if you're using the `--snapshot` flag
 - `main.commit`: Current git commit SHA
 - `main.date`: Date in the
-  [RFC3339](https://golang.org/pkg/time/#pkg-constants) format
+  [RFC3339](https://pkg.go.dev/time#pkg-constants) format
 
 You can use them in your `main.go` file to print more build details:
 

--- a/www/docs/customization/builds.md
+++ b/www/docs/customization/builds.md
@@ -93,7 +93,7 @@ builds:
         {{- end }}
 
     # GOOS list to build for.
-    # For more info refer to: https://golang.org/doc/install/source#environment
+    # For more info refer to: https://go.dev/doc/install/source#environment
     #
     # Default: [ 'darwin', 'linux', 'windows' ]
     goos:
@@ -101,7 +101,7 @@ builds:
       - windows
 
     # GOARCH to build for.
-    # For more info refer to: https://golang.org/doc/install/source#environment
+    # For more info refer to: https://go.dev/doc/install/source#environment
     #
     # Default: [ '386', 'amd64', 'arm64' ]
     goarch:
@@ -110,7 +110,7 @@ builds:
       - arm64
 
     # GOARM to build for when GOARCH is arm.
-    # For more info refer to: https://golang.org/doc/install/source#environment
+    # For more info refer to: https://go.dev/doc/install/source#environment
     #
     # Default: [ 6 ]
     goarm:
@@ -118,7 +118,7 @@ builds:
       - 7
 
     # GOAMD64 to build when GOARCH is amd64.
-    # For more info refer to: https://golang.org/doc/install/source#environment
+    # For more info refer to: https://go.dev/doc/install/source#environment
     #
     # Default: [ 'v1' ]
     goamd64:
@@ -126,7 +126,7 @@ builds:
       - v3
 
     # GOMIPS and GOMIPS64 to build when GOARCH is mips, mips64, mipsle or mips64le.
-    # For more info refer to: https://golang.org/doc/install/source#environment
+    # For more info refer to: https://go.dev/doc/install/source#environment
     #
     # Default: [ 'hardfloat' ]
     gomips:

--- a/www/docs/customization/templates.md
+++ b/www/docs/customization/templates.md
@@ -143,18 +143,18 @@ On all fields, you have these available functions:
 
 | Usage                             | Description                                                                                                                     |
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `replace "v1.2" "v" ""`           | replaces all matches. See [ReplaceAll](https://golang.org/pkg/strings/#ReplaceAll).                                             |
-| `split "1.2" "."`                 | split string at separator. See [Split](https://golang.org/pkg/strings/#Split). Since v1.11                                      |
+| `replace "v1.2" "v" ""`           | replaces all matches. See [ReplaceAll](https://pkg.go.dev/strings#ReplaceAll).                                                  |
+| `split "1.2" "."`                 | split string at separator. See [Split](https://pkg.go.dev/strings#Split). Since v1.11                                           |
 | `time "01/02/2006"`               | current UTC time in the specified format (this is not deterministic, a new time for every call).                                |
-| `contains "foobar" "foo"`         | checks whether the first string contains the second. See [ToLower](https://golang.org/pkg/strings/#Contains). Since 1.24        |
-| `tolower "V1.2"`                  | makes input string lowercase. See [ToLower](https://golang.org/pkg/strings/#ToLower).                                           |
-| `toupper "v1.2"`                  | makes input string uppercase. See [ToUpper](https://golang.org/pkg/strings/#ToUpper).                                           |
-| `trim " v1.2  "`                  | removes all leading and trailing white space. See [TrimSpace](https://golang.org/pkg/strings/#TrimSpace).                       |
-| `trimprefix "v1.2" "v"`           | removes provided leading prefix string, if present. See [TrimPrefix](https://golang.org/pkg/strings/#TrimPrefix).               |
+| `contains "foobar" "foo"`         | checks whether the first string contains the second. See [ToLower](https://pkg.go.dev/strings#Contains). Since 1.24             |
+| `tolower "V1.2"`                  | makes input string lowercase. See [ToLower](https://pkg.go.dev/strings#ToLower).                                                |
+| `toupper "v1.2"`                  | makes input string uppercase. See [ToUpper](https://pkg.go.dev/strings#ToUpper).                                                |
+| `trim " v1.2  "`                  | removes all leading and trailing white space. See [TrimSpace](https://pkg.go.dev/strings#TrimSpace).                            |
+| `trimprefix "v1.2" "v"`           | removes provided leading prefix string, if present. See [TrimPrefix](https://pkg.go.dev/strings#TrimPrefix).                    |
 | `trimsuffix "1.2v" "v"`           | removes provided trailing suffix string, if present. See [TrimSuffix](https://pkg.go.dev/strings#TrimSuffix).                   |
-| `dir .Path`                       | returns all but the last element of path, typically the path's directory. See [Dir](https://golang.org/pkg/path/filepath/#Dir). |
-| `base .Path`                      | returns the last element of path. See [Base](https://golang.org/pkg/path/filepath/#Base). Since v1.16                           |
-| `abs .ArtifactPath`               | returns an absolute representation of path. See [Abs](https://golang.org/pkg/path/filepath/#Abs).                               |
+| `dir .Path`                       | returns all but the last element of path, typically the path's directory. See [Dir](https://pkg.go.dev/path/filepath#Dir).      |
+| `base .Path`                      | returns the last element of path. See [Base](https://pkg.go.dev/path/filepath#Base). Since v1.16                                |
+| `abs .ArtifactPath`               | returns an absolute representation of path. See [Abs](https://pkg.go.dev/path/filepath#Abs).                                    |
 | `filter "text" "regex"`           | keeps only the lines matching the given regex, analogous to `grep -E`. Since v1.6                                               |
 | `reverseFilter "text" "regex"`    | keeps only the lines **not** matching the given regex, analogous to `grep -vE`. Since v1.6                                      |
 | `title "foo"`                     | "titlenize" the string using english as language. See [Title](https://pkg.go.dev/golang.org/x/text/cases#Title). Since v1.14    |


### PR DESCRIPTION
The PR updates the links in the docs, replacing the old `golang.org` with the new `go.dev`.