### PR TITLE
fix: close HTTP resp body to prevent resource leak

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,6 +5,7 @@ linters:
   enable:
     - thelper
     - gofumpt
+    - bodyclose
     - tparallel
     - unconvert
     - unparam

--- a/internal/pipe/blob/blob_minio_test.go
+++ b/internal/pipe/blob/blob_minio_test.go
@@ -55,8 +55,12 @@ func TestMain(m *testing.M) {
 	})
 	requireNoErr(err)
 	requireNoErr(pool.Retry(func() error {
-		_, err := http.Get(fmt.Sprintf("http://localhost:%s/minio/health/ready", resource.GetPort("9000/tcp")))
-		return err
+		resp, err := http.Get(fmt.Sprintf("http://localhost:%s/minio/health/ready", resource.GetPort("9000/tcp")))
+		if err != nil {
+			return err
+		}
+		resp.Body.Close()
+		return nil
 	}))
 	listen = "localhost:" + resource.GetPort("9000/tcp")
 

--- a/internal/pipe/discord/discord.go
+++ b/internal/pipe/discord/discord.go
@@ -91,6 +91,7 @@ func (p Pipe) Announce(ctx *context.Context) error {
 	if err != nil {
 		return fmt.Errorf("discord: %w", err)
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != 204 && resp.StatusCode != 200 {
 		return fmt.Errorf("discord: %s", resp.Status)


### PR DESCRIPTION
This PR fixes possible resource leaks by adding a statement that closes a response body.

From the [documentation](https://pkg.go.dev/net/http):
> The caller must close the response body when finished with it

Also, see this [article](https://golang50shad.es/index.html#close_http_resp_body) for a deep dive into the problem.