### PR TITLE
feat(chocolatey): allow template in copyright, provide ctx.ReleaseNotes

### DIFF
--- a/internal/pipe/chocolatey/chocolatey.go
+++ b/internal/pipe/chocolatey/chocolatey.go
@@ -219,7 +219,10 @@ func doPush(ctx *context.Context, art *artifact.Artifact) error {
 func buildNuspec(ctx *context.Context, choco config.Chocolatey) ([]byte, error) {
 	tpl := tmpl.New(ctx)
 
-	if err := tpl.ApplyAll(
+	if err := tpl.WithExtraFields(tmpl.Fields{
+		"Changelog": ctx.ReleaseNotes,
+	}).ApplyAll(
+		&choco.Copyright,
 		&choco.Summary,
 		&choco.Description,
 		&choco.ReleaseNotes,

--- a/www/docs/customization/chocolatey.md
+++ b/www/docs/customization/chocolatey.md
@@ -70,6 +70,8 @@ chocolateys:
     icon_url: "https://rawcdn.githack.com/foo/bar/efbdc760-395b-43f1-bf69-ba25c374d473/icon.png"
 
     # Your app's copyright details.
+    #
+    # Templates: allowed (since v2.1)
     copyright: 2022 Drummer Roll Inc
 
     # App's license information url.


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

This PR allows `chocolateys.copyright` to be templated, and provides `ctx.ReleaseNotes` as `.Changelog`.

<!-- Why is this change being made? -->

Allowing templates for the copyright will enable, for example:

```yaml
chocolateys:
- ...
  copyright: Copyright (c) 1970-{{ .Now.Format "2006" }} Foo Bar
  ...
```

Without this change:

```xml
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
  <metadata>
    ...
    <copyright>Copyright (c) 1970-{{ .Now.Format &#34;2006&#34; }} Foo Bar</copyright>
    ...
  </metadata>
  ...
</package>
```

With this change:

```xml
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
  <metadata>
    ...
    <copyright>Copyright (c) 1970-2024 Foo Bar</copyright>
    ...
  </metadata>
  ...
</package>
```

---

Providing the release notes means they can be placed directly in the package page instead of linking to them, for example:

```yaml
chocolateys:
- ...
  release_notes: '{{ .Changelog }}'
  ...
```

Without this change:

```console
❯ goreleaser release --skip=sign,announce,publish --clean
  • starting release...
  ...
  • chocolatey packages
    ⨯ release failed after 4s                  error=template: failed to apply "{{ .Changelog }}": template: failed to apply "{{ .Changelog }}": map has no entry for key "Changelog"
```

With this change:

```xml
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
  <metadata>
    ...
    <releaseNotes>## Changelog&#xA;### Other&#xA;* cfa5cbfa5 test&#xA;</releaseNotes>
    ...
  </metadata>
  ...
</package>
```

<!-- # Provide links to any relevant tickets, URLs or other resources -->

---

These are already supported for WinGet.

There is probably a better way of doing this, and I've probably also missed something, so feedback is welcome!