### PR TITLE
chore: fix exe typo in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ dist/
 bin/
 coverage.txt
 goreleaser
-gorelaser.exe
+goreleaser.exe
 debug.test
 snap.login
 site/


### PR DESCRIPTION
I noticed this while working on https://github.com/goreleaser/goreleaser/pull/4858.