### PR TITLE
fix(build): do not print 'go: downloading' bits of go build output

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -381,10 +381,21 @@ func run(ctx *context.Context, command, env []string, dir string) error {
 	if err != nil {
 		return fmt.Errorf("%w: %s", err, string(out))
 	}
-	if s := strings.TrimSpace(string(out)); s != "" {
+	if s := buildOutput(out); s != "" {
 		log.Info(s)
 	}
 	return nil
+}
+
+func buildOutput(out []byte) string {
+	var lines []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if strings.HasPrefix(line, "go: downloading") {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n")
 }
 
 func checkMain(build config.Build) error {

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -1433,6 +1433,25 @@ func TestInvalidGoBinaryTpl(t *testing.T) {
 	}))
 }
 
+func TestBuildOutput(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		require.Empty(t, buildOutput([]byte{}))
+	})
+	t.Run("downloading only", func(t *testing.T) {
+		require.Empty(t, buildOutput([]byte(`
+go: downloading github.com/atotto/clipboard v0.1.4
+go: downloading github.com/caarlos0/duration v0.0.0-20240108180406-5d492514f3c7
+		`)))
+	})
+	t.Run("mixed", func(t *testing.T) {
+		require.NotEmpty(t, buildOutput([]byte(`
+go: downloading github.com/atotto/clipboard v0.1.4
+go: downloading github.com/caarlos0/duration v0.0.0-20240108180406-5d492514f3c7
+something something
+		`)))
+	})
+}
+
 //
 // Helpers
 //


### PR DESCRIPTION
this prevents printing `go: downloading` on go builds in case the mods weren't previously downloaded...