### PR TITLE
feat(archive): support `.tzst` suffix

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -32,7 +32,7 @@ func New(w io.Writer, format string) (Archive, error) {
 		return gzip.New(w), nil
 	case "tar.xz", "txz":
 		return tarxz.New(w), nil
-	case "tar.zst":
+	case "tar.zst", "tzst":
 		return tarzst.New(w), nil
 	case "zip":
 		return zip.New(w), nil

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -18,7 +18,7 @@ func TestArchive(t *testing.T) {
 	require.NoError(t, empty.Close())
 	require.NoError(t, os.Mkdir(folder+"/folder-inside", 0o755))
 
-	for _, format := range []string{"tar.gz", "zip", "gz", "tar.xz", "tar", "tgz", "txz", "tar.zst"} {
+	for _, format := range []string{"tar.gz", "zip", "gz", "tar.xz", "tar", "tgz", "txz", "tar.zst", "tzst"} {
 		t.Run(format, func(t *testing.T) {
 			f1, err := os.Create(filepath.Join(t.TempDir(), "1.tar"))
 			require.NoError(t, err)
@@ -36,7 +36,7 @@ func TestArchive(t *testing.T) {
 			require.NoError(t, archive.Close())
 			require.NoError(t, f1.Close())
 
-			if format == "tar.xz" || format == "txz" || format == "gz" || format == "tar.zst" {
+			if format == "tar.xz" || format == "txz" || format == "gz" || format == "tar.zst" || format == "tzst" {
 				_, err := Copying(f1, io.Discard, format)
 				require.Error(t, err)
 				return

--- a/www/docs/customization/archive.md
+++ b/www/docs/customization/archive.md
@@ -29,8 +29,8 @@ archives:
     # - `tgz`
     # - `tar.xz`
     # - `txz`
-    # - `tar.zst` (Since v1.26)
-    # - `tzst`
+    # - `tar.zst` (since v1.26)
+    # - `tzst` (since v2.1)
     # - `tar`
     # - `gz`
     # - `zip`

--- a/www/docs/customization/archive.md
+++ b/www/docs/customization/archive.md
@@ -30,6 +30,7 @@ archives:
     # - `tar.xz`
     # - `txz`
     # - `tar.zst` (Since v1.26)
+    # - `tzst`
     # - `tar`
     # - `gz`
     # - `zip`


### PR DESCRIPTION
See <https://lists.gnu.org/archive/html/info-gnu/2019-01/msg00001.html>:

> When '-a' option is in effect, zstd compression is selected if the
> destination archive name ends in '.zst' or '.tzst'.