### PR TITLE
Add support for Platform and RPM.Arch, plus AIX

### DIFF
--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -200,7 +200,7 @@ func create(ctx *context.Context, fpm config.NFPM, format string, artifacts []*a
 	// Additionally, it is recommended to set the rpmArch to ppc
 	// As AIX, while being ppc64, expects the rpms to specify ppc.
 	// We will default to setting ppc here, but again this can be
-	// overriden by setting it in your .goreleaser.yaml See the following:
+	// overridden by setting it in your .goreleaser.yaml See the following:
 	// https://developer.ibm.com/articles/au-aix-build-open-source-rpm-packages/
 	// https://developer.ibm.com/articles/configure-yum-on-aix/
 	if infoPlatform == "aix" {

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -818,7 +818,7 @@ func TestNoBuildsFound(t *testing.T) {
 			artifact.ExtraID: "default",
 		},
 	})
-	require.EqualError(t, Pipe{}.Run(ctx), `no linux binaries found for builds [nope]`)
+	require.EqualError(t, Pipe{}.Run(ctx), `no linux/unix binaries found for builds [nope]`)
 }
 
 func TestCreateFileDoesntExist(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -765,6 +765,7 @@ type NFPM struct {
 	Builds      []string `yaml:"builds,omitempty" json:"builds,omitempty"`
 	Formats     []string `yaml:"formats,omitempty" json:"formats,omitempty" jsonschema:"enum=apk,enum=deb,enum=rpm,enum=termux.deb,enum=archlinux,enum=ipk"`
 	Section     string   `yaml:"section,omitempty" json:"section,omitempty"`
+	Platform    string   `yaml:"platform,omitempty" json:"platform,omitempty"`
 	Priority    string   `yaml:"priority,omitempty" json:"priority,omitempty"`
 	Vendor      string   `yaml:"vendor,omitempty" json:"vendor,omitempty"`
 	Homepage    string   `yaml:"homepage,omitempty" json:"homepage,omitempty"`
@@ -812,6 +813,7 @@ type NFPMRPM struct {
 	Scripts     NFPMRPMScripts   `yaml:"scripts,omitempty" json:"scripts,omitempty"`
 	Prefixes    []string         `yaml:"prefixes,omitempty" json:"prefixes,omitempty"`
 	Packager    string           `yaml:"packager,omitempty" json:"packager,omitempty"`
+	Arch        string           `yaml:"arch,omitempty" json:"arch,omitempty"`
 }
 
 // NFPMDebScripts is scripts only available on deb packages.


### PR DESCRIPTION
First pass at adding support for AIX rpm files by allowing platform and rpm.arch to be set

If applied, this commit will add the ability to manually specify the platform and rpm.arch fields for nfpm. This brings parity to the product with the experience of standalone nfpm.

Additionally, it brings in support for creating AIX rpm files, for which the 2 fields above are necessary.

This change is being made, due to a desire from my team to add support for AIX for our customers.

Addresses #4853
Based on findings from goreleaser/nfpm#821