### PR TITLE
feat(nfpm): support arm in termux

### DIFF
--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -147,7 +147,7 @@ func isSupportedTermuxArch(goos, goarch string) bool {
 	if goos != "android" {
 		return false
 	}
-	for _, arch := range []string{"amd64", "arm64", "386"} {
+	for _, arch := range []string{"amd64", "arm64", "arm", "386"} {
 		if strings.HasPrefix(goarch, arch) {
 			return true
 		}
@@ -173,6 +173,7 @@ var termuxArchReplacer = strings.NewReplacer(
 	"386", "i686",
 	"amd64", "x86_64",
 	"arm64", "aarch64",
+	"arm6", "arm",
 )
 
 func create(ctx *context.Context, fpm config.NFPM, format string, artifacts []*artifact.Artifact) error {

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -389,7 +389,7 @@ func TestRunPipe(t *testing.T) {
 	}
 	require.NoError(t, Pipe{}.Run(ctx))
 	packages := ctx.Artifacts.Filter(artifact.ByType(artifact.LinuxPackage)).List()
-	require.Len(t, packages, 44)
+	require.Len(t, packages, 46)
 	for _, pkg := range packages {
 		format := pkg.Format()
 		require.NotEmpty(t, format)


### PR DESCRIPTION
This adds `arm` support for termux (arch needs to be called `arm` as well).

---

Ok this drove me nuts, but I think I've got it working now: https://github.com/carapace-sh/carapace-bin/releases/tag/v1.0.3

1.  First of all most of the `android` targets need `CGO_ENABLED=1`.

2. Then there's the need for a [patched  runtime](https://github.com/carapace-sh/go/tree/master/termux) due to the `/data/data/com.termux/files` prefix (adopted from the [golang package](https://github.com/termux/termux-packages/tree/master/packages/golang)).

3. Two builds so that for termux the patched `gobinary` can be used. Then add a `termux` suffix to the archives for clarity.

```yaml
builds:
  - id: default
    env:
      - CGO_ENABLED=0
    goos:
      - linux
      - windows
      - darwin
    main: ./cmd/carapace
    binary: carapace
    tags:
      - release
  - id: termux
    env:
      - CGO_ENABLED=1
    goos:
      - android
    goarch:
      - amd64
      - arm64
      - arm
      - "386"
    main: ./cmd/carapace
    binary: carapace
    tags:
      - release
    gobinary: go-termux
archives:
  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
    builds:
     - default
    format_overrides:
      - goos: windows
        format: zip
  - id: termux
    builds:
      - termux
    name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}.termux'
```

4. Compiling needs the [Android NDK](https://developer.android.com/ndk) with the `CC` environment variable set. I used a [script](https://github.com/carapace-sh/go/blob/master/go-termux.sh) for this (`/usr/local/bin/go-termux`).

```sh
#!/bin/bash

bindir="/opt/android-sdk/ndk/${NDK_VERSION}/toolchains/llvm/prebuilt/linux-x86_64/bin"
[ "$GOARCH" = "amd64" ] && export CC="$bindir/x86_64-linux-android${ANDROID_VERSION}-clang"
[ "$GOARCH" = "arm64" ] && export CC="$bindir/aarch64-linux-android${ANDROID_VERSION}-clang"
[ "$GOARCH" = "arm" ] && export CC="$bindir/armv7a-linux-androideabi${ANDROID_VERSION}-clang"
[ "$GOARCH" = "386" ] && export CC="$bindir/i686-linux-android${ANDROID_VERSION}-clang"

exec /usr/local/go-termux/bin/go "$@"
```

5. There's [termux-apt-repo](https://github.com/termux/termux-apt-repo) which makes repo creation pretty easy with `gh_pages`. Just needs a [fix](https://github.com/termux/termux-apt-repo/pull/25) as goreleaser uses `data.tar.gz`.

related #3333
related #4812 
related https://github.com/termux/termux-apt-repo/pull/25