### PR TITLE
docs: added the missing deprecation notices deep link to v2 section

### DIFF
--- a/www/docs/blog/posts/2024-06-04-goreleaser-v2.md
+++ b/www/docs/blog/posts/2024-06-04-goreleaser-v2.md
@@ -150,3 +150,4 @@ Happy releasing! 🚀
 [last-v1]: https://goreleaser.com/blog/goreleaser-v1.26
 [v1]: https://goreleaser.com/blog/goreleaser-v1
 [discord]: https://goreleaser.com/discord
+[notices]: https://goreleaser.com/deprecations/#removed-in-v2


### PR DESCRIPTION
Added the missing deprecation notices deep link to v2 section.

> If you keep up with the [deprecation notices][notices], it's likely you don't need to do anything.

_<https://goreleaser.com/blog/goreleaser-v2/#upgrading>_