### PR TITLE
docs(notarize): use a Application cert not an Installer cert

### DIFF
--- a/www/docs/customization/notarize.md
+++ b/www/docs/customization/notarize.md
@@ -9,7 +9,7 @@ To use it, you'll need:
 
 - An [Apple Developer Account](https://developer.apple.com/) ($99/year).
 - A [certificate](https://developer.apple.com/account/resources/certificates/add)
-  from said account. It should be of "Developer ID Installer" type.
+  from said account. It should be of "Developer ID Application" type.
   This will give you a `.cer` file. You'll need to import it into KeyChain.app,
   and then export it as a `.p12` file. It'll will have a password.
 - An App Store Connect


### PR DESCRIPTION
<!-- If applied, this commit will... -->

Changes the documentation to reflect a Developer ID _Application_ certificate being required to notarize a binary as opposed to a Developer ID _Installer_ certificate.

<!-- Why is this change being made? -->

Without this, a cryptic `x509: unhandled critical extension` error will be thrown from quill.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

Related: https://github.com/anchore/quill/issues/431
