### PR TITLE
fix: actually respect changelog.abbrev

### DIFF
--- a/internal/client/gitea.go
+++ b/internal/client/gitea.go
@@ -84,7 +84,7 @@ func (c *giteaClient) Changelog(_ *context.Context, repo Repo, prev, current str
 
 	for _, commit := range result.Commits {
 		log = append(log, ChangelogItem{
-			SHA:            commit.SHA[:7],
+			SHA:            commit.SHA,
 			Message:        strings.Split(commit.RepoCommit.Message, "\n")[0],
 			AuthorName:     commit.Author.FullName,
 			AuthorEmail:    commit.Author.Email,

--- a/internal/client/gitea_test.go
+++ b/internal/client/gitea_test.go
@@ -650,7 +650,7 @@ func TestGiteaChangelog(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []ChangelogItem{
 		{
-			SHA:            "c8488dc",
+			SHA:            "c8488dc825debca26ade35aefca234b142a515c9",
 			Message:        "feat: impl something",
 			AuthorUsername: "johndoe",
 			AuthorName:     "John Doe",

--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -94,7 +94,7 @@ func (c *gitlabClient) Changelog(_ *context.Context, repo Repo, prev, current st
 
 	for _, commit := range result.Commits {
 		log = append(log, ChangelogItem{
-			SHA:         commit.ShortID,
+			SHA:         commit.ID,
 			Message:     strings.Split(commit.Message, "\n")[0],
 			AuthorName:  commit.AuthorName,
 			AuthorEmail: commit.AuthorEmail,

--- a/internal/client/gitlab_test.go
+++ b/internal/client/gitlab_test.go
@@ -511,7 +511,7 @@ func TestGitLabChangelog(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []ChangelogItem{
 		{
-			SHA:            "6dcb09b5",
+			SHA:            "6dcb09b5b57875f334f61aebed695e2e4193db5e",
 			Message:        "Fix all the bugs",
 			AuthorName:     "Joey User",
 			AuthorEmail:    "joey@user.edu",

--- a/internal/pipe/changelog/changelog.go
+++ b/internal/pipe/changelog/changelog.go
@@ -431,7 +431,7 @@ type gitChangeloger struct{}
 var validSHA1 = regexp.MustCompile(`^[a-fA-F0-9]{40}$`)
 
 func (g gitChangeloger) Log(ctx *context.Context) (string, error) {
-	args := []string{"log", "--pretty=oneline", "--abbrev-commit", "--no-decorate", "--no-color"}
+	args := []string{"log", "--pretty=oneline", "--no-decorate", "--no-color"}
 	prev, current := comparePair(ctx)
 	if validSHA1.MatchString(prev) {
 		args = append(args, prev, current)

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -949,7 +949,7 @@ func TestAbbrev(t *testing.T) {
 		}, testctx.WithCurrentTag("v0.0.2"), withFirstCommit(t))
 
 		require.NoError(t, Pipe{}.Run(ctx))
-		ensureCommitHashLen(t, ctx.ReleaseNotes, 7)
+		ensureCommitHashLen(t, ctx.ReleaseNotes, 40)
 	})
 
 	t.Run("abbrev -1", func(t *testing.T) {
@@ -984,15 +984,15 @@ func TestAbbrev(t *testing.T) {
 		ensureCommitHashLen(t, ctx.ReleaseNotes, 7)
 	})
 
-	t.Run("abbrev 40", func(t *testing.T) {
+	t.Run("abbrev 50", func(t *testing.T) {
 		ctx := testctx.NewWithCfg(config.Project{
 			Dist: folder,
 			Changelog: config.Changelog{
-				Abbrev: 40,
+				Abbrev: 50,
 			},
 		}, testctx.WithCurrentTag("v0.0.2"), withFirstCommit(t))
 		require.NoError(t, Pipe{}.Run(ctx))
-		ensureCommitHashLen(t, ctx.ReleaseNotes, 7)
+		ensureCommitHashLen(t, ctx.ReleaseNotes, 40)
 	})
 }
 


### PR DESCRIPTION
Some changelogers were always returning the short sha instead of the full one, so setting an abbrev had no effect.

This fixes these changelogers, which should now always return the full sha.

Note that github usually still shortens the SHAs rendered in markdown, so the changes might not even be visible in most cases.

closes #4829
