### PR TITLE
Fixed missing closing quote

### DIFF
--- a/www/docs/customization/notarize.md
+++ b/www/docs/customization/notarize.md
@@ -31,7 +31,7 @@ notarize:
       #
       # Default: false
       # Templates: allowed
-      enabled: '{{ isEnvSet "MACOS_SIGN_P12 }}'
+      enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
 
       # IDs to use to filter the built binaries.
       #


### PR DESCRIPTION
With the current example build fails with:

> notarize: macos: template: failed to apply "{{ isEnvSet \"MACOS_SIGN_P12 }}": unterminated quoted string
