### PR TITLE
fix: snapcraft temporary directory + concurrency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get -yq --no-install-suggests --no-install-recommends install snapcraft
-          mkdir -p $HOME/.cache/snapcraft/download
-          mkdir -p $HOME/.cache/snapcraft/stage-packages
       - uses: crazy-max/ghaction-upx@v3
         with:
           install-only: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,8 +84,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get -yq --no-install-suggests --no-install-recommends install snapcraft
-          mkdir -p $HOME/.cache/snapcraft/download
-          mkdir -p $HOME/.cache/snapcraft/stage-packages
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v4
         with:
           go-version: stable

--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -180,7 +180,7 @@ func doRun(ctx *context.Context, snap config.Snapcraft) error {
 		return ErrNoSnapcraft
 	}
 
-	g := semerrgroup.New(ctx.Parallelism)
+	g := semerrgroup.NewGrowing(ctx.Parallelism)
 	for platform, binaries := range ctx.Artifacts.Filter(
 		artifact.And(
 			artifact.ByGoos("linux"),

--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -180,7 +180,7 @@ func doRun(ctx *context.Context, snap config.Snapcraft) error {
 		return ErrNoSnapcraft
 	}
 
-	g := semerrgroup.NewGrowing(ctx.Parallelism)
+	g := semerrgroup.NewBlockingFirst(semerrgroup.New(ctx.Parallelism))
 	for platform, binaries := range ctx.Artifacts.Filter(
 		artifact.And(
 			artifact.ByGoos("linux"),

--- a/internal/semerrgroup/sem.go
+++ b/internal/semerrgroup/sem.go
@@ -30,8 +30,7 @@ func (g *blockingFirstGroup) Go(fn func() error) {
 		g.firstMu.Unlock()
 		return
 	}
-	err := fn()
-	if err != nil {
+	if err := fn(); err != nil {
 		g.g.Go(func() error { return err })
 	}
 	g.firstDone = true


### PR DESCRIPTION
this bug comes and goes every couple of versions it seems.

this will change the snapcraft implementation to run the first item without concurrency, so all needed shared directories can be created without issues, and then grows the limit of the wait group so the other ones can run in parallel.

I haven't tested this yet, but I think it'll work.

- [x] test
- [x] godoc

refs https://github.com/goreleaser/goreleaser/issues/1715 refs https://bugs.launchpad.net/snapcraft/+bug/1889741
