### PR TITLE
fix(snapcraft): skip publish if not authorized

### DIFF
--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -215,6 +215,9 @@ func isValidArch(arch string) bool {
 
 // Publish packages.
 func (Pipe) Publish(ctx *context.Context) error {
+	if _, err := exec.CommandContext(ctx, "snapcraft", "whoami").CombinedOutput(); err != nil {
+		return pipe.Skip("snapcraft is not authorized, cannot publish")
+	}
 	snaps := ctx.Artifacts.Filter(artifact.ByType(artifact.PublishableSnapcraft)).List()
 	for _, snap := range snaps {
 		if err := push(ctx, snap); err != nil {


### PR DESCRIPTION
Prevents an entire release for failing because I forgot to update the snapcraft secrets...