### PR TITLE
ko: rework error message for relative path for .go suffix

### DIFF
--- a/internal/pipe/ko/ko.go
+++ b/internal/pipe/ko/ko.go
@@ -49,8 +49,9 @@ var (
 		azureKeychain,
 	)
 
-	errNoRepository    = errors.New("ko: missing repository: please set either the repository field or a $KO_DOCKER_REPO environment variable")
-	errInvalidMainPath = errors.New("ko: invalid Main path: ko.main (or build.main if ko.main is not set) should be a relative path")
+	errNoRepository      = errors.New("ko: missing repository: please set either the repository field or a $KO_DOCKER_REPO environment variable")
+	errInvalidMainPath   = errors.New("ko: invalid Main path: ko.main (or build.main if ko.main is not set) should be a relative path")
+	errInvalidMainGoPath = errors.New("ko: invalid Main path: your path should point to a directory instead of a .go file")
 )
 
 // Pipe that build OCI compliant images with ko.
@@ -437,7 +438,7 @@ func validateMainPath(path string) error {
 	}
 	// paths sure can have dots in them, but if the path ends in .go, it's propably a file that one misundertood as a valid value
 	if strings.HasSuffix(path, ".go") {
-		return errInvalidMainPath
+		return errInvalidMainGoPath
 	}
 	return nil
 }

--- a/internal/pipe/ko/ko_test.go
+++ b/internal/pipe/ko/ko_test.go
@@ -353,7 +353,7 @@ func TestKoValidateMainPathIssue4382(t *testing.T) {
 	require.ErrorIs(t, validateMainPath("app/"), errInvalidMainPath)
 	require.ErrorIs(t, validateMainPath("/src/"), errInvalidMainPath)
 	require.ErrorIs(t, validateMainPath("/src/app"), errInvalidMainPath)
-	require.ErrorIs(t, validateMainPath("./testdata/app/main.go"), errInvalidMainPath)
+	require.ErrorIs(t, validateMainPath("./testdata/app/main.go"), errInvalidMainGoPath)
 
 	// testing with real context
 	ctxOk := testctx.NewWithCfg(config.Project{


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

...

<!-- Why is this change being made? -->

Even though `^\.?(\.\/[^\/]?.*)?$` was matching with `./cmd/main.go`, I spent ~10m to figure this out why it was complaining. And noticed that, we were returning the same error on different case, which is `HasSuffix` check. Let's clarify the error message a bit for better UX.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

...
