### PR TITLE
fix(gitlab): release file URL broken

### DIFF
--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -523,12 +523,7 @@ func (c *gitlabClient) Upload(
 			return fmt.Errorf("templating GitLab Download URL: %w", err)
 		}
 
-		// search for project details based on projectID
-		projectDetails, _, err := c.client.Projects.GetProject(projectID, nil)
-		if err != nil {
-			return err
-		}
-		linkURL = gitlabBaseURL + "/" + projectDetails.PathWithNamespace + baseLinkURL
+		linkURL = gitlabBaseURL + "/" + projectFile.FullPath
 	}
 
 	log.WithField("file", file.Name()).


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

Fix the GitLab upload URL.

<!-- Why is this change being made? -->
Gitlab changed upload URLs from 
`https://gitlab.com/{user}/{repo}/uploads/{hash}/file.ext` to `https://gitlab.com/-/project/{projectID}/uploads/{hash}/file.ext`.

To avoid future issues like this the PR https://github.com/xanzy/go-gitlab/pull/1968 was created upstream which adds the `full_path` field to `go-gitlab` which this PR uses. 

<!-- # Provide links to any relevant tickets, URLs or other resources -->

Fixes https://github.com/goreleaser/goreleaser/issues/4974
