### PR TITLE
feat: allow --clean to run on a dirty git tree

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -56,20 +56,20 @@ type Piper interface {
 var BuildPipeline = []Piper{
 	// load and validate environment variables
 	env.Pipe{},
+	// load default configs
+	defaults.Pipe{},
+	// ensure ./dist is clean
+	dist.Pipe{},
 	// get and validate git repo state
 	git.Pipe{},
 	// parse current tag to a semver
 	semver.Pipe{},
-	// load default configs
-	defaults.Pipe{},
 	// setup things for partial builds/releases
 	partial.Pipe{},
 	// snapshot version handling
 	snapshot.Pipe{},
 	// run global hooks before build
 	before.Pipe{},
-	// ensure ./dist is clean
-	dist.Pipe{},
 	// setup metadata options
 	metadata.Pipe{},
 	// creates a metadta.json files in the dist directory


### PR DESCRIPTION
This follows up on our Discord discussion: https://discord.com/channels/890434333251362866/1262586479415136278/1262586479415136278

The status quo is that if `dist/` is not included in `.gitignore`, Goreleaser will start by checking `git status`, and if `dist/` is present, the tree will be considered dirty and the build will not proceed, regardless of any other options or flags. With this change, `--clean` will preemptively delete `dist/` before checking the git status.

The normal workaround for this is to include `dist/` in `.gitignore`. It's easy to forget to do this (hence 8c451c256940147918bc9881e9851fdc79ff3a8d, although it may not be straightforward to find that documentation starting from the Goreleaser error message).

Thanks very much for your time!