### PR TITLE
chore: use snapshot.version_template in own config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,7 +12,7 @@ before:
     - ./scripts/manpages.sh
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 gomod:
   proxy: true


### PR DESCRIPTION
If applied, this commit will fix the self-check failure reported in https://github.com/goreleaser/goreleaser/issues/5086#issue-2471620837.

tl;dr goreleaser v2.2 switched from `snapshot.name_template` to `snapshot.version_template`. This PR updates goreleaser's own config to use the new variable.