### PR TITLE
build: constant archive files owner, group, and mtime

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -188,11 +188,28 @@ archives:
     builds_info:
       group: root
       owner: root
+      mtime: "{{ .CommitDate }}"
     files:
-      - README.md
-      - LICENSE.md
-      - completions/*
-      - manpages/*
+      - src: README.md
+        info:
+          owner: root
+          group: root
+          mtime: "{{ .CommitDate }}"
+      - src: LICENSE.md
+        info:
+          owner: root
+          group: root
+          mtime: "{{ .CommitDate }}"
+      - src: completions/*
+        info:
+          owner: root
+          group: root
+          mtime: "{{ .CommitDate }}"
+      - src: manpages/*
+        info:
+          owner: root
+          group: root
+          mtime: "{{ .CommitDate }}"
 
 brews:
   - repository:


### PR DESCRIPTION
before:

```sh
$ tar tvzf dist/goreleaser_Linux_x86_64.tar.gz                                  
-rw-rw-r-- twp/twp        1085 2024-08-17 09:19 LICENSE.md
-rw-rw-r-- twp/twp       12982 2024-08-17 09:19 README.md
-rw-rw-r-- twp/twp       11975 2024-08-17 18:10 completions/goreleaser.bash
-rw-rw-r-- twp/twp       10061 2024-08-17 18:10 completions/goreleaser.fish
-rw-rw-r-- twp/twp        7892 2024-08-17 18:10 completions/goreleaser.zsh
-rw-rw-r-- twp/twp        1594 2024-08-17 18:10 manpages/goreleaser.1.gz
-rwxrwxr-x root/root  66003096 2024-08-16 19:49 goreleaser
```

after this change:

```sh
$ tar tvf dist/goreleaser_Linux_arm64.tar.gz
-rw-r--r-- root/root      1085 2024-08-18 15:36 LICENSE.md
-rw-r--r-- root/root     12982 2024-08-18 15:36 README.md
-rw-r--r-- root/root     11975 2024-08-18 15:36 completions/goreleaser.bash
-rw-r--r-- root/root     10061 2024-08-18 15:36 completions/goreleaser.fish
-rw-r--r-- root/root      7892 2024-08-18 15:36 completions/goreleaser.zsh
-rw-r--r-- root/root      1594 2024-08-18 15:36 manpages/goreleaser.1.gz
-rwxr-xr-x root/root  63439000 2024-08-18 15:36 goreleaser
```

closes #5086