### PR TITLE
chore(deps): upgrade cosign to 2.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --no-cache bash \
 	tini
 
 # install cosign
-COPY --from=gcr.io/projectsigstore/cosign:v2.1.1@sha256:411ace177097a33cb2ee74028a87ffdcb70965003cd1378c1ec7bf9f9dec9359 /ko-app/cosign /usr/bin/cosign
+COPY --from=gcr.io/projectsigstore/cosign:v2.4.0@sha256:9d50ceb15f023eda8f58032849eedc0216236d2e2f4cfe1cdf97c00ae7798cfe /ko-app/cosign /usr/bin/cosign
 
 # install syft
 RUN curl -sSfL https://raw.githubusercontent.com/anchore/syft/v0.84.1/install.sh | sh -s -- -b /usr/local/bin


### PR DESCRIPTION
goreleaser currently uses `cosign` `v2.1.1`, this change switches it to `v2.4.0`.

While there may be other useful updates, I'd like this update to workaround a bug which I'm experiencing: https://github.com/sigstore/cosign/issues/3614#issuecomment-2012521670, and which is solved by upgrading the `cosign` version.  