### PR TITLE
internal/builders/golang: ignore empty flags after templating

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -365,6 +365,11 @@ func processFlags(ctx *context.Context, a *artifact.Artifact, env, flags []strin
 		if err != nil {
 			return nil, err
 		}
+
+		if flag == "" {
+			continue
+		}
+
 		processed = append(processed, flagPrefix+flag)
 	}
 	return processed, nil

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -992,6 +992,16 @@ func TestProcessFlagsInvalid(t *testing.T) {
 	require.Nil(t, flags)
 }
 
+func TestProcessFlagsIgnoreEmptyFlags(t *testing.T) {
+	ctx := testctx.New()
+	source := []string{
+		"{{if eq 1 2}}-ignore-me{{end}}",
+	}
+	flags, err := processFlags(ctx, &artifact.Artifact{}, []string{}, source, "")
+	require.NoError(t, err)
+	require.Len(t, flags, 0)
+}
+
 func TestBuildModTimestamp(t *testing.T) {
 	// round to seconds since this will be a unix timestamp
 	modTime := time.Now().AddDate(-1, 0, 0).Round(1 * time.Second).UTC()


### PR DESCRIPTION
Ignore empty flags after templating is applied for final Go build line.

This caused us some problems since we had an `if` without `else`, resulting in an empty flag, causing the whole build to fail with an obscure error message like:

```
malformed import path "-myflag": leading dash
```