### PR TITLE
fix: Handle error on failed release (github)

### DIFF
--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -449,6 +449,19 @@ func (c *githubClient) createOrUpdateRelease(ctx *context.Context, data *github.
 			ctx.Config.Release.GitHub.Name,
 			data,
 		)
+		if resp == nil {
+			log.WithField("name", data.GetName()).
+				WithError(err).
+				Debug("release creation failed")
+			return nil, err
+		}
+		if err != nil {
+			log.WithField("name", data.GetName()).
+				WithField("request-id", resp.Header.Get("X-Github-Request-Id")).
+				WithError(err).
+				Debug("release creation failed")
+			return nil, err
+		}
 		log.WithField("name", data.GetName()).
 			WithField("release-id", release.GetID()).
 			WithField("request-id", resp.Header.Get("X-GitHub-Request-Id")).


### PR DESCRIPTION
When trying to release an artifact to github and it fails, I observed the following stacktrace:
```
• publishing
    • scm releases
      • releasing                                    tag=v1.11.0 repo=my-github-repo
      • could not check rate limits, hoping for the best...
      • could not check rate limits, hoping for the best...
      • took: 1m40s
  • took: 1m40s
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xe28b72]
goroutine 55 [running]:
github.com/goreleaser/goreleaser/v2/internal/client.(*githubClient).createOrUpdateRelease(0xc0001b24c8, 0xc0002c5108, 0xc000b478, {0xc00039ed00, 0x80e})
	github.com/goreleaser/goreleaser/v2@v2.2.0/internal/client/github.go:454 +0x3b2
github.com/goreleaser/goreleaser/v2/internal/client.(*githubClient).CreateRelease(0xc0001b24c8, 0xc0002c5108, {0xc00039ed00, 0x80e})
	github.com/goreleaser/goreleaser/v2@v2.2.0/internal/client/github.go:402 +0x339
github.com/goreleaser/goreleaser/v2/internal/pipe/release.doPublish(0xc0002c5108, {0x2ce2d40, 0xc0001b24c8})
...
```

I believe this happens because if the [CreateRelease](https://github.com/google/go-github/blob/c96ef954c31ce1a9f74675b8ec2c66e24292ea51/github/repos_releases.go#L221) fails, resp might be empty and the resp.Header does not exist, which causes a segfault.
```
WithField("request-id", resp.Header.Get("X-GitHub-Request-Id")).
```

