### PR TITLE
chore: fix linter errors

### DIFF
--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -999,7 +999,7 @@ func TestProcessFlagsIgnoreEmptyFlags(t *testing.T) {
 	}
 	flags, err := processFlags(ctx, &artifact.Artifact{}, []string{}, source, "")
 	require.NoError(t, err)
-	require.Len(t, flags, 0)
+	require.Empty(t, flags)
 }
 
 func TestBuildModTimestamp(t *testing.T) {

--- a/internal/client/gitea_test.go
+++ b/internal/client/gitea_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/goreleaser/goreleaser/v2/pkg/config"
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
 	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -626,9 +627,9 @@ func TestGiteaChangelog(t *testing.T) {
 					},
 				},
 			})
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			_, err = w.Write(bts)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}
 	}))
 	defer srv.Close()

--- a/internal/client/github_test.go
+++ b/internal/client/github_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/internal/testlib"
 	"github.com/goreleaser/goreleaser/v2/pkg/config"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -272,9 +273,9 @@ func TestGitHubChangelog(t *testing.T) {
 
 		if r.URL.Path == "/repos/someone/something/compare/v1.0.0...v1.1.0" {
 			r, err := os.Open("testdata/github/compare.json")
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			_, err = io.Copy(w, r)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			return
 		}
 		if r.URL.Path == "/rate_limit" {
@@ -317,9 +318,9 @@ func TestGitHubReleaseNotes(t *testing.T) {
 
 		if r.URL.Path == "/repos/someone/something/releases/generate-notes" {
 			r, err := os.Open("testdata/github/releasenotes.json")
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			_, err = io.Copy(w, r)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			return
 		}
 		if r.URL.Path == "/rate_limit" {
@@ -387,9 +388,9 @@ func TestGitHubCloseMilestone(t *testing.T) {
 
 		if r.URL.Path == "/repos/someone/something/milestones" {
 			r, err := os.Open("testdata/github/milestones.json")
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			_, err = io.Copy(w, r)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			return
 		}
 
@@ -434,16 +435,16 @@ func TestGitHubOpenPullRequestCrossRepo(t *testing.T) {
 
 		if r.URL.Path == "/repos/someone/something/pulls" {
 			got, err := io.ReadAll(r.Body)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			var pr github.NewPullRequest
-			require.NoError(t, json.Unmarshal(got, &pr))
-			require.Equal(t, "main", pr.GetBase())
-			require.Equal(t, "someoneelse:something:foo", pr.GetHead())
-			require.Equal(t, testPRTemplate+"\n"+prFooter, pr.GetBody())
+			assert.NoError(t, json.Unmarshal(got, &pr))
+			assert.Equal(t, "main", pr.GetBase())
+			assert.Equal(t, "someoneelse:something:foo", pr.GetHead())
+			assert.Equal(t, testPRTemplate+"\n"+prFooter, pr.GetBody())
 			r, err := os.Open("testdata/github/pull.json")
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			_, err = io.Copy(w, r)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			return
 		}
 
@@ -493,9 +494,9 @@ func TestGitHubOpenPullRequestHappyPath(t *testing.T) {
 
 		if r.URL.Path == "/repos/someone/something/pulls" {
 			r, err := os.Open("testdata/github/pull.json")
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			_, err = io.Copy(w, r)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			return
 		}
 
@@ -536,17 +537,17 @@ func TestGitHubOpenPullRequestNoBaseBranchDraft(t *testing.T) {
 
 		if r.URL.Path == "/repos/someone/something/pulls" {
 			got, err := io.ReadAll(r.Body)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			var pr github.NewPullRequest
-			require.NoError(t, json.Unmarshal(got, &pr))
-			require.Equal(t, "main", pr.GetBase())
-			require.Equal(t, "someone:something:foo", pr.GetHead())
-			require.True(t, pr.GetDraft())
+			assert.NoError(t, json.Unmarshal(got, &pr))
+			assert.Equal(t, "main", pr.GetBase())
+			assert.Equal(t, "someone:something:foo", pr.GetHead())
+			assert.True(t, pr.GetDraft())
 
 			r, err := os.Open("testdata/github/pull.json")
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			_, err = io.Copy(w, r)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			return
 		}
 
@@ -595,9 +596,9 @@ func TestGitHubOpenPullRequestPRExists(t *testing.T) {
 		if r.URL.Path == "/repos/someone/something/pulls" {
 			w.WriteHeader(http.StatusUnprocessableEntity)
 			r, err := os.Open("testdata/github/pull.json")
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			_, err = io.Copy(w, r)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			return
 		}
 
@@ -638,9 +639,9 @@ func TestGitHubOpenPullRequestBaseEmpty(t *testing.T) {
 
 		if r.URL.Path == "/repos/someone/something/pulls" {
 			r, err := os.Open("testdata/github/pull.json")
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			_, err = io.Copy(w, r)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			return
 		}
 
@@ -687,9 +688,9 @@ func TestGitHubOpenPullRequestHeadEmpty(t *testing.T) {
 
 		if r.URL.Path == "/repos/someone/something/pulls" {
 			r, err := os.Open("testdata/github/pull.json")
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			_, err = io.Copy(w, r)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			return
 		}
 

--- a/internal/pipe/blob/blob_test.go
+++ b/internal/pipe/blob/blob_test.go
@@ -1,7 +1,7 @@
 package blob
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
@@ -28,7 +28,7 @@ func TestErrors(t *testing.T) {
 		"other":                        "failed to write to bucket: other",
 	} {
 		t.Run(k, func(t *testing.T) {
-			require.EqualError(t, handleError(fmt.Errorf(k), "someurl"), v)
+			require.EqualError(t, handleError(errors.New(k), "someurl"), v)
 		})
 	}
 }

--- a/internal/pipe/mattermost/mattermost_test.go
+++ b/internal/pipe/mattermost/mattermost_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
@@ -68,14 +69,14 @@ func TestPostWebhook(t *testing.T) {
 
 		body, _ := io.ReadAll(r.Body)
 		err := json.Unmarshal(body, rc)
-		require.NoError(t, err)
-		require.Equal(t, defaultColor, rc.Attachments[0].Color)
-		require.Equal(t, "Honk v1.0.0 is out!", rc.Attachments[0].Title)
-		require.Equal(t, "Honk v1.0.0 is out! Check it out at https://github.com/honk/honk/releases/tag/v1.0.0", rc.Attachments[0].Text)
+		assert.NoError(t, err)
+		assert.Equal(t, defaultColor, rc.Attachments[0].Color)
+		assert.Equal(t, "Honk v1.0.0 is out!", rc.Attachments[0].Title)
+		assert.Equal(t, "Honk v1.0.0 is out! Check it out at https://github.com/honk/honk/releases/tag/v1.0.0", rc.Attachments[0].Text)
 
 		w.WriteHeader(200)
 		_, err = w.Write([]byte{})
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	defer ts.Close()
 

--- a/internal/pipe/webhook/webhook_test.go
+++ b/internal/pipe/webhook/webhook_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/internal/testlib"
 	"github.com/goreleaser/goreleaser/v2/pkg/config"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -67,13 +68,13 @@ func TestAnnounceWebhook(t *testing.T) {
 		defer r.Body.Close()
 
 		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-		require.Equal(t, "webhook-test", string(body))
+		assert.NoError(t, err)
+		assert.Equal(t, "webhook-test", string(body))
 
 		w.WriteHeader(http.StatusCreated)
 		w.Header().Set("Content-Type", "application/json")
 		err = json.NewEncoder(w).Encode(responseServer)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	defer srv.Close()
 
@@ -98,12 +99,12 @@ func TestAnnounceTLSWebhook(t *testing.T) {
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-		require.Equal(t, "webhook-test", string(body))
+		assert.NoError(t, err)
+		assert.Equal(t, "webhook-test", string(body))
 		w.WriteHeader(http.StatusCreated)
 		w.Header().Set("Content-Type", "application/json")
 		err = json.NewEncoder(w).Encode(responseServer)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	defer srv.Close()
 	fmt.Println(srv.URL)
@@ -131,7 +132,7 @@ func TestAnnounceTLSCheckCertWebhook(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 		w.Header().Set("Content-Type", "application/json")
 		err := json.NewEncoder(w).Encode(responseServer)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	defer srv.Close()
 	fmt.Println(srv.URL)
@@ -157,16 +158,16 @@ func TestAnnounceBasicAuthWebhook(t *testing.T) {
 		defer r.Body.Close()
 
 		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-		require.Equal(t, "webhook-test", string(body))
+		assert.NoError(t, err)
+		assert.Equal(t, "webhook-test", string(body))
 
 		auth := r.Header.Get("Authorization")
-		require.Equal(t, fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte("user:pass"))), auth)
+		assert.Equal(t, fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte("user:pass"))), auth)
 
 		w.WriteHeader(http.StatusCreated)
 		w.Header().Set("Content-Type", "application/json")
 		err = json.NewEncoder(w).Encode(responseServer)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 
 	defer srv.Close()
@@ -194,16 +195,16 @@ func TestAnnounceAdditionalHeadersWebhook(t *testing.T) {
 		defer r.Body.Close()
 
 		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-		require.Equal(t, "webhook-test", string(body))
+		assert.NoError(t, err)
+		assert.Equal(t, "webhook-test", string(body))
 
 		customHeader := r.Header.Get("X-Custom-Header")
-		require.Equal(t, "custom-value", customHeader)
+		assert.Equal(t, "custom-value", customHeader)
 
 		w.WriteHeader(http.StatusCreated)
 		w.Header().Set("Content-Type", "application/json")
 		err = json.NewEncoder(w).Encode(responseServer)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	defer srv.Close()
 


### PR DESCRIPTION
If applied, this commit will fix the current linter errors, which are currently causing all Github Actions to fail.

See, for example, the latest `main` run: https://github.com/goreleaser/goreleaser/actions/runs/10607661596/job/29400451251.