### PR TITLE
fix: build --single-target filters

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -55,7 +55,7 @@ Its intended usage is, for example, within Makefiles to avoid setting up ldflags
 
 It also allows you to generate a local build for your current machine only using the ` + "`--single-target`" + ` option, and specific build IDs using the ` + "`--id`" + ` option in case you have more than one.
 
-When using ` + "`--single-target`" + `, the ` + "`GOOS`" + ` and ` + "`GOARCH`" + ` environment variables are used to determine the target, defaulting to the current machine target if not set.
+When using ` + "`--single-target`" + `, the ` + "`GOOS`, `GOARCH`, `GOARM`, `GOAMD64`, and `GOMIPS`" + ` environment variables are used to determine the target, defaulting to the current machine target if not set.
 `,
 		SilenceUsage:      true,
 		SilenceErrors:     true,

--- a/internal/pipe/build/filter.go
+++ b/internal/pipe/build/filter.go
@@ -2,7 +2,6 @@ package build
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
@@ -18,7 +17,7 @@ func filter(ctx *context.Context, targets []string) []string {
 
 	var result []string
 	for _, t := range targets {
-		if !strings.HasPrefix(t, target) {
+		if t != target {
 			continue
 		}
 		result = append(result, t)

--- a/internal/pipe/build/filter_test.go
+++ b/internal/pipe/build/filter_test.go
@@ -15,6 +15,7 @@ var filterTestTargets = []string{
 	"darwin_amd64_v1",
 	"darwin_amd64_v2",
 	"darwin_arm64",
+	"darwin_arm_7",
 }
 
 func TestFilter(t *testing.T) {
@@ -26,7 +27,7 @@ func TestFilter(t *testing.T) {
 	t.Run("target", func(t *testing.T) {
 		ctx := testctx.New(func(ctx *context.Context) {
 			ctx.Partial = true
-			ctx.PartialTarget = "darwin_amd64"
+			ctx.PartialTarget = "darwin_amd64_v1"
 		})
 		require.Equal(t, []string{
 			"darwin_amd64_v1",

--- a/internal/pipe/partial/partial.go
+++ b/internal/pipe/partial/partial.go
@@ -3,6 +3,7 @@ package partial
 import (
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/charmbracelet/x/exp/ordered"
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
@@ -21,5 +22,22 @@ func (Pipe) Run(ctx *context.Context) error {
 func getFilter() string {
 	goos := ordered.First(os.Getenv("GGOOS"), os.Getenv("GOOS"), runtime.GOOS)
 	goarch := ordered.First(os.Getenv("GGOARCH"), os.Getenv("GOARCH"), runtime.GOARCH)
-	return goos + "_" + goarch
+	target := goos + "_" + goarch
+
+	if strings.HasSuffix(target, "_amd64") {
+		goamd64 := ordered.First(os.Getenv("GGOAMD64"), os.Getenv("GOAMD64"), "v1")
+		target = target + "_" + goamd64
+	}
+	if strings.HasSuffix(target, "_arm") {
+		goarm := ordered.First(os.Getenv("GGOARM"), os.Getenv("GOARM"), "6")
+		target = target + "_" + goarm
+	}
+	if strings.HasSuffix(target, "_mips") ||
+		strings.HasSuffix(target, "_mips64") ||
+		strings.HasSuffix(target, "_mipsle") ||
+		strings.HasSuffix(target, "_mips64le") {
+		gomips := ordered.First(os.Getenv("GGOMIPS"), os.Getenv("GOMIPS"), "hardfloat")
+		target = target + "_" + gomips
+	}
+	return target
 }

--- a/internal/pipe/partial/partial_test.go
+++ b/internal/pipe/partial/partial_test.go
@@ -46,12 +46,68 @@ func TestRun(t *testing.T) {
 		require.NoError(t, pipe.Run(ctx))
 		require.Equal(t, "windows_arm64", ctx.PartialTarget)
 	})
+	t.Run("custom GGOARM", func(t *testing.T) {
+		ctx := testctx.NewWithCfg(config.Project{
+			Dist: "dist",
+		}, testctx.Partial)
+		t.Setenv("GGOOS", "linux")
+		t.Setenv("GGOARCH", "arm")
+		t.Run("default", func(t *testing.T) {
+			require.NoError(t, pipe.Run(ctx))
+			require.Equal(t, "linux_arm_6", ctx.PartialTarget)
+		})
+		t.Run("default", func(t *testing.T) {
+			t.Setenv("GGOARM", "7")
+			require.NoError(t, pipe.Run(ctx))
+			require.Equal(t, "linux_arm_7", ctx.PartialTarget)
+		})
+	})
+	t.Run("custom GGOAMD64", func(t *testing.T) {
+		ctx := testctx.NewWithCfg(config.Project{
+			Dist: "dist",
+		}, testctx.Partial)
+		t.Setenv("GGOOS", "linux")
+		t.Setenv("GGOARCH", "amd64")
+		t.Run("default", func(t *testing.T) {
+			require.NoError(t, pipe.Run(ctx))
+			require.Equal(t, "linux_amd64_v1", ctx.PartialTarget)
+		})
+		t.Run("default", func(t *testing.T) {
+			t.Setenv("GGOAMD64", "v4")
+			require.NoError(t, pipe.Run(ctx))
+			require.Equal(t, "linux_amd64_v4", ctx.PartialTarget)
+		})
+	})
+	t.Run("custom GGOMIPS", func(t *testing.T) {
+		ctx := testctx.NewWithCfg(config.Project{
+			Dist: "dist",
+		}, testctx.Partial)
+		t.Setenv("GGOOS", "linux")
+		for _, mips := range []string{"mips", "mips64", "mipsle", "mips64le"} {
+			t.Run(mips, func(t *testing.T) {
+				t.Setenv("GGOARCH", mips)
+				t.Run("default", func(t *testing.T) {
+					require.NoError(t, pipe.Run(ctx))
+					require.Equal(t, "linux_"+mips+"_hardfloat", ctx.PartialTarget)
+				})
+				t.Run("default", func(t *testing.T) {
+					t.Setenv("GGOMIPS", "softfloat")
+					require.NoError(t, pipe.Run(ctx))
+					require.Equal(t, "linux_"+mips+"_softfloat", ctx.PartialTarget)
+				})
+			})
+		}
+	})
 	t.Run("using runtime", func(t *testing.T) {
 		ctx := testctx.NewWithCfg(config.Project{
 			Dist: "dist",
 		}, testctx.Partial)
 		require.NoError(t, pipe.Run(ctx))
 		target := fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH)
+		switch runtime.GOARCH {
+		case "amd64":
+			target += "_v1"
+		}
 		require.Equal(t, target, ctx.PartialTarget)
 	})
 }

--- a/internal/pipe/partial/partial_test.go
+++ b/internal/pipe/partial/partial_test.go
@@ -104,8 +104,8 @@ func TestRun(t *testing.T) {
 		}, testctx.Partial)
 		require.NoError(t, pipe.Run(ctx))
 		target := fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH)
-		switch runtime.GOARCH {
-		case "amd64":
+		// commonly tests will run on either arm64 or amd64.
+		if runtime.GOARCH == "amd64" {
 			target += "_v1"
 		}
 		require.Equal(t, target, ctx.PartialTarget)


### PR DESCRIPTION
make them more precise, as its currently only taking GOOS/GOARCH into account, and we can do more.

closes #5112 