### PR TITLE
feat(ko): snapshot builds

### DIFF
--- a/internal/pipe/ko/ko.go
+++ b/internal/pipe/ko/ko.go
@@ -138,15 +138,13 @@ func (Pipe) Default(ctx *context.Context) error {
 	return ids.Validate()
 }
 
-func (Pipe) Run(ctx *context.Context) error {
-	if !ctx.Snapshot {
-		return nil
+func (p Pipe) Run(ctx *context.Context) error {
+	if ctx.Snapshot {
+		// publish actually handles pushing to the local docker daemon when
+		// snapshot is true.
+		return p.Publish(ctx)
 	}
-	g := semerrgroup.New(ctx.Parallelism)
-	for _, ko := range ctx.Config.Kos {
-		g.Go(doBuild(ctx, ko))
-	}
-	return g.Wait()
+	return nil
 }
 
 // Publish executes the Pipe.

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -20,6 +20,7 @@ import (
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/env"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/git"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/gomod"
+	"github.com/goreleaser/goreleaser/v2/internal/pipe/ko"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/krew"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/metadata"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/nfpm"
@@ -146,6 +147,8 @@ var Pipeline = append(
 	reportsizes.Pipe{},
 	// create and push docker images
 	docker.Pipe{},
+	// create and push docker images using ko
+	ko.Pipe{},
 	// publishes artifacts
 	publish.New(),
 	// creates a artifacts.json files in the dist directory

--- a/www/docs/customization/ko.md
+++ b/www/docs/customization/ko.md
@@ -133,7 +133,7 @@ builds:
       - linux
     goarch:
       - amd64
-      - arch64
+      - arm64
 
 kos:
   - repository: ghcr.io/caarlos0/test-ko


### PR DESCRIPTION
this makes ko run on snapshot builds, too.

the image will be `goreleaser.ko.local:[your tags]`, not sure if we can change this, seems like we can't.

also fixed a small doc error around it, as well as added a new test to cover this.

closes #4683