### PR TITLE
fix(build,release): c-shared build and release when target is wasm

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -182,7 +182,7 @@ func (*Builder) Build(ctx *context.Context, build config.Build, options api.Opti
 		a.Type = artifact.CArchive
 		ctx.Artifacts.Add(getHeaderArtifactForLibrary(build, options))
 	}
-	if build.Buildmode == "c-shared" {
+	if build.Buildmode == "c-shared" && !strings.Contains(options.Target, "wasm") {
 		a.Type = artifact.CShared
 		ctx.Artifacts.Add(getHeaderArtifactForLibrary(build, options))
 	}

--- a/internal/pipe/build/build.go
+++ b/internal/pipe/build/build.go
@@ -228,6 +228,9 @@ func extFor(target string, build config.BuildDetails) string {
 		if strings.Contains(target, "windows") {
 			return ".dll"
 		}
+		if strings.Contains(target, "wasm") {
+			return ".wasm"
+		}
 		return ".so"
 	case "c-archive":
 		if strings.Contains(target, "windows") {
@@ -236,7 +239,7 @@ func extFor(target string, build config.BuildDetails) string {
 		return ".a"
 	}
 
-	if target == "js_wasm" {
+	if strings.Contains(target, "wasm") {
 		return ".wasm"
 	}
 

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -462,6 +462,8 @@ func TestExtWindows(t *testing.T) {
 
 func TestExtWasm(t *testing.T) {
 	require.Equal(t, ".wasm", extFor("js_wasm", config.BuildDetails{}))
+	require.Equal(t, ".wasm", extFor("wasip1_wasm", config.BuildDetails{}))
+	require.Equal(t, ".wasm", extFor("wasip1_wasm", config.BuildDetails{Buildmode: "c-shared"}))
 }
 
 func TestExtOthers(t *testing.T) {


### PR DESCRIPTION
This commit fixes the automatic extension when building the wasip1_wasm target.

Additionally, in future Go versions, support will be added for generating c-shared WASM binaries. https://github.com/golang/go/issues/65199


Therefore, this PR corrects the extension in the build process and removes the .h file from the release when c-shared is enabled and the target is WASM.

