### PR TITLE
feat(docker): install upx in docker container for using in the build pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN apk add --no-cache bash \
 	make \
 	openssh-client \
 	build-base \
-	tini
+	tini \
+	upx
 
 # install cosign
 COPY --from=gcr.io/projectsigstore/cosign:v2.4.0@sha256:9d50ceb15f023eda8f58032849eedc0216236d2e2f4cfe1cdf97c00ae7798cfe /ko-app/cosign /usr/bin/cosign


### PR DESCRIPTION
I like to use the goreleaser for my private project and would like to have the binary scaled down with the UPX in the GitLab build pipeline.
Therefore, it would be nice if the UPX tool is pre-installed in the Docker container.