### PR TITLE
docs: Add GH Actions OIDC permission docs

### DIFF
--- a/www/docs/ci/actions.md
+++ b/www/docs/ci/actions.md
@@ -27,6 +27,7 @@ permissions:
   contents: write
   # packages: write
   # issues: write
+  # id-token: write
 
 jobs:
   goreleaser:
@@ -178,6 +179,7 @@ are required by GoReleaser:
   GitHub
 - `issues: write` if you use [milestone closing
   capability](../customization/milestone.md)
+- `id-token: write` if you wish use [Cosign][cosign] with [GitHub OIDC][oidc]
 
 `GITHUB_TOKEN` permissions [are limited to the repository][about-github-token]
 that contains your workflow.
@@ -227,3 +229,5 @@ You can check [this example repository](https://github.com/goreleaser/example) f
 [about-github-token]: https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#about-the-github_token-secret
 [pat]: https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
 [secrets]: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets
+[oidc]: https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
+[cosign]: https://github.com/sigstore/cosign


### PR DESCRIPTION
## What is this?

Just adding documentation for using cosign with GitHub's OIDC in CI.

## Why?

I spent 4 hours looking through goreleaser and GitHub's docs before I finally discovered I was missing the `id-token: write` permission in my workflow file.

This PR serves to just include the `id-token: write` scope in the `CI -> (GH) actions` section of the docs to hopefully save other devs the trouble 🤣

### Additional

I also considered adding this to docs for the other CI providers, but I am not too familiar on the OIDC side of things; might be worth considering for the team?

Cheers

---

Been using goreleaser for one of my [oss projects](https://github.com/caffeine-addictt/waku) recently and it's been great! Just wanted to contribute something back, keep up the great work! :>
