### PR TITLE
fix: signature template failed silently after signing process completed

### DIFF
--- a/internal/pipe/sign/sign.go
+++ b/internal/pipe/sign/sign.go
@@ -255,8 +255,14 @@ func signone(ctx *context.Context, cfg config.Sign, art *artifact.Artifact) ([]*
 
 	// re-execute template results, using artifact desc as artifact so they eval to the actual needed file desc.
 	env["artifact"] = art.Name
-	name, _ = tmpl.New(ctx).WithEnv(env).Apply(expand(cfg.Signature, env))   // could never error as it passed the previous check
-	cert, _ = tmpl.New(ctx).WithEnv(env).Apply(expand(cfg.Certificate, env)) // could never error as it passed the previous check
+	name, err = tmpl.New(ctx).WithArtifact(art).WithEnv(env).Apply(expand(cfg.Signature, env))
+	if err != nil {
+		return nil, fmt.Errorf("sign failed: %s: %w", art.Name, err)
+	}
+	cert, err = tmpl.New(ctx).WithArtifact(art).WithEnv(env).Apply(expand(cfg.Certificate, env))
+	if err != nil {
+		return nil, fmt.Errorf("sign failed: %s: %w", art.Name, err)
+	}
 
 	if cfg.Signature != "" {
 		result = append(result, &artifact.Artifact{


### PR DESCRIPTION
The presence of an artifact field in the `signature` or `certificate` template field caused a silent failure in the template when re-applied after the external signing process was called.

This was due to the artifact being presence in the template context before the signing process, but not after. An error here was also ignored.

The fix supplies the artifact to the template context, and also allows a template failure to
fail the overall process.

As far as I can tell, this change aligns behaviour to match existing documentation.

Fixes #5147 
