### PR TITLE
fix: remove filetype exe from chocolatey template

### DIFF
--- a/internal/pipe/chocolatey/template.go
+++ b/internal/pipe/chocolatey/template.go
@@ -20,7 +20,6 @@ $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $packageArgs = @{
     packageName    = $packageName
     unzipLocation  = $toolsDir
-    fileType       = 'exe'
     {{- range $release := .Packages }}
     {{- if eq $release.Arch "amd64" }}
     url64bit       = '{{ $release.DownloadURL }}'


### PR DESCRIPTION
When submitting a new project to chocolatey using goreleaser, a reviewer told me that a line in the template is incorrect:

<img width="1054" alt="image" src="https://github.com/user-attachments/assets/423c4493-85fa-4cc5-8a74-97d2a561743b">

<img width="1052" alt="image" src="https://github.com/user-attachments/assets/04425da1-eb90-4504-9308-9a2e49ca85d8">

> since that is not a valid parameter to the Install-ChocolateyZipPackage function: https://docs.chocolatey.org/en-us/create/functions/install-chocolateyzippackage/

This PR aims to correct that by removing the line from the template as requested
