### PR TITLE
perf(changelog): improve changelog sort performance

### DIFF
--- a/internal/pipe/changelog/changelog.go
+++ b/internal/pipe/changelog/changelog.go
@@ -2,12 +2,13 @@
 package changelog
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/caarlos0/log"
@@ -211,7 +212,7 @@ func formatChangelog(ctx *context.Context, entries []string) (string, error) {
 		}
 	}
 
-	sort.Slice(groups, groupSort(groups))
+	slices.SortFunc(groups, groupSort)
 	for _, group := range groups {
 		if len(group.entries) > 0 {
 			result = append(result, group.title)
@@ -221,10 +222,8 @@ func formatChangelog(ctx *context.Context, entries []string) (string, error) {
 	return strings.Join(result, newLineFor(ctx)), nil
 }
 
-func groupSort(groups []changelogGroup) func(i, j int) bool {
-	return func(i, j int) bool {
-		return groups[i].order < groups[j].order
-	}
+func groupSort(i, j changelogGroup) int {
+	return cmp.Compare(i.order, j.order)
 }
 
 func filterAndPrefixItems(ss []string) []string {
@@ -306,17 +305,16 @@ func sortEntries(ctx *context.Context, entries []string) []string {
 	if direction == "" {
 		return entries
 	}
-	result := make([]string, len(entries))
-	copy(result, entries)
-	sort.Slice(result, func(i, j int) bool {
-		imsg := extractCommitInfo(result[i])
-		jmsg := extractCommitInfo(result[j])
+	slices.SortFunc(entries, func(i, j string) int {
+		imsg := extractCommitInfo(i)
+		jmsg := extractCommitInfo(j)
+		compareRes := strings.Compare(imsg, jmsg)
 		if direction == "asc" {
-			return strings.Compare(imsg, jmsg) < 0
+			return compareRes
 		}
-		return strings.Compare(imsg, jmsg) > 0
+		return -compareRes
 	})
-	return result
+	return entries
 }
 
 func keep(filter *regexp.Regexp, entries []string) (result []string) {


### PR DESCRIPTION
This commit removes the unnecessary slice copy in `sortEntries`, and replaces `sort.Slice` [^1] with the new `slices.SortFunc` [^2].

As recommended by the Go documentation, `slices.SortFunc` is generally faster because it uses generic, whereas `sort.Slice` relies on reflection, which incurs additional allocations

The benchmark result from the newly added `Benchmark_sortEntries` show approximately a 64% performance improvement.


Benchmark result:

```
                     │   old.txt    │               new.txt               │
                     │    sec/op    │   sec/op     vs base                │
_sortEntries/asc-16    16.458µ ± 1%   5.958µ ± 1%  -63.80% (p=0.000 n=10)
_sortEntries/desc-16   17.675µ ± 1%   6.020µ ± 0%  -65.94% (p=0.000 n=10)
geomean                 17.06µ        5.989µ       -64.89%

                     │   old.txt    │               new.txt                │
                     │     B/op     │     B/op      vs base                │
_sortEntries/asc-16    3.164Ki ± 0%   1.164Ki ± 0%  -63.21% (p=0.000 n=10)
_sortEntries/desc-16   3.422Ki ± 0%   1.164Ki ± 0%  -65.98% (p=0.000 n=10)
geomean                3.290Ki        1.164Ki       -64.62%

                     │  old.txt   │              new.txt               │
                     │ allocs/op  │ allocs/op   vs base                │
_sortEntries/asc-16    68.00 ± 0%   25.00 ± 0%  -63.24% (p=0.000 n=10)
_sortEntries/desc-16   72.00 ± 0%   25.00 ± 0%  -65.28% (p=0.000 n=10)
geomean                69.97        25.00       -64.27%
```

[^1]: https://pkg.go.dev/sort#Slice
[^2]: https://pkg.go.dev/slices#SortFunc