### PR TITLE
fix(changelog): fix random order of first commit in first release

### DIFF
--- a/internal/pipe/changelog/changelog.go
+++ b/internal/pipe/changelog/changelog.go
@@ -426,13 +426,12 @@ type changeloger interface {
 
 type gitChangeloger struct{}
 
-var validSHA1 = regexp.MustCompile(`^[a-fA-F0-9]{40}$`)
-
 func (g gitChangeloger) Log(ctx *context.Context) (string, error) {
 	args := []string{"log", "--pretty=oneline", "--no-decorate", "--no-color"}
 	prev, current := comparePair(ctx)
-	if validSHA1.MatchString(prev) {
-		args = append(args, prev, current)
+	if prev == "" {
+		// log all commits since the first commit
+		args = append(args, current)
 	} else {
 		args = append(args, fmt.Sprintf("tags/%s..tags/%s", ctx.Git.PreviousTag, ctx.Git.CurrentTag))
 	}
@@ -479,8 +478,5 @@ func (c *githubNativeChangeloger) Log(ctx *context.Context) (string, error) {
 func comparePair(ctx *context.Context) (prev string, current string) {
 	prev = ctx.Git.PreviousTag
 	current = ctx.Git.CurrentTag
-	if prev == "" {
-		prev = ctx.Git.FirstCommit
-	}
 	return
 }

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -848,7 +848,6 @@ func TestGroup(t *testing.T) {
 ### Bots
 \* \w+ feat\(deps\): update foobar \[bot\]
 ### Others
-\* \w+ first
 \* \w+ this is not a Merge pull request
 \* \w+ chore: something about cArs we dont need
 \* \w+ docs: whatever
@@ -856,6 +855,7 @@ func TestGroup(t *testing.T) {
 \* \w+ ignored: whatever
 \* \w+ fixed bug 2
 \* \w+ added feature 1
+\* \w+ first
 `, ctx.ReleaseNotes)
 }
 


### PR DESCRIPTION
## Background

This is a bug that occurs randomly under a very specific condition.

Not sure how long this bug has been around. I first noticed it in the failed Dagger test job in https://github.com/goreleaser/goreleaser/pull/5161 after the `TestGroup` unit test was updated to use regex matching https://github.com/goreleaser/goreleaser/pull/5161#discussion_r1781302054.

Log: https://github.com/goreleaser/goreleaser/actions/runs/11108665571/job/30862144417#step:4:680

```
--- FAIL: TestGroup (0.23s)
    changelog_test.go:843: 
        	Error Trace:	/src/internal/pipe/changelog/changelog_test.go:843
        	Error:      	Expect "## Changelog
        	            	### Features
        	            	* a77c0b89a457ee6a78447f6c9113b79cf4dce8ce feat: added that thing
        	            	### Bug Fixes
        	            	* 3e2908a87e5fdfdbd5efaad013c0b2d196c64c40 bug: Merge pull request #999 from goreleaser/some-branch
        	            	### Bots
        	            	* e2b7fbaaf1387cd4af575f5e329d9441ce1a917b feat(deps): update foobar [bot]
        	            	### Others
        	            	* 3643389d7150dc191eca4ac8428274fb31213a12 this is not a Merge pull request
        	            	* 3e1421263cd99fbd9a1a6c0196a355efe96e631d chore: something about cArs we dont need
        	            	* c094f150bc948d76f920219ef9729fd63747324b docs: whatever
        	            	* 242178ede64b3ff570dfbde6416f2c4718dd5b68 fix: whatever
        	            	* 02b7e77076dfed7475d42d728d69d13d19a10a39 ignored: whatever
        	            	* c3b78e347e5c38acc6b78e5a963b28221ac0cfee fixed bug 2
        	            	* fc5f56a9d915d19bc3630dc40aabd99a3eede02b added feature 1
        	            	* dc67ddaae25db36fe70d3b96311243621c176169 first
        	            	" to match "## Changelog
        	            	### Features
        	            	\* \w+ feat: added that thing
        	            	### Bug Fixes
        	            	\* \w+ bug: Merge pull request #999 from goreleaser\/some-branch
        	            	### Bots
        	            	\* \w+ feat\(deps\): update foobar \[bot\]
        	            	### Others
        	            	\* \w+ first
        	            	\* \w+ this is not a Merge pull request
        	            	\* \w+ chore: something about cArs we dont need
        	            	\* \w+ docs: whatever
        	            	\* \w+ fix: whatever
        	            	\* \w+ ignored: whatever
        	            	\* \w+ fixed bug 2
        	            	\* \w+ added feature 1
        	            	"
        	Test:       	TestGroup
```


Then it also failed in:

1. 71e7a63ca111d184ac9ab3f68187b12c63b2c13e

   Log: https://github.com/goreleaser/goreleaser/actions/runs/11166871425/job/31041794426#step:4:667

```
--- FAIL: TestGroup (0.13s)
    changelog_test.go:843: 
        	Error Trace:	/src/internal/pipe/changelog/changelog_test.go:843
        	Error:      	Expect "## Changelog
        	            	### Features
        	            	* 7a9c58e3f299b347754c02a149f77d4450768aba feat: added that thing
        	            	### Bug Fixes
        	            	* 9d5982da0fa36817c9c907271ece0a238bc24918 bug: Merge pull request #999 from goreleaser/some-branch
        	            	### Bots
        	            	* 6890859be3907f8f1b60b1a82cb4af277a0bc425 feat(deps): update foobar [bot]
        	            	### Others
        	            	* 6acc3600c5fe17d0330b566e6d5703e48725f300 this is not a Merge pull request
        	            	* 31abf613e4c3a5fcaebb0a1a23bcd418d61d2c4d first
        	            	* 14a53e66c59c532a81e729b6717aa4137cc292fb chore: something about cArs we dont need
        	            	* df77c2f0d8b1bbdc697e843e1dd2764a716a2aa5 docs: whatever
        	            	* a4802f6fc858cbc12ceca360a89894a61a0a097f fix: whatever
        	            	* 7a2645a1262516ca24443a65c137680e2e3857fc ignored: whatever
        	            	* b66e319579a7eeb319d1d2a95cb938d6316d3edb fixed bug 2
        	            	* 377012fb77758238b46a20c8bbd348e55d011168 added feature 1
        	            	" to match "## Changelog
        	            	### Features
        	            	\* \w+ feat: added that thing
        	            	### Bug Fixes
        	            	\* \w+ bug: Merge pull request #999 from goreleaser\/some-branch
        	            	### Bots
        	            	\* \w+ feat\(deps\): update foobar \[bot\]
        	            	### Others
        	            	\* \w+ first
        	            	\* \w+ this is not a Merge pull request
        	            	\* \w+ chore: something about cArs we dont need
        	            	\* \w+ docs: whatever
        	            	\* \w+ fix: whatever
        	            	\* \w+ ignored: whatever
        	            	\* \w+ fixed bug 2
        	            	\* \w+ added feature 1
        	            	"
        	Test:       	TestGroup
```

2. 747c11d83301405c40df3a5b56adf976c8382b0f

   Log: https://github.com/goreleaser/goreleaser/actions/runs/11166873534/job/31041800714#step:4:677

```
--- FAIL: TestGroup (0.09s)
    changelog_test.go:843: 
        	Error Trace:	/src/internal/pipe/changelog/changelog_test.go:843
        	Error:      	Expect "## Changelog
        	            	### Features
        	            	* 49f56e2d8ca352d4641828efd167dbfe91f5769a feat: added that thing
        	            	### Bug Fixes
        	            	* 11c8dafa67d5973c359ed3bcf859b81d571396ed bug: Merge pull request #999 from goreleaser/some-branch
        	            	### Bots
        	            	* df888fe601a92afe5d8d4fcae5a551b0eaa57684 feat(deps): update foobar [bot]
        	            	### Others
        	            	* 03f397c28cd4f5484afee71f7edd99977f85deec this is not a Merge pull request
        	            	* 16333c2d178e4911a049ba63b0b8783bbc7e497b chore: something about cArs we dont need
        	            	* e7b30e58579bdaaeea184d78ddb5017a2bdc3459 docs: whatever
        	            	* ab9abbc7aa88208f2b3dc44dc9f7b0e55771b826 fix: whatever
        	            	* 87fc355911ca94f0a1e5a6c332e36b1f73654fbe ignored: whatever
        	            	* 189fa3fb4ceb246084404247ad1b521747f30991 fixed bug 2
        	            	* 49fdca4fd96ec600d79722f3453c1b84e82dd6e5 added feature 1
        	            	* ea1e16eb97b432d9c111df934ea4b6ce3691438a first
        	            	" to match "## Changelog
        	            	### Features
        	            	\* \w+ feat: added that thing
        	            	### Bug Fixes
        	            	\* \w+ bug: Merge pull request #999 from goreleaser\/some-branch
        	            	### Bots
        	            	\* \w+ feat\(deps\): update foobar \[bot\]
        	            	### Others
        	            	\* \w+ first
        	            	\* \w+ this is not a Merge pull request
        	            	\* \w+ chore: something about cArs we dont need
        	            	\* \w+ docs: whatever
        	            	\* \w+ fix: whatever
        	            	\* \w+ ignored: whatever
        	            	\* \w+ fixed bug 2
        	            	\* \w+ added feature 1
        	            	"
        	Test:       	TestGroup
```

3. 10980311a53bf90e3d5d469a9c3e916d67c0050d

   Log: https://github.com/goreleaser/goreleaser/actions/runs/11183904433/job/31093519567#step:14:41

```
--- FAIL: TestGroup (0.14s)
    changelog_test.go:843: 
        	Error Trace:	/home/runner/work/goreleaser/goreleaser/internal/pipe/changelog/changelog_test.go:843
        	Error:      	Expect "## Changelog
        	            	### Features
        	            	* ec216fc3537667e300da4181c6b51520367afd28 feat: added that thing
        	            	### Bug Fixes
        	            	* 5132e678d5f69a366415474cefce012c640a7de9 bug: Merge pull request #999 from goreleaser/some-branch
        	            	### Bots
        	            	* dd9571e27c5a4f19882b8062a790636376b677bc feat(deps): update foobar [bot]
        	            	### Others
        	            	* c9b95e3b52ad6a82bacabae63decd45b1038d137 this is not a Merge pull request
        	            	* 260f70d5c2b6e31a35058b727818a78a7d589a22 chore: something about cArs we dont need
        	            	* 0969cba5b1363473e05eb251ffefbccd46fa6fc8 first
        	            	* c504cb0173a1f312ab39d17852f86b95504ff767 docs: whatever
        	            	* d57cab9360470d0e0a03d1ecb4763e89fe182f8f fix: whatever
        	            	* 2e659ceef3f2231ed107c80954833d9073091dd3 ignored: whatever
        	            	* 72658b11fd2789a03e83496d723a9196f7b14467 fixed bug 2
        	            	* 883d4fab813e6849520463b5325077a9ef45131d added feature 1
        	            	" to match "## Changelog
        	            	### Features
        	            	\* \w+ feat: added that thing
        	            	### Bug Fixes
        	            	\* \w+ bug: Merge pull request #999 from goreleaser\/some-branch
        	            	### Bots
        	            	\* \w+ feat\(deps\): update foobar \[bot\]
        	            	### Others
        	            	\* \w+ first
        	            	\* \w+ this is not a Merge pull request
        	            	\* \w+ chore: something about cArs we dont need
        	            	\* \w+ docs: whatever
        	            	\* \w+ fix: whatever
        	            	\* \w+ ignored: whatever
        	            	\* \w+ fixed bug 2
        	            	\* \w+ added feature 1
        	            	"
        	Test:       	TestGroup
```


As we can see from the log, the first commit with the `first` message can appear in a random order in the changelog.

---

## Solution

In the `TestGroup` unit test, we are making 11 git commits, all within a second. There seems to be a bug with `git log` where it is unable to order the commits in reverse chronological order if all commits have the same authored and committed date, as shown below.

> [!note]
> `/tmp/TestGroup4125952855/001` is the temporary directory created by `testlib.Mktmp` in `TestGroup` test.

`git log` without revision range:

```
/tmp/TestGroup4125952855/001 main ❯ git log --oneline
85f005f (HEAD -> main, tag: v0.0.2) this is not a Merge pull request
27dbd0e bug: Merge pull request #999 from goreleaser/some-branch
3495034 feat: added that thing
9f0db77 chore: something about cArs we dont need
634e043 docs: whatever
ef52fef fix: whatever
ff49bea feat(deps): update foobar [bot]
e0f4e4b ignored: whatever
ce7fbfa fixed bug 2
940a684 added feature 1
2750980 (tag: v0.0.1) first
```

`git log` with multiple revision ranges, the "first" commit appears at the top:

```
/tmp/TestGroup4125952855/001 main ❯ git log --oneline 2750980 v0.0.2
2750980 (tag: v0.0.1) first
85f005f (HEAD -> main, tag: v0.0.2) this is not a Merge pull request
27dbd0e bug: Merge pull request #999 from goreleaser/some-branch
3495034 feat: added that thing
9f0db77 chore: something about cArs we dont need
634e043 docs: whatever
ef52fef fix: whatever
ff49bea feat(deps): update foobar [bot]
e0f4e4b ignored: whatever
ce7fbfa fixed bug 2
940a684 added feature 1
```

If we specify only one revision, then the commits are ordered correctly in reverse chronological order:

```
/tmp/TestGroup4125952855/001 main ❯ git log --oneline v0.0.2
85f005f (HEAD -> main, tag: v0.0.2) this is not a Merge pull request
27dbd0e bug: Merge pull request #999 from goreleaser/some-branch
3495034 feat: added that thing
9f0db77 chore: something about cArs we dont need
634e043 docs: whatever
ef52fef fix: whatever
ff49bea feat(deps): update foobar [bot]
e0f4e4b ignored: whatever
ce7fbfa fixed bug 2
940a684 added feature 1
2750980 (tag: v0.0.1) first
```

Based on my observations, this bug can only happen when all commits are created at the same time, and the user is creating their first release note.

This commit fixes the bug by excluding the first commit SHA-1 hash from `git log` in `gitChangeLogger`.
