### PR TITLE
Create directories under `dist` if needed by nfpm `file_name_template`

### DIFF
--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -507,6 +507,7 @@ func create(ctx *context.Context, fpm config.NFPM, format string, artifacts []*a
 
 	path := filepath.Join(ctx.Config.Dist, packageFilename)
 	log.WithField("file", path).Info("creating")
+	os.MkdirAll(filepath.Dir(path), 0750)
 	w, err := os.Create(path)
 	if err != nil {
 		return err


### PR DESCRIPTION
closes #5204

