### PR TITLE
fix: standardize .Ext to always have the preceding `.`

### DIFF
--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -152,7 +152,7 @@ func (t Type) String() string {
 const (
 	ExtraID         = "ID"
 	ExtraBinary     = "Binary"
-	ExtraExt        = "Ext"
+	ExtraExt        = "Ext" // should always have the preceding '.'
 	ExtraFormat     = "Format"
 	ExtraWrappedIn  = "WrappedIn"
 	ExtraBinaries   = "Binaries"
@@ -512,11 +512,15 @@ func ByIDs(ids ...string) Filter {
 }
 
 // ByExt filter artifact by their 'Ext' extra field.
+//
+// The comp is done ignoring the preceding '.', so `ByExt("deb")` and
+// `ByExt(".deb")` have the same result.
 func ByExt(exts ...string) Filter {
 	filters := make([]Filter, 0, len(exts))
 	for _, ext := range exts {
 		filters = append(filters, func(a *Artifact) bool {
-			return ExtraOr(*a, ExtraExt, "") == ext
+			actual := ExtraOr(*a, ExtraExt, "")
+			return strings.TrimPrefix(actual, ".") == strings.TrimPrefix(ext, ".")
 		})
 	}
 	return Or(filters...)

--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -477,7 +477,7 @@ func TestByExts(t *testing.T) {
 		{
 			Name: "foo",
 			Extra: map[string]interface{}{
-				ExtraExt: "deb",
+				ExtraExt: ".deb",
 			},
 		},
 		{
@@ -504,7 +504,7 @@ func TestByExts(t *testing.T) {
 
 	require.Len(t, artifacts.Filter(ByExt("deb")).items, 2)
 	require.Len(t, artifacts.Filter(ByExt("rpm")).items, 1)
-	require.Len(t, artifacts.Filter(ByExt("rpm", "deb")).items, 3)
+	require.Len(t, artifacts.Filter(ByExt("rpm", ".deb")).items, 3)
 	require.Empty(t, artifacts.Filter(ByExt("foo")).items)
 }
 

--- a/internal/http/http_test.go
+++ b/internal/http/http_test.go
@@ -239,21 +239,21 @@ func TestUpload(t *testing.T) {
 		ext string
 		typ artifact.Type
 	}{
-		{"---", artifact.DockerImage},
-		{"deb", artifact.LinuxPackage},
-		{"bin", artifact.Binary},
-		{"tar", artifact.UploadableArchive},
-		{"tar.gz", artifact.UploadableSourceArchive},
-		{"ubi", artifact.UploadableBinary},
-		{"sum", artifact.Checksum},
-		{"meta", artifact.Metadata},
-		{"sig", artifact.Signature},
-		{"pem", artifact.Certificate},
+		{"", artifact.DockerImage},
+		{".deb", artifact.LinuxPackage},
+		{".bin", artifact.Binary},
+		{".tar", artifact.UploadableArchive},
+		{".tar.gz", artifact.UploadableSourceArchive},
+		{".ubi", artifact.UploadableBinary},
+		{".sum", artifact.Checksum},
+		{".meta", artifact.Metadata},
+		{".sig", artifact.Signature},
+		{".pem", artifact.Certificate},
 	} {
-		file := filepath.Join(folder, "a."+a.ext)
+		file := filepath.Join(folder, "a"+a.ext)
 		require.NoError(t, os.WriteFile(file, []byte("lorem ipsum"), 0o644))
 		ctx.Artifacts.Add(&artifact.Artifact{
-			Name:   "a." + a.ext,
+			Name:   "a" + a.ext,
 			Goos:   "linux",
 			Goarch: "amd64",
 			Path:   file,

--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -531,7 +531,7 @@ func create(ctx *context.Context, fpm config.NFPM, format string, artifacts []*a
 		Extra: map[string]interface{}{
 			artifact.ExtraID:     fpm.ID,
 			artifact.ExtraFormat: format,
-			artifact.ExtraExt:    format,
+			artifact.ExtraExt:    "." + format,
 			extraFiles:           contents,
 		},
 	})

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -397,7 +397,7 @@ func TestRunPipe(t *testing.T) {
 	for _, pkg := range packages {
 		format := pkg.Format()
 		require.NotEmpty(t, format)
-		require.Equal(t, pkg.Format(), artifact.ExtraOr(*pkg, artifact.ExtraExt, ""))
+		require.Equal(t, "."+pkg.Format(), artifact.ExtraOr(*pkg, artifact.ExtraExt, ""))
 		arch := pkg.Goarch
 		if pkg.Goarm != "" {
 			arch += "v" + pkg.Goarm

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -30,7 +30,7 @@ func For(name string) Builder {
 type Options struct {
 	Name      string
 	Path      string
-	Ext       string
+	Ext       string // with the leading `.`.
 	Target    string
 	Goos      string
 	Goarch    string

--- a/www/docs/customization/templates.md
+++ b/www/docs/customization/templates.md
@@ -102,23 +102,23 @@ You should be able to use all its fields on each item:
 On fields that are related to a single artifact (e.g., the binary name), you
 may have some extra fields:
 
-| Key             | Description                    |
-| --------------- | ------------------------------ |
-| `.Os`           | `GOOS`                         |
-| `.Arch`         | `GOARCH`                       |
-| `.Arm`          | `GOARM`                        |
-| `.Mips`         | `GOMIPS`                       |
-| `.Amd64`        | `GOAMD64`                      |
-| `.Arm64`        | `GOARM64` (since v2.4)         |
-| `.Mips64`       | `GOMIPS64` (since v2.4)        |
-| `.Ppc64`        | `GOPPC64` (since v2.4)         |
-| `.Riscv64`      | `GORISCV64` (since v2.4)       |
-| `.I386`         | `GO386` (since v2.4)           |
-| `.Binary`       | binary name                    |
-| `.ArtifactID`   | archive id (since v2.3[^pro])  |
-| `.ArtifactName` | archive name                   |
-| `.ArtifactPath` | absolute path to artifact      |
-| `.ArtifactExt`  | binary extension (e.g. `.exe`) |
+| Key             | Description                                   |
+| --------------- | --------------------------------------------- |
+| `.Os`           | `GOOS`                                        |
+| `.Arch`         | `GOARCH`                                      |
+| `.Arm`          | `GOARM`                                       |
+| `.Mips`         | `GOMIPS`                                      |
+| `.Amd64`        | `GOAMD64`                                     |
+| `.Arm64`        | `GOARM64` (since v2.4)                        |
+| `.Mips64`       | `GOMIPS64` (since v2.4)                       |
+| `.Ppc64`        | `GOPPC64` (since v2.4)                        |
+| `.Riscv64`      | `GORISCV64` (since v2.4)                      |
+| `.I386`         | `GO386` (since v2.4)                          |
+| `.Binary`       | artifact name                                 |
+| `.ArtifactID`   | artifact id (since v2.3[^pro])                |
+| `.ArtifactName` | artifact name                                 |
+| `.ArtifactPath` | absolute path to artifact                     |
+| `.ArtifactExt`  | artifact extension (e.g. `.exe`, `.dmg`, etc) |
 
 ## nFPM extra fields
 


### PR DESCRIPTION
historically this is kind of a mess, some places set the prefixed ext (e.g. `.exe`) others don't (e.g. `msi`)

this standardize it to have the preceding `.`

also makes `ByExt` works with or without it so it doesn't break anyone's config.