### PR TITLE
feat(release): allow using existing draft release

### DIFF
--- a/internal/client/testdata/github/releases.json
+++ b/internal/client/testdata/github/releases.json
@@ -1,0 +1,9 @@
+[
+  {
+	"id": 1,
+	"name": "v1.0.0",
+	"tag_name": "v1.0.0",
+	"draft": true,
+	"body": "Existing draft release"
+  }
+]

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -742,6 +742,7 @@ type Release struct {
 	Gitea                  Repo        `yaml:"gitea,omitempty" json:"gitea,omitempty"`
 	Draft                  bool        `yaml:"draft,omitempty" json:"draft,omitempty"`
 	ReplaceExistingDraft   bool        `yaml:"replace_existing_draft,omitempty" json:"replace_existing_draft,omitempty"`
+	UseExistingDraft       bool        `yaml:"use_existing_draft,omitempty" json:"use_existing_draft,omitempty"`
 	TargetCommitish        string      `yaml:"target_commitish,omitempty" json:"target_commitish,omitempty"`
 	Disable                string      `yaml:"disable,omitempty" json:"disable,omitempty" jsonschema:"oneof_type=string;boolean"`
 	SkipUpload             string      `yaml:"skip_upload,omitempty" json:"skip_upload,omitempty" jsonschema:"oneof_type=string;boolean"`

--- a/www/docs/customization/release.md
+++ b/www/docs/customization/release.md
@@ -39,6 +39,7 @@ release:
   # Whether to use an existing draft release as the target release.
   #
   # Available only for GitHub.
+  # Since: v2.5.
   use_existing_draft: true
 
   # Whether to remove an artifact that already exists.

--- a/www/docs/customization/release.md
+++ b/www/docs/customization/release.md
@@ -36,6 +36,11 @@ release:
   # Available only for GitHub.
   replace_existing_draft: true
 
+  # Whether to use an existing draft release as the target release.
+  #
+  # Available only for GitHub.
+  use_existing_draft: true
+
   # Whether to remove an artifact that already exists.
   #
   # Available only for GitHub.


### PR DESCRIPTION
The PR allows setting a `release.use_existing_draft` config option to use an existing draft release instead of creating a new release.

Our release process creates a draft PR before calling GoReleaser. While we can delete an old draft and create a new one, it would be nice to keep the existing draft PR and use that instead of creating a new one.