### PR TITLE
refactor: rename archive.Copying to archive.Copy

### DIFF
--- a/internal/pipe/sourcearchive/source.go
+++ b/internal/pipe/sourcearchive/source.go
@@ -97,7 +97,7 @@ func appendExtraFilesToArchive(ctx *context.Context, prefix, path, format string
 	}
 	defer af.Close()
 
-	arch, err := archive.Copying(of, af, format)
+	arch, err := archive.Copy(of, af, format)
 	if err != nil {
 		return err
 	}

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -40,16 +40,16 @@ func New(w io.Writer, format string) (Archive, error) {
 	return nil, fmt.Errorf("invalid archive format: %s", format)
 }
 
-// Copying copies the source archive into a new one, which can be appended at.
+// Copy copies the source archive into a new one, which can be appended at.
 // Source needs to be in the specified format.
-func Copying(r *os.File, w io.Writer, format string) (Archive, error) {
+func Copy(r *os.File, w io.Writer, format string) (Archive, error) {
 	switch format {
 	case "tar.gz", "tgz":
-		return targz.Copying(r, w)
+		return targz.Copy(r, w)
 	case "tar":
-		return tar.Copying(r, w)
+		return tar.Copy(r, w)
 	case "zip":
-		return zip.Copying(r, w)
+		return zip.Copy(r, w)
 	}
 	return nil, fmt.Errorf("invalid archive format: %s", format)
 }

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -37,7 +37,7 @@ func TestArchive(t *testing.T) {
 			require.NoError(t, f1.Close())
 
 			if format == "tar.xz" || format == "txz" || format == "gz" || format == "tar.zst" || format == "tzst" {
-				_, err := Copying(f1, io.Discard, format)
+				_, err := Copy(f1, io.Discard, format)
 				require.Error(t, err)
 				return
 			}
@@ -47,7 +47,7 @@ func TestArchive(t *testing.T) {
 			f2, err := os.Create(filepath.Join(t.TempDir(), "2.tar"))
 			require.NoError(t, err)
 
-			a, err := Copying(f1, f2, format)
+			a, err := Copy(f1, f2, format)
 			require.NoError(t, err)
 			require.NoError(t, f1.Close())
 

--- a/pkg/archive/tar/tar.go
+++ b/pkg/archive/tar/tar.go
@@ -25,8 +25,8 @@ func New(target io.Writer) Archive {
 	}
 }
 
-// Copying creates a new tar with the contents of the given tar.
-func Copying(source io.Reader, target io.Writer) (Archive, error) {
+// Copy creates a new tar with the contents of the given tar.
+func Copy(source io.Reader, target io.Writer) (Archive, error) {
 	w := New(target)
 	r := tar.NewReader(source)
 	for {

--- a/pkg/archive/tar/tar_test.go
+++ b/pkg/archive/tar/tar_test.go
@@ -186,7 +186,7 @@ func TestCopying(t *testing.T) {
 	f1, err = os.Open(f1.Name())
 	require.NoError(t, err)
 
-	t2, err := Copying(f1, f2)
+	t2, err := Copy(f1, f2)
 	require.NoError(t, err)
 	require.NoError(t, t2.Add(config.File{
 		Source:      "../testdata/sub1/executable",

--- a/pkg/archive/targz/targz.go
+++ b/pkg/archive/targz/targz.go
@@ -27,14 +27,14 @@ func New(target io.Writer) Archive {
 	}
 }
 
-func Copying(source io.Reader, target io.Writer) (Archive, error) {
+func Copy(source io.Reader, target io.Writer) (Archive, error) {
 	// the error will be nil since the compression level is valid
 	gw, _ := gzip.NewWriterLevel(target, gzip.BestCompression)
 	srcgz, err := gzip.NewReader(source)
 	if err != nil {
 		return Archive{}, err
 	}
-	tw, err := tar.Copying(srcgz, gw)
+	tw, err := tar.Copy(srcgz, gw)
 	return Archive{
 		gw: gw,
 		tw: &tw,

--- a/pkg/archive/zip/zip.go
+++ b/pkg/archive/zip/zip.go
@@ -32,8 +32,7 @@ func New(target io.Writer) Archive {
 	}
 }
 
-// New zip archive.
-func Copying(source *os.File, target io.Writer) (Archive, error) {
+func Copy(source *os.File, target io.Writer) (Archive, error) {
 	info, err := source.Stat()
 	if err != nil {
 		return Archive{}, err


### PR DESCRIPTION
This PR renames `Copying` functions in the `archive` package to `Copy` because it is a more common method name.