### PR TITLE
fix: build override

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -282,9 +282,9 @@ func (*Builder) Build(ctx *context.Context, build config.Build, options api.Opti
 }
 
 func withOverrides(ctx *context.Context, build config.Build, options api.Options) (config.BuildDetails, error) {
-	optsTarget := options.Goos + options.Goarch + options.Goamd64 + options.Go386 + options.Goarm + options.Gomips
+	optsTarget := options.Goos + options.Goarch + options.Goamd64 + options.Go386 + options.Goarm + options.Gomips + options.Goppc64 + options.Goriscv64
 	for _, o := range build.BuildDetailsOverrides {
-		overrideTarget, err := tmpl.New(ctx).Apply(o.Goos + o.Goarch + o.Gomips + o.Goarm + o.Goamd64)
+		overrideTarget, err := tmpl.New(ctx).Apply(o.Goos + o.Goarch + o.Goamd64 + o.Go386 + o.Goarm + o.Gomips + o.Goppc64 + o.Goriscv64)
 		if err != nil {
 			return build.BuildDetails, err
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -528,9 +528,13 @@ type Build struct {
 type BuildDetailsOverride struct {
 	Goos         string `yaml:"goos,omitempty" json:"goos,omitempty"`
 	Goarch       string `yaml:"goarch,omitempty" json:"goarch,omitempty"`
+	Goamd64      string `yaml:"goamd64,omitempty" json:"goamd64,omitempty"`
+	Go386        string `yaml:"go386,omitempty" json:"go386,omitempty"`
+	Goarm64      string `yaml:"goarm64,omitempty" json:"goarm64,omitempty"`
 	Goarm        string `yaml:"goarm,omitempty" json:"goarm,omitempty" jsonschema:"oneof_type=string;integer"`
 	Gomips       string `yaml:"gomips,omitempty" json:"gomips,omitempty"`
-	Goamd64      string `yaml:"goamd64,omitempty" json:"goamd64,omitempty"`
+	Goppc64      string `yaml:"goppc64,omitempty" json:"goppc64,omitempty"`
+	Goriscv64    string `yaml:"goriscv64,omitempty" json:"goriscv64,omitempty"`
 	BuildDetails `yaml:",inline" json:",inline"`
 }
 


### PR DESCRIPTION
Since Go386 now has a default value, existing configurations no longer match 386 builds (d583861e0606f2bb9e97c0d0e28f9b82df6a187a).

Since we used to need to write goamd64=1 to match _amd64 builds, I added new opts to fix that. (If you think you need to set some default for override, that would be even better)
