### PR TITLE
fix(changelog): first release default to git changelogger 

### DIFF
--- a/internal/pipe/changelog/changelog.go
+++ b/internal/pipe/changelog/changelog.go
@@ -344,6 +344,9 @@ func getChangeloger(ctx *context.Context) (changeloger, error) {
 	case useGit, "":
 		return gitChangeloger{}, nil
 	case useGitLab, useGitea, useGitHub:
+		if ctx.Git.PreviousTag == "" {
+			return gitChangeloger{}, nil
+		}
 		return newSCMChangeloger(ctx)
 	case useGitHubNative:
 		return newGithubChangeloger(ctx)

--- a/internal/pipe/changelog/changelog.go
+++ b/internal/pipe/changelog/changelog.go
@@ -345,6 +345,7 @@ func getChangeloger(ctx *context.Context) (changeloger, error) {
 		return gitChangeloger{}, nil
 	case useGitLab, useGitea, useGitHub:
 		if ctx.Git.PreviousTag == "" {
+			log.Warnf("there's no previous tag, using 'git' instead of '%s'", ctx.Config.Changelog.Use)
 			return gitChangeloger{}, nil
 		}
 		return newSCMChangeloger(ctx)

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -645,10 +645,21 @@ func TestGetChangeloger(t *testing.T) {
 			Changelog: config.Changelog{
 				Use: useGitHub,
 			},
-		}, testctx.GitHubTokenType)
+		}, testctx.GitHubTokenType, testctx.WithPreviousTag("v1.2.3"))
 		c, err := getChangeloger(ctx)
 		require.NoError(t, err)
 		require.IsType(t, &scmChangeloger{}, c)
+	})
+
+	t.Run(useGitHub+" no previous", func(t *testing.T) {
+		ctx := testctx.NewWithCfg(config.Project{
+			Changelog: config.Changelog{
+				Use: useGitHub,
+			},
+		}, testctx.GitHubTokenType)
+		c, err := getChangeloger(ctx)
+		require.NoError(t, err)
+		require.IsType(t, gitChangeloger{}, c)
 	})
 
 	t.Run(useGitHubNative, func(t *testing.T) {
@@ -656,7 +667,7 @@ func TestGetChangeloger(t *testing.T) {
 			Changelog: config.Changelog{
 				Use: useGitHubNative,
 			},
-		}, testctx.GitHubTokenType)
+		}, testctx.GitHubTokenType, testctx.WithPreviousTag("v1.2.3"))
 		c, err := getChangeloger(ctx)
 		require.NoError(t, err)
 		require.IsType(t, &githubNativeChangeloger{}, c)
@@ -681,7 +692,7 @@ func TestGetChangeloger(t *testing.T) {
 			Changelog: config.Changelog{
 				Use: useGitLab,
 			},
-		}, testctx.GitLabTokenType)
+		}, testctx.GitLabTokenType, testctx.WithPreviousTag("v1.2.3"))
 		c, err := getChangeloger(ctx)
 		require.NoError(t, err)
 		require.IsType(t, &scmChangeloger{}, c)
@@ -695,7 +706,7 @@ func TestGetChangeloger(t *testing.T) {
 			Changelog: config.Changelog{
 				Use: useGitHub,
 			},
-		}, testctx.GitHubTokenType)
+		}, testctx.GitHubTokenType, testctx.WithPreviousTag("v1.2.3"))
 		c, err := getChangeloger(ctx)
 		require.EqualError(t, err, "unsupported repository URL: https://gist.github.com/")
 		require.Nil(t, c)
@@ -717,7 +728,7 @@ func TestGetChangeloger(t *testing.T) {
 			GiteaURLs: config.GiteaURLs{
 				API: srv.URL,
 			},
-		}, testctx.GiteaTokenType)
+		}, testctx.GiteaTokenType, testctx.WithPreviousTag("v1.2.3"))
 		c, err := getChangeloger(ctx)
 		require.NoError(t, err)
 		require.IsType(t, &scmChangeloger{}, c)


### PR DESCRIPTION
the `/compare` api doesn't allow to omit the previous reference, nor to use a git commit, so, if `previous tag` is empty, we're now defaulting to the git changelog implementation, which should resolve the problem.

closes #5240 