### PR TITLE
Update deprecated config documentation

### DIFF
--- a/www/docs/errors/resource-not-accessible-by-integration.md
+++ b/www/docs/errors/resource-not-accessible-by-integration.md
@@ -29,7 +29,7 @@ You'll need to add it as secret and pass it to the action, for instance:
 ```yaml
 # .github/workflows/release.yaml
 # ...
-- uses: goreleaser/goreleaser-action@v4
+- uses: goreleaser/goreleaser-action@v6
   env:
     GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 # ...
@@ -46,7 +46,7 @@ We would need to change the workflow file:
 ```yaml
 # .github/workflows/release.yaml
 # ...
-- uses: goreleaser/goreleaser-action@v4
+- uses: goreleaser/goreleaser-action@v6
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
@@ -60,7 +60,7 @@ And also the `.goreleaser.yaml` file:
 # ...
 brews:
   - name: myproject
-    tap:
+    repository:
       owner: user
       name: homebrew-tap
       token: "{{ .Env.TAP_GITHUB_TOKEN }}"


### PR DESCRIPTION
This pull request updates the documentation to reflect changes in the `goreleaser-action` version and modifies the `.goreleaser.yaml` configuration for better clarity.

Documentation updates:

* [`www/docs/errors/resource-not-accessible-by-integration.md`](diffhunk://#diff-165fd8d8fb477ae98173556cce7fbd52eb9c5fca03b713c7c8d59bc96e46fe50L32-R32): Updated the `goreleaser-action` version from `v4` to `v6` in the workflow file examples. [[1]](diffhunk://#diff-165fd8d8fb477ae98173556cce7fbd52eb9c5fca03b713c7c8d59bc96e46fe50L32-R32) [[2]](diffhunk://#diff-165fd8d8fb477ae98173556cce7fbd52eb9c5fca03b713c7c8d59bc96e46fe50L49-R49)

Configuration changes:

* [`www/docs/errors/resource-not-accessible-by-integration.md`](diffhunk://#diff-165fd8d8fb477ae98173556cce7fbd52eb9c5fca03b713c7c8d59bc96e46fe50L63-R63): Changed the `.goreleaser.yaml` configuration to use `repository` instead of `tap` for specifying the brew repository.
