### PR TITLE
docs: fix typos in comments

### DIFF
--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -260,7 +260,7 @@ func TestWithDefaults(t *testing.T) {
 			targets:  append(go118FirstClassAdjustedTargets, "darwin_amd64_v2"),
 			goBinary: "go",
 		},
-		"repeatin targets": {
+		"repeating targets": {
 			build: config.Build{
 				ID:      "foo3",
 				Binary:  "foo",

--- a/internal/client/gitlab_test.go
+++ b/internal/client/gitlab_test.go
@@ -105,7 +105,7 @@ func TestGitLabURLsAPITemplate(t *testing.T) {
 			wantHost: "gitlab.com",
 		},
 		{
-			name:     "speicifed_api_env_key",
+			name:     "specified_api_env_key",
 			apiURL:   "https://gitlab.mycompany.com",
 			wantHost: "gitlab.mycompany.com",
 		},

--- a/internal/pipe/blob/upload.go
+++ b/internal/pipe/blob/upload.go
@@ -86,7 +86,7 @@ func urlFor(ctx *context.Context, conf config.Blob) (string, error) {
 	return bucketURL, nil
 }
 
-// Takes goreleaser context(which includes artificats) and bucketURL for
+// Takes goreleaser context(which includes artifacts) and bucketURL for
 // upload to destination (eg: gs://gorelease-bucket) using the given uploader
 // implementation.
 func doUpload(ctx *context.Context, conf config.Blob) error {

--- a/internal/pipe/sign/sign_test.go
+++ b/internal/pipe/sign/sign_test.go
@@ -728,7 +728,7 @@ func verifySignature(tb testing.TB, ctx *context.Context, sig string, user strin
 	artifact := strings.TrimSuffix(sig, filepath.Ext(sig))
 	artifact = strings.TrimSuffix(artifact, "."+fakeGPGKeyID)
 
-	// verify signature was made with key for usesr 'nopass'
+	// verify signature was made with key for user 'nopass'
 	cmd := exec.Command("gpg", "--homedir", keyring, "--verify", filepath.Join(ctx.Config.Dist, sig), filepath.Join(ctx.Config.Dist, artifact))
 	out, err := cmd.CombinedOutput()
 	require.NoError(tb, err, string(out))

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -75,7 +75,7 @@ var BuildPipeline = []Piper{
 	dist.Pipe{},
 	// setup metadata options
 	metadata.Pipe{},
-	// creates a metadta.json files in the dist directory
+	// creates a metadata.json files in the dist directory
 	metadata.MetaPipe{},
 	// setup gomod-related stuff
 	gomod.Pipe{},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1495,7 +1495,7 @@ type Chocolatey struct {
 	Goamd64                  string                 `yaml:"goamd64,omitempty" json:"goamd64,omitempty"`
 }
 
-// ChcolateyDependency represents Chocolatey dependency.
+// ChocolateyDependency represents Chocolatey dependency.
 type ChocolateyDependency struct {
 	ID      string `yaml:"id,omitempty" json:"id,omitempty"`
 	Version string `yaml:"version,omitempty" json:"version,omitempty"`


### PR DESCRIPTION
The PR correct grammar mistakes in Go comments and tests.