### PR TITLE
chore: disable gochecknoglobals and remove nolint directives

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,6 +2,8 @@ run:
   go: "1.23"
   timeout: 5m
 linters:
+  disable:
+    - gochecknoglobals
   enable:
     - copyloopvar
     - thelper

--- a/internal/builders/buildtarget/targets.go
+++ b/internal/builders/buildtarget/targets.go
@@ -192,8 +192,6 @@ func contains(s string, ss []string) bool {
 }
 
 // lists from https://go.dev/doc/install/source#environment
-//
-//nolint:gochecknoglobals
 var (
 	validTargets = []string{
 		"aixppc64",

--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -26,8 +26,6 @@ import (
 )
 
 // Default builder instance.
-//
-//nolint:gochecknoglobals
 var Default = &Builder{}
 
 //nolint:gochecknoinits

--- a/internal/exec/exec_mock.go
+++ b/internal/exec/exec_mock.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 )
 
-//nolint:gochecknoglobals
 var (
 	MockEnvVar = "GORELEASER_MOCK_DATA"
 	MockCmd    = os.Args[0]

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -35,7 +35,6 @@ type asset struct {
 
 type assetOpenFunc func(string, *artifact.Artifact) (*asset, error)
 
-//nolint:gochecknoglobals
 var assetOpen assetOpenFunc
 
 // TODO: fix this.

--- a/internal/pipe/announce/announce.go
+++ b/internal/pipe/announce/announce.go
@@ -31,7 +31,6 @@ type Announcer interface {
 	Announce(ctx *context.Context) error
 }
 
-//nolint:gochecknoglobals
 var announcers = []Announcer{
 	// XXX: keep asc sorting
 	bluesky.Pipe{},

--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -35,7 +35,6 @@ const (
 // GoReleaser breaks in these cases as it will only cause confusion to other users.
 var ErrArchiveDifferentBinaryCount = errors.New("archive has different count of binaries for each platform, which may cause your users confusion.\nLearn more at https://goreleaser.com/errors/multiple-binaries-archive\n") //nolint:revive
 
-//nolint:gochecknoglobals
 var lock sync.Mutex
 
 // Pipe for archive.

--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -54,7 +54,6 @@ func (Pipe) Run(ctx *context.Context) error {
 	return validate(ctx)
 }
 
-//nolint:gochecknoglobals
 var fakeInfo = context.GitInfo{
 	Branch:      "none",
 	CurrentTag:  "v0.0.0",

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -52,8 +52,6 @@ type Piper interface {
 }
 
 // BuildPipeline contains all build-related pipe implementations in order.
-//
-//nolint:gochecknoglobals
 var BuildPipeline = []Piper{
 	// set default dist folder and remove it if `--clean` is set
 	dist.CleanPipe{},
@@ -100,8 +98,6 @@ var BuildPipeline = []Piper{
 }
 
 // BuildCmdPipeline is the pipeline run by goreleaser build.
-//
-//nolint:gochecknoglobals
 var BuildCmdPipeline = append(
 	BuildPipeline,
 	reportsizes.Pipe{},
@@ -109,8 +105,6 @@ var BuildCmdPipeline = append(
 )
 
 // Pipeline contains all pipe implementations in order.
-//
-//nolint:gochecknoglobals
 var Pipeline = append(
 	BuildPipeline,
 	// builds the release changelog

--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ import (
 	"go.uber.org/automaxprocs/maxprocs"
 )
 
-//nolint:gochecknoglobals
 var (
 	version   = ""
 	commit    = ""

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -8,7 +8,6 @@ import (
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
 )
 
-//nolint:gochecknoglobals
 var (
 	builders = map[string]Builder{}
 	lock     sync.Mutex

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -61,8 +61,6 @@ type Defaulter interface {
 }
 
 // Defaulters is the list of defaulters.
-//
-//nolint:gochecknoglobals
 var Defaulters = []Defaulter{
 	dist.Pipe{},
 	snapshot.Pipe{},

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -23,8 +23,6 @@ type Healthchecker interface {
 }
 
 // Healthcheckers is the list of healthchekers.
-//
-//nolint:gochecknoglobals
 var Healthcheckers = []Healthchecker{
 	system{},
 	snapcraft.Pipe{},


### PR DESCRIPTION
The PR adds `gochecknoglobals` linter to `linters.disable` section in golangci-lint config and removes `nolint:gochecknoglobals` from Go files. In that case, the linter is disabled only once in the configuration file, and we do not need to add `//nolint:gochecknoglobals` comments.