### PR TITLE
chore: fix typos in test names

### DIFF
--- a/internal/pipe/slack/slack_test.go
+++ b/internal/pipe/slack/slack_test.go
@@ -156,7 +156,7 @@ func TestRichText(t *testing.T) {
 	})
 }
 
-func TestUnmarshall(t *testing.T) {
+func TestUnmarshal(t *testing.T) {
 	t.Parallel()
 
 	t.Run("happy unmarshal", func(t *testing.T) {

--- a/internal/pipe/snapcraft/snapcraft_test.go
+++ b/internal/pipe/snapcraft/snapcraft_test.go
@@ -98,7 +98,7 @@ func TestRunPipe(t *testing.T) {
 	require.Len(t, list, 9)
 }
 
-func TestBadTemolate(t *testing.T) {
+func TestBadTemplate(t *testing.T) {
 	testlib.CheckPath(t, "snapcraft")
 	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")


### PR DESCRIPTION
The PR corrects grammar mistakes in test names.