### PR TITLE
fix: typo in JSON property for OpenCollective announce

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1314,7 +1314,7 @@ type Announce struct {
 	LinkedIn       LinkedIn       `yaml:"linkedin,omitempty" json:"linkedin,omitempty"`
 	Telegram       Telegram       `yaml:"telegram,omitempty" json:"telegram,omitempty"`
 	Webhook        Webhook        `yaml:"webhook,omitempty" json:"webhook,omitempty"`
-	OpenCollective OpenCollective `yaml:"opencollective,omitempty" json:"opencolletive,omitempty"`
+	OpenCollective OpenCollective `yaml:"opencollective,omitempty" json:"opencollective,omitempty"`
 	Bluesky        Bluesky        `yaml:"bluesky,omitempty" json:"bluesky,omitempty"`
 }
 

--- a/www/docs/static/schema-pro.json
+++ b/www/docs/static/schema-pro.json
@@ -163,7 +163,7 @@
 					"webhook": {
 						"$ref": "#/$defs/Webhook"
 					},
-					"opencolletive": {
+					"opencollective": {
 						"$ref": "#/$defs/OpenCollective"
 					},
 					"bluesky": {

--- a/www/docs/static/schema.json
+++ b/www/docs/static/schema.json
@@ -154,7 +154,7 @@
 					"webhook": {
 						"$ref": "#/$defs/Webhook"
 					},
-					"opencolletive": {
+					"opencollective": {
 						"$ref": "#/$defs/OpenCollective"
 					},
 					"bluesky": {


### PR DESCRIPTION
The PR corrects grammar mistake in the property name for `OpenCollective` in the JSON schema.