### PR TITLE
test: remove redundant require.Error

### DIFF
--- a/internal/pipe/slack/slack_test.go
+++ b/internal/pipe/slack/slack_test.go
@@ -120,7 +120,6 @@ func TestParseRichText(t *testing.T) {
 		require.NoError(t, yaml.Unmarshal(badBlocksSlackConf(), &project))
 		ctx := testctx.NewWithCfg(project, testctx.WithVersion(testVersion))
 		_, _, err := parseAdvancedFormatting(ctx)
-		require.Error(t, err)
 		require.ErrorContains(t, err, "json")
 	})
 
@@ -130,7 +129,6 @@ func TestParseRichText(t *testing.T) {
 		require.NoError(t, yaml.Unmarshal(badAttachmentsSlackConf(), &project))
 		ctx := testctx.NewWithCfg(project, testctx.WithVersion(testVersion))
 		_, _, err := parseAdvancedFormatting(ctx)
-		require.Error(t, err)
 		require.ErrorContains(t, err, "json")
 	})
 }
@@ -151,7 +149,6 @@ func TestRichText(t *testing.T) {
 		require.NoError(t, yaml.Unmarshal(badBlocksSlackConf(), &project))
 		ctx := testctx.NewWithCfg(project, testctx.WithVersion(testVersion))
 		err := Pipe{}.Announce(ctx)
-		require.Error(t, err)
 		require.ErrorContains(t, err, "json")
 	})
 }

--- a/pkg/config/config_slack_test.go
+++ b/pkg/config/config_slack_test.go
@@ -125,7 +125,6 @@ func TestUnmarshalYAMLSlackBlocks(t *testing.T) {
 
 		var block SlackBlock
 		err := block.UnmarshalYAML(erf)
-		require.Error(t, err)
 		require.ErrorContains(t, err, testError)
 	})
 
@@ -134,7 +133,6 @@ func TestUnmarshalYAMLSlackBlocks(t *testing.T) {
 
 		var attachment SlackAttachment
 		err := attachment.UnmarshalYAML(erf)
-		require.Error(t, err)
 		require.ErrorContains(t, err, testError)
 	})
 }


### PR DESCRIPTION
The PR refactors tests by removing redundant `require.Error` statements that are followed by `require.ErrorContains`. `require.ErrorContains` will fail if `err` is `nil`, so `require.Error` is not needed.