### PR TITLE
test: remove redundant os.Exit in TestMain

### DIFF
--- a/internal/exec/exec_mock_test.go
+++ b/internal/exec/exec_mock_test.go
@@ -11,5 +11,5 @@ func TestMain(m *testing.M) {
 		return
 	}
 
-	os.Exit(m.Run())
+	m.Run()
 }

--- a/internal/pipe/before/before_test.go
+++ b/internal/pipe/before/before_test.go
@@ -1,7 +1,6 @@
 package before
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -15,9 +14,8 @@ import (
 
 func TestMain(m *testing.M) {
 	log.SetLevel(log.DebugLevel)
-	code := m.Run()
+	m.Run()
 	log.SetLevel(log.InfoLevel)
-	os.Exit(code)
 }
 
 func TestDescription(t *testing.T) {

--- a/internal/pipe/blob/blob_minio_test.go
+++ b/internal/pipe/blob/blob_minio_test.go
@@ -30,7 +30,8 @@ var listen string
 
 func TestMain(m *testing.M) {
 	if !testlib.InPath("docker") {
-		os.Exit(m.Run())
+		m.Run()
+		return
 	}
 	prepareEnv()
 
@@ -67,10 +68,9 @@ func TestMain(m *testing.M) {
 	}))
 	listen = "localhost:" + resource.GetPort("9000/tcp")
 
-	code := m.Run()
+	m.Run()
 
 	requireNoErr(pool.Purge(resource))
-	os.Exit(code)
 }
 
 func TestMinioUpload(t *testing.T) {

--- a/internal/pipe/env/env_test.go
+++ b/internal/pipe/env/env_test.go
@@ -24,13 +24,11 @@ func TestMain(m *testing.M) {
 		}
 	}
 
-	code := m.Run()
+	m.Run()
 
 	for k, v := range restores {
 		_ = os.Setenv(k, v)
 	}
-
-	os.Exit(code)
 }
 
 func TestDescription(t *testing.T) {

--- a/internal/pipe/sign/sign_test.go
+++ b/internal/pipe/sign/sign_test.go
@@ -46,9 +46,8 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	code := m.Run()
+	m.Run()
 	_ = os.RemoveAll(keyring)
-	os.Exit(code)
 }
 
 func TestDescription(t *testing.T) {


### PR DESCRIPTION
This PR simplifies tests by removing redundant `os.Exit` calls in `TestMain` functions. 

As of Go 1.15, we do not need to call `os.Exit(m.Run())` explicitly, as value returned by `m.Run()` is stored into unexported field of `m` and go test executable is smart enough to automatically call `os.Exit(retValue)` when `TestMain` returns. See golang/go#34129.
