### PR TITLE
fix(jsonschema): add custom JSONSchema type to umask

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -945,7 +945,7 @@ type NFPMOverridables struct {
 	Recommends       []string       `yaml:"recommends,omitempty" json:"recommends,omitempty"`
 	Suggests         []string       `yaml:"suggests,omitempty" json:"suggests,omitempty"`
 	Conflicts        []string       `yaml:"conflicts,omitempty" json:"conflicts,omitempty"`
-	Umask            fs.FileMode    `yaml:"umask,omitempty" json:"umask,omitempty"`
+	Umask            fs.FileMode    `yaml:"umask,omitempty" json:"umask,omitempty" jsonschema:"oneof_type=string;integer"`
 	Replaces         []string       `yaml:"replaces,omitempty" json:"replaces,omitempty"`
 	Provides         []string       `yaml:"provides,omitempty" json:"provides,omitempty"`
 	Contents         files.Contents `yaml:"contents,omitempty" json:"contents,omitempty"`

--- a/www/docs/static/schema-pro.json
+++ b/www/docs/static/schema-pro.json
@@ -2340,7 +2340,14 @@
 						"type": "array"
 					},
 					"umask": {
-						"type": "integer"
+						"oneOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "integer"
+							}
+						]
 					},
 					"replaces": {
 						"items": {
@@ -2726,7 +2733,14 @@
 						"type": "array"
 					},
 					"umask": {
-						"type": "integer"
+						"oneOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "integer"
+							}
+						]
 					},
 					"replaces": {
 						"items": {

--- a/www/docs/static/schema.json
+++ b/www/docs/static/schema.json
@@ -1828,7 +1828,14 @@
 						"type": "array"
 					},
 					"umask": {
-						"type": "integer"
+						"oneOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "integer"
+							}
+						]
 					},
 					"replaces": {
 						"items": {
@@ -2205,7 +2212,14 @@
 						"type": "array"
 					},
 					"umask": {
-						"type": "integer"
+						"oneOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "integer"
+							}
+						]
 					},
 					"replaces": {
 						"items": {


### PR DESCRIPTION
<!-- If applied, this commit will... -->

Currently, the JSONSchema defines the type of `umask` as an `integer` because the type is inherited from `fs.FileMode` (`uint32`).

https://github.com/goreleaser/goreleaser/blob/a7721dc1fed1168b71a06384d6a8136f9bae31ff/www/docs/static/schema.json#L1830-L1832

https://github.com/goreleaser/goreleaser/blob/a7721dc1fed1168b71a06384d6a8136f9bae31ff/pkg/config/config.go#L948

The documentation says octal values (`0o002`) can be used.

https://github.com/goreleaser/goreleaser/blob/a7721dc1fed1168b71a06384d6a8136f9bae31ff/www/docs/customization/nfpm.md?plain=1#L79-L80

But as this value contains a letter (`o`), so this field becomes a `string` and the JSON validation fails.

![Screenshot_20241114_044553](https://github.com/user-attachments/assets/e8684057-ae6a-4194-9248-0bed3eeda9af)


This PR adds a struct tag on the field `Umask` to allow `integer` and `string`.


I generated the JSONSchema by using the following command and I copy-pasted the changes to the pro schema.

```bash
go run . schema -o ./www/docs/static/schema.json
```
