### PR TITLE
ci: release build using too much space

### DIFF
--- a/.github/workflows/nightly-oss.yml
+++ b/.github/workflows/nightly-oss.yml
@@ -17,60 +17,45 @@ jobs:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
       - run: df -h
-      - run: sudo rm -rf /usr/share/dotnet
-      - run: df -h
-      - run: sudo rm -rf /usr/local/lib/android
-      - run: df -h
-      - run: sudo rm -rf /opt/ghc
-      - run: df -h
-      - run: sudo rm -rf /opt/hostedtoolcache/CodeQL
-      - run: df -h
-      - run: sudo docker image prune --all --force
-      - run: df -h
-      - run: sudo docker builder prune -a
+      - name: "node-cleanup"
+        # this should increase free space from ~21gb to ~38gb
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
       - run: df -h
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 1000 # never anything near had that many commits in a release anyway.
-      - run: df -h
+          fetch-tags: true
       - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v1
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: df -h
       - uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v2
-      - run: df -h
       - uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3
-      - run: df -h
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v4
         with:
           go-version: stable
-      - run: df -h
       - uses: sigstore/cosign-installer@v3.7.0
-      - run: df -h
       - uses: anchore/sbom-action/download-syft@v0.17.7
-      - run: df -h
       - uses: crazy-max/ghaction-upx@v3
         with:
           install-only: true
-      - run: df -h
       - uses: cachix/install-nix-action@v30
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - run: df -h
       - name: dockerhub-login
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - run: df -h
       - name: ghcr-login
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - run: df -h
       - uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro

--- a/.github/workflows/nightly-oss.yml
+++ b/.github/workflows/nightly-oss.yml
@@ -16,6 +16,17 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
+      - name: maximize build space
+        shell: bash
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
+          df -h
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0

--- a/.github/workflows/nightly-oss.yml
+++ b/.github/workflows/nightly-oss.yml
@@ -16,48 +16,61 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - name: maximize build space
-        shell: bash
-        run: |
-          df -h
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force
-          sudo docker builder prune -a
-          df -h
+      - run: df -h
+      - run: sudo rm -rf /usr/share/dotnet
+      - run: df -h
+      - run: sudo rm -rf /usr/local/lib/android
+      - run: df -h
+      - run: sudo rm -rf /opt/ghc
+      - run: df -h
+      - run: sudo rm -rf /opt/hostedtoolcache/CodeQL
+      - run: df -h
+      - run: sudo docker image prune --all --force
+      - run: df -h
+      - run: sudo docker builder prune -a
+      - run: df -h
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1000 # never anything near had that many commits in a release anyway.
+      - run: df -h
       - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v1
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - run: df -h
       - uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v2
+      - run: df -h
       - uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3
+      - run: df -h
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v4
         with:
           go-version: stable
+      - run: df -h
       - uses: sigstore/cosign-installer@v3.7.0
+      - run: df -h
       - uses: anchore/sbom-action/download-syft@v0.17.7
+      - run: df -h
       - uses: crazy-max/ghaction-upx@v3
         with:
           install-only: true
+      - run: df -h
       - uses: cachix/install-nix-action@v30
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - run: df -h
       - name: dockerhub-login
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - run: df -h
       - name: ghcr-login
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - run: df -h
       - uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
@@ -71,6 +84,8 @@ jobs:
           MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+      - run: df -h
+        if: ${{ always() }}
   notify:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,9 +70,18 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
+      - run: df -h
+      - name: "node-cleanup"
+        # this should increase free space from ~21gb to ~38gb
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
+      - run: df -h
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1000 # never anything near had that many commits in a release anyway.
+          fetch-tags: true
       - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v1
         with:
           version: 3.x
@@ -136,3 +145,5 @@ jobs:
           MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_LOGIN }}
         run: task goreleaser
+      - run: df -h
+        if: ${{ always() }}


### PR DESCRIPTION
I'm not sure what changed, I guess something in the runner, but anyway, it seems now we're hitting the limits of it.

To work around it, I'm doing the following:

- removing some unused things that take a lot of space and not used (codeql, haskell, android, dotnet)
- prune docker images
- clone only the last 1000 commits + tags instead of the entire history (which is getting kinda big)

Hopefully that is enough. The cleanups alone should increase the free space from ~21GB to ~38GB. I doubt we're using that much.