### PR TITLE
fix(aur): missing arm v6 filter

### DIFF
--- a/internal/pipe/aur/aur.go
+++ b/internal/pipe/aur/aur.go
@@ -111,6 +111,7 @@ func doRun(ctx *context.Context, aur config.AUR, cl client.ReleaseURLTemplater) 
 				artifact.ByGoarch("arm"),
 				artifact.Or(
 					artifact.ByGoarm("7"),
+					artifact.ByGoarm("6"),
 				),
 			),
 		),


### PR DESCRIPTION
The AUR pipe can handle arm v6 but there is a missing filter.

https://github.com/goreleaser/goreleaser/blob/82fd112f7774669e5997a9e7513274686ddd6cdc/internal/pipe/aur/aur.go#L275-L276