### PR TITLE
chore(aur): remove dead code about armv6

### DIFF
--- a/internal/pipe/aur/aur.go
+++ b/internal/pipe/aur/aur.go
@@ -272,8 +272,6 @@ func toPkgBuildArch(arch string) string {
 		return "i686"
 	case "arm64":
 		return "aarch64"
-	case "arm6":
-		return "armv6h"
 	case "arm7":
 		return "armv7h"
 	default:


### PR DESCRIPTION
Follows https://github.com/goreleaser/goreleaser/pull/4695, remove dead code about armv6.