### PR TITLE
build: update golangci-lint to v1.62

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,4 +26,4 @@ jobs:
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         with:
           args: --timeout=5m
-          version: v1.60
+          version: v1.62

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -149,11 +149,11 @@ func deprecateWarn(ctx *context.Context) {
 	}
 }
 
-func timedRunE(verb string, rune func(cmd *cobra.Command, args []string) error) func(cmd *cobra.Command, args []string) error {
+func timedRunE(verb string, runE func(cmd *cobra.Command, args []string) error) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		start := time.Now()
 
-		if err := rune(cmd, args); err != nil {
+		if err := runE(cmd, args); err != nil {
 			return wrapError(err, boldStyle.Render(fmt.Sprintf("%s failed after %s", verb, time.Since(start).Truncate(time.Second))))
 		}
 

--- a/internal/archivefiles/archivefiles.go
+++ b/internal/archivefiles/archivefiles.go
@@ -140,6 +140,8 @@ func longestCommonPrefix(strs []string) string {
 }
 
 // copied from nfpm
+//
+//nolint:revive // redefines-builtin-id
 func strlcp(a, b string) string {
 	var min int
 	if len(a) > len(b) {

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -2,7 +2,6 @@ package git_test
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/v2/internal/git"
@@ -36,7 +35,7 @@ func TestRelativeRemote(t *testing.T) {
 	require.NoError(t, err)
 	gitCfg, err := git.Run(ctx, "config", "--local", "--list")
 	require.NoError(t, err)
-	require.True(t, strings.Contains(gitCfg, "branch.relative_branch.remote=."))
+	require.Contains(t, gitCfg, "branch.relative_branch.remote=.")
 	repo, err := git.ExtractRepoFromConfig(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "goreleaser/goreleaser", repo.String())


### PR DESCRIPTION
This PR updates the version of golangci-lint to the latest [v1.62](https://github.com/golangci/golangci-lint/releases/tag/v1.62.0) and fixes appeared lint issues:

```
❯ golangci-lint run
internal/archivefiles/archivefiles.go:144:2: redefines-builtin-id: redefinition of the built-in function min (revive)
        var min int
        ^
internal/archivefiles/archivefiles.go:146:3: redefines-builtin-id: redefinition of the built-in function min (revive)
                min = len(b)
                ^
internal/archivefiles/archivefiles.go:148:3: redefines-builtin-id: redefinition of the built-in function min (revive)
                min = len(a)
                ^
cmd/root.go:152:29: redefines-builtin-id: redefinition of the built-in type rune (revive)
func timedRunE(verb string, rune func(cmd *cobra.Command, args []string) error) func(cmd *cobra.Command, args []string) error {
                            ^
internal/git/config_test.go:39:2: contains: use require.Contains (testifylint)
        require.True(t, strings.Contains(gitCfg, "branch.relative_branch.remote=."))
        ^
```