### PR TITLE
feat: pass context.Context to HTTP requests

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -19,6 +19,7 @@ linters:
     - testifylint
     - gocritic
     - nolintlint
+    - noctx
 linters-settings:
   gocritic:
     disabled-checks:
@@ -74,3 +75,8 @@ linters-settings:
     enable-all: true
     disable:
       - error-is-as # false positive
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - noctx

--- a/internal/pipe/linkedin/client_test.go
+++ b/internal/pipe/linkedin/client_test.go
@@ -1,6 +1,7 @@
 package linkedin
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -75,7 +76,7 @@ func TestClient_Share(t *testing.T) {
 
 	c.baseURL = server.URL
 
-	link, err := c.Share("test")
+	link, err := c.Share(context.Background(), "test")
 	if err != nil {
 		t.Fatalf("could not share: %v", err)
 	}
@@ -110,7 +111,7 @@ func TestClientLegacyProfile_Share(t *testing.T) {
 
 	c.baseURL = server.URL
 
-	link, err := c.Share("test")
+	link, err := c.Share(context.Background(), "test")
 	if err != nil {
 		t.Fatalf("could not share: %v", err)
 	}

--- a/internal/pipe/linkedin/linkedin.go
+++ b/internal/pipe/linkedin/linkedin.go
@@ -47,7 +47,7 @@ func (Pipe) Announce(ctx *context.Context) error {
 		return fmt.Errorf("linkedin: %w", err)
 	}
 
-	url, err := c.Share(message)
+	url, err := c.Share(ctx, message)
 	if err != nil {
 		return fmt.Errorf("linkedin: %w", err)
 	}

--- a/internal/pipe/webhook/webhook.go
+++ b/internal/pipe/webhook/webhook.go
@@ -82,7 +82,7 @@ func (p Pipe) Announce(ctx *context.Context) error {
 		Transport: customTransport,
 	}
 
-	req, err := http.NewRequest(http.MethodPost, endpointURL.String(), strings.NewReader(msg))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL.String(), strings.NewReader(msg))
 	if err != nil {
 		return fmt.Errorf("webhook: %w", err)
 	}


### PR DESCRIPTION
This PR adds using `context.Context` in HTTP requests. Changes are similar to #5232.

Additionally, it enables `noctx` to automatically detect missing context:
```
internal/pipe/webhook/webhook.go:85:29: should rewrite http.NewRequestWithContext or add (*Request).WithContext (noctx)
internal/pipe/linkedin/client.go:68:27: (*net/http.Client).Get must not be called (noctx)
internal/pipe/linkedin/client.go:101:27: (*net/http.Client).Get must not be called (noctx)
internal/pipe/linkedin/client.go:172:28: (*net/http.Client).Post must not be called (noctx)
```