### PR TITLE
refactor: replace fmt.Errorf with errors.New for consistency

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -20,6 +20,7 @@ linters:
     - gocritic
     - nolintlint
     - noctx
+    - perfsprint
 linters-settings:
   gocritic:
     disabled-checks:
@@ -43,6 +44,12 @@ linters-settings:
         deny:
           - pkg: "github.com/pkg/errors"
             desc: "use stdlib instead"
+  perfsprint:
+    int-conversion: false
+    err-error: false
+    errorf: true
+    sprintf1: false
+    strconcat: false
   revive:
     enable-all-rules: false
     rules:
@@ -80,3 +87,4 @@ issues:
     - path: _test\.go
       linters:
         - noctx
+        - perfsprint

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -229,7 +230,7 @@ func (w withOutputPipe) String() string {
 func (w withOutputPipe) Run(ctx *context.Context) error {
 	bins := ctx.Artifacts.Filter(artifact.ByType(artifact.Binary)).List()
 	if len(bins) == 0 {
-		return fmt.Errorf("no binary found")
+		return errors.New("no binary found")
 	}
 	path := bins[0].Path
 	out := w.output

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -62,7 +63,7 @@ func newCheckCmd() *checkCmd {
 
 				if ctx.Deprecated {
 					errs = append(errs, wrapErrorWithCode(
-						fmt.Errorf("configuration is valid, but uses deprecated properties"),
+						errors.New("configuration is valid, but uses deprecated properties"),
 						2,
 						path,
 					))

--- a/cmd/healthcheck.go
+++ b/cmd/healthcheck.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"fmt"
+	"errors"
 	"io"
 	"os/exec"
 	"sync"
@@ -71,7 +71,7 @@ func newHealthcheckCmd() *healthcheckCmd {
 					return nil
 				}
 
-				return fmt.Errorf("one or more needed tools are not present")
+				return errors.New("one or more needed tools are not present")
 			}); err != nil {
 				return err
 			}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2,6 +2,7 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -20,11 +21,11 @@ const (
 )
 
 // ErrNotImplemented is returned when a client does not implement certain feature.
-var ErrNotImplemented = fmt.Errorf("not implemented")
+var ErrNotImplemented = errors.New("not implemented")
 
 // ErrReleaseDisabled happens when a configuration tries to use the default
 // url_template even though the release is disabled.
-var ErrReleaseDisabled = fmt.Errorf("release is disabled, cannot use default url_template")
+var ErrReleaseDisabled = errors.New("release is disabled, cannot use default url_template")
 
 // Info of the repository.
 type Info struct {

--- a/internal/client/git.go
+++ b/internal/client/git.go
@@ -155,7 +155,7 @@ func keyPath(key string) (string, error) {
 
 	_, err := ssh.ParsePrivateKey([]byte(key))
 	if isPasswordError(err) {
-		return "", fmt.Errorf("git: key is password-protected")
+		return "", errors.New("git: key is password-protected")
 	}
 
 	if err == nil {

--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -75,7 +76,7 @@ func (c *gitlabClient) checkIsPrivateToken() error {
 	if c.authType == gitlab.PrivateToken {
 		return nil
 	}
-	return fmt.Errorf("the necessary APIs are not available when using CI_JOB_TOKEN")
+	return errors.New("the necessary APIs are not available when using CI_JOB_TOKEN")
 }
 
 func (c *gitlabClient) Changelog(_ *context.Context, repo Repo, prev, current string) ([]ChangelogItem, error) {

--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -19,7 +19,7 @@ func ExtractRepoFromConfig(ctx context.Context) (result config.Repo, err error) 
 	}
 	out, err := Clean(Run(ctx, "ls-remote", "--get-url"))
 	if err != nil {
-		return result, fmt.Errorf("no remote configured to list refs from")
+		return result, errors.New("no remote configured to list refs from")
 	}
 	// This is a relative remote URL and requires some additional processing
 	if out == "." {
@@ -32,15 +32,15 @@ func ExtractRepoFromConfig(ctx context.Context) (result config.Repo, err error) 
 func extractRelativeRepoFromConfig(ctx context.Context) (result config.Repo, err error) {
 	out, err := Clean(Run(ctx, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"))
 	if err != nil || out == "" {
-		return result, fmt.Errorf("unable to get upstream while qualifying relative remote")
+		return result, errors.New("unable to get upstream while qualifying relative remote")
 	}
 	out, err = Clean(Run(ctx, "config", "--get", fmt.Sprintf("branch.%s.remote", out)))
 	if err != nil || out == "" {
-		return result, fmt.Errorf("unable to get upstream's remote while qualifying relative remote")
+		return result, errors.New("unable to get upstream's remote while qualifying relative remote")
 	}
 	out, err = Clean(Run(ctx, "ls-remote", "--get-url", out))
 	if err != nil {
-		return result, fmt.Errorf("unable to get upstream while qualifying relative remote")
+		return result, errors.New("unable to get upstream while qualifying relative remote")
 	}
 	return ExtractRepoFromURL(out)
 }

--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -191,7 +191,7 @@ func create(ctx *context.Context, arch config.Archive, binaries []*artifact.Arti
 		return fmt.Errorf("failed to find files to archive: %w", err)
 	}
 	if arch.Meta && len(files) == 0 {
-		return fmt.Errorf("no files found")
+		return errors.New("no files found")
 	}
 	for _, f := range files {
 		if err = a.Add(f); err != nil {

--- a/internal/pipe/blob/blob.go
+++ b/internal/pipe/blob/blob.go
@@ -2,7 +2,7 @@
 package blob
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/goreleaser/goreleaser/v2/internal/pipe"
 	"github.com/goreleaser/goreleaser/v2/internal/semerrgroup"
@@ -22,7 +22,7 @@ func (Pipe) Default(ctx *context.Context) error {
 	for i := range ctx.Config.Blobs {
 		blob := &ctx.Config.Blobs[i]
 		if blob.Bucket == "" || blob.Provider == "" {
-			return fmt.Errorf("bucket or provider cannot be empty")
+			return errors.New("bucket or provider cannot be empty")
 		}
 		if blob.Directory == "" {
 			blob.Directory = "{{ .ProjectName }}/{{ .Tag }}"

--- a/internal/pipe/blob/upload.go
+++ b/internal/pipe/blob/upload.go
@@ -1,11 +1,13 @@
 package blob
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -63,7 +65,7 @@ func urlFor(ctx *context.Context, conf config.Blob) (string, error) {
 		if conf.S3ForcePathStyle == nil {
 			query.Add("s3ForcePathStyle", "true")
 		} else {
-			query.Add("s3ForcePathStyle", fmt.Sprintf("%t", *conf.S3ForcePathStyle))
+			query.Add("s3ForcePathStyle", strconv.FormatBool(*conf.S3ForcePathStyle))
 		}
 	}
 
@@ -109,7 +111,7 @@ func doUpload(ctx *context.Context, conf config.Blob) error {
 		up.beforeWrite = func(asFunc func(interface{}) bool) error {
 			req := &s3manager.UploadInput{}
 			if !asFunc(&req) {
-				return fmt.Errorf("could not apply before write")
+				return errors.New("could not apply before write")
 			}
 			req.ACL = aws.String(conf.ACL)
 			return nil

--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -189,7 +189,7 @@ func doPublish(ctx *context.Context, formula *artifact.Artifact, cl client.Clien
 	log.Info("brews.pull_request enabled, creating a PR")
 	pcl, ok := cl.(client.PullRequestOpener)
 	if !ok {
-		return fmt.Errorf("client does not support pull requests")
+		return errors.New("client does not support pull requests")
 	}
 
 	return pcl.OpenPullRequest(ctx, base, repo, msg, brew.Repository.PullRequest.Draft)

--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -238,7 +239,7 @@ Previous error:
 %w`, tmp, strings.Join(files, "\n "), err)
 		}
 		if isBuildxContextError(err.Error()) {
-			return fmt.Errorf("docker buildx is not set to default context - please switch with 'docker context use default'")
+			return errors.New("docker buildx is not set to default context - please switch with 'docker context use default'")
 		}
 		return err
 	}

--- a/internal/pipe/krew/krew.go
+++ b/internal/pipe/krew/krew.go
@@ -83,10 +83,10 @@ func doRun(ctx *context.Context, krew config.Krew, cl client.ReleaseURLTemplater
 		return pipe.Skip("krew: manifest name is not set")
 	}
 	if krew.Description == "" {
-		return fmt.Errorf("krew: manifest description is not set")
+		return errors.New("krew: manifest description is not set")
 	}
 	if krew.ShortDescription == "" {
-		return fmt.Errorf("krew: manifest short description is not set")
+		return errors.New("krew: manifest short description is not set")
 	}
 
 	filters := []artifact.Filter{
@@ -355,7 +355,7 @@ func doPublish(ctx *context.Context, manifest *artifact.Artifact, cl client.Clie
 	log.Info("krews.pull_request enabled, creating a PR")
 	pcl, ok := cl.(client.PullRequestOpener)
 	if !ok {
-		return fmt.Errorf("client does not support pull requests")
+		return errors.New("client does not support pull requests")
 	}
 
 	return pcl.OpenPullRequest(ctx, base, repo, msg, cfg.Repository.PullRequest.Draft)

--- a/internal/pipe/linkedin/client.go
+++ b/internal/pipe/linkedin/client.go
@@ -37,11 +37,11 @@ type postShareRequest struct {
 
 func createLinkedInClient(cfg oauthClientConfig) (client, error) {
 	if cfg.Context == nil {
-		return client{}, fmt.Errorf("context is nil")
+		return client{}, errors.New("context is nil")
 	}
 
 	if cfg.AccessToken == "" {
-		return client{}, fmt.Errorf("empty access token")
+		return client{}, errors.New("empty access token")
 	}
 
 	config := oauth2.Config{}
@@ -51,7 +51,7 @@ func createLinkedInClient(cfg oauthClientConfig) (client, error) {
 	})
 
 	if c == nil {
-		return client{}, fmt.Errorf("client is nil")
+		return client{}, errors.New("client is nil")
 	}
 
 	return client{

--- a/internal/pipe/nix/nix.go
+++ b/internal/pipe/nix/nix.go
@@ -406,7 +406,7 @@ func doPublish(ctx *context.Context, prefetcher shaPrefetcher, cl client.Client,
 	log.Info("nix.pull_request enabled, creating a PR")
 	pcl, ok := cl.(client.PullRequestOpener)
 	if !ok {
-		return fmt.Errorf("client does not support pull requests")
+		return errors.New("client does not support pull requests")
 	}
 
 	return pcl.OpenPullRequest(ctx, base, repo, msg, nix.Repository.PullRequest.Draft)

--- a/internal/pipe/project/project.go
+++ b/internal/pipe/project/project.go
@@ -2,7 +2,7 @@
 package project
 
 import (
-	"fmt"
+	"errors"
 	"os/exec"
 	"strings"
 
@@ -37,7 +37,7 @@ func (Pipe) Default(ctx *context.Context) error {
 		return nil
 	}
 
-	return fmt.Errorf("couldn't guess project_name, please add it to your config")
+	return errors.New("couldn't guess project_name, please add it to your config")
 }
 
 func moduleName() string {

--- a/internal/pipe/sbom/sbom.go
+++ b/internal/pipe/sbom/sbom.go
@@ -2,6 +2,7 @@ package sbom
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -242,7 +243,7 @@ func catalogArtifact(ctx *context.Context, cfg config.SBOM, a *artifact.Artifact
 	}
 
 	if len(artifacts) == 0 {
-		return nil, fmt.Errorf("cataloging artifacts: command did not write any files, check your configuration")
+		return nil, errors.New("cataloging artifacts: command did not write any files, check your configuration")
 	}
 
 	return artifacts, nil

--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -4,6 +4,7 @@ package scoop
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -273,7 +274,7 @@ func doPublish(ctx *context.Context, manifest *artifact.Artifact, cl client.Clie
 	log.Info("scoop.pull_request enabled, creating a PR")
 	pcl, ok := cl.(client.PullRequestOpener)
 	if !ok {
-		return fmt.Errorf("client does not support pull requests")
+		return errors.New("client does not support pull requests")
 	}
 
 	return pcl.OpenPullRequest(ctx, base, repo, commitMessage, scoop.Repository.PullRequest.Draft)

--- a/internal/pipe/smtp/smtp.go
+++ b/internal/pipe/smtp/smtp.go
@@ -2,6 +2,7 @@ package smtp
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 
 	"github.com/caarlos0/env/v11"
@@ -90,9 +91,9 @@ func (Pipe) Announce(ctx *context.Context) error {
 }
 
 var (
-	errNoPort     = fmt.Errorf("SMTP: missing smtp.port or $SMTP_PORT")
-	errNoUsername = fmt.Errorf("SMTP: missing smtp.username or $SMTP_USERNAME")
-	errNoHost     = fmt.Errorf("SMTP: missing smtp.host or $SMTP_HOST")
+	errNoPort     = errors.New("SMTP: missing smtp.port or $SMTP_PORT")
+	errNoUsername = errors.New("SMTP: missing smtp.username or $SMTP_USERNAME")
+	errNoHost     = errors.New("SMTP: missing smtp.host or $SMTP_HOST")
 )
 
 func getConfig(smtp config.SMTP) (Config, error) {

--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -130,10 +130,10 @@ func (Pipe) Default(ctx *context.Context) error {
 			snap.Confinement = "strict"
 		}
 		if snap.Description == "" {
-			return fmt.Errorf("description is required")
+			return errors.New("description is required")
 		}
 		if snap.Summary == "" {
-			return fmt.Errorf("summary is required")
+			return errors.New("summary is required")
 		}
 		if len(snap.ChannelTemplates) == 0 {
 			switch snap.Grade {

--- a/internal/pipe/snapshot/snapshot.go
+++ b/internal/pipe/snapshot/snapshot.go
@@ -2,6 +2,7 @@
 package snapshot
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/caarlos0/log"
@@ -34,7 +35,7 @@ func (Pipe) Run(ctx *context.Context) error {
 		return fmt.Errorf("failed to parse snapshot name: %w", err)
 	}
 	if name == "" {
-		return fmt.Errorf("empty snapshot name")
+		return errors.New("empty snapshot name")
 	}
 	ctx.Version = name
 	log.WithField("version", ctx.Version).Infof("building snapshot...")

--- a/internal/pipe/winget/winget.go
+++ b/internal/pipe/winget/winget.go
@@ -1,6 +1,7 @@
 package winget
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -351,7 +352,7 @@ func doPublish(ctx *context.Context, cl client.Client, wingets []*artifact.Artif
 	log.Info("winget.pull_request enabled, creating a PR")
 	pcl, ok := cl.(client.PullRequestOpener)
 	if !ok {
-		return fmt.Errorf("client does not support pull requests")
+		return errors.New("client does not support pull requests")
 	}
 
 	return pcl.OpenPullRequest(ctx, base, repo, msg, winget.Repository.PullRequest.Draft)


### PR DESCRIPTION
The PR replaces usages of `fmt.Errorf` with `errors.New` for creating errors. Enables `perfsprint` linter to prevent future regressions.