### PR TITLE
refactor: use cmp.Or instead of ordered.First

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/caarlos0/log v0.4.6
 	github.com/charmbracelet/keygen v0.5.1
 	github.com/charmbracelet/lipgloss v1.0.0
-	github.com/charmbracelet/x/exp/ordered v0.1.0
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20230304212654-82a0ddb27589
 	github.com/dghubble/go-twitter v0.0.0-20211115160449-93a8679adecb
 	github.com/dghubble/oauth1 v0.7.3

--- a/go.sum
+++ b/go.sum
@@ -229,8 +229,6 @@ github.com/charmbracelet/lipgloss v1.0.0 h1:O7VkGDvqEdGi93X+DeqsQ7PKHDgtQfF8j8/O
 github.com/charmbracelet/lipgloss v1.0.0/go.mod h1:U5fy9Z+C38obMs+T+tJqst9VGzlOYGj4ri9reL3qUlo=
 github.com/charmbracelet/x/ansi v0.4.2 h1:0JM6Aj/g/KC154/gOP4vfxun0ff6itogDYk41kof+qk=
 github.com/charmbracelet/x/ansi v0.4.2/go.mod h1:dk73KoMTT5AX5BsX0KrqhsTqAnhZZoCBjs7dGWp4Ktw=
-github.com/charmbracelet/x/exp/ordered v0.1.0 h1:55/qLwjIh0gL0Vni+QAWk7T/qRVP6sBf+2agPBgnOFE=
-github.com/charmbracelet/x/exp/ordered v0.1.0/go.mod h1:5UHwmG+is5THxMyCJHNPCn2/ecI07aKNrW+LcResjJ8=
 github.com/chrismellard/docker-credential-acr-env v0.0.0-20230304212654-82a0ddb27589 h1:krfRl01rzPzxSxyLyrChD+U+MzsBXbm0OwYYB67uF+4=
 github.com/chrismellard/docker-credential-acr-env v0.0.0-20230304212654-82a0ddb27589/go.mod h1:OuDyvmLnMCwa2ep4Jkm6nyA0ocJuZlGyk2gGseVzERM=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/internal/client/git.go
+++ b/internal/client/git.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"io"
@@ -11,7 +12,6 @@ import (
 	"time"
 
 	"github.com/caarlos0/log"
-	"github.com/charmbracelet/x/exp/ordered"
 	"github.com/goreleaser/goreleaser/v2/internal/git"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe"
 	"github.com/goreleaser/goreleaser/v2/internal/tmpl"
@@ -56,7 +56,7 @@ func (g *gitClient) CreateFiles(
 		return pipe.Skip("url is empty")
 	}
 
-	repo.Name = ordered.First(repo.Name, nameFromURL(url))
+	repo.Name = cmp.Or(repo.Name, nameFromURL(url))
 
 	key, err := tmpl.New(ctx).Apply(repo.PrivateKey)
 	if err != nil {
@@ -70,7 +70,7 @@ func (g *gitClient) CreateFiles(
 
 	sshcmd, err := tmpl.New(ctx).WithExtraFields(tmpl.Fields{
 		"KeyPath": key,
-	}).Apply(ordered.First(repo.GitSSHCommand, DefaultGitSSHCommand))
+	}).Apply(cmp.Or(repo.GitSSHCommand, DefaultGitSSHCommand))
 	if err != nil {
 		return fmt.Errorf("git: failed to template ssh command: %w", err)
 	}
@@ -94,7 +94,7 @@ func (g *gitClient) CreateFiles(
 			{"config", "--local", "user.name", commitAuthor.Name},
 			{"config", "--local", "user.email", commitAuthor.Email},
 			{"config", "--local", "commit.gpgSign", "false"},
-			{"config", "--local", "init.defaultBranch", ordered.First(g.branch, "master")},
+			{"config", "--local", "init.defaultBranch", cmp.Or(g.branch, "master")},
 		}); err != nil {
 			return fmt.Errorf("git: failed to setup local repository: %w", err)
 		}

--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"cmp"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -13,7 +14,6 @@ import (
 	"time"
 
 	"github.com/caarlos0/log"
-	"github.com/charmbracelet/x/exp/ordered"
 	"github.com/google/go-github/v66/github"
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/tmpl"
@@ -174,9 +174,9 @@ func (c *githubClient) CloseMilestone(ctx *context.Context, repo Repo, title str
 
 func headString(base, head Repo) string {
 	return strings.Join([]string{
-		ordered.First(head.Owner, base.Owner),
-		ordered.First(head.Name, base.Name),
-		ordered.First(head.Branch, base.Branch),
+		cmp.Or(head.Owner, base.Owner),
+		cmp.Or(head.Name, base.Name),
+		cmp.Or(head.Branch, base.Branch),
 	}, ":")
 }
 
@@ -201,8 +201,8 @@ func (c *githubClient) OpenPullRequest(
 	draft bool,
 ) error {
 	c.checkRateLimit(ctx)
-	base.Owner = ordered.First(base.Owner, head.Owner)
-	base.Name = ordered.First(base.Name, head.Name)
+	base.Owner = cmp.Or(base.Owner, head.Owner)
+	base.Name = cmp.Or(base.Name, head.Name)
 	if base.Branch == "" {
 		def, err := c.getDefaultBranch(ctx, base)
 		if err != nil {

--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"cmp"
 	"crypto/tls"
 	"fmt"
 	"net/http"
@@ -9,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/caarlos0/log"
-	"github.com/charmbracelet/x/exp/ordered"
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/tmpl"
 	"github.com/goreleaser/goreleaser/v2/pkg/config"
@@ -647,8 +647,8 @@ func (c *gitlabClient) OpenPullRequest(
 		targetProjectID = p.ID
 	}
 
-	base.Owner = ordered.First(base.Owner, head.Owner)
-	base.Name = ordered.First(base.Name, head.Name)
+	base.Owner = cmp.Or(base.Owner, head.Owner)
+	base.Name = cmp.Or(base.Name, head.Name)
 
 	if base.Branch == "" {
 		def, err := c.getDefaultBranch(ctx, base)

--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"cmp"
 	"fmt"
 	"net/url"
 	"os"
@@ -10,7 +11,6 @@ import (
 	"time"
 
 	"github.com/caarlos0/log"
-	"github.com/charmbracelet/x/exp/ordered"
 	"github.com/goreleaser/goreleaser/v2/internal/git"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe"
 	"github.com/goreleaser/goreleaser/v2/internal/skips"
@@ -47,7 +47,7 @@ func (Pipe) Run(ctx *context.Context) error {
 	log.WithField("commit", info.Commit).
 		WithField("branch", info.Branch).
 		WithField("current_tag", info.CurrentTag).
-		WithField("previous_tag", ordered.First(info.PreviousTag, "<unknown>")).
+		WithField("previous_tag", cmp.Or(info.PreviousTag, "<unknown>")).
 		WithField("dirty", info.Dirty).
 		Info("git state")
 	ctx.Version = strings.TrimPrefix(ctx.Git.CurrentTag, "v")

--- a/internal/pipe/partial/partial.go
+++ b/internal/pipe/partial/partial.go
@@ -1,11 +1,11 @@
 package partial
 
 import (
+	"cmp"
 	"os"
 	"runtime"
 	"strings"
 
-	"github.com/charmbracelet/x/exp/ordered"
 	"github.com/goreleaser/goreleaser/v2/internal/experimental"
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
 )
@@ -21,39 +21,39 @@ func (Pipe) Run(ctx *context.Context) error {
 }
 
 func getFilter() string {
-	goos := ordered.First(os.Getenv("GGOOS"), os.Getenv("GOOS"), runtime.GOOS)
-	goarch := ordered.First(os.Getenv("GGOARCH"), os.Getenv("GOARCH"), runtime.GOARCH)
+	goos := cmp.Or(os.Getenv("GGOOS"), os.Getenv("GOOS"), runtime.GOOS)
+	goarch := cmp.Or(os.Getenv("GGOARCH"), os.Getenv("GOARCH"), runtime.GOARCH)
 	target := goos + "_" + goarch
 
 	if strings.HasSuffix(target, "_amd64") {
-		goamd64 := ordered.First(os.Getenv("GGOAMD64"), os.Getenv("GOAMD64"), "v1")
+		goamd64 := cmp.Or(os.Getenv("GGOAMD64"), os.Getenv("GOAMD64"), "v1")
 		target = target + "_" + goamd64
 	}
 	if strings.HasSuffix(target, "_arm") {
-		goarm := ordered.First(os.Getenv("GGOARM"), os.Getenv("GOARM"), experimental.DefaultGOARM())
+		goarm := cmp.Or(os.Getenv("GGOARM"), os.Getenv("GOARM"), experimental.DefaultGOARM())
 		target = target + "_" + goarm
 	}
 	if strings.HasSuffix(target, "_arm64") {
-		goarm := ordered.First(os.Getenv("GGOARM64"), os.Getenv("GOARM64"), "v8.0")
+		goarm := cmp.Or(os.Getenv("GGOARM64"), os.Getenv("GOARM64"), "v8.0")
 		target = target + "_" + goarm
 	}
 	if strings.HasSuffix(target, "_386") {
-		goarm := ordered.First(os.Getenv("GGO386"), os.Getenv("GO386"), "sse2")
+		goarm := cmp.Or(os.Getenv("GGO386"), os.Getenv("GO386"), "sse2")
 		target = target + "_" + goarm
 	}
 	if strings.HasSuffix(target, "_ppc64") {
-		goarm := ordered.First(os.Getenv("GGOPPC64"), os.Getenv("GOPPC64"), "power8")
+		goarm := cmp.Or(os.Getenv("GGOPPC64"), os.Getenv("GOPPC64"), "power8")
 		target = target + "_" + goarm
 	}
 	if strings.HasSuffix(target, "_riscv64") {
-		goarm := ordered.First(os.Getenv("GGORISCV64"), os.Getenv("GORISCV64"), "rva20u64")
+		goarm := cmp.Or(os.Getenv("GGORISCV64"), os.Getenv("GORISCV64"), "rva20u64")
 		target = target + "_" + goarm
 	}
 	if strings.HasSuffix(target, "_mips") ||
 		strings.HasSuffix(target, "_mips64") ||
 		strings.HasSuffix(target, "_mipsle") ||
 		strings.HasSuffix(target, "_mips64le") {
-		gomips := ordered.First(os.Getenv("GGOMIPS"), os.Getenv("GOMIPS"), "hardfloat")
+		gomips := cmp.Or(os.Getenv("GGOMIPS"), os.Getenv("GOMIPS"), "hardfloat")
 		target = target + "_" + gomips
 	}
 	return target

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -2,13 +2,13 @@ package shell
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
 	"io"
 	"os/exec"
 	"strings"
 
 	"github.com/caarlos0/log"
-	"github.com/charmbracelet/x/exp/ordered"
 	"github.com/goreleaser/goreleaser/v2/internal/gio"
 	"github.com/goreleaser/goreleaser/v2/internal/logext"
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
@@ -40,10 +40,7 @@ func Run(ctx *context.Context, dir string, command, env []string, output bool) e
 			"shell: '%s': %w: %s",
 			strings.Join(command, " "),
 			err,
-			ordered.First(
-				strings.TrimSpace(b.String()),
-				"[no output]",
-			),
+			cmp.Or(strings.TrimSpace(b.String()), "[no output]"),
 		)
 	}
 


### PR DESCRIPTION
This PR replaces usages of [`ordered.First`](https://pkg.go.dev/github.com/charmbracelet/x/exp/ordered#First) with [`cmp.Or`](https://pkg.go.dev/cmp#Or). No need to use an external library when the same functionality is present in stdlib.

You can compare implementations: [ordered.First](https://github.com/charmbracelet/x/blob/exp/ordered/v0.1.0/exp/ordered/ordered.go#L31) vs [cmp.Or](https://cs.opensource.google/go/go/+/refs/tags/go1.23.3:src/cmp/cmp.go;l=69).

Additional reading https://blog.carlana.net/post/2024/golang-cmp-or-uses-and-history/