### PR TITLE
fix(build): overrides without specifying goarm64 et al

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -282,12 +282,21 @@ func (*Builder) Build(ctx *context.Context, build config.Build, options api.Opti
 }
 
 func withOverrides(ctx *context.Context, build config.Build, options api.Options) (config.BuildDetails, error) {
-	optsTarget := options.Goos + options.Goarch + options.Goamd64 + options.Go386 + options.Goarm + options.Goarm64 + options.Gomips + options.Goppc64 + options.Goriscv64
+	optsTarget := options.Goos + "_" + options.Goarch
+	if extra := options.Goamd64 + options.Go386 + options.Goarm + options.Goarm64 + options.Gomips + options.Goppc64 + options.Goriscv64; extra != "" {
+		optsTarget += "_" + extra
+	}
+	optsTarget = fixTarget(optsTarget)
 	for _, o := range build.BuildDetailsOverrides {
-		overrideTarget, err := tmpl.New(ctx).Apply(o.Goos + o.Goarch + o.Goamd64 + o.Go386 + o.Goarm + o.Goarm64 + o.Gomips + o.Goppc64 + o.Goriscv64)
+		s := o.Goos + "_" + o.Goarch
+		if extra := o.Goamd64 + o.Go386 + o.Goarm + o.Goarm64 + o.Gomips + o.Goppc64 + o.Goriscv64; extra != "" {
+			s += "_" + extra
+		}
+		overrideTarget, err := tmpl.New(ctx).Apply(s)
 		if err != nil {
 			return build.BuildDetails, err
 		}
+		overrideTarget = fixTarget(overrideTarget)
 
 		if optsTarget == overrideTarget {
 			dets := config.BuildDetails{

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -1418,6 +1418,35 @@ func TestOverrides(t *testing.T) {
 		}, dets)
 	})
 
+	t.Run("with goarm64 unespecified", func(t *testing.T) {
+		dets, err := withOverrides(
+			testctx.New(),
+			config.Build{
+				BuildDetails: config.BuildDetails{
+					Ldflags: []string{"original"},
+				},
+				BuildDetailsOverrides: []config.BuildDetailsOverride{
+					{
+						Goos:   "linux",
+						Goarch: "arm64",
+						BuildDetails: config.BuildDetails{
+							Ldflags: []string{"overridden"},
+						},
+					},
+				},
+			}, api.Options{
+				Goos:    "linux",
+				Goarch:  "arm64",
+				Goarm64: "v8.0",
+			},
+		)
+		require.NoError(t, err)
+		require.Equal(t, config.BuildDetails{
+			Ldflags: []string{"overridden"},
+			Env:     []string{},
+		}, dets)
+	})
+
 	t.Run("with goarm", func(t *testing.T) {
 		dets, err := withOverrides(
 			testctx.New(),
@@ -1430,6 +1459,35 @@ func TestOverrides(t *testing.T) {
 						Goos:   "linux",
 						Goarch: "arm",
 						Goarm:  "6",
+						BuildDetails: config.BuildDetails{
+							Ldflags: []string{"overridden"},
+						},
+					},
+				},
+			}, api.Options{
+				Goos:   "linux",
+				Goarch: "arm",
+				Goarm:  "6",
+			},
+		)
+		require.NoError(t, err)
+		require.Equal(t, config.BuildDetails{
+			Ldflags: []string{"overridden"},
+			Env:     []string{},
+		}, dets)
+	})
+
+	t.Run("with goarm unespecified", func(t *testing.T) {
+		dets, err := withOverrides(
+			testctx.New(),
+			config.Build{
+				BuildDetails: config.BuildDetails{
+					Ldflags: []string{"original"},
+				},
+				BuildDetailsOverrides: []config.BuildDetailsOverride{
+					{
+						Goos:   "linux",
+						Goarch: "arm",
 						BuildDetails: config.BuildDetails{
 							Ldflags: []string{"overridden"},
 						},
@@ -1478,6 +1536,35 @@ func TestOverrides(t *testing.T) {
 		}, dets)
 	})
 
+	t.Run("with gomips unespecified", func(t *testing.T) {
+		dets, err := withOverrides(
+			testctx.New(),
+			config.Build{
+				BuildDetails: config.BuildDetails{
+					Ldflags: []string{"original"},
+				},
+				BuildDetailsOverrides: []config.BuildDetailsOverride{
+					{
+						Goos:   "linux",
+						Goarch: "mips",
+						BuildDetails: config.BuildDetails{
+							Ldflags: []string{"overridden"},
+						},
+					},
+				},
+			}, api.Options{
+				Goos:   "linux",
+				Goarch: "mips",
+				Gomips: "hardfloat",
+			},
+		)
+		require.NoError(t, err)
+		require.Equal(t, config.BuildDetails{
+			Ldflags: []string{"overridden"},
+			Env:     []string{},
+		}, dets)
+	})
+
 	t.Run("with goriscv64", func(t *testing.T) {
 		dets, err := withOverrides(
 			testctx.New(),
@@ -1508,7 +1595,67 @@ func TestOverrides(t *testing.T) {
 		}, dets)
 	})
 
+	t.Run("with goriscv64 unespecified", func(t *testing.T) {
+		dets, err := withOverrides(
+			testctx.New(),
+			config.Build{
+				BuildDetails: config.BuildDetails{
+					Ldflags: []string{"original"},
+				},
+				BuildDetailsOverrides: []config.BuildDetailsOverride{
+					{
+						Goos:      "linux",
+						Goarch:    "riscv64",
+						Goriscv64: "rva22u64",
+						BuildDetails: config.BuildDetails{
+							Ldflags: []string{"overridden"},
+						},
+					},
+				},
+			}, api.Options{
+				Goos:      "linux",
+				Goarch:    "riscv64",
+				Goriscv64: "rva22u64",
+			},
+		)
+		require.NoError(t, err)
+		require.Equal(t, config.BuildDetails{
+			Ldflags: []string{"overridden"},
+			Env:     []string{},
+		}, dets)
+	})
+
 	t.Run("with go386", func(t *testing.T) {
+		dets, err := withOverrides(
+			testctx.New(),
+			config.Build{
+				BuildDetails: config.BuildDetails{
+					Ldflags: []string{"original"},
+				},
+				BuildDetailsOverrides: []config.BuildDetailsOverride{
+					{
+						Goos:   "linux",
+						Goarch: "386",
+						Go386:  "sse2",
+						BuildDetails: config.BuildDetails{
+							Ldflags: []string{"overridden"},
+						},
+					},
+				},
+			}, api.Options{
+				Goos:   "linux",
+				Goarch: "386",
+				Go386:  "sse2",
+			},
+		)
+		require.NoError(t, err)
+		require.Equal(t, config.BuildDetails{
+			Ldflags: []string{"overridden"},
+			Env:     []string{},
+		}, dets)
+	})
+
+	t.Run("with go386 unespecified", func(t *testing.T) {
 		dets, err := withOverrides(
 			testctx.New(),
 			config.Build{


### PR DESCRIPTION
this will use the default value for GOMIPS, GOARM, GO386, and etc in build overrides if they are not specified.