### PR TITLE
docs: fix I386 variable naming mismatch

### DIFF
--- a/www/docs/customization/templates.md
+++ b/www/docs/customization/templates.md
@@ -93,7 +93,7 @@ You should be able to use all its fields on each item:
 - `.Gomips64` (since v2.4)
 - `.Goppc64` (since v2.4)
 - `.Goriscv64` (since v2.4)
-- `.Go386` (since v2.4)
+- `.I386` (since v2.4)
 - `.Target` (Since v2.5)
 - `.Type`
 - `.Extra`


### PR DESCRIPTION
This PR fixes a small docs issue where the `GO386` has 2 different names, but only one of them is correct.
