### PR TITLE
feat: rename builds.*.gobinary to builds.*.tool

### DIFF
--- a/internal/builders/buildtarget/targets_test.go
+++ b/internal/builders/buildtarget/targets_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAllBuildTargets(t *testing.T) {
 	build := config.Build{
-		GoBinary: "go",
+		Tool: "go",
 		Goos: []string{
 			"linux",
 			"darwin",
@@ -267,10 +267,10 @@ func TestGoosGoarchCombos(t *testing.T) {
 func TestList(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		targets, err := List(config.Build{
-			Goos:     []string{"linux"},
-			Goarch:   []string{"amd64"},
-			Goamd64:  []string{"v2"},
-			GoBinary: "go",
+			Goos:    []string{"linux"},
+			Goarch:  []string{"amd64"},
+			Goamd64: []string{"v2"},
+			Tool:    "go",
 		})
 		require.NoError(t, err)
 		require.Equal(t, []string{"linux_amd64_v2"}, targets)
@@ -278,11 +278,11 @@ func TestList(t *testing.T) {
 
 	t.Run("success with dir", func(t *testing.T) {
 		targets, err := List(config.Build{
-			Goos:     []string{"linux"},
-			Goarch:   []string{"amd64"},
-			Goamd64:  []string{"v2"},
-			GoBinary: "go",
-			Dir:      "./testdata",
+			Goos:    []string{"linux"},
+			Goarch:  []string{"amd64"},
+			Goamd64: []string{"v2"},
+			Tool:    "go",
+			Dir:     "./testdata",
 		})
 		require.NoError(t, err)
 		require.Equal(t, []string{"linux_amd64_v2"}, targets)

--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -80,8 +80,8 @@ func (b *Builder) Parse(target string) (api.Target, error) {
 
 // WithDefaults sets the defaults for a golang build and returns it.
 func (*Builder) WithDefaults(build config.Build) (config.Build, error) {
-	if build.GoBinary == "" {
-		build.GoBinary = "go"
+	if build.Tool == "" {
+		build.Tool = "go"
 	}
 	if build.Command == "" {
 		build.Command = "build"
@@ -360,7 +360,7 @@ func buildGoBuildLine(
 	artifact *artifact.Artifact,
 	env []string,
 ) ([]string, error) {
-	gobin, err := tmpl.New(ctx).WithBuildOptions(options).Apply(build.GoBinary)
+	gobin, err := tmpl.New(ctx).WithBuildOptions(options).Apply(build.Tool)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -108,9 +108,9 @@ func TestParse(t *testing.T) {
 
 func TestWithDefaults(t *testing.T) {
 	for name, testcase := range map[string]struct {
-		build    config.Build
-		targets  []string
-		goBinary string
+		build   config.Build
+		targets []string
+		tool    string
 	}{
 		"full": {
 			build: config.Build{
@@ -136,7 +136,7 @@ func TestWithDefaults(t *testing.T) {
 					"v2",
 					"v3",
 				},
-				GoBinary: "go1.2.3",
+				Tool: "go1.2.3",
 			},
 			targets: []string{
 				"linux_amd64_v2",
@@ -149,7 +149,7 @@ func TestWithDefaults(t *testing.T) {
 				"windows_arm_6",
 				"linux_arm_6",
 			},
-			goBinary: "go1.2.3",
+			tool: "go1.2.3",
 		},
 		"empty": {
 			build: config.Build{
@@ -166,7 +166,7 @@ func TestWithDefaults(t *testing.T) {
 				"windows_arm64_v8.0",
 				"windows_386_sse2",
 			},
-			goBinary: "go",
+			tool: "go",
 		},
 		"custom targets": {
 			build: config.Build{
@@ -181,7 +181,7 @@ func TestWithDefaults(t *testing.T) {
 				"linux_386_sse2",
 				"darwin_amd64_v2",
 			},
-			goBinary: "go",
+			tool: "go",
 		},
 		"custom targets no amd64": {
 			build: config.Build{
@@ -196,7 +196,7 @@ func TestWithDefaults(t *testing.T) {
 				"linux_386_sse2",
 				"darwin_amd64_v1",
 			},
-			goBinary: "go",
+			tool: "go",
 		},
 		"custom targets no arm": {
 			build: config.Build{
@@ -204,8 +204,8 @@ func TestWithDefaults(t *testing.T) {
 				Binary:  "foo",
 				Targets: []string{"linux_arm"},
 			},
-			targets:  []string{"linux_arm_6"},
-			goBinary: "go",
+			targets: []string{"linux_arm_6"},
+			tool:    "go",
 		},
 		"custom targets no arm64": {
 			build: config.Build{
@@ -213,8 +213,8 @@ func TestWithDefaults(t *testing.T) {
 				Binary:  "foo",
 				Targets: []string{"linux_arm64"},
 			},
-			targets:  []string{"linux_arm64_v8.0"},
-			goBinary: "go",
+			targets: []string{"linux_arm64_v8.0"},
+			tool:    "go",
 		},
 		"custom targets no ppc64": {
 			build: config.Build{
@@ -222,8 +222,8 @@ func TestWithDefaults(t *testing.T) {
 				Binary:  "foo",
 				Targets: []string{"linux_ppc64le", "linux_ppc64"},
 			},
-			targets:  []string{"linux_ppc64le_power8", "linux_ppc64_power8"},
-			goBinary: "go",
+			targets: []string{"linux_ppc64le_power8", "linux_ppc64_power8"},
+			tool:    "go",
 		},
 		"custom targets no riscv64": {
 			build: config.Build{
@@ -231,8 +231,8 @@ func TestWithDefaults(t *testing.T) {
 				Binary:  "foo",
 				Targets: []string{"linux_riscv64"},
 			},
-			targets:  []string{"linux_riscv64_rva20u64"},
-			goBinary: "go",
+			targets: []string{"linux_riscv64_rva20u64"},
+			tool:    "go",
 		},
 		"custom targets no mips": {
 			build: config.Build{
@@ -240,8 +240,8 @@ func TestWithDefaults(t *testing.T) {
 				Binary:  "foo",
 				Targets: []string{"linux_mips"},
 			},
-			targets:  []string{"linux_mips_hardfloat"},
-			goBinary: "go",
+			targets: []string{"linux_mips_hardfloat"},
+			tool:    "go",
 		},
 		"custom targets no mipsle": {
 			build: config.Build{
@@ -249,8 +249,8 @@ func TestWithDefaults(t *testing.T) {
 				Binary:  "foo",
 				Targets: []string{"linux_mipsle"},
 			},
-			targets:  []string{"linux_mipsle_hardfloat"},
-			goBinary: "go",
+			targets: []string{"linux_mipsle_hardfloat"},
+			tool:    "go",
 		},
 		"custom targets no mips64": {
 			build: config.Build{
@@ -258,8 +258,8 @@ func TestWithDefaults(t *testing.T) {
 				Binary:  "foo",
 				Targets: []string{"linux_mips64"},
 			},
-			targets:  []string{"linux_mips64_hardfloat"},
-			goBinary: "go",
+			targets: []string{"linux_mips64_hardfloat"},
+			tool:    "go",
 		},
 		"custom targets no mips64le": {
 			build: config.Build{
@@ -267,8 +267,8 @@ func TestWithDefaults(t *testing.T) {
 				Binary:  "foo",
 				Targets: []string{"linux_mips64le"},
 			},
-			targets:  []string{"linux_mips64le_hardfloat"},
-			goBinary: "go",
+			targets: []string{"linux_mips64le_hardfloat"},
+			tool:    "go",
 		},
 		"empty with custom dir": {
 			build: config.Build{
@@ -286,7 +286,7 @@ func TestWithDefaults(t *testing.T) {
 				"windows_arm64_v8.0",
 				"windows_386_sse2",
 			},
-			goBinary: "go",
+			tool: "go",
 		},
 		"empty with custom dir that doesn't exist": {
 			build: config.Build{
@@ -304,7 +304,7 @@ func TestWithDefaults(t *testing.T) {
 				"windows_arm64_v8.0",
 				"windows_386_sse2",
 			},
-			goBinary: "go",
+			tool: "go",
 		},
 		"go first class targets": {
 			build: config.Build{
@@ -312,8 +312,8 @@ func TestWithDefaults(t *testing.T) {
 				Binary:  "foo",
 				Targets: []string{goStableFirstClassTargetsName},
 			},
-			targets:  go118FirstClassAdjustedTargets,
-			goBinary: "go",
+			targets: go118FirstClassAdjustedTargets,
+			tool:    "go",
 		},
 		"go 1.18 first class targets": {
 			build: config.Build{
@@ -321,8 +321,8 @@ func TestWithDefaults(t *testing.T) {
 				Binary:  "foo",
 				Targets: []string{go118FirstClassTargetsName},
 			},
-			targets:  go118FirstClassAdjustedTargets,
-			goBinary: "go",
+			targets: go118FirstClassAdjustedTargets,
+			tool:    "go",
 		},
 		"go 1.18 first class targets plus custom": {
 			build: config.Build{
@@ -330,8 +330,8 @@ func TestWithDefaults(t *testing.T) {
 				Binary:  "foo",
 				Targets: []string{"linux_amd64_v1", go118FirstClassTargetsName, "darwin_amd64_v2"},
 			},
-			targets:  append(go118FirstClassAdjustedTargets, "darwin_amd64_v2"),
-			goBinary: "go",
+			targets: append(go118FirstClassAdjustedTargets, "darwin_amd64_v2"),
+			tool:    "go",
 		},
 		"repeating targets": {
 			build: config.Build{
@@ -339,13 +339,13 @@ func TestWithDefaults(t *testing.T) {
 				Binary:  "foo",
 				Targets: []string{go118FirstClassTargetsName, go118FirstClassTargetsName, goStableFirstClassTargetsName},
 			},
-			targets:  go118FirstClassAdjustedTargets,
-			goBinary: "go",
+			targets: go118FirstClassAdjustedTargets,
+			tool:    "go",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			if testcase.build.GoBinary != "" && testcase.build.GoBinary != "go" {
-				createFakeGoBinaryWithVersion(t, testcase.build.GoBinary, "go1.18")
+			if testcase.build.Tool != "" && testcase.build.Tool != "go" {
+				createFakeGoBinaryWithVersion(t, testcase.build.Tool, "go1.18")
 			}
 			ctx := testctx.NewWithCfg(config.Project{
 				Builds: []config.Build{
@@ -355,7 +355,7 @@ func TestWithDefaults(t *testing.T) {
 			build, err := Default.WithDefaults(ctx.Config.Builds[0])
 			require.NoError(t, err)
 			require.ElementsMatch(t, build.Targets, testcase.targets)
-			require.EqualValues(t, testcase.goBinary, build.GoBinary)
+			require.EqualValues(t, testcase.tool, build.Tool)
 		})
 	}
 }
@@ -467,8 +467,8 @@ func TestBuild(t *testing.T) {
 					"linux_mips_softfloat",
 					"linux_mips64le_softfloat",
 				},
-				GoBinary: "{{ .Env.GOBIN }}",
-				Command:  "build",
+				Tool:    "{{ .Env.GOBIN }}",
+				Command: "build",
 				BuildDetails: config.BuildDetails{
 					Env: []string{
 						"GO111MODULE=off",
@@ -667,7 +667,7 @@ func TestBuildInvalidEnv(t *testing.T) {
 				Targets: []string{
 					runtimeTarget,
 				},
-				GoBinary: "go",
+				Tool: "go",
 				BuildDetails: config.BuildDetails{
 					Env: []string{"GO111MODULE={{ .Nope }}"},
 				},
@@ -699,8 +699,8 @@ func TestBuildCodeInSubdir(t *testing.T) {
 				Targets: []string{
 					runtimeTarget,
 				},
-				GoBinary: "go",
-				Command:  "build",
+				Tool:    "go",
+				Command: "build",
 				BuildDetails: config.BuildDetails{
 					Env: []string{"GO111MODULE=off"},
 				},
@@ -724,11 +724,11 @@ func TestBuildWithDotGoDir(t *testing.T) {
 	ctx := testctx.NewWithCfg(config.Project{
 		Builds: []config.Build{
 			{
-				ID:       "foo",
-				Binary:   "foo",
-				Targets:  []string{runtimeTarget},
-				GoBinary: "go",
-				Command:  "build",
+				ID:      "foo",
+				Binary:  "foo",
+				Targets: []string{runtimeTarget},
+				Tool:    "go",
+				Command: "build",
 				BuildDetails: config.BuildDetails{
 					Env: []string{"GO111MODULE=off"},
 				},
@@ -757,8 +757,8 @@ func TestBuildFailed(t *testing.T) {
 				Targets: []string{
 					runtimeTarget,
 				},
-				GoBinary: "go",
-				Command:  "build",
+				Tool:    "go",
+				Command: "build",
 			},
 		},
 	}, testctx.WithCurrentTag("5.6.7"))
@@ -969,8 +969,8 @@ import _ "github.com/goreleaser/goreleaser"
 				Targets: []string{
 					runtimeTarget,
 				},
-				GoBinary: "go",
-				Command:  "build",
+				Tool:    "go",
+				Command: "build",
 			},
 		},
 	})
@@ -998,8 +998,8 @@ func TestRunPipeWithMainFuncNotInMainGoFile(t *testing.T) {
 				BuildDetails: config.BuildDetails{
 					Env: []string{"GO111MODULE=off"},
 				},
-				GoBinary: "go",
-				Command:  "build",
+				Tool:    "go",
+				Command: "build",
 			},
 		},
 	}, testctx.WithCurrentTag("5.6.7"))
@@ -1154,7 +1154,7 @@ func TestBuildModTimestamp(t *testing.T) {
 					Flags:    []string{"{{.Env.GO_FLAGS}}"},
 				},
 				ModTimestamp: fmt.Sprintf("%d", modTime.Unix()),
-				GoBinary:     "go",
+				Tool:         "go",
 				Command:      "build",
 			}},
 		},
@@ -1236,9 +1236,9 @@ func TestBuildGoBuildLine(t *testing.T) {
 				Tags:     []string{"tag1", "tag2"},
 				Ldflags:  []string{"ldflag1", "ldflag2"},
 			},
-			Binary:   "foo",
-			GoBinary: "{{ .Env.GOBIN }}",
-			Command:  "build",
+			Binary:  "foo",
+			Tool:    "{{ .Env.GOBIN }}",
+			Command: "build",
 		}, []string{
 			"go", "build",
 			"-flag1", "-flag2",
@@ -1273,9 +1273,9 @@ func TestBuildGoBuildLine(t *testing.T) {
 					},
 				},
 			},
-			GoBinary: "go",
-			Binary:   "foo",
-			Command:  "build",
+			Tool:    "go",
+			Binary:  "foo",
+			Command: "build",
 		}, []string{
 			"go", "build",
 			"-flag3",
@@ -1289,19 +1289,19 @@ func TestBuildGoBuildLine(t *testing.T) {
 
 	t.Run("simple", func(t *testing.T) {
 		requireEqualCmd(t, config.Build{
-			Main:     ".",
-			GoBinary: "go",
-			Command:  "build",
-			Binary:   "foo",
+			Main:    ".",
+			Tool:    "go",
+			Command: "build",
+			Binary:  "foo",
 		}, strings.Fields("go build -o foo ."))
 	})
 
 	t.Run("test", func(t *testing.T) {
 		requireEqualCmd(t, config.Build{
-			Main:     ".",
-			GoBinary: "go",
-			Command:  "test",
-			Binary:   "foo.test",
+			Main:    ".",
+			Tool:    "go",
+			Command: "test",
+			Binary:  "foo.test",
 			BuildDetails: config.BuildDetails{
 				Flags: []string{"-c"},
 			},
@@ -1310,10 +1310,10 @@ func TestBuildGoBuildLine(t *testing.T) {
 
 	t.Run("build test always as c flags", func(t *testing.T) {
 		requireEqualCmd(t, config.Build{
-			Main:     ".",
-			GoBinary: "go",
-			Command:  "test",
-			Binary:   "foo.test",
+			Main:    ".",
+			Tool:    "go",
+			Command: "test",
+			Binary:  "foo.test",
 		}, strings.Fields("go test -c -o foo.test ."))
 	})
 
@@ -1323,9 +1323,9 @@ func TestBuildGoBuildLine(t *testing.T) {
 			BuildDetails: config.BuildDetails{
 				Ldflags: []string{"-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.builtBy=goreleaser"},
 			},
-			GoBinary: "go",
-			Command:  "build",
-			Binary:   "foo",
+			Tool:    "go",
+			Command: "build",
+			Binary:  "foo",
 		}, []string{
 			"go", "build",
 			"-ldflags=-s -w -X main.version=1.2.3 -X main.commit=aaa -X main.builtBy=goreleaser",
@@ -1339,9 +1339,9 @@ func TestBuildGoBuildLine(t *testing.T) {
 			BuildDetails: config.BuildDetails{
 				Ldflags: []string{"-s -w", "-X main.version={{.Version}}"},
 			},
-			GoBinary: "go",
-			Binary:   "foo",
-			Command:  "build",
+			Tool:    "go",
+			Binary:  "foo",
+			Command: "build",
 		}, []string{"go", "build", "-ldflags=-s -w -X main.version=1.2.3", "-o", "foo", "."})
 	})
 }
@@ -1749,9 +1749,9 @@ func TestInvalidGoBinaryTpl(t *testing.T) {
 	ctx := testctx.NewWithCfg(config.Project{
 		Builds: []config.Build{
 			{
-				Targets:  []string{runtimeTarget},
-				GoBinary: "{{.Foo}}",
-				Command:  "build",
+				Targets: []string{runtimeTarget},
+				Tool:    "{{.Foo}}",
+				Command: "build",
 			},
 		},
 	})

--- a/internal/builders/rust/build.go
+++ b/internal/builders/rust/build.go
@@ -81,8 +81,8 @@ func (b *Builder) WithDefaults(build config.Build) (config.Build, error) {
 		build.Targets = defaultTargets()
 	}
 
-	if build.GoBinary == "" {
-		build.GoBinary = "cargo"
+	if build.Tool == "" {
+		build.Tool = "cargo"
 	}
 
 	if build.Command == "" {
@@ -181,7 +181,7 @@ func (b *Builder) Build(ctx *context.Context, build config.Build, options api.Op
 		WithEnvS(env).
 		WithArtifact(a)
 
-	cargo, err := tpl.Apply(build.GoBinary)
+	cargo, err := tpl.Apply(build.Tool)
 	if err != nil {
 		return err
 	}

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -26,10 +26,10 @@ func TestWithDefaults(t *testing.T) {
 		build, err := Default.WithDefaults(config.Build{})
 		require.NoError(t, err)
 		require.Equal(t, config.Build{
-			GoBinary: "cargo",
-			Command:  "zigbuild",
-			Dir:      ".",
-			Targets:  defaultTargets(),
+			Tool:    "cargo",
+			Command: "zigbuild",
+			Dir:     ".",
+			Targets: defaultTargets(),
 		}, build)
 	})
 

--- a/internal/builders/zig/build.go
+++ b/internal/builders/zig/build.go
@@ -59,8 +59,8 @@ func (b *Builder) WithDefaults(build config.Build) (config.Build, error) {
 		build.Targets = defaultTargets()
 	}
 
-	if build.GoBinary == "" {
-		build.GoBinary = "zig"
+	if build.Tool == "" {
+		build.Tool = "zig"
 	}
 
 	if build.Command == "" {
@@ -153,7 +153,7 @@ func (b *Builder) Build(ctx *context.Context, build config.Build, options api.Op
 		WithEnvS(env).
 		WithArtifact(a)
 
-	zigbin, err := tpl.Apply(build.GoBinary)
+	zigbin, err := tpl.Apply(build.Tool)
 	if err != nil {
 		return err
 	}

--- a/internal/builders/zig/build_test.go
+++ b/internal/builders/zig/build_test.go
@@ -63,10 +63,10 @@ func TestWithDefaults(t *testing.T) {
 		build, err := Default.WithDefaults(config.Build{})
 		require.NoError(t, err)
 		require.Equal(t, config.Build{
-			GoBinary: "zig",
-			Command:  "build",
-			Dir:      ".",
-			Targets:  defaultTargets(),
+			Tool:    "zig",
+			Command: "build",
+			Dir:     ".",
+			Targets: defaultTargets(),
 		}, build)
 	})
 

--- a/internal/pipe/build/build.go
+++ b/internal/pipe/build/build.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/caarlos0/go-shellwords"
 	"github.com/caarlos0/log"
+	"github.com/goreleaser/goreleaser/v2/internal/deprecate"
 	"github.com/goreleaser/goreleaser/v2/internal/ids"
 	"github.com/goreleaser/goreleaser/v2/internal/semerrgroup"
 	"github.com/goreleaser/goreleaser/v2/internal/shell"
@@ -83,6 +84,10 @@ func prepare(ctx *context.Context, build config.Build) error {
 func (Pipe) Default(ctx *context.Context) error {
 	ids := ids.New("builds")
 	for i, build := range ctx.Config.Builds {
+		if build.GoBinary != "" {
+			build.Tool = build.GoBinary
+			deprecate.Notice(ctx, "builds.gobinary")
+		}
 		build, err := buildWithDefaults(ctx, build)
 		if err != nil {
 			return err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -514,7 +514,8 @@ type Build struct {
 	Builder         string          `yaml:"builder,omitempty" json:"builder,omitempty" jsonschema:"enum=,enum=go,enum=rust,enum=zig"`
 	ModTimestamp    string          `yaml:"mod_timestamp,omitempty" json:"mod_timestamp,omitempty"`
 	Skip            string          `yaml:"skip,omitempty" json:"skip,omitempty" jsonschema:"oneof_type=string;boolean"`
-	GoBinary        string          `yaml:"gobinary,omitempty" json:"gobinary,omitempty"`
+	GoBinary        string          `yaml:"gobinary,omitempty" json:"gobinary,omitempty"` // Deprecated: use [ToolBinary].
+	Tool            string          `yaml:"tool,omitempty" json:"tool,omitempty"`
 	Command         string          `yaml:"command,omitempty" json:"command,omitempty"`
 	NoUniqueDistDir string          `yaml:"no_unique_dist_dir,omitempty" json:"no_unique_dist_dir,omitempty" jsonschema:"oneof_type=string;boolean"`
 	NoMainCheck     bool            `yaml:"no_main_check,omitempty" json:"no_main_check,omitempty"`

--- a/www/docs/customization/builds.md
+++ b/www/docs/customization/builds.md
@@ -202,7 +202,8 @@ builds:
     #
     # Default: "go".
     # Templates: allowed.
-    gobinary: "go1.13.4"
+    # <!-- md:inline_version v2.5 -->.
+    tool: "go1.13.4"
 
     # Sets the command to run to build.
     # Can be useful if you want to build tests, for example,
@@ -292,6 +293,14 @@ builds:
           - foobaz
         env:
           - CGO_ENABLED=1
+
+    # Set a specific go binary to use when building.
+    # It is safe to ignore this option in most cases.
+    #
+    # Default: "go".
+    # Templates: allowed.
+    # Deprecated: use `tool` instead.
+    gobinary: "go1.13.4"
 ```
 
 !!! warning "GOAMD64, GORISCV64, GOPPC64, GO386, GOARM, GOARM64"

--- a/www/docs/customization/rust-builds.md
+++ b/www/docs/customization/rust-builds.md
@@ -42,7 +42,7 @@ builds:
     #
     # Default: "cargo".
     # Templates: allowed.
-    gobinary: "cross"
+    tool: "cross"
 
     # Sets the command to run to build.
     # Can be useful if you want to build tests, for example,
@@ -71,7 +71,7 @@ then make few changes:
 builds:
   - # Use Rust zigbuild
     builder: rust
-    gobinary: cross # TODO: rename gobinary to something more generic, like 'builder_binary' maybe?
+    tool: cross
     command: build
     targets:
       - x86_64-apple-darwin

--- a/www/docs/customization/zig-builds.md
+++ b/www/docs/customization/zig-builds.md
@@ -42,7 +42,7 @@ builds:
     #
     # Default: "zig".
     # Templates: allowed.
-    gobinary: "zig-nightly"
+    tool: "zig-nightly"
 
     # Sets the command to run to build.
     # Can be useful if you want to build tests, for example,

--- a/www/docs/deprecations.md
+++ b/www/docs/deprecations.md
@@ -39,6 +39,26 @@ Description.
 
 -->
 
+### builds.gobinary
+
+> since v2.5
+
+The property was renamed to `tool`, as to better accommodate multiple languages.
+
+=== "Before"
+
+    ```yaml
+    builds:
+      - gobinary: 'go1.2.3'
+    ```
+
+=== "After"
+
+    ```yaml
+    builds:
+      - tool: 'go1.2.3'
+    ```
+
 ### kos.sbom
 
 > since v2.2


### PR DESCRIPTION
This should better accommodate other languages, as it makes no sense to set `gobinary` for rust or zig.

refs #5327 