### PR TITLE
feat: add rustup and zig to packages optional dependencies

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -226,6 +226,10 @@ brews:
     dependencies:
       - name: go
         type: optional
+      - name: rustup
+        type: optional
+      - name: zig
+        type: optional
       - name: git
     conflicts:
       - goreleaser-pro
@@ -345,6 +349,8 @@ nfpms:
       - git
     recommends:
       - golang
+      - rustup
+      - zig
     deb:
       lintian_overrides:
         - statically-linked-binary


### PR DESCRIPTION
this will affect goreleaser packages themselves.

go was already optional, as people might install it from source, and so are now zig and rust.