### PR TITLE
feat: --release and -Doptimize=ReleaseSafe for rust and zig

### DIFF
--- a/internal/builders/rust/build.go
+++ b/internal/builders/rust/build.go
@@ -89,6 +89,10 @@ func (b *Builder) WithDefaults(build config.Build) (config.Build, error) {
 		build.Command = "zigbuild"
 	}
 
+	if len(build.Flags) == 0 {
+		build.Flags = []string{"--release"}
+	}
+
 	if build.Dir == "" {
 		build.Dir = "."
 	}
@@ -190,7 +194,6 @@ func (b *Builder) Build(ctx *context.Context, build config.Build, options api.Op
 		cargo,
 		build.Command,
 		"--target=" + t.Target,
-		"--release",
 	}
 
 	for _, e := range build.Env {

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -30,6 +30,9 @@ func TestWithDefaults(t *testing.T) {
 			Command:  "zigbuild",
 			Dir:      ".",
 			Targets:  defaultTargets(),
+			BuildDetails: config.BuildDetails{
+				Flags: []string{"--release"},
+			},
 		}, build)
 	})
 
@@ -128,7 +131,7 @@ func TestBuild(t *testing.T) {
 				Dir:          "./testdata/proj/",
 				ModTimestamp: fmt.Sprintf("%d", modTime.Unix()),
 				BuildDetails: config.BuildDetails{
-					Flags: []string{"--locked"},
+					Flags: []string{"--locked", "--release"},
 					Env: []string{
 						`TEST_T={{- if eq .Os "windows" -}}
 							w

--- a/internal/builders/zig/build.go
+++ b/internal/builders/zig/build.go
@@ -71,6 +71,10 @@ func (b *Builder) WithDefaults(build config.Build) (config.Build, error) {
 		build.Dir = "."
 	}
 
+	if len(build.Flags) == 0 {
+		build.Flags = []string{"-Doptimize=ReleaseSafe"}
+	}
+
 	if build.Main != "" {
 		return build, errors.New("main is not used for zig")
 	}

--- a/internal/builders/zig/build_test.go
+++ b/internal/builders/zig/build_test.go
@@ -67,6 +67,9 @@ func TestWithDefaults(t *testing.T) {
 			Command:  "build",
 			Dir:      ".",
 			Targets:  defaultTargets(),
+			BuildDetails: config.BuildDetails{
+				Flags: []string{"-Doptimize=ReleaseSafe"},
+			},
 		}, build)
 	})
 
@@ -146,7 +149,7 @@ func TestBuild(t *testing.T) {
 		Dist:        dist,
 		ProjectName: "proj",
 		Env: []string{
-			"OPTIMIZE_FOR=ReleaseSafe",
+			"OPTIMIZE_FOR=ReleaseSmall",
 		},
 		Builds: []config.Build{
 			{

--- a/internal/static/config.rust.yaml
+++ b/internal/static/config.rust.yaml
@@ -18,6 +18,8 @@ before:
 
 builds:
   - builder: rust
+    flags:
+      - --release
     targets:
       - x86_64-unknown-linux-gnu
       - x86_64-apple-darwin

--- a/internal/static/config.zig.yaml
+++ b/internal/static/config.zig.yaml
@@ -10,6 +10,8 @@ version: 2
 
 builds:
   - builder: zig
+    flags:
+      - -Doptimize=ReleaseSafe
     targets:
       - x86_64-linux
       - x86_64-windows


### PR DESCRIPTION
- remove `--release` from the default build cmd in rust, add it as a default flag (thus it can be overridden)
- also added `--release` to the generated config for rust
- did the same with `-Doptimize=ReleaseSafe` for zig