### PR TITLE
Doc fixes

### DIFF
--- a/www/README.md
+++ b/www/README.md
@@ -24,8 +24,8 @@ To drop into a shell with all the needed dependencies.
 
 ```bash
 cd ./www
-docker build -t material-mkdocs
-docker run --rm -it -p 8000:8000 -v .:/docs material
+docker build -t material-mkdocs .
+docker run --rm -it -p 8000:8000 -v .:/docs material-mkdocs
 ```
 
 ---

--- a/www/docs/overrides/home.html
+++ b/www/docs/overrides/home.html
@@ -225,7 +225,7 @@
 					Release engineering, simplified.
 				</h1>
 				<p>
-					We handle the complexities of of releasing so you can focus
+					We handle the complexities of releasing so you can focus
 					in building what really matters: your software.
 				</p>
 				<a


### PR DESCRIPTION
Fix docs on how to build and run the docs locally for development, and fixes a typo on the front page of the website.

* The docker build command required an additional parameter, the current directory, in order to build the image
* The docker image name was incomplete on the following line
* There was a typo in the first paragraph on the website