### PR TITLE
fix: keep underscores in deprecation urls

### DIFF
--- a/internal/deprecate/deprecate.go
+++ b/internal/deprecate/deprecate.go
@@ -21,14 +21,12 @@ func Notice(ctx *context.Context, property string) {
 
 var urlPropertyReplacer = strings.NewReplacer(
 	".", "",
-	"_", "",
 	":", "",
 	" ", "-",
 )
 
 // NoticeCustom warns the user about the deprecation of the given property.
 func NoticeCustom(ctx *context.Context, property, tmpl string) {
-	// replaces . and _ with -
 	url := baseURL + urlPropertyReplacer.Replace(property)
 	var out bytes.Buffer
 	if err := template.

--- a/internal/deprecate/deprecate_test.go
+++ b/internal/deprecate/deprecate_test.go
@@ -20,7 +20,7 @@ func TestNotice(t *testing.T) {
 
 	log.Info("first")
 	ctx := testctx.New()
-	Notice(ctx, "foo.bar.whatever: foobar")
+	Notice(ctx, "foo.bar_whatever: foobar")
 	log.Info("last")
 	require.True(t, ctx.Deprecated)
 

--- a/internal/deprecate/testdata/TestNotice.txt.golden
+++ b/internal/deprecate/testdata/TestNotice.txt.golden
@@ -1,3 +1,3 @@
   • first
-  • DEPRECATED:  foo.bar.whatever: foobar  should not be used anymore, check https://goreleaser.com/deprecations#foobarwhatever-foobar for more info
+  • DEPRECATED:  foo.bar_whatever: foobar  should not be used anymore, check https://goreleaser.com/deprecations#foobar_whatever-foobar for more info
   • last


### PR DESCRIPTION
### Summary

:wave: Hello! This PR keeps underscores in the URLs used to show the before and after of deprecations :books: :sparkles:

### Preview

After this change is applied, a difference is printed in the URLs for this deprecation page:

https://goreleaser.com/deprecations/#snapshotname_template

#### Before changes

https://goreleaser.com/deprecations/#snapshotnametemplate

![before](https://github.com/user-attachments/assets/601a928c-0e67-4463-a8af-3165a5509659)

#### After changes

![after](https://github.com/user-attachments/assets/0d49b75c-fe96-4870-8029-6ceb8dcd9ed7)

### Notes

I'm not sure if replacing the underscore is expected, but I'm open to updating tests to make this more clear however! Or closing the PR if it's alright as is :pray:
