### PR TITLE
refactor: change from sort functions to slices functions

### DIFF
--- a/internal/archivefiles/archivefiles.go
+++ b/internal/archivefiles/archivefiles.go
@@ -2,12 +2,13 @@
 package archivefiles
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/caarlos0/log"
@@ -62,8 +63,8 @@ func Eval(template *tmpl.Template, files []config.File) ([]config.File, error) {
 		}
 	}
 
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].Destination < result[j].Destination
+	slices.SortFunc(result, func(a, b config.File) int {
+		return cmp.Compare(a.Destination, b.Destination)
 	})
 
 	return unique(result), nil

--- a/internal/exec/exec_mock.go
+++ b/internal/exec/exec_mock.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -82,10 +82,10 @@ func ExecuteMockData(jsonData string) int {
 			item.ExpectedEnv = []string{}
 		}
 
-		sort.Strings(givenEnv)
-		sort.Strings(item.ExpectedEnv)
-		sort.Strings(givenArgs)
-		sort.Strings(item.ExpectedArgs)
+		slices.Sort(givenEnv)
+		slices.Sort(item.ExpectedEnv)
+		slices.Sort(givenArgs)
+		slices.Sort(item.ExpectedArgs)
 
 		if reflect.DeepEqual(item.ExpectedArgs, givenArgs) &&
 			reflect.DeepEqual(item.ExpectedEnv, givenEnv) {

--- a/internal/pipe/aur/aur.go
+++ b/internal/pipe/aur/aur.go
@@ -3,13 +3,14 @@ package aur
 import (
 	"bufio"
 	"bytes"
+	"cmp"
 	"crypto/sha256"
 	"errors"
 	"fmt"
 	"os"
 	"path"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"text/template"
 
@@ -340,9 +341,9 @@ func dataFor(ctx *context.Context, cfg config.AUR, cl client.ReleaseURLTemplater
 		result.Arches = append(result.Arches, releasePackage.Arch)
 	}
 
-	sort.Strings(result.Arches)
-	sort.Slice(result.ReleasePackages, func(i, j int) bool {
-		return result.ReleasePackages[i].Arch < result.ReleasePackages[j].Arch
+	slices.Sort(result.Arches)
+	slices.SortFunc(result.ReleasePackages, func(a, b releasePackage) int {
+		return cmp.Compare(a.Arch, b.Arch)
 	})
 	return result, nil
 }

--- a/internal/pipe/aursources/aursources.go
+++ b/internal/pipe/aursources/aursources.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"text/template"
 
@@ -304,7 +304,7 @@ func dataFor(ctx *context.Context, cfg config.AURSource, cl client.ReleaseURLTem
 		}
 	}
 
-	sort.Strings(result.Arches)
+	slices.Sort(result.Arches)
 
 	return result, nil
 }

--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"maps"
 	"net/http"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -88,17 +89,13 @@ func (Pipe) Default(ctx *context.Context) error {
 }
 
 func validateImager(use string) error {
-	valid := make([]string, 0, len(imagers))
-	for k := range imagers {
-		valid = append(valid, k)
-	}
-	for _, s := range valid {
+	valid := maps.Keys(imagers)
+	for s := range valid {
 		if s == use {
 			return nil
 		}
 	}
-	sort.Strings(valid)
-	return fmt.Errorf("docker: invalid use: %s, valid options are %v", use, valid)
+	return fmt.Errorf("docker: invalid use: %s, valid options are %v", use, slices.Sorted(valid))
 }
 
 // Publish the docker images.

--- a/internal/pipe/docker/manifest.go
+++ b/internal/pipe/docker/manifest.go
@@ -2,7 +2,8 @@ package docker
 
 import (
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/caarlos0/log"
@@ -113,17 +114,13 @@ func (ManifestPipe) Publish(ctx *context.Context) error {
 }
 
 func validateManifester(use string) error {
-	valid := make([]string, 0, len(manifesters))
-	for k := range manifesters {
-		valid = append(valid, k)
-	}
-	for _, s := range valid {
+	valid := maps.Keys(manifesters)
+	for s := range valid {
 		if s == use {
 			return nil
 		}
 	}
-	sort.Strings(valid)
-	return fmt.Errorf("docker manifest: invalid use: %s, valid options are %v", use, valid)
+	return fmt.Errorf("docker manifest: invalid use: %s, valid options are %v", use, slices.Sorted(valid))
 }
 
 func manifestName(ctx *context.Context, manifest config.DockerManifest) (string, error) {

--- a/internal/pipe/krew/krew.go
+++ b/internal/pipe/krew/krew.go
@@ -5,12 +5,13 @@
 package krew
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"os"
 	"path"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/caarlos0/log"
@@ -251,8 +252,8 @@ func manifestFor(
 		}
 	}
 
-	sort.Slice(result.Spec.Platforms, func(i, j int) bool {
-		return result.Spec.Platforms[i].URI > result.Spec.Platforms[j].URI
+	slices.SortFunc(result.Spec.Platforms, func(a, b Platform) int {
+		return -cmp.Compare(a.URI, b.URI)
 	})
 
 	return result, nil

--- a/internal/pipe/sbom/sbom_test.go
+++ b/internal/pipe/sbom/sbom_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"testing"
 
@@ -561,7 +560,6 @@ func testSBOMCataloging(
 	)
 
 	wantFiles := append(artifacts, sbomPaths...)
-	sort.Strings(wantFiles)
 	require.ElementsMatch(tb, wantFiles, gotFiles, "SBOM paths differ")
 
 	var sbomArtifacts []string

--- a/internal/pipe/sign/sign_test.go
+++ b/internal/pipe/sign/sign_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -708,7 +707,6 @@ func testSign(
 	)
 
 	wantFiles := append(artifacts, signaturePaths...)
-	sort.Strings(wantFiles)
 	require.ElementsMatch(tb, wantFiles, gotFiles)
 
 	// verify the signatures

--- a/internal/skips/skips.go
+++ b/internal/skips/skips.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"maps"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
@@ -98,7 +97,7 @@ func (keys Keys) Complete(prefix string) []string {
 			result = append(result, string(k))
 		}
 	}
-	sort.Strings(result)
+	slices.Sort(result)
 	return result
 }
 


### PR DESCRIPTION
The PR replaces using `sort` with `slices` package. It's because the latter is slightly faster and easier to use.

`sort.Strings(wantFiles)` is removed because `require.ElementsMatch(tb, wantFiles, gotFiles)` compares slices, ignoring the order of the elements.

See https://go-review.googlesource.com/c/go/+/626038