### PR TITLE
fix: typo in the YAML tag for Webhook.ExpectedStatusCodes

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1358,7 +1358,7 @@ type Webhook struct {
 	EndpointURL         string            `yaml:"endpoint_url,omitempty" json:"endpoint_url,omitempty"`
 	Headers             map[string]string `yaml:"headers,omitempty" json:"headers,omitempty"`
 	ContentType         string            `yaml:"content_type,omitempty" json:"content_type,omitempty"`
-	ExpectedStatusCodes []int             `yaml:"exected_status_codes,omitempty" json:"expected_status_codes,omitempty"`
+	ExpectedStatusCodes []int             `yaml:"expected_status_codes,omitempty" json:"expected_status_codes,omitempty"`
 }
 
 type Twitter struct {


### PR DESCRIPTION
The PR corrects the tag name for the `Webhook.ExpectedStatusCodes` in the `config` package.