### PR TITLE
refactor: simplify validateImager, validateManifester

### DIFF
--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -89,13 +89,10 @@ func (Pipe) Default(ctx *context.Context) error {
 }
 
 func validateImager(use string) error {
-	valid := maps.Keys(imagers)
-	for s := range valid {
-		if s == use {
-			return nil
-		}
+	if _, ok := imagers[use]; ok {
+		return nil
 	}
-	return fmt.Errorf("docker: invalid use: %s, valid options are %v", use, slices.Sorted(valid))
+	return fmt.Errorf("docker: invalid use: %s, valid options are %v", use, slices.Sorted(maps.Keys(imagers)))
 }
 
 // Publish the docker images.

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -1442,3 +1442,25 @@ func TestIsFileNotFoundError(t *testing.T) {
 		require.True(t, isFileNotFoundError(`./foo: not found: not found`))
 	})
 }
+
+func TestValidateImager(t *testing.T) {
+	tests := []struct {
+		use       string
+		wantError string
+	}{
+		{use: "docker"},
+		{use: "buildx"},
+		{use: "notFound", wantError: "docker: invalid use: notFound, valid options are [buildx docker]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.use, func(t *testing.T) {
+			err := validateImager(tt.use)
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/pipe/docker/manifest.go
+++ b/internal/pipe/docker/manifest.go
@@ -114,13 +114,10 @@ func (ManifestPipe) Publish(ctx *context.Context) error {
 }
 
 func validateManifester(use string) error {
-	valid := maps.Keys(manifesters)
-	for s := range valid {
-		if s == use {
-			return nil
-		}
+	if _, ok := manifesters[use]; ok {
+		return nil
 	}
-	return fmt.Errorf("docker manifest: invalid use: %s, valid options are %v", use, slices.Sorted(valid))
+	return fmt.Errorf("docker manifest: invalid use: %s, valid options are %v", use, slices.Sorted(maps.Keys(manifesters)))
 }
 
 func manifestName(ctx *context.Context, manifest config.DockerManifest) (string, error) {

--- a/internal/pipe/docker/manifest_test.go
+++ b/internal/pipe/docker/manifest_test.go
@@ -1,0 +1,28 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateManifester(t *testing.T) {
+	tests := []struct {
+		use       string
+		wantError string
+	}{
+		{use: "docker"},
+		{use: "buildx", wantError: "docker manifest: invalid use: buildx, valid options are [docker]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.use, func(t *testing.T) {
+			err := validateManifester(tt.use)
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
The PR simplifies `validateManifester` and `validateImager` functions. Also, adds tests to prove that refactoring doesn't break anything.