### PR TITLE
fix(rust,zig): improve init, experimental warn

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -37,12 +37,12 @@ func newInitCmd() *initCmd {
 			// try to figure out which kind of project is this...
 			if _, err := os.Stat("build.zig"); err == nil {
 				root.lang = "zig"
-				log.Info("Project contains a " + codeStyle.Render("build.zig") + " file, using default zig configuration")
+				log.Info("project contains a " + codeStyle.Render("build.zig") + " file, using default zig configuration")
 				return
 			}
 			if _, err := os.Stat("Cargo.toml"); err == nil {
 				root.lang = "rust"
-				log.Info("Project contains a " + codeStyle.Render("Cargo.toml") + " file, using default rust configuration")
+				log.Info("project contains a " + codeStyle.Render("Cargo.toml") + " file, using default rust configuration")
 				return
 			}
 		},
@@ -56,7 +56,7 @@ func newInitCmd() *initCmd {
 			}
 			defer conf.Close()
 
-			log.Infof(boldStyle.Render("Generating ") + codeStyle.Render(root.config))
+			log.Infof(boldStyle.Render("generating ") + codeStyle.Render(root.config))
 
 			gitignoreLines := []string{"dist/"}
 			var example []byte
@@ -79,15 +79,15 @@ func newInitCmd() *initCmd {
 
 			gitignoreModified, err := setupGitignore(gitignorePath, gitignoreLines)
 			if gitignoreModified {
-				log.Infof(boldStyle.Render("Setting up " + gitignorePath))
+				log.Infof(boldStyle.Render("setting up " + codeStyle.Render(gitignorePath)))
 			}
 			if err != nil {
 				return err
 			}
 
 			done := []string{
-				boldStyle.Render("Done!"),
-				"Please edit", codeStyle.Render(root.config),
+				boldStyle.Render("done!"),
+				"please edit", codeStyle.Render(root.config),
 			}
 			if gitignoreModified {
 				done = append(done, "and", codeStyle.Render(gitignorePath))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,7 +81,7 @@ Check out our website for more information, examples and documentation: https://
 			}
 		},
 		PersistentPostRun: func(*cobra.Command, []string) {
-			log.Info("thanks for using goreleaser!")
+			log.Info("Thanks for using GoReleaser!")
 		},
 	}
 	cmd.SetVersionTemplate("{{.Version}}")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,7 +81,7 @@ Check out our website for more information, examples and documentation: https://
 			}
 		},
 		PersistentPostRun: func(*cobra.Command, []string) {
-			log.Info("Thanks for using GoReleaser!")
+			log.Info("thanks for using GoReleaser!")
 		},
 	}
 	cmd.SetVersionTemplate("{{.Version}}")

--- a/internal/builders/rust/build.go
+++ b/internal/builders/rust/build.go
@@ -86,7 +86,7 @@ var once sync.Once
 // WithDefaults implements build.Builder.
 func (b *Builder) WithDefaults(build config.Build) (config.Build, error) {
 	once.Do(func() {
-		log.Warn("You are using the experimental Rust builder")
+		log.Warn("you are using the experimental Rust builder")
 	})
 
 	if len(build.Targets) == 0 {

--- a/internal/builders/rust/build.go
+++ b/internal/builders/rust/build.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
@@ -80,9 +81,13 @@ func (b *Builder) Parse(target string) (api.Target, error) {
 	return t, nil
 }
 
+var once sync.Once
+
 // WithDefaults implements build.Builder.
 func (b *Builder) WithDefaults(build config.Build) (config.Build, error) {
-	log.Warn("you are using the experimental Rust builder")
+	once.Do(func() {
+		log.Warn("You are using the experimental Rust builder")
+	})
 
 	if len(build.Targets) == 0 {
 		build.Targets = defaultTargets()

--- a/internal/builders/zig/build.go
+++ b/internal/builders/zig/build.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
@@ -62,9 +63,13 @@ func (b *Builder) Parse(target string) (api.Target, error) {
 	return t, nil
 }
 
+var once sync.Once
+
 // WithDefaults implements build.Builder.
 func (b *Builder) WithDefaults(build config.Build) (config.Build, error) {
-	log.Warn("you are using the experimental Zig builder")
+	once.Do(func() {
+		log.Warn("You are using the experimental Zig builder")
+	})
 
 	if len(build.Targets) == 0 {
 		build.Targets = defaultTargets()

--- a/internal/builders/zig/build.go
+++ b/internal/builders/zig/build.go
@@ -68,7 +68,7 @@ var once sync.Once
 // WithDefaults implements build.Builder.
 func (b *Builder) WithDefaults(build config.Build) (config.Build, error) {
 	once.Do(func() {
-		log.Warn("You are using the experimental Zig builder")
+		log.Warn("you are using the experimental Zig builder")
 	})
 
 	if len(build.Targets) == 0 {


### PR DESCRIPTION
- adds common rust/cargo-zigbuild/zig folders/files to .gitignore on init
- improves log output a little bit
- avoid repeating "you are using the experimental Foo builder" 