### PR TITLE
Introducing GoReleaser Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Please refer to our [contributing guidelines](CONTRIBUTING.md) for further infor
 [![Sponsors on Open Collective](https://opencollective.com/goreleaser/sponsors/badge.svg?style=for-the-badge)](https://opencollective.com/goreleaser/sponsors/)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?style=for-the-badge)](https://conventionalcommits.org)
 [![CII Best Practices](https://img.shields.io/cii/summary/5420?label=openssf%20best%20practices&style=for-the-badge)](https://bestpractices.coreinfrastructure.org/projects/5420)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20GoReleaser%20Guru-006BFF?style=for-the-badge)](https://gurubase.io/g/goreleaser)
 
 ## GitHub Sponsors
 


### PR DESCRIPTION
Hello team,

We are the maintainers of [Anteon](https://github.com/getanteon/anteon). Recently, we created Gurubase.io with the mission of building a centralized, open-source, tool-focused knowledge base. Each "guru" in Gurubase is equipped with custom knowledge to answer user questions based on data related to the respective tool.

We’re excited to let you know that [GoReleaser Guru](https://gurubase.io/g/goreleaser) has been manually added to Gurubase. GoReleaser Guru uses the data from this repo and data from the [docs](https://goreleaser.com) to answer questions by leveraging the LLM.

This PR introduces the "GoReleaser Guru", showcasing that GoReleaser now has an AI assistant available to help users with their questions. We’d love to hear your feedback on this contribution.

You also have the option to maintain the "GoReleaser Guru" by following the instructions in the [Gurubase Repo](https://github.com/getanteon/gurubase?tab=readme-ov-file#how-to-claim-a-guru) and to add an ASK AI widget to the GoReleaser documentation website as detailed [here](https://github.com/getanteon/gurubase?tab=readme-ov-file#widget).

If you’d prefer us to disable GoReleaser Guru in Gurubase, just let us know that's totally fine.
