### PR TITLE
Update documentation links

### DIFF
--- a/www/docs/customization/builds.md
+++ b/www/docs/customization/builds.md
@@ -117,6 +117,7 @@ builds:
 
     # GOARM to build for when GOARCH is arm.
     # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Environment_variables
+    # and https://go.dev/wiki/MinimumRequirements#microarchitecture-support
     #
     # Default: [ 6 ].
     goarm:
@@ -125,6 +126,7 @@ builds:
 
     # GOAMD64 to build when GOARCH is amd64.
     # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Environment_variables
+    # and https://go.dev/wiki/MinimumRequirements#microarchitecture-support
     #
     # Default: [ 'v1' ].
     goamd64:
@@ -133,6 +135,7 @@ builds:
 
     # GOARM64 to build when GOARCH is arm64.
     # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Environment_variables
+    # and https://go.dev/wiki/MinimumRequirements#microarchitecture-support
     #
     # Default: [ 'v8.0' ].
     # <!-- md:inline_version v2.4 -->.
@@ -141,6 +144,7 @@ builds:
 
     # GOMIPS and GOMIPS64 to build when GOARCH is mips, mips64, mipsle or mips64le.
     # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Environment_variables
+    # and https://go.dev/wiki/MinimumRequirements#microarchitecture-support
     #
     # Default: [ 'hardfloat' ].
     # <!-- md:inline_version v2.4 -->.
@@ -150,6 +154,7 @@ builds:
 
     # GO386 to build when GOARCH is 386.
     # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Environment_variables
+    # and https://go.dev/wiki/MinimumRequirements#microarchitecture-support
     #
     # Default: [ 'sse2' ].
     # <!-- md:inline_version v2.4 -->.
@@ -159,6 +164,7 @@ builds:
 
     # GOPPC64 to build when GOARCH is PPC64.
     # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Environment_variables
+    # and https://go.dev/wiki/MinimumRequirements#microarchitecture-support
     #
     # Default: [ 'power8' ].
     # <!-- md:inline_version v2.4 -->.
@@ -168,6 +174,7 @@ builds:
 
     # GORISCV64 to build when GOARCH is RISCV64.
     # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Environment_variables
+    # and https://go.dev/wiki/MinimumRequirements#microarchitecture-support
     #
     # Default: [ 'rva20u64' ].
     # <!-- md:inline_version v2.4 -->.

--- a/www/docs/customization/builds.md
+++ b/www/docs/customization/builds.md
@@ -36,6 +36,8 @@ builds:
       - -v
 
     # Custom asmflags.
+    # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Compile_packages_and_dependencies
+    # and https://pkg.go.dev/cmd/asm
     #
     # Templates: allowed.
     asmflags:
@@ -43,6 +45,8 @@ builds:
       - all=-trimpath={{.Env.GOPATH}}
 
     # Custom gcflags.
+    # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Compile_packages_and_dependencies
+    # and https://pkg.go.dev/cmd/compile
     #
     # Templates: allowed.
     gcflags:
@@ -50,6 +54,8 @@ builds:
       - ./dontoptimizeme=-N
 
     # Custom ldflags.
+    # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Compile_packages_and_dependencies
+    # and https://pkg.go.dev/cmd/link 
     #
     # Default: '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser'.
     # Templates: allowed.
@@ -58,6 +64,7 @@ builds:
       - ./usemsan=-msan
 
     # Custom Go build mode.
+    # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Build_modes
     #
     # Valid options:
     # - `c-shared`
@@ -66,6 +73,7 @@ builds:
     buildmode: c-shared
 
     # Custom build tags templates.
+    # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Build_constraints
     tags:
       - osusergo
       - netgo
@@ -74,6 +82,7 @@ builds:
 
     # Custom environment variables to be set during the builds.
     # Invalid environment variables will be ignored.
+    # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Environment_variables
     #
     # Default: os.Environ() ++ env config section.
     # Templates: allowed.

--- a/www/docs/customization/builds.md
+++ b/www/docs/customization/builds.md
@@ -90,7 +90,7 @@ builds:
         {{- end }}
 
     # GOOS list to build for.
-    # For more info refer to: https://go.dev/doc/install/source#environment
+    # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Environment_variables
     #
     # Default: [ 'darwin', 'linux', 'windows' ].
     goos:
@@ -98,7 +98,7 @@ builds:
       - windows
 
     # GOARCH to build for.
-    # For more info refer to: https://go.dev/doc/install/source#environment
+    # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Environment_variables
     #
     # Default: [ '386', 'amd64', 'arm64' ].
     goarch:
@@ -107,7 +107,7 @@ builds:
       - arm64
 
     # GOARM to build for when GOARCH is arm.
-    # For more info refer to: https://go.dev/doc/install/source#environment
+    # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Environment_variables
     #
     # Default: [ 6 ].
     goarm:
@@ -115,7 +115,7 @@ builds:
       - 7
 
     # GOAMD64 to build when GOARCH is amd64.
-    # For more info refer to: https://go.dev/doc/install/source#environment
+    # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Environment_variables
     #
     # Default: [ 'v1' ].
     goamd64:
@@ -123,7 +123,7 @@ builds:
       - v3
 
     # GOARM64 to build when GOARCH is arm64.
-    # For more info refer to: https://go.dev/doc/install/source#environment
+    # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Environment_variables
     #
     # Default: [ 'v8.0' ].
     # <!-- md:inline_version v2.4 -->.
@@ -131,7 +131,7 @@ builds:
       - v9.0
 
     # GOMIPS and GOMIPS64 to build when GOARCH is mips, mips64, mipsle or mips64le.
-    # For more info refer to: https://go.dev/doc/install/source#environment
+    # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Environment_variables
     #
     # Default: [ 'hardfloat' ].
     # <!-- md:inline_version v2.4 -->.
@@ -140,7 +140,7 @@ builds:
       - softfloat
 
     # GO386 to build when GOARCH is 386.
-    # For more info refer to: https://go.dev/doc/install/source#environment
+    # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Environment_variables
     #
     # Default: [ 'sse2' ].
     # <!-- md:inline_version v2.4 -->.
@@ -149,7 +149,7 @@ builds:
       - softfloat
 
     # GOPPC64 to build when GOARCH is PPC64.
-    # For more info refer to: https://go.dev/doc/install/source#environment
+    # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Environment_variables
     #
     # Default: [ 'power8' ].
     # <!-- md:inline_version v2.4 -->.
@@ -158,7 +158,7 @@ builds:
       - power9
 
     # GORISCV64 to build when GOARCH is RISCV64.
-    # For more info refer to: https://go.dev/doc/install/source#environment
+    # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Environment_variables
     #
     # Default: [ 'rva20u64' ].
     # <!-- md:inline_version v2.4 -->.


### PR DESCRIPTION
Update documentation links.
This doc: https://go.dev/doc/install/source#environment
is about compiling go from source.

This doc https://pkg.go.dev/cmd/go#hdr-Environment_variables
is about go tool (including `go build`).

I feel like the latter is more likely to stay up to date. 
E.g. goamd64 is not documented in the former, and is documented in the latter.

Also, add extra links for relevant build flags documentation. 