### PR TITLE
fix(rust): artifact filter when builder is rust

### DIFF
--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -500,7 +500,7 @@ func ByGoarch(s string) Filter {
 func ByGoarm(s string) Filter {
 	return func(a *Artifact) bool {
 		switch ExtraOr(*a, ExtraBuilder, "") {
-		case "zig":
+		case "zig", "rust":
 			return s == experimental.DefaultGOARM()
 		default:
 			return a.Goarm == s
@@ -512,7 +512,7 @@ func ByGoarm(s string) Filter {
 func ByGoamd64(s string) Filter {
 	return func(a *Artifact) bool {
 		switch ExtraOr(*a, ExtraBuilder, "") {
-		case "zig":
+		case "zig", "rust":
 			return s == "v1"
 		default:
 			return a.Goamd64 == s

--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -63,6 +63,9 @@ func TestFilter(t *testing.T) {
 	zig := map[string]any{
 		ExtraBuilder: "zig",
 	}
+	rust := map[string]any{
+		ExtraBuilder: "rust",
+	}
 	data := []*Artifact{
 		{
 			Name:   "foo",
@@ -78,6 +81,11 @@ func TestFilter(t *testing.T) {
 			Name:   "bar",
 			Goarch: "amd64",
 			Extra:  zig,
+		},
+		{
+			Name:   "bar",
+			Goarch: "amd64",
+			Extra:  rust,
 		},
 		{
 			Name:    "bar",
@@ -103,6 +111,11 @@ func TestFilter(t *testing.T) {
 			Name:   "foobar",
 			Goarch: "arm",
 			Extra:  zig,
+		},
+		{
+			Name:   "foobar",
+			Goarch: "arm",
+			Extra:  rust,
 		},
 		{
 			Name: "check",
@@ -137,24 +150,24 @@ func TestFilter(t *testing.T) {
 	require.Len(t, artifacts.Filter(ByGoos("linux")).items, 1)
 	require.Len(t, artifacts.Filter(ByGoos("darwin")).items, 2)
 
-	require.Len(t, artifacts.Filter(ByGoarch("amd64")).items, 5)
+	require.Len(t, artifacts.Filter(ByGoarch("amd64")).items, 6)
 	require.Empty(t, artifacts.Filter(ByGoarch("386")).items)
 
-	require.Len(t, artifacts.Filter(And(ByGoarch("amd64"), ByGoamd64("v1"))).items, 2)
+	require.Len(t, artifacts.Filter(And(ByGoarch("amd64"), ByGoamd64("v1"))).items, 3)
 	require.Len(t, artifacts.Filter(ByGoamd64("v2")).items, 1)
 	require.Len(t, artifacts.Filter(ByGoamd64("v3")).items, 1)
 	require.Len(t, artifacts.Filter(ByGoamd64("v4")).items, 1)
 
-	require.Len(t, artifacts.Filter(And(ByGoarch("arm"), ByGoarm("6"))).items, 2)
+	require.Len(t, artifacts.Filter(And(ByGoarch("arm"), ByGoarm("6"))).items, 3)
 	require.Empty(t, artifacts.Filter(ByGoarm("7")).items)
 
 	require.Len(t, artifacts.Filter(ByType(Checksum)).items, 2)
 	require.Empty(t, artifacts.Filter(ByType(Binary)).items)
 
-	require.Len(t, artifacts.Filter(OnlyReplacingUnibins).items, 11)
+	require.Len(t, artifacts.Filter(OnlyReplacingUnibins).items, 13)
 	require.Len(t, artifacts.Filter(And(OnlyReplacingUnibins, ByGoos("darwin"))).items, 1)
 
-	require.Len(t, artifacts.Filter(nil).items, 12)
+	require.Len(t, artifacts.Filter(nil).items, 14)
 
 	require.Len(t, artifacts.Filter(
 		And(


### PR DESCRIPTION
rust also doesn't set goamd64 and guarm in the artifacts, it should.