### PR TITLE
fix: don't assume username in tests

### DIFF
--- a/internal/pipe/release/scm_test.go
+++ b/internal/pipe/release/scm_test.go
@@ -71,7 +71,6 @@ func TestSetupGitea(t *testing.T) {
 	t.Run("no repo", func(t *testing.T) {
 		ctx := testctx.New()
 		require.NoError(t, setupGitea(ctx))
-		require.Equal(t, "goreleaser", ctx.Config.Release.Gitea.Owner)
 		require.Equal(t, "goreleaser", ctx.Config.Release.Gitea.Name)
 	})
 
@@ -127,7 +126,6 @@ func TestSetupGitHub(t *testing.T) {
 	t.Run("no repo", func(t *testing.T) {
 		ctx := testctx.New()
 		require.NoError(t, setupGitHub(ctx))
-		require.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Owner)
 		require.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Name)
 	})
 


### PR DESCRIPTION
If the repo is not set then the repo owner is set to the user's name. The tests assume that this username is `goreleaser`, which is not true for most users. This PR removes the assumption that the username is `goreleaser`.

If applied, this commit will help goreleaser's tests pass on other people's machines.

This change being made so I can run goreleaser's tests successfully on my machine, so I can be confident that any failing tests in future PRs that I propose are due to any changes that I made in the PR.

Refs https://github.com/goreleaser/goreleaser/pull/3412.