### PR TITLE
fix: do not return nil if builder is invalid

### DIFF
--- a/pkg/build/fail.go
+++ b/pkg/build/fail.go
@@ -1,0 +1,34 @@
+package build
+
+import (
+	"errors"
+
+	"github.com/goreleaser/goreleaser/v2/pkg/config"
+	"github.com/goreleaser/goreleaser/v2/pkg/context"
+)
+
+var (
+	_ Builder           = failBuilder{}
+	_ DependingBuilder  = failBuilder{}
+	_ PreparedBuilder   = failBuilder{}
+	_ ConcurrentBuilder = failBuilder{}
+	_ TargetFixer       = failBuilder{}
+)
+
+func newFail(name string) failBuilder {
+	return failBuilder{
+		err: errors.New("invalid builder: " + name),
+	}
+}
+
+type failBuilder struct {
+	err error
+}
+
+func (f failBuilder) WithDefaults(b config.Build) (config.Build, error)      { return b, f.err }
+func (f failBuilder) Build(*context.Context, config.Build, Options) error    { return f.err }
+func (f failBuilder) Parse(target string) (Target, error)                    { return nil, f.err }
+func (f failBuilder) Dependencies() []string                                 { return nil }
+func (f failBuilder) Prepare(ctx *context.Context, build config.Build) error { return f.err }
+func (f failBuilder) AllowConcurrentBuilds() bool                            { return false }
+func (f failBuilder) FixTarget(target string) string                         { return "" }

--- a/pkg/build/fail.go
+++ b/pkg/build/fail.go
@@ -25,10 +25,10 @@ type failBuilder struct {
 	err error
 }
 
-func (f failBuilder) WithDefaults(b config.Build) (config.Build, error)      { return b, f.err }
-func (f failBuilder) Build(*context.Context, config.Build, Options) error    { return f.err }
-func (f failBuilder) Parse(target string) (Target, error)                    { return nil, f.err }
-func (f failBuilder) Dependencies() []string                                 { return nil }
-func (f failBuilder) Prepare(ctx *context.Context, build config.Build) error { return f.err }
-func (f failBuilder) AllowConcurrentBuilds() bool                            { return false }
-func (f failBuilder) FixTarget(target string) string                         { return "" }
+func (f failBuilder) WithDefaults(b config.Build) (config.Build, error)   { return b, f.err }
+func (f failBuilder) Build(*context.Context, config.Build, Options) error { return f.err }
+func (f failBuilder) Parse(string) (Target, error)                        { return nil, f.err }
+func (f failBuilder) Dependencies() []string                              { return nil }
+func (f failBuilder) Prepare(*context.Context, config.Build) error        { return f.err }
+func (f failBuilder) AllowConcurrentBuilds() bool                         { return false }
+func (f failBuilder) FixTarget(string) string                             { return "" }

--- a/pkg/build/fail_test.go
+++ b/pkg/build/fail_test.go
@@ -1,0 +1,21 @@
+package build
+
+import (
+	"testing"
+
+	"github.com/goreleaser/goreleaser/v2/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFailBuilder(t *testing.T) {
+	b := newFail("a")
+	_, err := b.WithDefaults(config.Build{})
+	require.EqualError(t, err, b.err.Error())
+	require.EqualError(t, b.Build(nil, config.Build{}, Options{}), b.err.Error())
+	_, err = b.Parse("")
+	require.EqualError(t, err, b.err.Error())
+	require.Empty(t, b.Dependencies())
+	require.EqualError(t, b.Prepare(nil, config.Build{}), b.err.Error())
+	require.False(t, b.AllowConcurrentBuilds())
+	require.Empty(t, b.FixTarget("a"))
+}

--- a/pkg/build/fail_test.go
+++ b/pkg/build/fail_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 func TestFailBuilder(t *testing.T) {
-	b := newFail("a")
+	f := For("a")
+	b, ok := f.(failBuilder)
+	require.True(t, ok)
 	_, err := b.WithDefaults(config.Build{})
 	require.EqualError(t, err, b.err.Error())
 	require.EqualError(t, b.Build(nil, config.Build{}, Options{}), b.err.Error())


### PR DESCRIPTION
this improves error handling when `builds.builder` is invalid.

currently it simply throws a nil pointer deference error.


it also fixes locking the map when reading it as well