### PR TITLE
fix(build): mkdir target dir before building

### DIFF
--- a/internal/builders/rust/build.go
+++ b/internal/builders/rust/build.go
@@ -3,7 +3,6 @@ package rust
 import (
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -193,9 +192,6 @@ func (b *Builder) Build(ctx *context.Context, build config.Build, options api.Op
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(options.Path), 0o755); err != nil {
-		return err
-	}
 	realPath := filepath.Join(build.Dir, "target", t.Target, "release", options.Name)
 	if err := gio.Copy(realPath, options.Path); err != nil {
 		return err

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -98,6 +98,7 @@ func TestBuild(t *testing.T) {
 	}
 	options.Target, err = Default.Parse("aarch64-apple-darwin")
 	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(options.Path), 0o755)) // this happens on internal/pipe/build/ when in prod
 
 	require.NoError(t, Default.Build(ctx, build, options))
 

--- a/internal/builders/zig/build.go
+++ b/internal/builders/zig/build.go
@@ -3,7 +3,6 @@ package zig
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -167,9 +166,6 @@ func (b *Builder) Build(ctx *context.Context, build config.Build, options api.Op
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(options.Path), 0o755); err != nil {
-		return err
-	}
 	realPath := filepath.Join(build.Dir, prefix, "bin", options.Name)
 	if err := gio.Copy(realPath, options.Path); err != nil {
 		return err

--- a/internal/builders/zig/build_test.go
+++ b/internal/builders/zig/build_test.go
@@ -135,6 +135,7 @@ func TestBuild(t *testing.T) {
 	}
 	options.Target, err = Default.Parse("aarch64-macos")
 	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(options.Path), 0o755)) // this happens on internal/pipe/build/ when in prod
 
 	require.NoError(t, Default.Build(ctx, build, options))
 

--- a/internal/pipe/build/build.go
+++ b/internal/pipe/build/build.go
@@ -137,19 +137,26 @@ func buildTarget(ctx *context.Context, build config.Build, target string) error 
 		return err
 	}
 
+	if err := os.MkdirAll(filepath.Dir(opts.Path), 0o755); err != nil { // nolint: gosec
+		return fmt.Errorf("create target directory: %w", err)
+	}
+
 	if !skips.Any(ctx, skips.PreBuildHooks) {
 		if err := runHook(ctx, *opts, build.Env, build.Hooks.Pre); err != nil {
 			return fmt.Errorf("pre hook failed: %w", err)
 		}
 	}
+
 	if err := doBuild(ctx, build, *opts); err != nil {
 		return fmt.Errorf("build failed: %w\ntarget: %s", err, target)
 	}
+
 	if !skips.Any(ctx, skips.PostBuildHooks) {
 		if err := runHook(ctx, *opts, build.Env, build.Hooks.Post); err != nil {
 			return fmt.Errorf("post hook failed: %w", err)
 		}
 	}
+
 	return nil
 }
 

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -64,9 +64,6 @@ func (f *fakeBuilder) Build(ctx *context.Context, _ config.Build, options api.Op
 	if f.fail {
 		return errFailedBuild
 	}
-	if err := os.MkdirAll(filepath.Dir(options.Path), 0o755); err != nil {
-		return err
-	}
 	if err := os.WriteFile(options.Path, []byte("foo"), 0o755); err != nil {
 		return err
 	}
@@ -114,9 +111,7 @@ func TestBuild(t *testing.T) {
 			Commit:     "123",
 		}),
 	)
-	opts, err := buildOptionsForTarget(ctx, ctx.Config.Builds[0], "darwin_amd64")
-	require.NoError(t, err)
-	require.NoError(t, doBuild(ctx, ctx.Config.Builds[0], *opts))
+	require.NoError(t, buildTarget(ctx, ctx.Config.Builds[0], "darwin_amd64"))
 }
 
 func TestRunPipe(t *testing.T) {


### PR DESCRIPTION
Some builders (like tinygo, rust, zig) don't do it, others do. Standarize doing it in pipe/build.
