### PR TITLE
ci(nfpm): suggest builders instead of recommends

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -357,7 +357,7 @@ nfpms:
       - archlinux
     dependencies:
       - git
-    recommends:
+    suggests:
       - golang
       - rustup
       - zig


### PR DESCRIPTION
I think this is probably better so it doesn't install too many things if users forget `--no-install-recommends` or whatever

wdyt?