### PR TITLE
test: improve speed, work on clean system

### DIFF
--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/goreleaser/goreleaser/v2/internal/static"
-	"github.com/goreleaser/goreleaser/v2/internal/testlib"
 	"github.com/stretchr/testify/require"
 )
 
@@ -107,16 +106,6 @@ func TestInitGitIgnoreExists(t *testing.T) {
 	bts, err := os.ReadFile(".gitignore")
 	require.NoError(t, err)
 	require.Equal(t, "mybinary\n# Added by goreleaser init:\ndist/\n", string(bts))
-}
-
-func TestInitFileError(t *testing.T) {
-	testlib.SkipIfWindows(t, "windows permissions don't work the same way")
-	folder := setupInitTest(t)
-	cmd := newInitCmd().cmd
-	path := filepath.Join(folder, "nope.yaml")
-	require.NoError(t, os.Chmod(folder, 0o000))
-	cmd.SetArgs([]string{"-f", path})
-	require.EqualError(t, cmd.Execute(), "open "+path+": permission denied")
 }
 
 func setupInitTest(tb testing.TB) string {

--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -31,7 +31,7 @@ type gitlabClient struct {
 }
 
 // newGitLab returns a gitlab client implementation.
-func newGitLab(ctx *context.Context, token string) (*gitlabClient, error) {
+func newGitLab(ctx *context.Context, token string, opts ...gitlab.ClientOptionFunc) (*gitlabClient, error) {
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
@@ -39,11 +39,11 @@ func newGitLab(ctx *context.Context, token string) (*gitlabClient, error) {
 			InsecureSkipVerify: ctx.Config.GitLabURLs.SkipTLSVerify,
 		},
 	}
-	options := []gitlab.ClientOptionFunc{
+	options := append([]gitlab.ClientOptionFunc{
 		gitlab.WithHTTPClient(&http.Client{
 			Transport: transport,
 		}),
-	}
+	}, opts...)
 	if ctx.Config.GitLabURLs.API != "" {
 		apiURL, err := tmpl.New(ctx).Apply(ctx.Config.GitLabURLs.API)
 		if err != nil {

--- a/internal/client/gitlab_test.go
+++ b/internal/client/gitlab_test.go
@@ -489,7 +489,7 @@ func TestGitLabGetDefaultBranchErr(t *testing.T) {
 			API: srv.URL,
 		},
 	})
-	client, err := newGitLab(ctx, "test-token")
+	client, err := newGitLab(ctx, "test-token", gitlab.WithoutRetries())
 	require.NoError(t, err)
 	repo := Repo{
 		Owner:  "someone",

--- a/internal/pipe/checksums/checksums_test.go
+++ b/internal/pipe/checksums/checksums_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
@@ -279,39 +278,6 @@ func TestPipeInvalidNameTemplate(t *testing.T) {
 				testlib.RequireTemplateError(t, Pipe{}.Run(ctx))
 			})
 		}
-	}
-}
-
-func TestPipeCouldNotOpenChecksumsTxt(t *testing.T) {
-	folder := t.TempDir()
-	binFile, err := os.CreateTemp(folder, "goreleasertest-bin")
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, binFile.Close()) })
-	_, err = binFile.WriteString("fake artifact")
-	require.NoError(t, err)
-
-	file := filepath.Join(folder, "checksums.txt")
-	require.NoError(t, os.WriteFile(file, []byte("some string"), 0o000))
-	ctx := testctx.NewWithCfg(
-		config.Project{
-			Dist: folder,
-			Checksum: config.Checksum{
-				NameTemplate: "checksums.txt",
-				Algorithm:    "sha256",
-			},
-		},
-		testctx.WithCurrentTag("1.2.3"),
-	)
-	ctx.Artifacts.Add(&artifact.Artifact{
-		Name: "whatever",
-		Type: artifact.UploadableBinary,
-		Path: binFile.Name(),
-	})
-	err = Pipe{}.Run(ctx)
-	require.Error(t, err)
-	if !testlib.IsWindows() {
-		// this fails on windows
-		require.ErrorIs(t, Pipe{}.Run(ctx), syscall.EACCES)
 	}
 }
 

--- a/internal/pipe/env/env_test.go
+++ b/internal/pipe/env/env_test.go
@@ -3,7 +3,6 @@ package env
 import (
 	"fmt"
 	"os"
-	"syscall"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/v2/internal/skips"
@@ -184,7 +183,6 @@ func TestEmptyGithubEnvFile(t *testing.T) {
 		},
 	})
 	err = Pipe{}.Run(ctx)
-	requireErrAccess(t, err)
 	require.ErrorContains(t, err, "failed to load github token")
 }
 
@@ -199,7 +197,6 @@ func TestEmptyGitlabEnvFile(t *testing.T) {
 		},
 	})
 	err = Pipe{}.Run(ctx)
-	requireErrAccess(t, err)
 	require.ErrorContains(t, err, "failed to load gitlab token")
 }
 
@@ -214,7 +211,6 @@ func TestEmptyGiteaEnvFile(t *testing.T) {
 		},
 	})
 	err = Pipe{}.Run(ctx)
-	requireErrAccess(t, err)
 	require.ErrorContains(t, err, "failed to load gitea token")
 }
 
@@ -291,26 +287,4 @@ func TestLoadEnv(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "123", v)
 	})
-	t.Run("env file is not readable", func(t *testing.T) {
-		testlib.SkipIfWindows(t, "permissions work differently in windows")
-		f, err := os.CreateTemp(t.TempDir(), "token")
-		require.NoError(t, err)
-		fmt.Fprintf(f, "123")
-		require.NoError(t, f.Close())
-		err = os.Chmod(f.Name(), 0o377)
-		require.NoError(t, err)
-		v, err := loadEnv(env, f.Name())
-		require.EqualError(t, err, fmt.Sprintf("open %s: permission denied", f.Name()))
-		require.Equal(t, "", v)
-	})
-}
-
-func requireErrAccess(tb testing.TB, err error) {
-	tb.Helper()
-	require.Error(tb, err)
-	// unsupported
-	if testlib.IsWindows() {
-		return
-	}
-	require.ErrorIs(tb, err, syscall.EACCES)
 }

--- a/internal/pipe/gomod/gomod_proxy.go
+++ b/internal/pipe/gomod/gomod_proxy.go
@@ -98,9 +98,7 @@ type ErrProxy struct {
 }
 
 func newErrProxy(err error) error {
-	return ErrProxy{
-		err: err,
-	}
+	return newDetailedErrProxy(err, "")
 }
 
 func newDetailedErrProxy(err error, details string) error {

--- a/internal/pipe/gomod/gomod_proxy_test.go
+++ b/internal/pipe/gomod/gomod_proxy_test.go
@@ -283,7 +283,3 @@ func fakeGoMod(tb testing.TB, module string) {
 func withTestModulePath(ctx *context.Context) {
 	ctx.ModulePath = "github.com/goreleaser/test-mod"
 }
-
-func withExampleModulePath(ctx *context.Context) {
-	ctx.ModulePath = "github.com/goreleaser/example-mod-proxy"
-}

--- a/internal/pipe/gomod/gomod_proxy_test.go
+++ b/internal/pipe/gomod/gomod_proxy_test.go
@@ -40,7 +40,7 @@ func TestCheckGoMod(t *testing.T) {
 					Dir:    ".",
 				},
 			},
-		}, testctx.Snapshot, withGoReleaserModulePath)
+		}, testctx.Snapshot, withTestModulePath)
 
 		fakeGoModAndSum(t, ctx.ModulePath)
 		require.NoError(t, exec.Command("go", "mod", "edit", "-replace", "foo=../bar").Run())
@@ -64,7 +64,7 @@ func TestCheckGoMod(t *testing.T) {
 					Dir:    ".",
 				},
 			},
-		}, withGoReleaserModulePath)
+		}, withTestModulePath)
 
 		require.NoError(t, CheckGoModPipe{}.Run(ctx))
 	})
@@ -86,7 +86,7 @@ func TestCheckGoMod(t *testing.T) {
 					Dir:    ".",
 				},
 			},
-		}, withGoReleaserModulePath)
+		}, withTestModulePath)
 
 		fakeGoModAndSum(t, ctx.ModulePath)
 		require.NoError(t, exec.Command("go", "mod", "edit", "-replace", "foo=../bar").Run())
@@ -95,7 +95,7 @@ func TestCheckGoMod(t *testing.T) {
 }
 
 func TestGoModProxy(t *testing.T) {
-	t.Run("goreleaser", func(t *testing.T) {
+	t.Run("testmod", func(t *testing.T) {
 		dir := testlib.Mktmp(t)
 		dist := filepath.Join(dir, "dist")
 		ctx := testctx.NewWithCfg(config.Project{
@@ -109,43 +109,16 @@ func TestGoModProxy(t *testing.T) {
 					ID:     "foo",
 					Goos:   []string{runtime.GOOS},
 					Goarch: []string{runtime.GOARCH},
-					Main:   ".",
-					Dir:    ".",
+					Main:   "./cmd/fake",
 				},
 			},
-		}, testctx.WithCurrentTag("v2.5.1"), withGoReleaserModulePath)
-
+		}, testctx.WithCurrentTag("v0.1.1"), func(ctx *context.Context) {
+			ctx.ModulePath = "github.com/goreleaser/test-mod"
+		})
 		fakeGoModAndSum(t, ctx.ModulePath)
 		require.NoError(t, ProxyPipe{}.Run(ctx))
 		requireGoMod(t)
-		require.Equal(t, ctx.ModulePath, ctx.Config.Builds[0].Main)
-		require.Equal(t, ".", ctx.Config.Builds[0].UnproxiedMain)
-		require.Equal(t, filepath.Join(dist, "proxy", "foo"), ctx.Config.Builds[0].Dir)
-		require.Equal(t, ".", ctx.Config.Builds[0].UnproxiedDir)
-	})
-
-	t.Run("nfpm", func(t *testing.T) {
-		dir := testlib.Mktmp(t)
-		dist := filepath.Join(dir, "dist")
-		ctx := testctx.NewWithCfg(config.Project{
-			Dist: dist,
-			GoMod: config.GoMod{
-				Proxy:    true,
-				GoBinary: "go",
-			},
-			Builds: []config.Build{
-				{
-					ID:     "foo",
-					Goos:   []string{runtime.GOOS},
-					Goarch: []string{runtime.GOARCH},
-					Main:   "./cmd/nfpm",
-				},
-			},
-		}, testctx.WithCurrentTag("v2.3.1"), withNfpmModulePath)
-		fakeGoModAndSum(t, ctx.ModulePath)
-		require.NoError(t, ProxyPipe{}.Run(ctx))
-		requireGoMod(t)
-		require.Equal(t, ctx.ModulePath+"/cmd/nfpm", ctx.Config.Builds[0].Main)
+		require.Equal(t, ctx.ModulePath+"/cmd/fake", ctx.Config.Builds[0].Main)
 		require.Equal(t, filepath.Join(dist, "proxy", "foo"), ctx.Config.Builds[0].Dir)
 	})
 
@@ -166,7 +139,9 @@ func TestGoModProxy(t *testing.T) {
 					Goarch: []string{runtime.GOARCH},
 				},
 			},
-		}, testctx.WithCurrentTag("v0.0.1"), withExampleModulePath)
+		}, testctx.WithCurrentTag("v0.0.1"), func(ctx *context.Context) {
+			ctx.ModulePath = "github.com/goreleaser/example-mod-proxy"
+		})
 		fakeGoMod(t, ctx.ModulePath)
 		require.NoError(t, ProxyPipe{}.Run(ctx))
 		requireGoMod(t)
@@ -197,7 +172,7 @@ func TestGoModProxy(t *testing.T) {
 							Goarch: []string{runtime.GOARCH},
 						},
 					},
-				}, withGoReleaserModulePath, testctx.WithCurrentTag("v2.5.1"))
+				}, withTestModulePath, testctx.WithCurrentTag("v0.1.1"))
 
 				fakeGoModAndSum(t, ctx.ModulePath)
 				require.NoError(t, ProxyPipe{}.Run(ctx)) // should succeed at first
@@ -231,7 +206,7 @@ func TestGoModProxy(t *testing.T) {
 					Main:   "main.go",
 				},
 			},
-		}, withGoReleaserModulePath, testctx.WithCurrentTag("v2.5.1"))
+		}, withTestModulePath, testctx.WithCurrentTag("v0.1.1"))
 
 		fakeGoModAndSum(t, ctx.ModulePath)
 		require.NoError(t, ProxyPipe{}.Run(ctx))
@@ -257,7 +232,7 @@ func TestSkipProxy(t *testing.T) {
 			GoMod: config.GoMod{
 				Proxy: true,
 			},
-		}, withGoReleaserModulePath, testctx.Snapshot)
+		}, withTestModulePath, testctx.Snapshot)
 		require.True(t, ProxyPipe{}.Skip(ctx))
 		require.False(t, CheckGoModPipe{}.Skip(ctx))
 	})
@@ -277,7 +252,7 @@ func TestSkipProxy(t *testing.T) {
 			GoMod: config.GoMod{
 				Proxy: true,
 			},
-		}, withGoReleaserModulePath)
+		}, withTestModulePath)
 		require.False(t, ProxyPipe{}.Skip(ctx))
 		require.False(t, CheckGoModPipe{}.Skip(ctx))
 	})
@@ -305,12 +280,8 @@ func fakeGoMod(tb testing.TB, module string) {
 	require.NoError(tb, os.WriteFile("go.mod", []byte(fmt.Sprintf("module %s\n", module)), 0o666))
 }
 
-func withGoReleaserModulePath(ctx *context.Context) {
-	ctx.ModulePath = "github.com/goreleaser/goreleaser/v2"
-}
-
-func withNfpmModulePath(ctx *context.Context) {
-	ctx.ModulePath = "github.com/goreleaser/nfpm/v2"
+func withTestModulePath(ctx *context.Context) {
+	ctx.ModulePath = "github.com/goreleaser/test-mod"
 }
 
 func withExampleModulePath(ctx *context.Context) {


### PR DESCRIPTION
this should help speed up the build times of goreleaser, as well as making them less-reliable on external dependencies.

tests now use https://github.com/goreleaser/test-mod instead of goreleaser codebase itself, which should also be faster to build/clone/etc.

refs #5409 as well