### PR TITLE
fix: bygoamd64 and bygoarm not work with anything other than binaries

### DIFF
--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -236,6 +236,7 @@ func create(ctx *context.Context, arch config.Archive, binaries []*artifact.Arti
 		art.Goriscv64 = binaries[0].Goriscv64
 		art.Target = binaries[0].Target
 		art.Extra[artifact.ExtraReplaces] = binaries[0].Extra[artifact.ExtraReplaces]
+		art.Extra[artifact.ExtraBuilder] = binaries[0].Extra[artifact.ExtraBuilder]
 	}
 
 	ctx.Artifacts.Add(art)
@@ -282,6 +283,7 @@ func skip(ctx *context.Context, archive config.Archive, binaries []*artifact.Art
 				artifact.ExtraFormat:   archive.Format,
 				artifact.ExtraBinary:   binary.Name,
 				artifact.ExtraReplaces: binaries[0].Extra[artifact.ExtraReplaces],
+				artifact.ExtraBuilder:  binaries[0].Extra[artifact.ExtraBuilder],
 			},
 		})
 	}

--- a/internal/pipe/archive/archive_test.go
+++ b/internal/pipe/archive/archive_test.go
@@ -442,8 +442,9 @@ func TestRunPipeBinary(t *testing.T) {
 		Path:   filepath.Join(dist, "darwinamd64", "mybin"),
 		Type:   artifact.Binary,
 		Extra: map[string]interface{}{
-			artifact.ExtraBinary: "mybin",
-			artifact.ExtraID:     "default",
+			artifact.ExtraBinary:  "mybin",
+			artifact.ExtraID:      "default",
+			artifact.ExtraBuilder: "rust",
 		},
 	})
 	ctx.Artifacts.Add(&artifact.Artifact{
@@ -456,6 +457,7 @@ func TestRunPipeBinary(t *testing.T) {
 			artifact.ExtraBinary:   "myunibin",
 			artifact.ExtraID:       "default",
 			artifact.ExtraReplaces: true,
+			artifact.ExtraBuilder:  "rust",
 		},
 	})
 	ctx.Artifacts.Add(&artifact.Artifact{
@@ -495,6 +497,7 @@ func TestRunPipeBinary(t *testing.T) {
 		artifact.ByGoarch("all"),
 	)).List()[0]
 	require.True(t, artifact.ExtraOr(*darwinUniversal, artifact.ExtraReplaces, false))
+	require.NotEmpty(t, artifact.ExtraOr(*darwinUniversal, artifact.ExtraBuilder, ""))
 	windows := binaries.Filter(artifact.ByGoos("windows")).List()[0]
 	windows2 := binaries.Filter(artifact.ByGoos("windows")).List()[1]
 	require.Equal(t, "mybin_0.0.1_darwin_amd64", darwinThin.Name)

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -1388,6 +1388,7 @@ func TestRunPipeUniversalBinary(t *testing.T) {
 			artifact.ExtraFormat:   "tar.gz",
 			artifact.ExtraBinaries: []string{"unibin"},
 			artifact.ExtraReplaces: true,
+			artifact.ExtraBuilder:  "rust",
 		},
 	})
 
@@ -1435,16 +1436,16 @@ func TestRunPipeUniversalBinaryNotReplacing(t *testing.T) {
 	)
 	path := filepath.Join(folder, "bin.tar.gz")
 	ctx.Artifacts.Add(&artifact.Artifact{
-		Name:    "bin_amd64.tar.gz",
-		Path:    path,
-		Goos:    "darwin",
-		Goarch:  "amd64",
-		Goamd64: "v1",
-		Type:    artifact.UploadableArchive,
+		Name:   "bin_amd64.tar.gz",
+		Path:   path,
+		Goos:   "darwin",
+		Goarch: "amd64",
+		Type:   artifact.UploadableArchive,
 		Extra: map[string]interface{}{
 			artifact.ExtraID:       "unibin",
 			artifact.ExtraFormat:   "tar.gz",
 			artifact.ExtraBinaries: []string{"unibin"},
+			artifact.ExtraBuilder:  "rust",
 		},
 	})
 	ctx.Artifacts.Add(&artifact.Artifact{
@@ -1471,6 +1472,7 @@ func TestRunPipeUniversalBinaryNotReplacing(t *testing.T) {
 			artifact.ExtraFormat:   "tar.gz",
 			artifact.ExtraBinaries: []string{"unibin"},
 			artifact.ExtraReplaces: false,
+			artifact.ExtraBuilder:  "zig",
 		},
 	})
 

--- a/internal/pipe/krew/krew_test.go
+++ b/internal/pipe/krew/krew_test.go
@@ -485,16 +485,16 @@ func TestRunPipeUniversalBinaryNotReplacing(t *testing.T) {
 	)
 	path := filepath.Join(folder, "bin.tar.gz")
 	ctx.Artifacts.Add(&artifact.Artifact{
-		Name:    "unibin_amd64.tar.gz",
-		Path:    path,
-		Goos:    "darwin",
-		Goarch:  "amd64",
-		Goamd64: "v1",
-		Type:    artifact.UploadableArchive,
+		Name:   "unibin_amd64.tar.gz",
+		Path:   path,
+		Goos:   "darwin",
+		Goarch: "amd64",
+		Type:   artifact.UploadableArchive,
 		Extra: map[string]interface{}{
 			artifact.ExtraID:       "unibin",
 			artifact.ExtraFormat:   "tar.gz",
 			artifact.ExtraBinaries: []string{"unibin"},
+			artifact.ExtraBuilder:  "rust",
 		},
 	})
 	ctx.Artifacts.Add(&artifact.Artifact{

--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -559,10 +559,11 @@ func create(ctx *context.Context, fpm config.NFPM, format string, artifacts []*a
 		Gomips:  artifacts[0].Gomips,
 		Goamd64: artifacts[0].Goamd64,
 		Extra: map[string]interface{}{
-			artifact.ExtraID:     fpm.ID,
-			artifact.ExtraFormat: format,
-			artifact.ExtraExt:    "." + format,
-			extraFiles:           contents,
+			artifact.ExtraID:      fpm.ID,
+			artifact.ExtraFormat:  format,
+			artifact.ExtraExt:     "." + format,
+			artifact.ExtraBuilder: artifacts[0].Extra[artifact.ExtraBuilder],
+			extraFiles:            contents,
 		},
 	})
 	return nil

--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -437,7 +437,8 @@ func create(ctx *context.Context, snap config.Snapcraft, arch string, binaries [
 		Goriscv64: binaries[0].Goriscv64,
 		Target:    binaries[0].Target,
 		Extra: map[string]interface{}{
-			releasesExtra: channels,
+			releasesExtra:         channels,
+			artifact.ExtraBuilder: binaries[0].Extra[artifact.ExtraBuilder],
 		},
 	})
 	return nil

--- a/internal/pipe/universalbinary/universalbinary_test.go
+++ b/internal/pipe/universalbinary/universalbinary_test.go
@@ -238,8 +238,9 @@ func TestRun(t *testing.T) {
 			Goarch: arch,
 			Type:   artifact.Binary,
 			Extra: map[string]interface{}{
-				artifact.ExtraBinary: "fake",
-				artifact.ExtraID:     "foo",
+				artifact.ExtraBinary:  "fake",
+				artifact.ExtraID:      "foo",
+				artifact.ExtraBuilder: "go",
 			},
 		}
 		ctx1.Artifacts.Add(&art)
@@ -254,8 +255,9 @@ func TestRun(t *testing.T) {
 			Goarch: arch,
 			Type:   artifact.Binary,
 			Extra: map[string]interface{}{
-				artifact.ExtraBinary: "fake",
-				artifact.ExtraID:     "foo",
+				artifact.ExtraBinary:  "fake",
+				artifact.ExtraID:      "foo",
+				artifact.ExtraBuilder: "rust",
 			},
 		})
 	}
@@ -266,6 +268,7 @@ func TestRun(t *testing.T) {
 		require.Len(t, unis, 1)
 		checkUniversalBinary(t, unis[0])
 		require.Equal(t, "foobar", unis[0].ID())
+		require.NotEmpty(t, artifact.ExtraOr(*unis[0], artifact.ExtraBuilder, ""))
 	})
 
 	t.Run("replacing", func(t *testing.T) {
@@ -275,6 +278,7 @@ func TestRun(t *testing.T) {
 		require.Len(t, unis, 1)
 		checkUniversalBinary(t, unis[0])
 		require.True(t, artifact.ExtraOr(*unis[0], artifact.ExtraReplaces, false))
+		require.NotEmpty(t, artifact.ExtraOr(*unis[0], artifact.ExtraBuilder, ""))
 	})
 
 	t.Run("keeping", func(t *testing.T) {
@@ -284,6 +288,7 @@ func TestRun(t *testing.T) {
 		require.Len(t, unis, 1)
 		checkUniversalBinary(t, unis[0])
 		require.False(t, artifact.ExtraOr(*unis[0], artifact.ExtraReplaces, true))
+		require.NotEmpty(t, artifact.ExtraOr(*unis[0], artifact.ExtraBuilder, ""))
 	})
 
 	t.Run("bad template", func(t *testing.T) {


### PR DESCRIPTION
in `artifact.ByGoAmd64` and `artifact.ByGoArm` we check for the artifact's builder, and if its not go, and we're filtering by the default, we just let it pass.

problem is we weren't setting the builder every where.

closes #5439
