### PR TITLE
fix: target filter byamd64 and byarm

### DIFF
--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -500,7 +500,7 @@ func ByGoarch(s string) Filter {
 func ByGoarm(s string) Filter {
 	return func(a *Artifact) bool {
 		return s == a.Goarm ||
-			(a.Goarm == "" && s == experimental.DefaultGOARM())
+			(a.Goarch == "arm" && a.Goarm == "" && s == experimental.DefaultGOARM())
 	}
 }
 
@@ -508,7 +508,7 @@ func ByGoarm(s string) Filter {
 func ByGoamd64(s string) Filter {
 	return func(a *Artifact) bool {
 		return s == a.Goamd64 ||
-			(a.Goamd64 == "" && s == "v1")
+			(a.Goarch == "amd64" && a.Goamd64 == "" && s == "v1")
 	}
 }
 

--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -499,24 +499,16 @@ func ByGoarch(s string) Filter {
 // ByGoarm is a predefined filter that filters by the given goarm.
 func ByGoarm(s string) Filter {
 	return func(a *Artifact) bool {
-		switch ExtraOr(*a, ExtraBuilder, "") {
-		case "go", "": // empty is usually tests
-			return s == a.Goarm
-		default:
-			return s == experimental.DefaultGOARM()
-		}
+		return s == a.Goarm ||
+			(a.Goarm == "" && s == experimental.DefaultGOARM())
 	}
 }
 
 // ByGoamd64 is a predefined filter that filters by the given goamd64.
 func ByGoamd64(s string) Filter {
 	return func(a *Artifact) bool {
-		switch ExtraOr(*a, ExtraBuilder, "") {
-		case "go", "": // empty is usually tests
-			return s == a.Goamd64
-		default:
-			return s == "v1"
-		}
+		return s == a.Goamd64 ||
+			(a.Goamd64 == "" && s == "v1")
 	}
 }
 

--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -60,18 +60,6 @@ func TestAdd(t *testing.T) {
 }
 
 func TestFilter(t *testing.T) {
-	zig := map[string]any{
-		ExtraBuilder: "zig",
-	}
-	bun := map[string]any{
-		ExtraBuilder: "bun",
-	}
-	deno := map[string]any{
-		ExtraBuilder: "deno",
-	}
-	rust := map[string]any{
-		ExtraBuilder: "rust",
-	}
 	data := []*Artifact{
 		{
 			Name:   "foo",
@@ -86,22 +74,6 @@ func TestFilter(t *testing.T) {
 		{
 			Name:   "bar",
 			Goarch: "amd64",
-			Extra:  zig,
-		},
-		{
-			Name:   "bar",
-			Goarch: "amd64",
-			Extra:  rust,
-		},
-		{
-			Name:   "bar",
-			Goarch: "amd64",
-			Extra:  bun,
-		},
-		{
-			Name:   "bar",
-			Goarch: "amd64",
-			Extra:  deno,
 		},
 		{
 			Name:    "bar",
@@ -126,22 +98,6 @@ func TestFilter(t *testing.T) {
 		{
 			Name:   "foobar",
 			Goarch: "arm",
-			Extra:  zig,
-		},
-		{
-			Name:   "foobar",
-			Goarch: "arm",
-			Extra:  rust,
-		},
-		{
-			Name:   "foobar",
-			Goarch: "arm",
-			Extra:  bun,
-		},
-		{
-			Name:   "foobar",
-			Goarch: "arm",
-			Extra:  deno,
 		},
 		{
 			Name: "check",
@@ -176,24 +132,24 @@ func TestFilter(t *testing.T) {
 	require.Len(t, artifacts.Filter(ByGoos("linux")).items, 1)
 	require.Len(t, artifacts.Filter(ByGoos("darwin")).items, 2)
 
-	require.Len(t, artifacts.Filter(ByGoarch("amd64")).items, 8)
+	require.Len(t, artifacts.Filter(ByGoarch("amd64")).items, 5)
 	require.Empty(t, artifacts.Filter(ByGoarch("386")).items)
 
-	require.Len(t, artifacts.Filter(And(ByGoarch("amd64"), ByGoamd64("v1"))).items, 5)
+	require.Len(t, artifacts.Filter(And(ByGoarch("amd64"), ByGoamd64("v1"))).items, 2)
 	require.Len(t, artifacts.Filter(ByGoamd64("v2")).items, 1)
 	require.Len(t, artifacts.Filter(ByGoamd64("v3")).items, 1)
 	require.Len(t, artifacts.Filter(ByGoamd64("v4")).items, 1)
 
-	require.Len(t, artifacts.Filter(And(ByGoarch("arm"), ByGoarm("6"))).items, 5)
+	require.Len(t, artifacts.Filter(And(ByGoarch("arm"), ByGoarm("6"))).items, 3)
 	require.Empty(t, artifacts.Filter(ByGoarm("7")).items)
 
 	require.Len(t, artifacts.Filter(ByType(Checksum)).items, 2)
 	require.Empty(t, artifacts.Filter(ByType(Binary)).items)
 
-	require.Len(t, artifacts.Filter(OnlyReplacingUnibins).items, 17)
+	require.Len(t, artifacts.Filter(OnlyReplacingUnibins).items, 11)
 	require.Len(t, artifacts.Filter(And(OnlyReplacingUnibins, ByGoos("darwin"))).items, 1)
 
-	require.Len(t, artifacts.Filter(nil).items, 18)
+	require.Len(t, artifacts.Filter(nil).items, 12)
 
 	require.Len(t, artifacts.Filter(
 		And(

--- a/internal/pipe/nix/nix.go
+++ b/internal/pipe/nix/nix.go
@@ -18,6 +18,7 @@ import (
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/client"
 	"github.com/goreleaser/goreleaser/v2/internal/commitauthor"
+	"github.com/goreleaser/goreleaser/v2/internal/experimental"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe"
 	"github.com/goreleaser/goreleaser/v2/internal/skips"
 	"github.com/goreleaser/goreleaser/v2/internal/tmpl"
@@ -308,6 +309,9 @@ func preparePkg(
 			data.SourceRoots[key] = folder
 			data.Archives[key] = archive
 			plat := goosToPlatform[art.Goos+goarch+art.Goarm]
+			if plat == "" {
+				return "", errors.New("invalid platform: " + art.Goos + goarch + art.Goarm)
+			}
 			platforms[plat] = true
 		}
 	}
@@ -330,6 +334,7 @@ func expandGoarch(goarch string) []string {
 var goosToPlatform = map[string]string{
 	"linuxamd64":  "x86_64-linux",
 	"linuxarm64":  "aarch64-linux",
+	"linuxarm":    "armv" + experimental.DefaultGOARM() + "l-linux",
 	"linuxarm6":   "armv6l-linux",
 	"linuxarm7":   "armv7l-linux",
 	"linux386":    "i686-linux",

--- a/internal/pipe/nix/testdata/TestRunPipe/unibin-replaces_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/unibin-replaces_build.nix.golden
@@ -53,6 +53,7 @@ stdenvNoCC.mkDerivation {
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"
+      "armv6l-linux"
       "i686-linux"
       "x86_64-darwin"
       "x86_64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/unibin-replaces_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/unibin-replaces_publish.nix.golden
@@ -53,6 +53,7 @@ stdenvNoCC.mkDerivation {
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"
+      "armv6l-linux"
       "i686-linux"
       "x86_64-darwin"
       "x86_64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/zip-with-dependencies_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip-with-dependencies_build.nix.golden
@@ -57,6 +57,7 @@ stdenvNoCC.mkDerivation {
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"
+      "armv6l-linux"
       "i686-linux"
       "x86_64-darwin"
       "x86_64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/zip-with-dependencies_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip-with-dependencies_publish.nix.golden
@@ -57,6 +57,7 @@ stdenvNoCC.mkDerivation {
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"
+      "armv6l-linux"
       "i686-linux"
       "x86_64-darwin"
       "x86_64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/zip_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip_build.nix.golden
@@ -54,6 +54,7 @@ stdenvNoCC.mkDerivation {
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"
+      "armv6l-linux"
       "i686-linux"
       "x86_64-darwin"
       "x86_64-linux"

--- a/internal/pipe/nix/testdata/TestRunPipe/zip_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip_publish.nix.golden
@@ -54,6 +54,7 @@ stdenvNoCC.mkDerivation {
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"
+      "armv6l-linux"
       "i686-linux"
       "x86_64-darwin"
       "x86_64-linux"

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -34,6 +34,7 @@ func TestRunCommand(t *testing.T) {
 
 	t.Run("cmd with output", func(t *testing.T) {
 		testlib.SkipIfWindows(t, "what would be a similar behavior in windows?")
+		testlib.CheckPath(t, "sh")
 		require.EqualError(
 			t,
 			shell.Run(testctx.New(), "", []string{"sh", "-c", `echo something; exit 1`}, []string{}, true),
@@ -43,6 +44,8 @@ func TestRunCommand(t *testing.T) {
 
 	t.Run("with env and dir", func(t *testing.T) {
 		testlib.SkipIfWindows(t, "what would be a similar behavior in windows?")
+		testlib.CheckPath(t, "sh")
+		testlib.CheckPath(t, "touch")
 		dir := t.TempDir()
 		require.NoError(t, shell.Run(testctx.New(), dir, []string{"sh", "-c", "touch $FOO"}, []string{"FOO=bar"}, false))
 		require.FileExists(t, filepath.Join(dir, "bar"))


### PR DESCRIPTION
this is an alternative implementation of #5440.

I think this is better, actually. We don't really need to care about the builder, if goamd64 is not set in the artifact, we can safely assume it's not a go build.

this is also simpler and less error-prone.

closes #5440 
closes #5439 