### PR TITLE
fix: build --single-target infer target from runtime

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -56,7 +56,7 @@ Its intended usage is, for example, within Makefiles to avoid setting up ldflags
 
 It also allows you to generate a local build for your current machine only using the ` + "`--single-target`" + ` option, and specific build IDs using the ` + "`--id`" + ` option in case you have more than one.
 
-When using ` + "`--single-target`" + `, the ` + "`GOOS`, `GOARCH`, `GOARM`, `GOAMD64`, `GOARM64`, `GORISCV64`, `GO386`, `GOPPC64`, and `GOMIPS`" + ` environment variables are used to determine the target, defaulting to the current machine target if not set.
+When using ` + "`--single-target`" + `, you use the ` + "`TARGET`, or GOOS`, `GOARCH`, `GOARM`, `GOAMD64`, `GOARM64`, `GORISCV64`, `GO386`, `GOPPC64`, and `GOMIPS`" + ` environment variables to determine the target, defaulting to the current machine target if not set.
 `,
 		SilenceUsage:      true,
 		SilenceErrors:     true,

--- a/internal/pipe/partial/partial.go
+++ b/internal/pipe/partial/partial.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"os"
 	"runtime"
+	"slices"
 	"strings"
 
+	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
 )
 
@@ -24,7 +26,9 @@ func (Pipe) Run(ctx *context.Context) error {
 	for _, b := range ctx.Config.Builds {
 		if b.Builder == "go" {
 			ctx.PartialTarget = getGoEnvFilter()
+			break
 		}
+		ctx.PartialTarget = findRuntime(b.Targets)
 	}
 
 	if ctx.PartialTarget == "" {
@@ -63,4 +67,45 @@ func getGoEnvFilter() string {
 		}
 	}
 	return target
+}
+
+// best effort figuring out the translation tables here, we support only the most common ones...
+var goosToOthers = map[string][]string{
+	"darwin":  {"macos", "darwin"},
+	"linux":   {"linux"},
+	"windows": {"windows"},
+}
+
+var goarchToOthers = map[string][]string{
+	"arm64": {"aarch64"},
+	"amd64": {"x86_64"},
+	"386":   {"i686", "i586", "i386"},
+}
+
+func findRuntime(targets []string) string {
+	goos := cmp.Or(os.Getenv("GGOOS"), os.Getenv("GOOS"), runtime.GOOS)
+	goarch := cmp.Or(os.Getenv("GGOARCH"), os.Getenv("GOARCH"), runtime.GOARCH)
+
+	oses := goosToOthers[goos]
+	arches := goarchToOthers[goarch]
+
+	for _, target := range targets {
+		parts := strings.Split(target, "-")
+		if hasAny(oses, parts) && hasAny(arches, parts) {
+			log.Infof("using %s based on runtime", target)
+			return target
+		}
+	}
+
+	// not found
+	return ""
+}
+
+func hasAny(s1, s2 []string) bool {
+	for _, s := range s1 {
+		if slices.Contains(s2, s) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/pipe/partial/partial_test.go
+++ b/internal/pipe/partial/partial_test.go
@@ -184,4 +184,41 @@ func TestRun(t *testing.T) {
 		target := fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH)
 		require.Equal(t, target, ctx.PartialTarget)
 	})
+
+	t.Run("using runtime with other languages", func(t *testing.T) {
+		t.Setenv("GGOOS", "darwin")
+		t.Setenv("GGOARCH", "amd64")
+		ctx := testctx.NewWithCfg(config.Project{
+			Dist: "dist",
+			Builds: []config.Build{{
+				Builder: "rust",
+				Targets: []string{
+					"x86_64-unknown-linux-gnu",
+					"x86_64-apple-darwin",
+					"x86_64-pc-windows-gnu",
+					"aarch64-unknown-linux-gnu",
+					"aarch64-apple-darwin",
+				},
+			}},
+		}, testctx.Partial)
+		require.NoError(t, pipe.Run(ctx))
+		require.Equal(t, "x86_64-apple-darwin", ctx.PartialTarget)
+	})
+
+	t.Run("using runtime with other languages no match", func(t *testing.T) {
+		t.Setenv("GGOOS", "darwin")
+		t.Setenv("GGOARCH", "amd64")
+		ctx := testctx.NewWithCfg(config.Project{
+			Dist: "dist",
+			Builds: []config.Build{{
+				Builder: "rust",
+				Targets: []string{
+					"x86_64-unknown-linux-gnu",
+					"aarch64-unknown-linux-gnu",
+				},
+			}},
+		}, testctx.Partial)
+		require.Error(t, pipe.Run(ctx))
+		require.Empty(t, ctx.PartialTarget)
+	})
 }


### PR DESCRIPTION
This works with Go already, but not with other languages. This PR adds a best-effort thingy to try to figure it out, based on common target patterns and names.

This should allow users to run `goreleaser build --single-target` with any language supported by goreleaser on most machines!
