### PR TITLE
feat(build): support solaris/sparc and solaris/sparc64 in golang builder

### DIFF
--- a/internal/builders/buildtarget/targets.go
+++ b/internal/builders/buildtarget/targets.go
@@ -2,6 +2,9 @@
 // goos, goarch, goarm, goamd64, gomips and go version.
 package buildtarget
 
+// TODO: move this to internal/builders/golang, as it actually is related to
+// and used in the go builder only.
+
 import (
 	"fmt"
 	"regexp"
@@ -237,6 +240,8 @@ var (
 		"plan9amd64",
 		"plan9arm",
 		"solarisamd64",
+		"solarissparc",
+		"solarissparc64",
 		"windowsarm",
 		"windowsarm64",
 		"windows386",
@@ -276,6 +281,8 @@ var (
 		"wasm",
 		"riscv64",
 		"loong64",
+		"sparc",
+		"sparc64",
 	}
 
 	validGoamd64   = []string{"v1", "v2", "v3", "v4"}

--- a/internal/builders/buildtarget/targets_test.go
+++ b/internal/builders/buildtarget/targets_test.go
@@ -247,6 +247,8 @@ func TestGoosGoarchCombos(t *testing.T) {
 		{"plan9", "amd64", true},
 		{"plan9", "arm", true},
 		{"solaris", "amd64", true},
+		{"solaris", "sparc", true},
+		{"solaris", "sparc64", true},
 		{"windows", "386", true},
 		{"windows", "amd64", true},
 		{"windows", "arm", true},


### PR DESCRIPTION
closes #5444

it seems that it'll be in go 1.24... I think its fine to merge it earlier?