### PR TITLE
test: improve stability of some tests

### DIFF
--- a/internal/pipe/blob/blob_minio_test.go
+++ b/internal/pipe/blob/blob_minio_test.go
@@ -29,7 +29,7 @@ const (
 var listen string
 
 func TestMain(m *testing.M) {
-	if !testlib.InPath("docker") || testlib.IsWindows() {
+	if !testlib.InPath("docker") || testlib.IsWindows() || !testlib.IsDockerRunning() {
 		// there's no minio windows image
 		m.Run()
 		return
@@ -75,7 +75,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestMinioUpload(t *testing.T) {
-	testlib.CheckPath(t, "docker")
+	testlib.CheckDocker(t)
 	testlib.SkipIfWindows(t, "minio image not available for windows")
 	name := "basic"
 	directory := t.TempDir()
@@ -182,7 +182,7 @@ func TestMinioUpload(t *testing.T) {
 }
 
 func TestMinioUploadCustomBucketID(t *testing.T) {
-	testlib.CheckPath(t, "docker")
+	testlib.CheckDocker(t)
 	testlib.SkipIfWindows(t, "minio image not available for windows")
 	name := "fromenv"
 	directory := t.TempDir()
@@ -220,7 +220,7 @@ func TestMinioUploadCustomBucketID(t *testing.T) {
 }
 
 func TestMinioUploadExtraFilesOnly(t *testing.T) {
-	testlib.CheckPath(t, "docker")
+	testlib.CheckDocker(t)
 	testlib.SkipIfWindows(t, "minio image not available for windows")
 	name := "only-extra-files"
 	directory := t.TempDir()
@@ -267,7 +267,7 @@ func TestMinioUploadExtraFilesOnly(t *testing.T) {
 }
 
 func TestMinioUploadRootDirectory(t *testing.T) {
-	testlib.CheckPath(t, "docker")
+	testlib.CheckDocker(t)
 	testlib.SkipIfWindows(t, "minio image not available for windows")
 	name := "rootdir"
 	directory := t.TempDir()
@@ -304,7 +304,7 @@ func TestMinioUploadRootDirectory(t *testing.T) {
 }
 
 func TestMinioUploadInvalidCustomBucketID(t *testing.T) {
-	testlib.CheckPath(t, "docker")
+	testlib.CheckDocker(t)
 	testlib.SkipIfWindows(t, "minio image not available for windows")
 	directory := t.TempDir()
 	tgzpath := filepath.Join(directory, "bin.tar.gz")
@@ -338,7 +338,7 @@ func TestMinioUploadInvalidCustomBucketID(t *testing.T) {
 }
 
 func TestMinioUploadSkip(t *testing.T) {
-	testlib.CheckPath(t, "docker")
+	testlib.CheckDocker(t)
 	testlib.SkipIfWindows(t, "minio image not available for windows")
 	name := "basic"
 	directory := t.TempDir()

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -34,7 +34,7 @@ func start(tb testing.TB) {
 
 // TODO: this test is too big... split in smaller tests? Mainly the manifest ones...
 func TestRunPipe(t *testing.T) {
-	testlib.CheckPath(t, "docker")
+	testlib.CheckDocker(t)
 	testlib.SkipIfWindows(t, "images only available for windows")
 	type errChecker func(*testing.T, error)
 	shouldErr := func(msg string) errChecker {

--- a/internal/pipe/ko/ko_test.go
+++ b/internal/pipe/ko/ko_test.go
@@ -159,7 +159,7 @@ func TestPublishPipeNoMatchingBuild(t *testing.T) {
 
 func TestPublishPipeSuccess(t *testing.T) {
 	testlib.SkipIfWindows(t, "ko doesn't work in windows")
-	testlib.CheckPath(t, "docker")
+	testlib.CheckDocker(t)
 	testlib.StartRegistry(t, "ko_registry1", registry1Port)
 	testlib.StartRegistry(t, "ko_registry2", registry2Port)
 

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -34,20 +34,30 @@ func TestRunCommand(t *testing.T) {
 
 	t.Run("cmd with output", func(t *testing.T) {
 		testlib.SkipIfWindows(t, "what would be a similar behavior in windows?")
-		testlib.CheckPath(t, "sh")
+		err := shell.Run(
+			testctx.New(),
+			".",
+			[]string{"sh", "-c", `echo something; exit 1`},
+			[]string{},
+			true,
+		)
 		require.EqualError(
-			t,
-			shell.Run(testctx.New(), "", []string{"sh", "-c", `echo something; exit 1`}, []string{}, true),
+			t, err,
 			`shell: 'sh -c echo something; exit 1': exit status 1: something`,
 		)
 	})
 
 	t.Run("with env and dir", func(t *testing.T) {
 		testlib.SkipIfWindows(t, "what would be a similar behavior in windows?")
-		testlib.CheckPath(t, "sh")
-		testlib.CheckPath(t, "touch")
 		dir := t.TempDir()
-		require.NoError(t, shell.Run(testctx.New(), dir, []string{"sh", "-c", "touch $FOO"}, []string{"FOO=bar"}, false))
+		err := shell.Run(
+			testctx.New(),
+			dir,
+			[]string{"sh", "-c", `/usr/bin/touch $FOO`},
+			[]string{"FOO=bar"},
+			false,
+		)
+		require.NoError(t, err)
 		require.FileExists(t, filepath.Join(dir, "bar"))
 	})
 }

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -1,6 +1,7 @@
 package shell_test
 
 import (
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -50,10 +51,12 @@ func TestRunCommand(t *testing.T) {
 	t.Run("with env and dir", func(t *testing.T) {
 		testlib.SkipIfWindows(t, "what would be a similar behavior in windows?")
 		dir := t.TempDir()
-		err := shell.Run(
+		touch, err := exec.LookPath("touch")
+		require.NoError(t, err)
+		err = shell.Run(
 			testctx.New(),
 			dir,
-			[]string{"sh", "-c", `/usr/bin/touch $FOO`},
+			[]string{"sh", "-c", touch + " $FOO"},
 			[]string{"FOO=bar"},
 			false,
 		)

--- a/internal/testlib/docker.go
+++ b/internal/testlib/docker.go
@@ -16,12 +16,6 @@ var (
 	dockerPool     *dockertest.Pool
 )
 
-type skipper func(args ...any)
-
-func (s skipper) Fatal(...any) {
-	s("docker is not available")
-}
-
 // CheckDocker skips the test if docker is not running.
 func CheckDocker(tb testing.TB) {
 	tb.Helper()

--- a/internal/testlib/docker.go
+++ b/internal/testlib/docker.go
@@ -1,6 +1,8 @@
 package testlib
 
 import (
+	"os"
+	"os/exec"
 	"sync"
 	"testing"
 
@@ -20,9 +22,21 @@ func (s skipper) Fatal(...any) {
 	s("docker is not available")
 }
 
+// CheckDocker skips the test if docker is not running.
 func CheckDocker(tb testing.TB) {
 	tb.Helper()
-	MustDockerPool(skipper(tb.Skip))
+	CheckPath(tb, "docker")
+	if !IsDockerRunning() {
+		tb.Skip("could not run 'docker ps'")
+	}
+}
+
+// IsDockerRunning executes a `docker ps` and returns true if it succeeds.
+func IsDockerRunning() bool {
+	if os.Getenv("CI") == "true" {
+		return true
+	}
+	return exec.Command("docker", "ps", "-q").Run() == nil
 }
 
 // MustDockerPool gets a single dockertet.Pool.


### PR DESCRIPTION
specially when running locally.

- better checking for docker: check its running, not merely in path
- for some reason `touch` from a `sh` from `go` doesn't not exist even though it totally do exist on my machine? anyway fixing it to `/usr/bin/touch` seems to fix it? May need to look into that in other OSes as well...