### PR TITLE
test: avoid cross-compile in test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
       - name: setup-cargo
         run: |
           rustup default stable
-          cargo bininstall cargo-zigbuild
+          cargo binstall cargo-zigbuild
       - uses: sigstore/cosign-installer@v3.7.0
       - uses: anchore/sbom-action/download-syft@v0.18.0
       - run: task setup

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -86,7 +86,7 @@ func TestBuild(t *testing.T) {
 				Dir:          ".",
 				ModTimestamp: fmt.Sprintf("%d", modTime.Unix()),
 				BuildDetails: config.BuildDetails{
-					Flags: []string{"--locked"},
+					Flags: []string{"--locked", "--release"},
 				},
 			},
 		},
@@ -96,10 +96,9 @@ func TestBuild(t *testing.T) {
 	require.NoError(t, Default.Prepare(ctx, build))
 
 	options := api.Options{
-		Name:   "proj" + maybeExe(target),
-		Path:   filepath.Join("dist", "proj-"+target, "proj") + maybeExe(target),
-		Target: nil,
-		Ext:    maybeExe(target),
+		Name: "proj" + maybeExe(target),
+		Path: filepath.Join("dist", "proj-"+target, "proj") + maybeExe(target),
+		Ext:  maybeExe(target),
 	}
 	options.Target, err = Default.Parse(target)
 	require.NoError(t, err)

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -82,6 +82,11 @@ func TestBuild(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, Default.Prepare(ctx, build))
 
+	target := runtimeTarget()
+	if target == "" {
+		t.Skip("runtime not supported")
+	}
+
 	options := api.Options{
 		Name: "proj" + maybeExe(target),
 		Path: filepath.Join("dist", "proj-"+target, "proj") + maybeExe(target),

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -99,6 +99,7 @@ func TestBuild(t *testing.T) {
 		Name:   "proj",
 		Path:   filepath.Join("dist", "proj-"+target, "proj"),
 		Target: nil,
+		Ext:    maybeExe(target),
 	}
 	options.Target, err = Default.Parse(target)
 	require.NoError(t, err)
@@ -196,4 +197,11 @@ func runtimeTarget() string {
 		"darwin-arm64":  "aarch64-apple-darwin",
 	}
 	return targets[runtime.GOOS+"-"+runtime.GOARCH]
+}
+
+func maybeExe(s string) string {
+	if strings.Contains(s, "windows") {
+		return ".exe"
+	}
+	return ""
 }

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -188,8 +188,8 @@ func TestIsSettingPackage(t *testing.T) {
 
 func runtimeTarget() string {
 	targets := map[string]string{
-		"windows-amd64": "x86_64-pc-windows-gnu",
-		"windows-arm64": "aarch64-pc-windows-gnullvm",
+		"windows-amd64": "x86_64-pc-windows-msvc",
+		"windows-arm64": "aarch64-pc-windows-msvc",
 		"linux-amd64":   "x86_64-unknown-linux-gnu",
 		"linux-arm64":   "aarch64-unknown-linux-gnu",
 		"darwin-amd64":  "x86_64-apple-darwin",

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -180,8 +180,7 @@ func TestIsSettingPackage(t *testing.T) {
 
 func runtimeTarget() string {
 	targets := map[string]string{
-		"windows-amd64": "x86_64-pc-windows-msvc",
-		"windows-arm64": "aarch64-pc-windows-msvc",
+		"windows-arm64": "aarch64-pc-windows-gnu",
 		"linux-amd64":   "x86_64-unknown-linux-gnu",
 		"linux-arm64":   "aarch64-unknown-linux-gnu",
 		"darwin-amd64":  "x86_64-apple-darwin",

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -97,7 +97,7 @@ func TestBuild(t *testing.T) {
 
 	options := api.Options{
 		Name:   "proj",
-		Path:   filepath.Join("dist", "proj-"+target, "proj"),
+		Path:   filepath.Join("dist", "proj-"+target, "proj") + maybeExe(target),
 		Target: nil,
 		Ext:    maybeExe(target),
 	}

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -63,8 +63,11 @@ func TestBuild(t *testing.T) {
 	_, err := exec.Command("cargo", "init", "--bin", "--name=proj").CombinedOutput()
 	require.NoError(t, err)
 
+	target := runtimeTarget()
+
 	for _, s := range []string{
 		"rustup default stable",
+		"rustup target add " + target,
 		"cargo update",
 		"cargo install --locked cargo-zigbuild",
 	} {
@@ -91,8 +94,6 @@ func TestBuild(t *testing.T) {
 	build, err := Default.WithDefaults(ctx.Config.Builds[0])
 	require.NoError(t, err)
 	require.NoError(t, Default.Prepare(ctx, build))
-
-	target := runtimeTarget()
 
 	options := api.Options{
 		Name:   "proj",

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -57,10 +57,6 @@ func TestWithDefaults(t *testing.T) {
 }
 
 func TestBuild(t *testing.T) {
-	// TODO: unskip
-	if testlib.IsCI() && testlib.IsWindows() {
-		t.Skip("recent runner updates broke cargo zigbuild on windows")
-	}
 	testlib.CheckPath(t, "cargo")
 	testlib.CheckPath(t, "cargo-zigbuild")
 	folder := testlib.Mktmp(t)

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -57,6 +57,10 @@ func TestWithDefaults(t *testing.T) {
 }
 
 func TestBuild(t *testing.T) {
+	// TODO: unskip
+	if testlib.IsCI() && testlib.IsWindows() {
+		t.Skip("recent runner updates broke cargo zigbuild on windows")
+	}
 	testlib.CheckPath(t, "cargo")
 	testlib.CheckPath(t, "cargo-zigbuild")
 	folder := testlib.Mktmp(t)
@@ -180,7 +184,7 @@ func TestIsSettingPackage(t *testing.T) {
 
 func runtimeTarget() string {
 	targets := map[string]string{
-		"windows-arm64": "aarch64-pc-windows-gnu",
+		"windows-arm64": "aarch64-pc-windows-msvc",
 		"linux-amd64":   "x86_64-unknown-linux-gnu",
 		"linux-arm64":   "aarch64-unknown-linux-gnu",
 		"darwin-amd64":  "x86_64-apple-darwin",

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -86,7 +86,7 @@ func TestBuild(t *testing.T) {
 				Dir:          ".",
 				ModTimestamp: fmt.Sprintf("%d", modTime.Unix()),
 				BuildDetails: config.BuildDetails{
-					Flags: []string{"--locked", "--release"},
+					Flags: []string{"--locked"},
 				},
 			},
 		},
@@ -96,7 +96,7 @@ func TestBuild(t *testing.T) {
 	require.NoError(t, Default.Prepare(ctx, build))
 
 	options := api.Options{
-		Name:   "proj",
+		Name:   "proj" + maybeExe(target),
 		Path:   filepath.Join("dist", "proj-"+target, "proj") + maybeExe(target),
 		Target: nil,
 		Ext:    maybeExe(target),
@@ -121,7 +121,7 @@ func TestBuild(t *testing.T) {
 
 	bin := bins[0]
 	require.Equal(t, artifact.Artifact{
-		Name:   "proj",
+		Name:   "proj" + maybeExe(target),
 		Path:   filepath.ToSlash(options.Path),
 		Goos:   runtime.GOOS,
 		Goarch: runtime.GOARCH,
@@ -130,7 +130,7 @@ func TestBuild(t *testing.T) {
 		Extra: artifact.Extras{
 			artifact.ExtraBinary:  "proj",
 			artifact.ExtraBuilder: "rust",
-			artifact.ExtraExt:     "",
+			artifact.ExtraExt:     maybeExe(target),
 			artifact.ExtraID:      "default",
 		},
 	}, *bin)

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -121,9 +121,9 @@ func TestBuild(t *testing.T) {
 	require.Equal(t, artifact.Artifact{
 		Name:   "proj",
 		Path:   filepath.ToSlash(options.Path),
-		Goos:   "darwin",
-		Goarch: "arm64",
-		Target: "aarch64-apple-darwin",
+		Goos:   runtime.GOOS,
+		Goarch: runtime.GOARCH,
+		Target: target,
 		Type:   artifact.Binary,
 		Extra: artifact.Extras{
 			artifact.ExtraBinary:  "proj",

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -91,12 +92,14 @@ func TestBuild(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, Default.Prepare(ctx, build))
 
+	target := runtimeTarget()
+
 	options := api.Options{
 		Name:   "proj",
-		Path:   filepath.Join("dist", "proj-aarch64-apple-darwin", "proj"),
+		Path:   filepath.Join("dist", "proj-"+target, "proj"),
 		Target: nil,
 	}
-	options.Target, err = Default.Parse("aarch64-apple-darwin")
+	options.Target, err = Default.Parse(target)
 	require.NoError(t, err)
 	require.NoError(t, os.MkdirAll(filepath.Dir(options.Path), 0o755)) // this happens on internal/pipe/build/ when in prod
 
@@ -180,4 +183,16 @@ func TestIsSettingPackage(t *testing.T) {
 			require.Equal(t, tt.expect, got)
 		})
 	}
+}
+
+func runtimeTarget() string {
+	targets := map[string]string{
+		"windows-amd64": "x86_64-pc-windows-gnu",
+		"windows-arm64": "aarch64-pc-windows-gnullvm",
+		"linux-amd64":   "x86_64-unknown-linux-gnu",
+		"linux-arm64":   "aarch64-unknown-linux-gnu",
+		"darwin-amd64":  "x86_64-apple-darwin",
+		"darwin-arm64":  "aarch64-apple-darwin",
+	}
+	return targets[runtime.GOOS+"-"+runtime.GOARCH]
 }

--- a/internal/testlib/path.go
+++ b/internal/testlib/path.go
@@ -16,9 +16,14 @@ func CheckPath(tb testing.TB, cmd string) {
 	}
 }
 
+// IsCI returns true if we have the "CI" environment variable set to true.
+func IsCI() bool {
+	return os.Getenv("CI") == "true"
+}
+
 // InPath returns true if the given cmd is in the PATH, or if CI is true.
 func InPath(cmd string) bool {
-	if os.Getenv("CI") == "true" {
+	if IsCI() {
 		return true
 	}
 	_, err := exec.LookPath(cmd)


### PR DESCRIPTION
Windows is failing some times, probably the version of something... to avoid it, gonna try to build only for the current runtime platform.
