### PR TITLE
fix(go): build env overrides

### DIFF
--- a/internal/builders/bun/build.go
+++ b/internal/builders/bun/build.go
@@ -133,7 +133,7 @@ func (b *Builder) Build(ctx *context.Context, build config.Build, options api.Op
 		build.Main,
 	)
 
-	tenv, err := common.TemplateEnv(build, tpl)
+	tenv, err := common.TemplateEnv(build.Env, tpl)
 	if err != nil {
 		return err
 	}

--- a/internal/builders/common/common.go
+++ b/internal/builders/common/common.go
@@ -74,20 +74,20 @@ func ChTimes(build config.Build, tpl *tmpl.Template, a *artifact.Artifact) error
 }
 
 // TemplateEnv templates the build.Env and returns it.
-func TemplateEnv(build config.Build, tpl *tmpl.Template) ([]string, error) {
-	var env []string
-	for _, e := range build.Env {
+func TemplateEnv(input []string, tpl *tmpl.Template) ([]string, error) {
+	var output []string
+	for _, e := range input {
 		ee, err := tpl.Apply(e)
 		if err != nil {
 			return nil, err
 		}
 		log.Debugf("env %q evaluated to %q", e, ee)
 		if ee != "" {
-			env = append(env, ee)
+			output = append(output, ee)
 			tpl = tpl.SetEnv(ee)
 		}
 	}
-	return env, nil
+	return output, nil
 }
 
 // Exec executes the given command with the given env in the given dir,

--- a/internal/builders/common/common_test.go
+++ b/internal/builders/common/common_test.go
@@ -144,7 +144,7 @@ func TestTemplateEnv(t *testing.T) {
 		Goos: "linux",
 	})
 
-	got, err := TemplateEnv(build, tpl)
+	got, err := TemplateEnv(build.Env, tpl)
 	require.NoError(t, err)
 	require.Equal(t, []string{
 		"FOO=foobar",

--- a/internal/builders/deno/build.go
+++ b/internal/builders/deno/build.go
@@ -119,7 +119,7 @@ func (b *Builder) Build(ctx *context.Context, build config.Build, options api.Op
 		build.Main,
 	)
 
-	tenv, err := common.TemplateEnv(build, tpl)
+	tenv, err := common.TemplateEnv(build.Env, tpl)
 	if err != nil {
 		return err
 	}

--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -298,16 +298,16 @@ func (*Builder) Build(ctx *context.Context, build config.Build, options api.Opti
 		WithEnvS(env).
 		WithArtifact(a)
 
-	tenv, err := common.TemplateEnv(build, tpl)
+	tenv, err := common.TemplateEnv(details.Env, tpl)
 	if err != nil {
 		return err
 	}
-	env = append(env, tenv...)
 	for _, e := range tenv {
 		if strings.HasPrefix(e, "TEST_") {
 			testEnvs = append(testEnvs, e)
 		}
 	}
+	env = append(env, tenv...)
 	env = append(env, t.env()...)
 	if v := os.Getenv("GOCACHEPROG"); v != "" {
 		env = append(env, "GOCACHEPROG="+v)

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -472,6 +472,15 @@ func TestBuild(t *testing.T) {
 				},
 				Tool:    "{{ .Env.GOBIN }}",
 				Command: "build",
+				BuildDetailsOverrides: []config.BuildDetailsOverride{
+					{
+						Goos:   "linux",
+						Goarch: "amd64",
+						BuildDetails: config.BuildDetails{
+							Env: []string{"TEST_O=1"},
+						},
+					},
+				},
 				BuildDetails: config.BuildDetails{
 					Env: []string{
 						"GO111MODULE=off",
@@ -533,7 +542,7 @@ func TestBuild(t *testing.T) {
 				artifact.ExtraBinary:  "foo-v5.6.7",
 				artifact.ExtraID:      "foo",
 				artifact.ExtraBuilder: "go",
-				"testEnvs":            []string{"TEST_T=l"},
+				"testEnvs":            []string{"TEST_T=l", "TEST_O=1"},
 			},
 		},
 		{

--- a/internal/builders/rust/build.go
+++ b/internal/builders/rust/build.go
@@ -176,7 +176,7 @@ func (b *Builder) Build(ctx *context.Context, build config.Build, options api.Op
 		"--target=" + t.Target,
 	}
 
-	tenv, err := common.TemplateEnv(build, tpl)
+	tenv, err := common.TemplateEnv(build.Env, tpl)
 	if err != nil {
 		return err
 	}

--- a/internal/builders/zig/build.go
+++ b/internal/builders/zig/build.go
@@ -150,7 +150,7 @@ func (b *Builder) Build(ctx *context.Context, build config.Build, options api.Op
 		"-p", prefix,
 	}
 
-	tenv, err := common.TemplateEnv(build, tpl)
+	tenv, err := common.TemplateEnv(build.Env, tpl)
 	if err != nil {
 		return err
 	}

--- a/internal/testlib/artifacts.go
+++ b/internal/testlib/artifacts.go
@@ -14,6 +14,9 @@ func RequireEqualArtifacts(tb testing.TB, expected, got []*artifact.Artifact) {
 	slices.SortFunc(expected, artifactSort)
 	slices.SortFunc(got, artifactSort)
 	require.Equal(tb, filenames(expected), filenames(got))
+	for i := range expected {
+		require.Equal(tb, *expected[i], *got[i], "item %d", i)
+	}
 	require.Equal(tb, expected, got)
 }
 


### PR DESCRIPTION
it was being ignored since a refactor in #5403

closes #5491
