### PR TITLE
refactor: use math/rand/v2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -44,6 +44,8 @@ linters-settings:
         deny:
           - pkg: "github.com/pkg/errors"
             desc: "use stdlib instead"
+          - pkg: "math/rand$"
+            desc: "use math/rand/v2 instead"
   perfsprint:
     int-conversion: false
     err-error: false

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -96,7 +96,7 @@ func TestCheckBodyMaxLength(t *testing.T) {
 	letters := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 	b := make([]rune, maxReleaseBodyLength)
 	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
+		b[i] = letters[rand.N(len(letters))]
 	}
 	out := truncateReleaseBody(string(b))
 	require.Len(t, out, maxReleaseBodyLength)

--- a/internal/pipe/sign/sign_test.go
+++ b/internal/pipe/sign/sign_test.go
@@ -3,13 +3,12 @@ package sign
 import (
 	"bytes"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -38,7 +37,6 @@ const (
 )
 
 func TestMain(m *testing.M) {
-	rand := rand.New(rand.NewSource(time.Now().UnixNano()))
 	keyring = filepath.Join(os.TempDir(), fmt.Sprintf("gorel_gpg_test.%d", rand.Int()))
 	fmt.Println("copying", originKeyring, "to", keyring)
 	if err := gio.Copy(originKeyring, keyring); err != nil {


### PR DESCRIPTION
This PR refactors tests to use [`math/rand/v2`](https://go.dev/blog/randv2) instead of `math/rand`.