### PR TITLE
fix(build): --output completion usage

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -97,7 +97,7 @@ When using ` + "`--single-target`" + `, you use the ` + "`TARGET`, or GOOS`, `GO
 	})
 	cmd.Flags().BoolVar(&root.opts.deprecated, "deprecated", false, "Force print the deprecation message - tests only")
 	cmd.Flags().StringVarP(&root.opts.output, "output", "o", "", "Copy the binary to the path after the build. Only taken into account when using --single-target and a single id (either with --id or if configuration only has one build)")
-	_ = cmd.MarkFlagFilename("output", "")
+	// _ = cmd.MarkFlagFilename("output") // no extensions to filter
 	_ = cmd.Flags().MarkHidden("deprecated")
 
 	cmd.Flags().StringSliceVar(


### PR DESCRIPTION
Passing the empty string as an extension is a functional no-op, but causes actual problems: https://github.com/spf13/cobra/pull/2228

Remove marking the flag as taking filename altogether, as there's no need to do that; cobra comments doing so as a mistake: https://github.com/spf13/cobra/blob/41b26ec8bb59dfba580f722201bf371c4f5703dd/completions.go#L387-L390

Leave MarkFlagFilename in comments so it's clear it's not inadvertently left out.