### PR TITLE
fix(init): prevent init from creating config files with deprecated fields

### DIFF
--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,11 +1,15 @@
 package cmd
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/goreleaser/goreleaser/v2/internal/pipe/defaults"
 	"github.com/goreleaser/goreleaser/v2/internal/static"
+	"github.com/goreleaser/goreleaser/v2/pkg/config"
+	"github.com/goreleaser/goreleaser/v2/pkg/context"
 	"github.com/stretchr/testify/require"
 )
 
@@ -152,4 +156,22 @@ func TestHasDistIgnored(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, string(content), "# Added by goreleaser init:\ndist/\ntarget/\n")
 	})
+}
+
+func checkExample(t *testing.T, exampleConfig []byte) {
+	t.Helper()
+	cfg, err := config.LoadReader(bytes.NewReader(exampleConfig))
+	require.NoError(t, err)
+	ctx := context.New(cfg)
+	err = defaults.Pipe{}.Run(ctx)
+	require.NoError(t, err)
+	require.False(t, ctx.Deprecated)
+}
+
+func TestInitExampleConfigsAreNotDeprecated(t *testing.T) {
+	checkExample(t, static.GoExampleConfig)
+	checkExample(t, static.ZigExampleConfig)
+	checkExample(t, static.BunExampleConfig)
+	checkExample(t, static.DenoExampleConfig)
+	checkExample(t, static.RustExampleConfig)
 }

--- a/internal/static/config.bun.yaml
+++ b/internal/static/config.bun.yaml
@@ -18,7 +18,7 @@ builds:
       - windows-x64-modern
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -29,7 +29,7 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 changelog:
   sort: asc

--- a/internal/static/config.deno.yaml
+++ b/internal/static/config.deno.yaml
@@ -18,7 +18,7 @@ builds:
       - aarch64-unknown-linux-gnu
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -29,7 +29,7 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 changelog:
   sort: asc

--- a/internal/static/config.rust.yaml
+++ b/internal/static/config.rust.yaml
@@ -28,7 +28,7 @@ builds:
       - aarch64-apple-darwin
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -39,7 +39,7 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 changelog:
   sort: asc

--- a/internal/static/config.yaml
+++ b/internal/static/config.yaml
@@ -24,7 +24,7 @@ builds:
       - darwin
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -36,7 +36,7 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 changelog:
   sort: asc

--- a/internal/static/config.zig.yaml
+++ b/internal/static/config.zig.yaml
@@ -20,7 +20,7 @@ builds:
       - aarch64-macos
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -31,7 +31,7 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 changelog:
   sort: asc


### PR DESCRIPTION
I noticed the default example config files were specifying `format` instead of `formats` so I fixed that and added a test to ensure this issue never happens again.

The test checks the default configuration files for deprecated fields.