### PR TITLE
docs: Replace deprecated key kos.repository

### DIFF
--- a/www/docs/customization/ko.md
+++ b/www/docs/customization/ko.md
@@ -163,7 +163,7 @@ builds:
       - arm64
 
 kos:
-  - repository: ghcr.io/caarlos0/test-ko
+  - repositories: [ghcr.io/caarlos0/test-ko]
     tags:
       - "{{.Version}}"
       - latest


### PR DESCRIPTION
The key `kos.repository` has been deprecated in 2.5.

<https://goreleaser.com/deprecations/#kosrepository>

Replaced by `kos.repositories`, which is a list of strings instead of a string.

 But it is still mentioned in this document as a valid example. 

<https://goreleaser.com/customization/ko/>