### PR TITLE
Fix typo in manifest.go

### DIFF
--- a/internal/pipe/docker/manifest.go
+++ b/internal/pipe/docker/manifest.go
@@ -169,6 +169,6 @@ func withDigest(name string, images []*artifact.Artifact) string {
 		}
 	}
 
-	log.Warnf("culd not find %q, did you mean %q?", name, suggestion)
+	log.Warnf("could not find %q, did you mean %q?", name, suggestion)
 	return name
 }


### PR DESCRIPTION
Fixes a small typo in a warning message