### PR TITLE
docs: correct redirect link for the `Name Templates` article

### DIFF
--- a/www/docs/customization/templates.md
+++ b/www/docs/customization/templates.md
@@ -159,7 +159,7 @@ On all fields, you have these available functions:
 | `replace "v1.2" "v" ""`           | replaces all matches. See [ReplaceAll](https://pkg.go.dev/strings#ReplaceAll).                                             |
 | `split "1.2" "."`                 | split string at separator. See [Split](https://pkg.go.dev/strings#Split)                                                   |
 | `time "01/02/2006"`               | current UTC time in the specified format (this is not deterministic, a new time for every call).                           |
-| `contains "foobar" "foo"`         | checks whether the first string contains the second. See [ToLower](https://pkg.go.dev/strings#Contains)                    |
+| `contains "foobar" "foo"`         | checks whether the first string contains the second. See [Contains](https://pkg.go.dev/strings#Contains)                    |
 | `tolower "V1.2"`                  | makes input string lowercase. See [ToLower](https://pkg.go.dev/strings#ToLower).                                           |
 | `toupper "v1.2"`                  | makes input string uppercase. See [ToUpper](https://pkg.go.dev/strings#ToUpper).                                           |
 | `trim " v1.2  "`                  | removes all leading and trailing white space. See [TrimSpace](https://pkg.go.dev/strings#TrimSpace).                       |


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

Set the correct redirect link name for the `contains` description for the Functions description in the `Name Templates` article.

<!-- Why is this change being made? -->

The description for the `contains` func should point to the `Contains` func documentation, not `ToLower`.


<!-- # Provide links to any relevant tickets, URLs or other resources -->
Article link:
- https://goreleaser.com/customization/templates/#functions
