### PR TITLE
feat(changelog): allow to use format when using the git changeloger

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -64,11 +64,11 @@ type Client interface {
 
 // ChangelogItem represents a changelog item, basically, a commit and its author.
 type ChangelogItem struct {
-	SHA            string
-	Message        string
-	AuthorName     string
-	AuthorEmail    string
-	AuthorUsername string
+	SHA            string `json:"sha"`
+	Message        string `json:"message"`
+	AuthorName     string `json:"name"`
+	AuthorEmail    string `json:"email"`
+	AuthorUsername string `json:"-"`
 }
 
 // ReleaseURLTemplater provides the release URL as a template, containing the

--- a/internal/pipe/changelog/changelog.go
+++ b/internal/pipe/changelog/changelog.go
@@ -129,7 +129,7 @@ func applyFormatTo(ctx *context.Context, entries ...client.ChangelogItem) ([]str
 	var lines []string
 	for _, item := range entries {
 		line, err := tmpl.New(ctx).WithExtraFields(tmpl.Fields{
-			"SHA":            abbrev(ctx.Config.Changelog.Abbrev, item.SHA),
+			"SHA":            abbrevEntry(item.SHA, ctx.Config.Changelog.Abbrev),
 			"Message":        item.Message,
 			"AuthorUsername": item.AuthorUsername,
 			"AuthorName":     item.AuthorName,
@@ -167,17 +167,17 @@ func newLineFor(ctx *context.Context) string {
 	return "\n"
 }
 
-func abbrev(l int, sha string) string {
-	switch l {
+func abbrevEntry(sha string, abbr int) string {
+	switch abbr {
 	case 0:
 		return sha
 	case -1:
 		return ""
 	default:
-		if l > len(sha) {
+		if abbr > len(sha) {
 			return sha
 		}
-		return sha[:l]
+		return sha[:abbr]
 	}
 }
 

--- a/internal/pipe/changelog/changelog.go
+++ b/internal/pipe/changelog/changelog.go
@@ -60,19 +60,6 @@ func (Pipe) Default(ctx *context.Context) error {
 			ctx.Config.Changelog.Format = "{{ .SHA }}: {{ .Message }} ({{ with .AuthorUsername }}@{{ . }}{{ else }}{{ .AuthorName }} <{{ .AuthorEmail }}>{{ end }})"
 		}
 	}
-
-	switch ctx.Config.Changelog.Sort {
-	case "", "asc", "desc":
-		// noop
-	default:
-		return ErrInvalidSortDirection
-	}
-
-	for _, g := range ctx.Config.Changelog.Groups {
-		if strings.TrimSpace(g.Title) == "" {
-			return ErrEmptyGroupTitle
-		}
-	}
 	return nil
 }
 
@@ -95,6 +82,10 @@ func (Pipe) Run(ctx *context.Context) error {
 
 	header, err := loadContent(ctx, ctx.ReleaseHeaderFile, ctx.ReleaseHeaderTmpl)
 	if err != nil {
+		return err
+	}
+
+	if err := checkSortDirection(ctx.Config.Changelog.Sort); err != nil {
 		return err
 	}
 
@@ -128,6 +119,9 @@ type changelogGroup struct {
 }
 
 func title(s string, level int) string {
+	if s == "" {
+		return ""
+	}
 	return fmt.Sprintf("%s %s", strings.Repeat("#", level), s)
 }
 
@@ -237,6 +231,15 @@ func loadFromFile(file string) (string, error) {
 	}
 	log.WithField("file", file).Debugf("read %d bytes", len(bts))
 	return string(bts), nil
+}
+
+func checkSortDirection(mode string) error {
+	switch mode {
+	case "", "asc", "desc":
+		return nil
+	default:
+		return ErrInvalidSortDirection
+	}
 }
 
 func buildChangelog(ctx *context.Context) (string, error) {

--- a/internal/pipe/changelog/changelog.go
+++ b/internal/pipe/changelog/changelog.go
@@ -89,11 +89,11 @@ func (Pipe) Run(ctx *context.Context) error {
 		return err
 	}
 
-	out, err := buildChangelog(ctx)
+	changes, err := buildChangelog(ctx)
 	if err != nil {
 		return err
 	}
-	changelogElements := []string{out}
+	changelogElements := []string{changes}
 
 	if header != "" {
 		changelogElements = append([]string{header}, changelogElements...)

--- a/internal/pipe/changelog/changelog.go
+++ b/internal/pipe/changelog/changelog.go
@@ -333,32 +333,6 @@ func remove(filter *regexp.Regexp, entries []Item) (result []Item) {
 	return result
 }
 
-func loadContent(ctx *context.Context, fileName, tmplName string) (string, error) {
-	if tmplName != "" {
-		log.Debugf("loading template %q", tmplName)
-		content, err := loadFromFile(tmplName)
-		if err != nil {
-			return "", err
-		}
-		content, err = tmpl.New(ctx).Apply(content)
-		if strings.TrimSpace(content) == "" && err == nil {
-			log.Warnf("loaded %q, but it evaluates to an empty string", tmplName)
-		}
-		return content, err
-	}
-
-	if fileName != "" {
-		log.Debugf("loading file %q", fileName)
-		content, err := loadFromFile(fileName)
-		if strings.TrimSpace(content) == "" && err == nil {
-			log.Warnf("loaded %q, but it is empty", fileName)
-		}
-		return content, err
-	}
-
-	return "", nil
-}
-
 func getChangeloger(ctx *context.Context) (changeloger, error) {
 	switch ctx.Config.Changelog.Use {
 	case useGit, "":
@@ -424,6 +398,32 @@ func newSCMChangeloger(ctx *context.Context) (changeloger, error) {
 			Name:  repo.Name,
 		},
 	}, nil
+}
+
+func loadContent(ctx *context.Context, fileName, tmplName string) (string, error) {
+	if tmplName != "" {
+		log.Debugf("loading template %q", tmplName)
+		content, err := loadFromFile(tmplName)
+		if err != nil {
+			return "", err
+		}
+		content, err = tmpl.New(ctx).Apply(content)
+		if strings.TrimSpace(content) == "" && err == nil {
+			log.Warnf("loaded %q, but it evaluates to an empty string", tmplName)
+		}
+		return content, err
+	}
+
+	if fileName != "" {
+		log.Debugf("loading file %q", fileName)
+		content, err := loadFromFile(fileName)
+		if strings.TrimSpace(content) == "" && err == nil {
+			log.Warnf("loaded %q, but it is empty", fileName)
+		}
+		return content, err
+	}
+
+	return "", nil
 }
 
 type changeloger interface {

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/goreleaser/goreleaser/v2/internal/client"
 	"github.com/goreleaser/goreleaser/v2/internal/git"
+	"github.com/goreleaser/goreleaser/v2/internal/golden"
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/internal/testlib"
 	"github.com/goreleaser/goreleaser/v2/pkg/config"
@@ -25,6 +26,7 @@ func TestDescription(t *testing.T) {
 func TestChangelogProvidedViaFlag(t *testing.T) {
 	ctx := testctx.New()
 	ctx.ReleaseNotesFile = "testdata/changes.md"
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Equal(t, "c0ff33 coffee\n", ctx.ReleaseNotes)
 }
@@ -32,6 +34,7 @@ func TestChangelogProvidedViaFlag(t *testing.T) {
 func TestChangelogProvidedViaFlagIsAWhitespaceOnlyFile(t *testing.T) {
 	ctx := testctx.New()
 	ctx.ReleaseNotesFile = "testdata/changes-empty.md"
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Equal(t, "\n", ctx.ReleaseNotes)
 }
@@ -39,6 +42,7 @@ func TestChangelogProvidedViaFlagIsAWhitespaceOnlyFile(t *testing.T) {
 func TestChangelogProvidedViaFlagIsReallyEmpty(t *testing.T) {
 	ctx := testctx.New()
 	ctx.ReleaseNotesFile = "testdata/changes-really-empty.md"
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Equal(t, "", ctx.ReleaseNotes)
 }
@@ -46,6 +50,7 @@ func TestChangelogProvidedViaFlagIsReallyEmpty(t *testing.T) {
 func TestChangelogTmplProvidedViaFlagIsReallyEmpty(t *testing.T) {
 	ctx := testctx.New()
 	ctx.ReleaseNotesTmpl = "testdata/changes-really-empty.md"
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Equal(t, "", ctx.ReleaseNotes)
 }
@@ -54,6 +59,7 @@ func TestTemplatedChangelogProvidedViaFlag(t *testing.T) {
 	ctx := testctx.New(testctx.WithCurrentTag("v0.0.1"), withFirstCommit(t))
 	ctx.ReleaseNotesFile = "testdata/changes.md"
 	ctx.ReleaseNotesTmpl = "testdata/changes-templated.md"
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Equal(t, "c0ff33 coffee v0.0.1\n", ctx.ReleaseNotes)
 }
@@ -61,6 +67,7 @@ func TestTemplatedChangelogProvidedViaFlag(t *testing.T) {
 func TestTemplatedChangelogProvidedViaFlagResultIsEmpty(t *testing.T) {
 	ctx := testctx.New(testctx.WithCurrentTag("v0.0.1"), withFirstCommit(t))
 	ctx.ReleaseNotesTmpl = "testdata/changes-templated-empty.md"
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Equal(t, "\n\n", ctx.ReleaseNotes)
 }
@@ -68,18 +75,21 @@ func TestTemplatedChangelogProvidedViaFlagResultIsEmpty(t *testing.T) {
 func TestChangelogProvidedViaFlagDoesntExist(t *testing.T) {
 	ctx := testctx.New()
 	ctx.ReleaseNotesFile = "testdata/changes.nope"
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.ErrorIs(t, Pipe{}.Run(ctx), os.ErrNotExist)
 }
 
 func TestReleaseHeaderProvidedViaFlagDoesntExist(t *testing.T) {
 	ctx := testctx.New()
 	ctx.ReleaseHeaderFile = "testdata/header.nope"
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.ErrorIs(t, Pipe{}.Run(ctx), os.ErrNotExist)
 }
 
 func TestReleaseFooterProvidedViaFlagDoesntExist(t *testing.T) {
 	ctx := testctx.New()
 	ctx.ReleaseFooterFile = "testdata/footer.nope"
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.ErrorIs(t, Pipe{}.Run(ctx), os.ErrNotExist)
 }
 
@@ -111,6 +121,7 @@ func TestChangelog(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v0.0.2"), testctx.WithPreviousTag("v0.0.1"))
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Contains(t, ctx.ReleaseNotes, "## Changelog")
 	require.NotContains(t, ctx.ReleaseNotes, "first")
@@ -161,6 +172,7 @@ func TestChangelogInclude(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v0.0.2"), testctx.WithPreviousTag("v0.0.1"))
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Contains(t, ctx.ReleaseNotes, "## Changelog")
 	require.NotContains(t, ctx.ReleaseNotes, "first")
@@ -215,6 +227,7 @@ func TestChangelogForGitlab(t *testing.T) {
 		testctx.WithCurrentTag("v0.0.2"),
 		testctx.WithPreviousTag("v0.0.1"),
 	)
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Contains(t, ctx.ReleaseNotes, "## Changelog")
 	require.NotContains(t, ctx.ReleaseNotes, "first")
@@ -281,7 +294,7 @@ func TestChangelogSort(t *testing.T) {
 			require.Len(t, entries, len(cfg.Entries))
 			var changes []string
 			for _, line := range entries {
-				changes = append(changes, extractCommitInfo(line))
+				changes = append(changes, line.Message)
 			}
 			require.EqualValues(t, cfg.Entries, changes)
 		})
@@ -290,15 +303,15 @@ func TestChangelogSort(t *testing.T) {
 
 func Benchmark_sortEntries(b *testing.B) {
 	ctx := testctx.New()
-	entries := []string{
-		"added feature 1",
-		"fixed bug 2",
-		"ignored: whatever",
-		"docs: whatever",
-		"something about cArs we dont need",
-		"feat: added that thing",
-		"Merge pull request #999 from goreleaser/some-branch",
-		"this is not a Merge pull request",
+	entries := []client.ChangelogItem{
+		{SHA: "cafebabe", Message: "added feature 1"},
+		{SHA: "cafebabe", Message: "fixed bug 2"},
+		{SHA: "cafebabe", Message: "ignored: whatever"},
+		{SHA: "cafebabe", Message: "docs: whatever"},
+		{SHA: "cafebabe", Message: "something about cArs we dont need"},
+		{SHA: "cafebabe", Message: "feat: added that thing"},
+		{SHA: "cafebabe", Message: "Merge pull request #999 from goreleaser/some-branch"},
+		{SHA: "cafebabe", Message: "this is not a Merge pull request"},
 	}
 
 	b.Run("asc", func(b *testing.B) {
@@ -321,6 +334,7 @@ func TestChangelogInvalidSort(t *testing.T) {
 			Sort: "dope",
 		},
 	})
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.EqualError(t, Pipe{}.Run(ctx), ErrInvalidSortDirection.Error())
 }
 
@@ -338,6 +352,7 @@ func TestChangelogOfFirstRelease(t *testing.T) {
 	}
 	testlib.GitTag(t, "v0.0.1")
 	ctx := testctx.New(testctx.WithCurrentTag("v0.0.1"), withFirstCommit(t))
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Contains(t, ctx.ReleaseNotes, "## Changelog")
 	for _, msg := range msgs {
@@ -361,6 +376,7 @@ func TestChangelogFilterInvalidRegex(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v0.0.4"), testctx.WithPreviousTag("v0.0.3"))
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.EqualError(t, Pipe{}.Run(ctx), "error parsing regexp: invalid or unsupported Perl syntax: `(?ia`")
 }
 
@@ -380,6 +396,7 @@ func TestChangelogFilterIncludeInvalidRegex(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v0.0.4"), testctx.WithPreviousTag("v0.0.3"))
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.EqualError(t, Pipe{}.Run(ctx), "error parsing regexp: invalid or unsupported Perl syntax: `(?ia`")
 }
 
@@ -391,6 +408,7 @@ func TestChangelogNoTags(t *testing.T) {
 		testlib.GitCommit(t, msg)
 	}
 	ctx := testctx.New()
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.NotEmpty(t, ctx.ReleaseNotes)
 	require.Contains(t, ctx.ReleaseNotes, "## Changelog")
@@ -414,6 +432,7 @@ func TestChangelogOnBranchWithSameNameAsTag(t *testing.T) {
 	testlib.GitTag(t, "v0.0.1")
 	testlib.GitCheckoutBranch(t, "v0.0.1")
 	ctx := testctx.New(testctx.WithCurrentTag("v0.0.1"), withFirstCommit(t))
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Contains(t, ctx.ReleaseNotes, "## Changelog")
 	for _, msg := range msgs {
@@ -440,6 +459,7 @@ func TestChangeLogWithReleaseHeader(t *testing.T) {
 	testlib.GitCheckoutBranch(t, "v0.0.1")
 	ctx := testctx.New(testctx.WithCurrentTag("v0.0.1"), withFirstCommit(t))
 	ctx.ReleaseHeaderFile = "testdata/release-header.md"
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Contains(t, ctx.ReleaseNotes, "## Changelog")
 	require.Contains(t, ctx.ReleaseNotes, "test header")
@@ -464,6 +484,7 @@ func TestChangeLogWithTemplatedReleaseHeader(t *testing.T) {
 	testlib.GitCheckoutBranch(t, "v0.0.1")
 	ctx := testctx.New(testctx.WithCurrentTag("v0.0.1"), withFirstCommit(t))
 	ctx.ReleaseHeaderTmpl = "testdata/release-header-templated.md"
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Contains(t, ctx.ReleaseNotes, "## Changelog")
 	require.Contains(t, ctx.ReleaseNotes, "test header with tag v0.0.1")
@@ -488,6 +509,7 @@ func TestChangeLogWithReleaseFooter(t *testing.T) {
 	testlib.GitCheckoutBranch(t, "v0.0.1")
 	ctx := testctx.New(testctx.WithCurrentTag("v0.0.1"), withFirstCommit(t))
 	ctx.ReleaseFooterFile = "testdata/release-footer.md"
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Contains(t, ctx.ReleaseNotes, "## Changelog")
 	require.Contains(t, ctx.ReleaseNotes, "test footer")
@@ -513,6 +535,7 @@ func TestChangeLogWithTemplatedReleaseFooter(t *testing.T) {
 	testlib.GitCheckoutBranch(t, "v0.0.1")
 	ctx := testctx.New(testctx.WithCurrentTag("v0.0.1"), withFirstCommit(t))
 	ctx.ReleaseFooterTmpl = "testdata/release-footer-templated.md"
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Contains(t, ctx.ReleaseNotes, "## Changelog")
 	require.Contains(t, ctx.ReleaseNotes, "test footer with tag v0.0.1")
@@ -537,41 +560,10 @@ func TestChangeLogWithoutReleaseFooter(t *testing.T) {
 	testlib.GitTag(t, "v0.0.1")
 	testlib.GitCheckoutBranch(t, "v0.0.1")
 	ctx := testctx.New(testctx.WithCurrentTag("v0.0.1"), withFirstCommit(t))
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Contains(t, ctx.ReleaseNotes, "## Changelog")
 	require.Equal(t, '\n', rune(ctx.ReleaseNotes[len(ctx.ReleaseNotes)-1]))
-}
-
-func TestGetChangelogGitHub(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
-		Changelog: config.Changelog{
-			Use: useGitHub,
-		},
-	}, testctx.WithCurrentTag("v0.180.2"), testctx.WithPreviousTag("v0.180.1"))
-	require.NoError(t, Pipe{}.Default(ctx))
-
-	expected := "c90f1085f255d0af0b055160bfff5ee40f47af79: fix: do not skip any defaults (#2521) (@caarlos0)"
-	mock := client.NewMock()
-	mock.Changes = []client.ChangelogItem{
-		{
-			SHA:            "c90f1085f255d0af0b055160bfff5ee40f47af79",
-			Message:        "fix: do not skip any defaults (#2521)",
-			AuthorName:     "Carlos",
-			AuthorEmail:    "nope@nope.com",
-			AuthorUsername: "caarlos0",
-		},
-	}
-	l := scmChangeloger{
-		client: mock,
-		repo: client.Repo{
-			Owner: "goreleaser",
-			Name:  "goreleaser",
-		},
-	}
-
-	log, err := l.Log(ctx)
-	require.NoError(t, err)
-	require.Equal(t, expected, log)
 }
 
 func TestGetChangelogGitHubNative(t *testing.T) {
@@ -632,13 +624,13 @@ func TestGetChangelogGitHubNativeFirstRelease(t *testing.T) {
 
 func TestGetChangeloger(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
-		c, err := getChangeloger(testctx.New())
+		c, err := getFormatableChangeloger(testctx.New())
 		require.NoError(t, err)
 		require.IsType(t, gitChangeloger{}, c)
 	})
 
 	t.Run(useGit, func(t *testing.T) {
-		c, err := getChangeloger(testctx.NewWithCfg(config.Project{
+		c, err := getFormatableChangeloger(testctx.NewWithCfg(config.Project{
 			Changelog: config.Changelog{
 				Use: useGit,
 			},
@@ -653,7 +645,7 @@ func TestGetChangeloger(t *testing.T) {
 				Use: useGitHub,
 			},
 		}, testctx.GitHubTokenType, testctx.WithPreviousTag("v1.2.3"))
-		c, err := getChangeloger(ctx)
+		c, err := getFormatableChangeloger(ctx)
 		require.NoError(t, err)
 		require.IsType(t, &scmChangeloger{}, c)
 	})
@@ -664,7 +656,7 @@ func TestGetChangeloger(t *testing.T) {
 				Use: useGitHub,
 			},
 		}, testctx.GitHubTokenType)
-		c, err := getChangeloger(ctx)
+		c, err := getFormatableChangeloger(ctx)
 		require.NoError(t, err)
 		require.IsType(t, gitChangeloger{}, c)
 	})
@@ -675,7 +667,7 @@ func TestGetChangeloger(t *testing.T) {
 				Use: useGitHubNative,
 			},
 		}, testctx.GitHubTokenType, testctx.WithPreviousTag("v1.2.3"))
-		c, err := getChangeloger(ctx)
+		c, err := newGithubChangeloger(ctx)
 		require.NoError(t, err)
 		require.IsType(t, &githubNativeChangeloger{}, c)
 	})
@@ -689,7 +681,7 @@ func TestGetChangeloger(t *testing.T) {
 				Use: useGitHubNative,
 			},
 		}, testctx.GitHubTokenType)
-		c, err := getChangeloger(ctx)
+		c, err := newGithubChangeloger(ctx)
 		require.EqualError(t, err, "unsupported repository URL: https://gist.github.com/")
 		require.Nil(t, c)
 	})
@@ -700,7 +692,7 @@ func TestGetChangeloger(t *testing.T) {
 				Use: useGitLab,
 			},
 		}, testctx.GitLabTokenType, testctx.WithPreviousTag("v1.2.3"))
-		c, err := getChangeloger(ctx)
+		c, err := getFormatableChangeloger(ctx)
 		require.NoError(t, err)
 		require.IsType(t, &scmChangeloger{}, c)
 	})
@@ -714,7 +706,7 @@ func TestGetChangeloger(t *testing.T) {
 				Use: useGitHub,
 			},
 		}, testctx.GitHubTokenType, testctx.WithPreviousTag("v1.2.3"))
-		c, err := getChangeloger(ctx)
+		c, err := getFormatableChangeloger(ctx)
 		require.EqualError(t, err, "unsupported repository URL: https://gist.github.com/")
 		require.Nil(t, c)
 	})
@@ -736,13 +728,13 @@ func TestGetChangeloger(t *testing.T) {
 				API: srv.URL,
 			},
 		}, testctx.GiteaTokenType, testctx.WithPreviousTag("v1.2.3"))
-		c, err := getChangeloger(ctx)
+		c, err := getFormatableChangeloger(ctx)
 		require.NoError(t, err)
 		require.IsType(t, &scmChangeloger{}, c)
 	})
 
 	t.Run("invalid", func(t *testing.T) {
-		c, err := getChangeloger(testctx.NewWithCfg(config.Project{
+		c, err := getFormatableChangeloger(testctx.NewWithCfg(config.Project{
 			Changelog: config.Changelog{
 				Use: "nope",
 			},
@@ -857,6 +849,7 @@ func TestGroup(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v0.0.2"), withFirstCommit(t))
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Regexp(t, `## Changelog
 ### Features
@@ -894,6 +887,7 @@ func TestGroupBadRegex(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v0.0.2"), withFirstCommit(t))
+	require.NoError(t, Pipe{}.Default(ctx))
 	require.EqualError(t, Pipe{}.Run(ctx), "failed to group into \"Something\": error parsing regexp: missing closing ]: `[a-z`")
 }
 
@@ -918,21 +912,6 @@ func TestChangelogFormat(t *testing.T) {
 * aef653 bar`, out)
 			})
 		}
-
-		t.Run(useGitHubNative, func(t *testing.T) {
-			out, err := formatChangelog(
-				testctx.NewWithCfg(makeConf(useGitHubNative)),
-				[]string{
-					"# What's changed",
-					"* aea123 foo",
-					"* aef653 bar",
-				},
-			)
-			require.NoError(t, err)
-			require.Equal(t, `# What's changed
-* aea123 foo
-* aef653 bar`, out)
-		})
 	})
 
 	t.Run("with groups", func(t *testing.T) {
@@ -947,20 +926,6 @@ func TestChangelogFormat(t *testing.T) {
 			}
 		}
 
-		t.Run(useGitHubNative, func(t *testing.T) {
-			out, err := formatChangelog(
-				testctx.NewWithCfg(makeConf(useGitHubNative)),
-				[]string{
-					"# What's changed",
-					"* aea123 foo",
-					"* aef653 bar",
-				},
-			)
-			require.NoError(t, err)
-			require.Equal(t, `# What's changed
-* aea123 foo
-* aef653 bar`, out)
-		})
 		for _, use := range []string{useGit, useGitHub, useGitLab, useGitea} {
 			t.Run(use, func(t *testing.T) {
 				out, err := formatChangelog(
@@ -1003,6 +968,7 @@ func TestAbbrev(t *testing.T) {
 			Changelog: config.Changelog{},
 		}, testctx.WithCurrentTag("v0.0.2"), withFirstCommit(t))
 
+		require.NoError(t, Pipe{}.Default(ctx))
 		require.NoError(t, Pipe{}.Run(ctx))
 		ensureCommitHashLen(t, ctx.ReleaseNotes, 40)
 	})
@@ -1014,6 +980,7 @@ func TestAbbrev(t *testing.T) {
 				Abbrev: -1,
 			},
 		}, testctx.WithCurrentTag("v0.0.2"), withFirstCommit(t))
+		require.NoError(t, Pipe{}.Default(ctx))
 		require.NoError(t, Pipe{}.Run(ctx))
 	})
 
@@ -1024,6 +991,7 @@ func TestAbbrev(t *testing.T) {
 				Abbrev: 3,
 			},
 		}, testctx.WithCurrentTag("v0.0.2"), withFirstCommit(t))
+		require.NoError(t, Pipe{}.Default(ctx))
 		require.NoError(t, Pipe{}.Run(ctx))
 		ensureCommitHashLen(t, ctx.ReleaseNotes, 3)
 	})
@@ -1035,6 +1003,7 @@ func TestAbbrev(t *testing.T) {
 				Abbrev: 7,
 			},
 		}, testctx.WithCurrentTag("v0.0.2"), withFirstCommit(t))
+		require.NoError(t, Pipe{}.Default(ctx))
 		require.NoError(t, Pipe{}.Run(ctx))
 		ensureCommitHashLen(t, ctx.ReleaseNotes, 7)
 	})
@@ -1046,9 +1015,97 @@ func TestAbbrev(t *testing.T) {
 				Abbrev: 50,
 			},
 		}, testctx.WithCurrentTag("v0.0.2"), withFirstCommit(t))
+		require.NoError(t, Pipe{}.Default(ctx))
 		require.NoError(t, Pipe{}.Run(ctx))
 		ensureCommitHashLen(t, ctx.ReleaseNotes, 40)
 	})
+}
+
+func TestIssue5595(t *testing.T) {
+	for name, format := range map[string]string{
+		"abbrev-sha": "[{{.SHA}}]: {{.Message}} (@{{.AuthorName}})",
+		"no-sha":     "{{.Message}} (@{{.AuthorName}})",
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := testctx.NewWithCfg(config.Project{
+				Changelog: config.Changelog{
+					Use:    useGitHub,
+					Format: format,
+					Groups: []config.ChangelogGroup{
+						{
+							Title:  "Features",
+							Regexp: `^.*?feat(\([[:word:]]+\))??!?:.+$`,
+							Order:  0,
+						},
+						{
+							Title:  "Fixes",
+							Regexp: `^.*?fix(\([[:word:]]+\))??!?:.+$`,
+							Order:  1,
+						},
+						{
+							Title: "Others",
+							Order: 999,
+						},
+					},
+					Filters: config.Filters{
+						Exclude: []string{
+							"^docs:",
+							"typo",
+							"(?i)foo",
+						},
+						Include: []string{
+							"^feat:",
+							"^fix:",
+						},
+					},
+				},
+			}, testctx.WithCurrentTag("v0.0.2"), withFirstCommit(t))
+			require.NoError(t, Pipe{}.Default(ctx))
+
+			mock := client.NewMock()
+
+			for i := 0; i < 20; i++ {
+				kind := "fix"
+				if i%2 == 0 {
+					kind = "feat"
+				}
+				if i%5 == 0 {
+					kind = "chore"
+				}
+				if i%7 == 0 {
+					kind = "docs"
+				}
+				msg := fmt.Sprintf("%s: commit #%d", kind, i)
+				mock.Changes = append(mock.Changes, client.ChangelogItem{
+					SHA:            "cafebabe",
+					Message:        msg,
+					AuthorName:     "Carlos",
+					AuthorEmail:    "nope@nope.com",
+					AuthorUsername: "caarlos0",
+				})
+			}
+
+			l := scmChangeloger{
+				client: mock,
+				abbrev: 3,
+				repo: client.Repo{
+					Owner: "test",
+					Name:  "test",
+				},
+			}
+			entries, err := l.Log(ctx)
+			require.NoError(t, err)
+			entries, err = filterEntries(ctx, entries)
+			require.NoError(t, err)
+			entries = sortEntries(ctx, entries)
+			lines, err := toLines(ctx, entries)
+			require.NoError(t, err)
+
+			log, err := formatChangelog(ctx, lines)
+			require.NoError(t, err)
+			golden.RequireEqualExt(t, []byte(log), ".md")
+		})
+	}
 }
 
 func ensureCommitHashLen(tb testing.TB, log string, l int) {
@@ -1059,6 +1116,7 @@ func ensureCommitHashLen(tb testing.TB, log string, l int) {
 		}
 		parts := strings.SplitN(line, " ", 3)
 		commit := strings.TrimPrefix(parts[1], "* ")
+		commit = strings.TrimSuffix(commit, ":")
 		require.Len(tb, commit, l)
 	}
 }

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -24,6 +24,7 @@ func TestDefault(t *testing.T) {
 		ctx := testctx.New()
 		require.NoError(t, Pipe{}.Default(ctx))
 		require.NotEmpty(t, ctx.Config.Changelog.Format)
+		require.NotContains(t, ctx.Config.Changelog.Format, "Author")
 	})
 	t.Run("github", func(t *testing.T) {
 		ctx := testctx.NewWithCfg(config.Project{
@@ -33,6 +34,7 @@ func TestDefault(t *testing.T) {
 		})
 		require.NoError(t, Pipe{}.Default(ctx))
 		require.NotEmpty(t, ctx.Config.Changelog.Format)
+		require.Contains(t, ctx.Config.Changelog.Format, "Author")
 	})
 }
 

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -19,6 +19,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestDefault(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		ctx := testctx.New()
+		require.NoError(t, Pipe{}.Default(ctx))
+		require.NotEmpty(t, ctx.Config.Changelog.Format)
+	})
+	t.Run("github", func(t *testing.T) {
+		ctx := testctx.NewWithCfg(config.Project{
+			Changelog: config.Changelog{
+				Use: useGitHub,
+			},
+		})
+		require.NoError(t, Pipe{}.Default(ctx))
+		require.NotEmpty(t, ctx.Config.Changelog.Format)
+	})
+}
+
 func TestDescription(t *testing.T) {
 	require.NotEmpty(t, Pipe{}.String())
 }

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -1099,20 +1099,18 @@ func TestIssue5595(t *testing.T) {
 				})
 			}
 
-			l := scmChangeloger{
-				client: mock,
-				abbrev: 3,
-				repo: client.Repo{
-					Owner: "test",
-					Name:  "test",
+			cl := wrappingChangeloger{
+				changeloger: &scmChangeloger{
+					client: mock,
+					abbrev: 3,
+					repo: client.Repo{
+						Owner: "test",
+						Name:  "test",
+					},
 				},
 			}
-			entries, err := l.Log(ctx)
-			require.NoError(t, err)
-			entries, err = filterEntries(ctx, entries)
-			require.NoError(t, err)
-			entries = sortEntries(ctx, entries)
-			log, err := formatChangelog(ctx, entries)
+
+			log, err := cl.Log(ctx)
 			require.NoError(t, err)
 			golden.RequireEqualExt(t, []byte(log), ".md")
 		})

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -894,16 +894,21 @@ func TestGroupBadRegex(t *testing.T) {
 func TestChangelogFormat(t *testing.T) {
 	t.Run("without groups", func(t *testing.T) {
 		makeConf := func(u string) config.Project {
-			return config.Project{Changelog: config.Changelog{Use: u}}
+			return config.Project{
+				Changelog: config.Changelog{
+					Use:    u,
+					Format: "{{.SHA}} {{.Message}}",
+				},
+			}
 		}
 
 		for _, use := range []string{useGit, useGitHub, useGitLab, useGitea} {
 			t.Run(use, func(t *testing.T) {
 				out, err := formatChangelog(
 					testctx.NewWithCfg(makeConf(use)),
-					[]string{
-						"aea123 foo",
-						"aef653 bar",
+					[]client.ChangelogItem{
+						{SHA: "aea123", Message: "foo"},
+						{SHA: "aef653", Message: "bar"},
 					},
 				)
 				require.NoError(t, err)
@@ -918,7 +923,8 @@ func TestChangelogFormat(t *testing.T) {
 		makeConf := func(u string) config.Project {
 			return config.Project{
 				Changelog: config.Changelog{
-					Use: u,
+					Use:    u,
+					Format: "{{.SHA}} {{.Message}}",
 					Groups: []config.ChangelogGroup{
 						{Title: "catch-all"},
 					},
@@ -930,9 +936,9 @@ func TestChangelogFormat(t *testing.T) {
 			t.Run(use, func(t *testing.T) {
 				out, err := formatChangelog(
 					testctx.NewWithCfg(makeConf(use)),
-					[]string{
-						"aea123 foo",
-						"aef653 bar",
+					[]client.ChangelogItem{
+						{SHA: "aea123", Message: "foo"},
+						{SHA: "aef653", Message: "bar"},
 					},
 				)
 				require.NoError(t, err)
@@ -1098,10 +1104,7 @@ func TestIssue5595(t *testing.T) {
 			entries, err = filterEntries(ctx, entries)
 			require.NoError(t, err)
 			entries = sortEntries(ctx, entries)
-			lines, err := toLines(ctx, entries)
-			require.NoError(t, err)
-
-			log, err := formatChangelog(ctx, lines)
+			log, err := formatChangelog(ctx, entries)
 			require.NoError(t, err)
 			golden.RequireEqualExt(t, []byte(log), ".md")
 		})

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -41,24 +41,6 @@ func TestDefault(t *testing.T) {
 		require.NotEmpty(t, ctx.Config.Changelog.Format)
 		require.Contains(t, ctx.Config.Changelog.Format, "Author")
 	})
-	t.Run("invalid order", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
-			Changelog: config.Changelog{
-				Sort: "nope",
-			},
-		})
-		require.ErrorIs(t, Pipe{}.Default(ctx), ErrInvalidSortDirection)
-	})
-	t.Run("invalid groups", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
-			Changelog: config.Changelog{
-				Groups: []config.ChangelogGroup{
-					{Title: "   "},
-				},
-			},
-		})
-		require.ErrorIs(t, Pipe{}.Default(ctx), ErrEmptyGroupTitle)
-	})
 }
 
 func TestDescription(t *testing.T) {
@@ -376,6 +358,15 @@ func Benchmark_sortEntries(b *testing.B) {
 			sortEntries(ctx, entries)
 		}
 	})
+}
+
+func TestChangelogInvalidSort(t *testing.T) {
+	ctx := testctx.NewWithCfg(config.Project{
+		Changelog: config.Changelog{
+			Sort: "dope",
+		},
+	})
+	require.EqualError(t, Pipe{}.Run(ctx), ErrInvalidSortDirection.Error())
 }
 
 func TestChangelogOfFirstRelease(t *testing.T) {

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -353,7 +353,7 @@ func TestChangelogSort(t *testing.T) {
 
 func Benchmark_sortEntries(b *testing.B) {
 	ctx := testctx.New()
-	entries := []client.ChangelogItem{
+	entries := []Item{
 		{SHA: "cafebabe", Message: "added feature 1"},
 		{SHA: "cafebabe", Message: "fixed bug 2"},
 		{SHA: "cafebabe", Message: "ignored: whatever"},
@@ -946,7 +946,7 @@ func TestChangelogFormat(t *testing.T) {
 			t.Run(use, func(t *testing.T) {
 				out, err := formatChangelog(
 					testctx.NewWithCfg(makeConf(use)),
-					[]client.ChangelogItem{
+					[]Item{
 						{SHA: "aea123", Message: "foo"},
 						{SHA: "aef653", Message: "bar"},
 					},
@@ -976,7 +976,7 @@ func TestChangelogFormat(t *testing.T) {
 			t.Run(use, func(t *testing.T) {
 				out, err := formatChangelog(
 					testctx.NewWithCfg(makeConf(use)),
-					[]client.ChangelogItem{
+					[]Item{
 						{SHA: "aea123", Message: "foo"},
 						{SHA: "aef653", Message: "bar"},
 					},
@@ -1122,7 +1122,7 @@ func TestIssue5595(t *testing.T) {
 					kind = "docs"
 				}
 				msg := fmt.Sprintf("%s: commit #%d", kind, i)
-				mock.Changes = append(mock.Changes, client.ChangelogItem{
+				mock.Changes = append(mock.Changes, Item{
 					SHA:            "cafebabe",
 					Message:        msg,
 					AuthorName:     "Carlos",

--- a/internal/pipe/changelog/testdata/TestIssue5595/abbrev-sha.md.golden
+++ b/internal/pipe/changelog/testdata/TestIssue5595/abbrev-sha.md.golden
@@ -1,0 +1,17 @@
+## Changelog
+### Features
+* [cafebabe]: feat: commit #2 (@Carlos)
+* [cafebabe]: feat: commit #4 (@Carlos)
+* [cafebabe]: feat: commit #6 (@Carlos)
+* [cafebabe]: feat: commit #8 (@Carlos)
+* [cafebabe]: feat: commit #12 (@Carlos)
+* [cafebabe]: feat: commit #16 (@Carlos)
+* [cafebabe]: feat: commit #18 (@Carlos)
+### Fixes
+* [cafebabe]: fix: commit #1 (@Carlos)
+* [cafebabe]: fix: commit #3 (@Carlos)
+* [cafebabe]: fix: commit #9 (@Carlos)
+* [cafebabe]: fix: commit #11 (@Carlos)
+* [cafebabe]: fix: commit #13 (@Carlos)
+* [cafebabe]: fix: commit #17 (@Carlos)
+* [cafebabe]: fix: commit #19 (@Carlos)

--- a/internal/pipe/changelog/testdata/TestIssue5595/no-sha.md.golden
+++ b/internal/pipe/changelog/testdata/TestIssue5595/no-sha.md.golden
@@ -1,0 +1,17 @@
+## Changelog
+### Features
+* feat: commit #2 (@Carlos)
+* feat: commit #4 (@Carlos)
+* feat: commit #6 (@Carlos)
+* feat: commit #8 (@Carlos)
+* feat: commit #12 (@Carlos)
+* feat: commit #16 (@Carlos)
+* feat: commit #18 (@Carlos)
+### Fixes
+* fix: commit #1 (@Carlos)
+* fix: commit #3 (@Carlos)
+* fix: commit #9 (@Carlos)
+* fix: commit #11 (@Carlos)
+* fix: commit #13 (@Carlos)
+* fix: commit #17 (@Carlos)
+* fix: commit #19 (@Carlos)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1222,7 +1222,7 @@ type Changelog struct {
 
 // ChangelogGroup holds the grouping criteria for the changelog.
 type ChangelogGroup struct {
-	Title  string `yaml:"title,omitempty" json:"title,omitempty"`
+	Title  string `yaml:"title" json:"title"`
 	Regexp string `yaml:"regexp,omitempty" json:"regexp,omitempty"`
 	Order  int    `yaml:"order,omitempty" json:"order,omitempty"`
 }

--- a/www/docs/customization/changelog.md
+++ b/www/docs/customization/changelog.md
@@ -21,22 +21,34 @@ changelog:
   # - `github`: uses the compare GitHub API, appending the author username to the changelog.
   # - `gitlab`: uses the compare GitLab API, appending the author name and email to the changelog (requires a personal access token).
   # - `gitea`: uses the compare Gitea API, appending the author username to the changelog.
-  # - `github-native`: uses the GitHub release notes generation API, disables the groups feature.
+  # - `github-native`: uses the GitHub release notes generation API, disables groups, sort, and any further formatting features.
   #
   # Default: 'git'.
   use: github
 
   # Format to use for commit formatting.
-  # Only available when use is one of `github`, `gitea`, or `gitlab`.
   #
-  # Default: '{{ .SHA }}: {{ .Message }} ({{ with .AuthorUsername }}@{{ . }}{{ else }}{{ .AuthorName }} <{{ .AuthorEmail }}>{{ end }})'.
-  # Extra template fields: `SHA`, `Message`, `AuthorName`, `AuthorEmail`, and
-  # `AuthorUsername`.
+  # Templates: allowed.
+  #
+  # Default:
+  #    if 'git': '{{ .SHA }} {{ .Message }}'
+  #   otherwise: '{{ .SHA }}: {{ .Message }} ({{ with .AuthorUsername }}@{{ . }}{{ else }}{{ .AuthorName }} <{{ .AuthorEmail }}>{{ end }})'.
+  #
+  # Extra template fields:
+  # - `SHA`: the commit SHA1
+  # - `Message`: the first line of the commit message, otherwise known as commit subject
+  # - `AuthorName`: the author full name (considers mailmap if 'git')
+  # - `AuthorEmail`: the author email (considers mailmap if 'git')
+  # - `AuthorUsername`: github/gitlab/gitea username - not available if 'git'
+  #
+  # Usage with 'git': <!-- md:inline_version v2.8-unreleased -->.
   format: "{{.SHA}}: {{.Message}} (@{{.AuthorUsername}})"
 
   # Sorts the changelog by the commit's messages.
   # Could either be asc, desc or empty
   # Empty means 'no sorting', it'll use the output of `git log` as is.
+  #
+  # Disabled when using 'github-native'.
   sort: asc
 
   # Max commit hash length to use in the changelog.
@@ -44,6 +56,8 @@ changelog:
   # 0: use whatever the changelog implementation gives you
   # -1: remove the commit hash from the changelog
   # any other number: max length.
+  #
+  # Disabled when using 'github-native'.
   abbrev: -1
 
   # Paths to filter the commits for.
@@ -51,6 +65,8 @@ changelog:
   #
   # This feature is only available in GoReleaser Pro.
   # Default: monorepo.dir value, or empty if no monorepo.
+  #
+  # Disabled when using 'github-native'.
   paths:
     - foo/
     - bar/
@@ -68,8 +84,9 @@ changelog:
   # Matches are performed against the first line of the commit message only,
   # prefixed with the commit SHA1, usually in the form of
   # `<abbrev-commit>[:] <title-commit>`.
-  # Groups are disabled when using github-native, as it already groups things by itself.
   # Regex use RE2 syntax as defined here: https://github.com/google/re2/wiki/Syntax.
+  #
+  # Disabled when using 'github-native'.
   groups:
     - title: Features
       regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
@@ -105,13 +122,14 @@ changelog:
   # This feature is only available in GoReleaser Pro.
   divider: "---"
 
+  # Further filter changelog entries.
+  #
+  # Disabled when using 'github-native'.
   filters:
     # Commit messages matching the regexp listed here will be removed from
     # the changelog
     #
-    # Matches are performed against the first line of the commit message only,
-    # prefixed with the commit SHA1, usually in the form of
-    # `<abbrev-commit>[:] <title-commit>`.
+    # Matches are performed against the first line of the commit message only.
     exclude:
       - "^docs:"
       - typo
@@ -122,9 +140,7 @@ changelog:
     #
     # If include is not-empty, exclude will be ignored.
     #
-    # Matches are performed against the first line of the commit message only,
-    # prefixed with the commit SHA1, usually in the form of
-    # `<abbrev-commit>[:] <title-commit>`.
+    # Matches are performed against the first line of the commit message only.
     include:
       - "^feat:"
 ```
@@ -133,7 +149,7 @@ changelog:
 
     Some things to keep an eye on:
 
-    * The `github-native` changelog does not support `sort` and `filter`.
+    * The `github-native` changelog does not support `groups`, `sort`, and `filter`.
     * When releasing a [nightly][], `use` will fallback to `git`.
     * The `github` changelog will only work if both tags exist in GitHub.
 


### PR DESCRIPTION
The git changeloger now uses a custom format that yields a JSON, which we later parse.

With this, I refactored most of how the changelog works, and now abbrev, filtering, sorting, and grouping, are all done with structured data instead of plain strings.

This allows to:

- properly handle commit abbrevs when using custom formats
- customize format when using 'use: git`, including adding author name and email 
- properly handle filters when the format doesn't have a leading SHA 

closes #5595
