### PR TITLE
fix: package comment for packagejson

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -85,6 +85,8 @@ linters-settings:
     disable:
       - error-is-as # false positive
 issues:
+  include:
+    - EXC0013 # Enable revive.package-comments
   exclude-rules:
     - path: _test\.go
       linters:

--- a/internal/packagejson/packagejson.go
+++ b/internal/packagejson/packagejson.go
@@ -1,4 +1,4 @@
-// Package cargo provides NodeJS/Bun package.json parsing.
+// Package packagejson provides NodeJS/Bun package.json parsing.
 package packagejson
 
 import (


### PR DESCRIPTION
The PR fixes package comment for `packagejson` and enables `revive.package-comments` to detect this issue in the future.