### PR TITLE
fix(archive): make sure binaries are executable

### DIFF
--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -96,6 +96,7 @@ func (Pipe) Default(ctx *context.Context) error {
 				archive.NameTemplate = defaultBinaryNameTemplate
 			}
 		}
+		archive.BuildsInfo.Mode = 0o755
 		ids.Inc(archive.ID)
 	}
 	return ids.Validate()


### PR DESCRIPTION
On windows, files have no executable bits.

We read the file permissions on disk to decide its permissions inside the archives - this means that, on windows, the binaries will not have the executable bit when unextracted.

This sets the build file info mode to 0o755 by default, which should resolve this issue.

This was also fixed at some point in time in the past, but apparently regressed. Now that we test on windows as well, this shouldn't happen again.

closes #5632
