### PR TITLE
Add Pixi installation instructions

### DIFF
--- a/www/docs/install.md
+++ b/www/docs/install.md
@@ -38,6 +38,24 @@ You can see the instructions for each of them below.
 
 [formula in homebrew-core]: https://github.com/Homebrew/homebrew-core/blob/master/Formula/g/goreleaser.rb
 
+## Pixi
+
+=== "OSS"
+
+    ```bash
+    pixi global install goreleaser
+    ```
+
+    !!! warning
+
+        The [recipe in conda-forge] might be slightly outdated.
+
+=== "Pro"
+
+    Not available.
+
+[recipe in conda-forge]: https://github.com/conda-forge/goreleaser-feedstock/blob/main/recipe/meta.yaml
+
 ## Snapcraft
 
 === "OSS"


### PR DESCRIPTION
This PR adds instructions for installing the conda-forge build of `goreleaser` using [Pixi](https://pixi.sh/latest/).

The conda-forge repository for `goreleaser` is available here: [conda-forge/goreleaser-feedstock](https://github.com/conda-forge/goreleaser-feedstock). 

I can add the `goreleaser` developers as maintainers to the feedstock. Currently, the conda-forge bot automatically opens a PR whenever a new release of `goreleaser` is published on GitHub. These PRs are merged automatically if the build succeeds and all tests pass.