### PR TITLE
fix(log): custom git log format and parsing

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -64,11 +64,11 @@ type Client interface {
 
 // ChangelogItem represents a changelog item, basically, a commit and its author.
 type ChangelogItem struct {
-	SHA            string `json:"sha"`
-	Message        string `json:"message"`
-	AuthorName     string `json:"name"`
-	AuthorEmail    string `json:"email"`
-	AuthorUsername string `json:"-"`
+	SHA            string
+	Message        string
+	AuthorName     string
+	AuthorEmail    string
+	AuthorUsername string
 }
 
 // ReleaseURLTemplater provides the release URL as a template, containing the

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -130,6 +130,9 @@ func TestChangelog(t *testing.T) {
 	testlib.GitCommit(t, "feat: added that thing")
 	testlib.GitCommit(t, "Merge pull request #999 from goreleaser/some-branch")
 	testlib.GitCommit(t, "this is not a Merge pull request")
+	testlib.GitCommit(t, `a commit message "with quotes inside it'`)
+	testlib.GitCommit(t, `a " quote ' fiest`)
+	testlib.GitCommit(t, `an unclosed <tag`)
 	testlib.GitTag(t, "v0.0.2")
 	ctx := testctx.NewWithCfg(config.Project{
 		Dist: folder,
@@ -151,6 +154,8 @@ func TestChangelog(t *testing.T) {
 	require.NotContains(t, ctx.ReleaseNotes, "first")
 	require.Contains(t, ctx.ReleaseNotes, "added feature 1")
 	require.Contains(t, ctx.ReleaseNotes, "fixed bug 2")
+	require.Contains(t, ctx.ReleaseNotes, `a commit message "with quotes inside it'`)
+	require.Contains(t, ctx.ReleaseNotes, `a " quote ' fiest`)
 	require.NotContains(t, ctx.ReleaseNotes, "docs")
 	require.NotContains(t, ctx.ReleaseNotes, "ignored")
 	require.NotContains(t, ctx.ReleaseNotes, "cArs")


### PR DESCRIPTION
JSON formatting was brittle, as quotes et al were note escaped. Thought about doing it with xml.Unmarshal, but it would have the same issue, but this time with unmatched `<>`.

This uses a custom XML-based format, but does not use `encoding/xml` to parse it.

thanks @raphamorim for reporting this (in Discord)
