### PR TITLE
fix: fix permissions of snapcraft binary

### DIFF
--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -328,7 +328,7 @@ func create(ctx *context.Context, snap config.Snapcraft, arch string, binaries [
 			WithField("dst", destBinaryPath).
 			Debug("copying")
 
-		if err = gio.CopyWithMode(binary.Path, destBinaryPath, 0o555); err != nil {
+		if err = gio.CopyWithMode(binary.Path, destBinaryPath, 0o777); err != nil {
 			return fmt.Errorf("failed to copy binary: %w", err)
 		}
 	}


### PR DESCRIPTION
If applied, this commit will fix a permissions problem when building snaps on Linux:

```
...
  • snapcraft packages
    • ignored unsupported arch                       arch=mips64
    • ignored unsupported arch                       arch=mips64le
    • ignored unsupported arch                       arch=riscv64
    • ignored unsupported arch                       arch=loong64
    • ignored unsupported arch                       arch=ppc64
    • creating                                       arch=i386 snap=dist/chezmoi_2.60.1-SNAPSHOT-25cb07370_linux_386.snap
    • creating                                       arch=armhf snap=dist/chezmoi_2.60.1-SNAPSHOT-25cb07370_linux_armv6.snap
    • creating                                       arch=arm64 snap=dist/chezmoi_2.60.1-SNAPSHOT-25cb07370_linux_arm64.snap
    • creating                                       arch=s390x snap=dist/chezmoi_2.60.1-SNAPSHOT-25cb07370_linux_s390x.snap
    • creating                                       arch=ppc64el snap=dist/chezmoi_2.60.1-SNAPSHOT-25cb07370_linux_ppc64le.snap
    • took: 15s
  ⨯ release failed after 1m37s               error=failed to copy binary: failed to open 'dist/chezmoi_2.60.1-SNAPSHOT-25cb07370_linux_amd64/prime/chezmoi': open dist/chezmoi_2.60.1-SNAPSHOT-25cb07370_linux_amd64/prime/chezmoi: permission denied
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.8.0/x64/goreleaser' failed with exit code 1
```

There's a [full log here](https://github.com/twpayne/chezmoi/actions/runs/13841104837/job/38728551503?pr=4344).

This problem occurred when upgrading goreleaser from v2.7.0 to v2.8.0.

Refs https://github.com/twpayne/chezmoi/pull/4344.