### PR TITLE
test: simplify tests with usetesting linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -19,6 +19,7 @@ linters:
     - tparallel
     - unconvert
     - unparam
+    - usetesting
     - wastedassign
   settings:
     depguard:
@@ -86,6 +87,14 @@ linters:
       enable-all: true
       disable:
         - error-is-as
+    usetesting:
+      context-background: true
+      context-todo: true
+      os-chdir: true
+      os-mkdir-temp: true
+      os-setenv: true
+      os-create-temp: true
+      os-temp-dir: true
   exclusions:
     generated: lax
     presets:

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -116,12 +116,7 @@ func setupInitTest(tb testing.TB) string {
 	tb.Helper()
 
 	folder := tb.TempDir()
-	wd, err := os.Getwd()
-	require.NoError(tb, err)
-	tb.Cleanup(func() {
-		require.NoError(tb, os.Chdir(wd))
-	})
-	require.NoError(tb, os.Chdir(folder))
+	tb.Chdir(folder)
 	return folder
 }
 

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -23,14 +23,8 @@ func setup(tb testing.TB) string {
 	_ = os.Unsetenv("GITLAB_TOKEN")
 	_ = os.Unsetenv("GITEA_TOKEN")
 
-	previous, err := os.Getwd()
-	require.NoError(tb, err)
-
 	folder := tb.TempDir()
-	require.NoError(tb, os.Chdir(folder))
-	tb.Cleanup(func() {
-		require.NoError(tb, os.Chdir(previous))
-	})
+	tb.Chdir(folder)
 
 	createGoReleaserYaml(tb)
 	createMainGo(tb)

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -1,7 +1,6 @@
 package git_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/v2/internal/git"
@@ -11,19 +10,19 @@ import (
 
 func TestNotARepo(t *testing.T) {
 	testlib.Mktmp(t)
-	_, err := git.ExtractRepoFromConfig(context.Background())
+	_, err := git.ExtractRepoFromConfig(t.Context())
 	require.EqualError(t, err, `current folder is not a git repository`)
 }
 
 func TestNoRemote(t *testing.T) {
 	testlib.Mktmp(t)
 	testlib.GitInit(t)
-	_, err := git.ExtractRepoFromConfig(context.Background())
+	_, err := git.ExtractRepoFromConfig(t.Context())
 	require.EqualError(t, err, `no remote configured to list refs from`)
 }
 
 func TestRelativeRemote(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAddWithName(t, "upstream", "https://github.com/goreleaser/goreleaser.git")
@@ -45,13 +44,13 @@ func TestRepoName(t *testing.T) {
 	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:goreleaser/goreleaser.git")
-	repo, err := git.ExtractRepoFromConfig(context.Background())
+	repo, err := git.ExtractRepoFromConfig(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, "goreleaser/goreleaser", repo.String())
 }
 
 func TestRepoNameWithDifferentRemote(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAddWithName(t, "upstream", "https://github.com/goreleaser/goreleaser.git")

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,8 +1,6 @@
 package git_test
 
 import (
-	"context"
-	"os"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/v2/internal/git"
@@ -11,7 +9,7 @@ import (
 )
 
 func TestGit(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	out, err := git.Run(ctx, "status")
 	require.NoError(t, err)
 	require.NotEmpty(t, out)
@@ -22,7 +20,7 @@ func TestGit(t *testing.T) {
 }
 
 func TestGitWarning(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitCommit(t, "foo")
@@ -43,15 +41,16 @@ func TestGitWarning(t *testing.T) {
 }
 
 func TestRepo(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	require.True(t, git.IsRepo(ctx), "goreleaser folder should be a git repo")
 
-	require.NoError(t, os.Chdir(os.TempDir()))
-	require.False(t, git.IsRepo(ctx), os.TempDir()+" folder should be a git repo")
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	require.False(t, git.IsRepo(ctx), tmpDir+" folder should be a git repo")
 }
 
 func TestClean(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("success", func(t *testing.T) {
 		out, err := git.Clean("asdasd 'ssadas'\nadasd", nil)

--- a/internal/http/http_test.go
+++ b/internal/http/http_test.go
@@ -51,7 +51,7 @@ func TestAssetOpenDefault(t *testing.T) {
 		t.Fatalf("should fail on missing file")
 	}
 	_, err = assetOpenDefault("blah", &artifact.Artifact{
-		Path: os.TempDir(),
+		Path: t.TempDir(),
 	})
 	if err == nil {
 		t.Fatalf("should fail on existing dir")

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -383,10 +383,7 @@ func TestDefaultPartialBuilds(t *testing.T) {
 		},
 	})
 	// Create any 'Dir' paths necessary for builds.
-	previous, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(t.TempDir()))
-	t.Cleanup(func() { require.NoError(t, os.Chdir(previous)) })
+	t.Chdir(t.TempDir())
 	for _, b := range ctx.Config.Builds {
 		if b.Dir != "" {
 			require.NoError(t, os.Mkdir(b.Dir, 0o755))

--- a/internal/pipe/linkedin/client_test.go
+++ b/internal/pipe/linkedin/client_test.go
@@ -1,7 +1,6 @@
 package linkedin
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -76,7 +75,7 @@ func TestClient_Share(t *testing.T) {
 
 	c.baseURL = server.URL
 
-	link, err := c.Share(context.Background(), "test")
+	link, err := c.Share(t.Context(), "test")
 	if err != nil {
 		t.Fatalf("could not share: %v", err)
 	}
@@ -111,7 +110,7 @@ func TestClientLegacyProfile_Share(t *testing.T) {
 
 	c.baseURL = server.URL
 
-	link, err := c.Share(context.Background(), "test")
+	link, err := c.Share(t.Context(), "test")
 	if err != nil {
 		t.Fatalf("could not share: %v", err)
 	}

--- a/internal/testlib/git.go
+++ b/internal/testlib/git.go
@@ -102,7 +102,7 @@ func GitMakeBareRepository(tb testing.TB) string {
 	tb.Helper()
 	dir := tb.TempDir()
 	_, err := git.Run(
-		context.Background(),
+		tb.Context(),
 		"-C", dir,
 		"-c", "init.defaultBranch=master",
 		"init",

--- a/internal/testlib/mktemp.go
+++ b/internal/testlib/mktemp.go
@@ -2,10 +2,7 @@
 package testlib
 
 import (
-	"os"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 // Mktmp creates a new tempdir, cd into it and automatically cd back when the
@@ -13,11 +10,6 @@ import (
 func Mktmp(tb testing.TB) string {
 	tb.Helper()
 	folder := tb.TempDir()
-	current, err := os.Getwd()
-	require.NoError(tb, err)
-	require.NoError(tb, os.Chdir(folder))
-	tb.Cleanup(func() {
-		require.NoError(tb, os.Chdir(current))
-	})
+	tb.Chdir(folder)
 	return folder
 }


### PR DESCRIPTION
This PR enables [`usetesting`](https://golangci-lint.run/usage/linters/#usetesting) linter and fixes up lint issues.