### PR TITLE
refactor: ExtraOr, MustExtra

### DIFF
--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -473,7 +473,7 @@ func TestExtra(t *testing.T) {
 		binaries, err := Extra[[]string](a, "binaries")
 		require.NoError(t, err)
 		require.Equal(t, []string{"foo", "bar"}, binaries)
-		require.Equal(t, []string{"foo", "bar"}, ExtraOr(a, "binaries", []string{}))
+		require.Equal(t, []string{"foo", "bar"}, MustExtra[[]string](a, "binaries"))
 	})
 
 	t.Run("unmarshal error", func(t *testing.T) {

--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -283,7 +283,7 @@ func skip(ctx *context.Context, archive config.Archive, binaries []*artifact.Art
 		if err != nil {
 			return err
 		}
-		finalName := name + artifact.ExtraOr(*binary, artifact.ExtraExt, "")
+		finalName := name + binary.Ext()
 		log.WithField("binary", binary.Name).
 			WithField("name", finalName).
 			Info("archiving")

--- a/internal/pipe/archive/archive_test.go
+++ b/internal/pipe/archive/archive_test.go
@@ -229,7 +229,7 @@ func TestRunPipe(t *testing.T) {
 					expectBin += ".exe"
 				}
 				require.Equal(t, "myid", arch.ID(), "all archives must have the archive ID set")
-				require.Equal(t, []string{expectBin}, artifact.ExtraOr(*arch, artifact.ExtraBinaries, []string{}))
+				require.Equal(t, []string{expectBin}, artifact.MustExtra[[]string](*arch, artifact.ExtraBinaries))
 				require.Empty(t, artifact.ExtraOr(*arch, artifact.ExtraBinary, ""))
 			}
 			require.Len(t, archives, 13)
@@ -508,17 +508,17 @@ func TestRunPipeBinary(t *testing.T) {
 		artifact.ByGoos("darwin"),
 		artifact.ByGoarch("all"),
 	)).List()[0]
-	require.True(t, artifact.ExtraOr(*darwinUniversal, artifact.ExtraReplaces, false))
+	require.True(t, artifact.MustExtra[bool](*darwinUniversal, artifact.ExtraReplaces))
 	windows := binaries.Filter(artifact.ByGoos("windows")).List()[0]
 	windows2 := binaries.Filter(artifact.ByGoos("windows")).List()[1]
 	require.Equal(t, "mybin_0.0.1_darwin_amd64", darwinThin.Name)
-	require.Equal(t, "mybin", artifact.ExtraOr(*darwinThin, artifact.ExtraBinary, ""))
+	require.Equal(t, "mybin", artifact.MustExtra[string](*darwinThin, artifact.ExtraBinary))
 	require.Equal(t, "myunibin_0.0.1_darwin_all", darwinUniversal.Name)
-	require.Equal(t, "myunibin", artifact.ExtraOr(*darwinUniversal, artifact.ExtraBinary, ""))
+	require.Equal(t, "myunibin", artifact.MustExtra[string](*darwinUniversal, artifact.ExtraBinary))
 	require.Equal(t, "mybin_0.0.1_windows_amd64.exe", windows.Name)
-	require.Equal(t, "mybin.exe", artifact.ExtraOr(*windows, artifact.ExtraBinary, ""))
+	require.Equal(t, "mybin.exe", artifact.MustExtra[string](*windows, artifact.ExtraBinary))
 	require.Equal(t, "myotherbin_0.0.1_windows_amd64.exe", windows2.Name)
-	require.Equal(t, "myotherbin.exe", artifact.ExtraOr(*windows2, artifact.ExtraBinary, ""))
+	require.Equal(t, "myotherbin.exe", artifact.MustExtra[string](*windows2, artifact.ExtraBinary))
 }
 
 func TestRunPipeDistRemoved(t *testing.T) {
@@ -788,7 +788,7 @@ func TestRunPipeWrap(t *testing.T) {
 
 	archives := ctx.Artifacts.Filter(artifact.ByType(artifact.UploadableArchive)).List()
 	require.Len(t, archives, 1)
-	require.Equal(t, "foo_darwin", artifact.ExtraOr(*archives[0], artifact.ExtraWrappedIn, ""))
+	require.Equal(t, "foo_darwin", artifact.MustExtra[string](*archives[0], artifact.ExtraWrappedIn))
 
 	require.ElementsMatch(
 		t,
@@ -966,7 +966,7 @@ func TestBinaryOverride(t *testing.T) {
 	windows := archives.Filter(artifact.ByGoos("windows")).List()[0]
 	require.Equal(t, "foobar_0.0.1_windows_amd64.exe", windows.Name)
 	require.Empty(t, artifact.ExtraOr(*windows, artifact.ExtraWrappedIn, ""))
-	require.Equal(t, "mybin.exe", artifact.ExtraOr(*windows, artifact.ExtraBinary, ""))
+	require.Equal(t, "mybin.exe", artifact.MustExtra[string](*windows, artifact.ExtraBinary))
 }
 
 func TestRunPipeSameArchiveFilename(t *testing.T) {

--- a/internal/pipe/aur/aur.go
+++ b/internal/pipe/aur/aur.go
@@ -146,11 +146,11 @@ func doRun(ctx *context.Context, aur config.AUR, cl client.ReleaseURLTemplater) 
 		switch art.Type {
 		case artifact.UploadableBinary:
 			name := art.Name
-			bin := artifact.ExtraOr(*art, artifact.ExtraBinary, art.Name)
+			bin := artifact.MustExtra[string](*art, artifact.ExtraBinary)
 			pkg = fmt.Sprintf(`install -Dm755 "./%s "${pkgdir}/usr/bin/%s"`, name, bin)
 		case artifact.UploadableArchive:
 			folder := artifact.ExtraOr(*art, artifact.ExtraWrappedIn, ".")
-			for _, bin := range artifact.ExtraOr(*art, artifact.ExtraBinaries, []string{}) {
+			for _, bin := range artifact.MustExtra[[]string](*art, artifact.ExtraBinaries) {
 				path := filepath.ToSlash(filepath.Clean(filepath.Join(folder, bin)))
 				pkg = fmt.Sprintf(`install -Dm755 "./%s" "${pkgdir}/usr/bin/%s"`, path, bin)
 				break
@@ -345,7 +345,7 @@ func dataFor(ctx *context.Context, cfg config.AUR, cl client.ReleaseURLTemplater
 			DownloadURL: url,
 			SHA256:      sum,
 			Arch:        toPkgBuildArch(art.Goarch + art.Goarm),
-			Format:      artifact.ExtraOr(*art, artifact.ExtraFormat, ""),
+			Format:      art.Format(),
 		}
 		result.ReleasePackages = append(result.ReleasePackages, releasePackage)
 		result.Arches = append(result.Arches, releasePackage.Arch)

--- a/internal/pipe/aur/aur.go
+++ b/internal/pipe/aur/aur.go
@@ -380,11 +380,7 @@ func (Pipe) Publish(ctx *context.Context) error {
 }
 
 func doPublish(ctx *context.Context, pkgs []*artifact.Artifact) error {
-	cfg, err := artifact.Extra[config.AUR](*pkgs[0], aurExtra)
-	if err != nil {
-		return err
-	}
-
+	cfg := artifact.MustExtra[config.AUR](*pkgs[0], aurExtra)
 	if strings.TrimSpace(cfg.SkipUpload) == "true" {
 		return pipe.Skip("aur.skip_upload is set")
 	}

--- a/internal/pipe/aursources/aursources.go
+++ b/internal/pipe/aursources/aursources.go
@@ -309,7 +309,7 @@ func dataFor(ctx *context.Context, cfg config.AURSource, cl client.ReleaseURLTem
 		result.Sources = sources{
 			DownloadURL: url,
 			SHA256:      sum,
-			Format:      artifact.ExtraOr(*art, artifact.ExtraFormat, ""),
+			Format:      art.Format(),
 		}
 	}
 

--- a/internal/pipe/aursources/aursources.go
+++ b/internal/pipe/aursources/aursources.go
@@ -340,11 +340,7 @@ func (Pipe) Publish(ctx *context.Context) error {
 }
 
 func doPublish(ctx *context.Context, pkgs []*artifact.Artifact) error {
-	cfg, err := artifact.Extra[config.AURSource](*pkgs[0], aurExtra)
-	if err != nil {
-		return err
-	}
-
+	cfg := artifact.MustExtra[config.AURSource](*pkgs[0], aurExtra)
 	if strings.TrimSpace(cfg.SkipUpload) == "true" {
 		return pipe.Skip("aur.skip_upload is set")
 	}

--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -371,10 +371,10 @@ func installs(ctx *context.Context, cfg config.Homebrew, art *artifact.Artifact)
 	switch art.Type {
 	case artifact.UploadableBinary:
 		name := art.Name
-		bin := artifact.ExtraOr(*art, artifact.ExtraBinary, art.Name)
+		bin := artifact.MustExtra[string](*art, artifact.ExtraBinary)
 		installMap[fmt.Sprintf("bin.install %q => %q", name, bin)] = true
 	case artifact.UploadableArchive:
-		for _, bin := range artifact.ExtraOr(*art, artifact.ExtraBinaries, []string{}) {
+		for _, bin := range artifact.MustExtra[[]string](*art, artifact.ExtraBinaries) {
 			installMap[fmt.Sprintf("bin.install %q", bin)] = true
 		}
 	}

--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -121,11 +121,7 @@ func publishAll(ctx *context.Context, cli client.Client) error {
 }
 
 func doPublish(ctx *context.Context, formula *artifact.Artifact, cl client.Client) error {
-	brew, err := artifact.Extra[config.Homebrew](*formula, brewConfigExtra)
-	if err != nil {
-		return err
-	}
-
+	brew := artifact.MustExtra[config.Homebrew](*formula, brewConfigExtra)
 	if strings.TrimSpace(brew.SkipUpload) == "true" {
 		return pipe.Skip("brew.skip_upload is set")
 	}

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -361,8 +361,9 @@ func TestFullPipe(t *testing.T) {
 				Goamd64: "v1",
 				Type:    artifact.UploadableArchive,
 				Extra: map[string]any{
-					artifact.ExtraID:     "bar",
-					artifact.ExtraFormat: "tar.gz",
+					artifact.ExtraID:       "bar",
+					artifact.ExtraFormat:   "tar.gz",
+					artifact.ExtraBinaries: []string{"bar"},
 				},
 			})
 			path := filepath.Join(folder, "bin.tar.gz")
@@ -374,8 +375,9 @@ func TestFullPipe(t *testing.T) {
 				Goamd64: "v1",
 				Type:    artifact.UploadableArchive,
 				Extra: map[string]any{
-					artifact.ExtraID:     "foo",
-					artifact.ExtraFormat: "tar.gz",
+					artifact.ExtraID:       "foo",
+					artifact.ExtraFormat:   "tar.gz",
+					artifact.ExtraBinaries: []string{"foo"},
 				},
 			})
 			ctx.Artifacts.Add(&artifact.Artifact{
@@ -385,8 +387,9 @@ func TestFullPipe(t *testing.T) {
 				Goarch: "arm64",
 				Type:   artifact.UploadableArchive,
 				Extra: map[string]any{
-					artifact.ExtraID:     "foo",
-					artifact.ExtraFormat: "tar.gz",
+					artifact.ExtraID:       "foo",
+					artifact.ExtraFormat:   "tar.gz",
+					artifact.ExtraBinaries: []string{"foo"},
 				},
 			})
 			ctx.Artifacts.Add(&artifact.Artifact{
@@ -397,8 +400,9 @@ func TestFullPipe(t *testing.T) {
 				Goamd64: "v1",
 				Type:    artifact.UploadableArchive,
 				Extra: map[string]any{
-					artifact.ExtraID:     "foo",
-					artifact.ExtraFormat: "tar.gz",
+					artifact.ExtraID:       "foo",
+					artifact.ExtraFormat:   "tar.gz",
+					artifact.ExtraBinaries: []string{"foo"},
 				},
 			})
 
@@ -488,8 +492,9 @@ func TestRunPipeNameTemplate(t *testing.T) {
 		Goamd64: "v1",
 		Type:    artifact.UploadableArchive,
 		Extra: map[string]any{
-			artifact.ExtraID:     "foo",
-			artifact.ExtraFormat: "tar.gz",
+			artifact.ExtraID:       "foo",
+			artifact.ExtraFormat:   "tar.gz",
+			artifact.ExtraBinaries: []string{"foo"},
 		},
 	})
 
@@ -580,8 +585,9 @@ func TestRunPipeMultipleBrewsWithSkip(t *testing.T) {
 		Goamd64: "v1",
 		Type:    artifact.UploadableArchive,
 		Extra: map[string]any{
-			artifact.ExtraID:     "foo",
-			artifact.ExtraFormat: "tar.gz",
+			artifact.ExtraID:       "foo",
+			artifact.ExtraFormat:   "tar.gz",
+			artifact.ExtraBinaries: []string{"foo"},
 		},
 	})
 
@@ -701,8 +707,9 @@ func TestRunPipeForMultipleAmd64Versions(t *testing.T) {
 					Goamd64: a.goamd64,
 					Type:    artifact.UploadableArchive,
 					Extra: map[string]any{
-						artifact.ExtraID:     a.name,
-						artifact.ExtraFormat: "tar.gz",
+						artifact.ExtraID:       a.name,
+						artifact.ExtraFormat:   "tar.gz",
+						artifact.ExtraBinaries: []string{a.name},
 					},
 				})
 				f, err := os.Create(path)
@@ -822,8 +829,9 @@ func TestRunPipeForMultipleArmVersions(t *testing.T) {
 					Goarm:  a.goarm,
 					Type:   artifact.UploadableArchive,
 					Extra: map[string]any{
-						artifact.ExtraID:     a.name,
-						artifact.ExtraFormat: "tar.gz",
+						artifact.ExtraID:       a.name,
+						artifact.ExtraFormat:   "tar.gz",
+						artifact.ExtraBinaries: []string{a.name},
 					},
 				})
 				f, err := os.Create(path)
@@ -999,8 +1007,9 @@ func TestRunPipeMultipleArchivesSameOsBuild(t *testing.T) {
 				Goarch: ttt.goarch,
 				Type:   artifact.UploadableArchive,
 				Extra: map[string]any{
-					artifact.ExtraID:     fmt.Sprintf("foo%d", idx),
-					artifact.ExtraFormat: "tar.gz",
+					artifact.ExtraID:       fmt.Sprintf("foo%d", idx),
+					artifact.ExtraFormat:   "tar.gz",
+					artifact.ExtraBinaries: []string{"foo"},
 				},
 			})
 		}
@@ -1143,8 +1152,9 @@ func TestRunPipeNoUpload(t *testing.T) {
 		Goamd64: "v1",
 		Type:    artifact.UploadableArchive,
 		Extra: map[string]any{
-			artifact.ExtraID:     "foo",
-			artifact.ExtraFormat: "tar.gz",
+			artifact.ExtraID:       "foo",
+			artifact.ExtraFormat:   "tar.gz",
+			artifact.ExtraBinaries: []string{"foo"},
 		},
 	})
 	client := client.NewMock()
@@ -1200,8 +1210,9 @@ func TestRunEmptyTokenType(t *testing.T) {
 		Goamd64: "v1",
 		Type:    artifact.UploadableArchive,
 		Extra: map[string]any{
-			artifact.ExtraID:     "foo",
-			artifact.ExtraFormat: "tar.gz",
+			artifact.ExtraID:       "foo",
+			artifact.ExtraFormat:   "tar.gz",
+			artifact.ExtraBinaries: []string{"foo"},
 		},
 	})
 	client := client.NewMock()

--- a/internal/pipe/checksums/checksums_test.go
+++ b/internal/pipe/checksums/checksums_test.go
@@ -469,8 +469,7 @@ func TestPipeCheckSumsWithExtraFiles(t *testing.T) {
 				if len(tt.ids) > 0 {
 					return nil
 				}
-				checkSum, err := artifact.Extra[string](*a, artifactChecksumExtra)
-				require.NoError(t, err)
+				checkSum := artifact.MustExtra[string](*a, artifactChecksumExtra)
 				require.NotEmptyf(t, checkSum, "failed: %v", a.Path)
 				return nil
 			})

--- a/internal/pipe/chocolatey/chocolatey.go
+++ b/internal/pipe/chocolatey/chocolatey.go
@@ -181,11 +181,7 @@ func doRun(ctx *context.Context, cl client.ReleaseURLTemplater, choco config.Cho
 }
 
 func doPush(ctx *context.Context, art *artifact.Artifact) error {
-	choco, err := artifact.Extra[config.Chocolatey](*art, chocoConfigExtra)
-	if err != nil {
-		return err
-	}
-
+	choco := artifact.MustExtra[config.Chocolatey](*art, chocoConfigExtra)
 	key, err := tmpl.New(ctx).Apply(choco.APIKey)
 	if err != nil {
 		return err

--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -301,11 +301,7 @@ func processBuildFlagTemplates(ctx *context.Context, docker config.Docker) ([]st
 func dockerPush(ctx *context.Context, image *artifact.Artifact) error {
 	log.WithField("image", image.Name).Info("pushing")
 
-	docker, err := artifact.Extra[config.Docker](*image, dockerConfigExtra)
-	if err != nil {
-		return err
-	}
-
+	docker := artifact.MustExtra[config.Docker](*image, dockerConfigExtra)
 	skip, err := tmpl.New(ctx).Apply(docker.SkipPush)
 	if err != nil {
 		return err

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -1076,8 +1076,7 @@ func TestRunPipe(t *testing.T) {
 						artifact.ByType(artifact.DockerManifest),
 					),
 				).Visit(func(a *artifact.Artifact) error {
-					digest, err := artifact.Extra[string](*a, artifact.ExtraDigest)
-					require.NoError(t, err)
+					digest := artifact.MustExtra[string](*a, artifact.ExtraDigest)
 					require.NotEmpty(t, digest, "missing digest for "+a.Name)
 					return nil
 				})

--- a/internal/pipe/krew/krew.go
+++ b/internal/pipe/krew/krew.go
@@ -284,11 +284,7 @@ func publishAll(ctx *context.Context, cli client.Client) error {
 }
 
 func doPublish(ctx *context.Context, manifest *artifact.Artifact, cl client.Client) error {
-	cfg, err := artifact.Extra[config.Krew](*manifest, krewConfigExtra)
-	if err != nil {
-		return err
-	}
-
+	cfg := artifact.MustExtra[config.Krew](*manifest, krewConfigExtra)
 	if strings.TrimSpace(cfg.SkipUpload) == "true" {
 		return pipe.Skip("krews.skip_upload is set")
 	}

--- a/internal/pipe/krew/krew.go
+++ b/internal/pipe/krew/krew.go
@@ -234,7 +234,7 @@ func manifestFor(
 		}
 
 		for _, arch := range goarch {
-			bins := artifact.ExtraOr(*art, artifact.ExtraBinaries, []string{})
+			bins := artifact.MustExtra[[]string](*art, artifact.ExtraBinaries)
 			if len(bins) != 1 {
 				return result, fmt.Errorf("krew: only one binary per archive allowed, got %d on %q", len(bins), art.Name)
 			}

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -413,7 +413,7 @@ func TestRunPipe(t *testing.T) {
 	for _, pkg := range packages {
 		format := pkg.Format()
 		require.NotEmpty(t, format)
-		require.Equal(t, "."+pkg.Format(), artifact.ExtraOr(*pkg, artifact.ExtraExt, ""))
+		require.Equal(t, "."+pkg.Format(), pkg.Ext())
 		arch := pkg.Goarch
 		if pkg.Goarm != "" {
 			arch += "v" + pkg.Goarm
@@ -451,7 +451,7 @@ func TestRunPipe(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, now.UTC(), stat.ModTime().UTC())
 
-		contents := artifact.ExtraOr(*pkg, extraFiles, files.Contents{})
+		contents := artifact.MustExtra[files.Contents](*pkg, extraFiles)
 		for _, src := range contents {
 			require.NotNil(t, src.FileInfo, src.Destination)
 			require.Equal(t, now.UTC(), src.FileInfo.MTime.UTC(), src.Destination)
@@ -508,7 +508,7 @@ func TestRunPipe(t *testing.T) {
 			header,
 			carchive,
 			cshared,
-		}, destinations(artifact.ExtraOr(*pkg, extraFiles, files.Contents{})))
+		}, destinations(artifact.MustExtra[files.Contents](*pkg, extraFiles)))
 	}
 	require.Len(t, ctx.Config.NFPMs[0].Contents, 8, "should not modify the config file list")
 }
@@ -789,8 +789,8 @@ func doTestRunPipeConventionalNameTemplate(t *testing.T, snapshot bool) {
 			prefix + "_1.0.0_riscv64.deb",
 		}, pkg.Name, "package name is not expected")
 		require.Equal(t, "someid", pkg.ID())
-		require.ElementsMatch(t, []string{binPath}, sources(artifact.ExtraOr(*pkg, extraFiles, files.Contents{})))
-		require.ElementsMatch(t, []string{"/usr/bin/subdir/mybin"}, destinations(artifact.ExtraOr(*pkg, extraFiles, files.Contents{})))
+		require.ElementsMatch(t, []string{binPath}, sources(artifact.MustExtra[files.Contents](*pkg, extraFiles)))
+		require.ElementsMatch(t, []string{"/usr/bin/subdir/mybin"}, destinations(artifact.MustExtra[files.Contents](*pkg, extraFiles)))
 	}
 }
 
@@ -1665,7 +1665,7 @@ func TestMeta(t *testing.T) {
 			"/usr/share/testfile.txt",
 			"/etc/nope.conf",
 			"/etc/nope-rpm.conf",
-		}, destinations(artifact.ExtraOr(*pkg, extraFiles, files.Contents{})))
+		}, destinations(artifact.MustExtra[files.Contents](*pkg, extraFiles)))
 	}
 
 	require.Len(t, ctx.Config.NFPMs[0].Contents, 4, "should not modify the config file list")
@@ -1802,7 +1802,7 @@ func TestBinDirTemplating(t *testing.T) {
 		// the final binary should contain the evaluated bindir (after template eval)
 		require.ElementsMatch(t, []string{
 			"/usr/lib/pro/nagios/plugins/subdir/mybin",
-		}, destinations(artifact.ExtraOr(*pkg, extraFiles, files.Contents{})))
+		}, destinations(artifact.MustExtra[files.Contents](*pkg, extraFiles)))
 	}
 }
 

--- a/internal/pipe/nix/nix.go
+++ b/internal/pipe/nix/nix.go
@@ -340,11 +340,7 @@ var goosToPlatform = map[string]string{
 }
 
 func doPublish(ctx *context.Context, hasher fileHasher, cl client.Client, pkg *artifact.Artifact) error {
-	nix, err := artifact.Extra[config.Nix](*pkg, nixConfigExtra)
-	if err != nil {
-		return err
-	}
-
+	nix := artifact.MustExtra[config.Nix](*pkg, nixConfigExtra)
 	if strings.TrimSpace(nix.SkipUpload) == "true" {
 		return errSkipUpload
 	}

--- a/internal/pipe/nix/nix.go
+++ b/internal/pipe/nix/nix.go
@@ -4,6 +4,7 @@ package nix
 import (
 	"bufio"
 	"bytes"
+	"cmp"
 	"errors"
 	"fmt"
 	"maps"
@@ -301,10 +302,7 @@ func preparePkg(
 			if _, ok := data.Archives[key]; ok {
 				return "", ErrMultipleArchivesSamePlatform
 			}
-			folder := artifact.ExtraOr(*art, artifact.ExtraWrappedIn, ".")
-			if folder == "" {
-				folder = "."
-			}
+			folder := cmp.Or(artifact.ExtraOr(*art, artifact.ExtraWrappedIn, ""), ".")
 			data.SourceRoots[key] = folder
 			data.Archives[key] = archive
 			plat := goosToPlatform[art.Goos+goarch+art.Goarm]
@@ -477,7 +475,7 @@ func installs(ctx *context.Context, nix config.Nix, art *artifact.Artifact) ([]s
 
 	result := []string{"mkdir -p $out/bin"}
 	binInstallFormat := binInstallFormats(nix)
-	for _, bin := range artifact.ExtraOr(*art, artifact.ExtraBinaries, []string{}) {
+	for _, bin := range artifact.MustExtra[[]string](*art, artifact.ExtraBinaries) {
 		for _, format := range binInstallFormat {
 			result = append(result, fmt.Sprintf(format, bin))
 		}

--- a/internal/pipe/reportsizes/reportsizes_test.go
+++ b/internal/pipe/reportsizes/reportsizes_test.go
@@ -60,6 +60,6 @@ func TestRun(t *testing.T) {
 	require.NoError(t, Pipe{}.Run(ctx))
 
 	for _, art := range ctx.Artifacts.List() {
-		require.NotZero(t, artifact.ExtraOr[int64](*art, artifact.ExtraSize, 0))
+		require.NotZero(t, artifact.MustExtra[int64](*art, artifact.ExtraSize))
 	}
 }

--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -208,11 +208,7 @@ func publishAll(ctx *context.Context, cli client.Client) error {
 }
 
 func doPublish(ctx *context.Context, manifest *artifact.Artifact, cl client.Client) error {
-	scoop, err := artifact.Extra[config.Scoop](*manifest, scoopConfigExtra)
-	if err != nil {
-		return err
-	}
-
+	scoop := artifact.MustExtra[config.Scoop](*manifest, scoopConfigExtra)
 	if strings.TrimSpace(scoop.SkipUpload) == "true" {
 		return pipe.Skip("scoop.skip_upload is true")
 	}
@@ -368,14 +364,9 @@ func dataFor(ctx *context.Context, scoop config.Scoop, cl client.ReleaseURLTempl
 			WithField("sum", sum).
 			Debug("scoop url templating")
 
-		binaries, err := binaries(*artifact)
-		if err != nil {
-			return manifest, err
-		}
-
 		manifest.Architecture[arch] = Resource{
 			URL:  url,
-			Bin:  binaries,
+			Bin:  binaries(*artifact),
 			Hash: sum,
 		}
 	}
@@ -383,16 +374,13 @@ func dataFor(ctx *context.Context, scoop config.Scoop, cl client.ReleaseURLTempl
 	return manifest, nil
 }
 
-func binaries(a artifact.Artifact) ([]string, error) {
+func binaries(a artifact.Artifact) []string {
 	//nolint:prealloc
 	var result []string
 	wrap := artifact.ExtraOr(a, artifact.ExtraWrappedIn, "")
-	bins, err := artifact.Extra[[]string](a, artifact.ExtraBinaries)
-	if err != nil {
-		return nil, err
-	}
+	bins := artifact.MustExtra[[]string](a, artifact.ExtraBinaries)
 	for _, b := range bins {
 		result = append(result, filepath.ToSlash(filepath.Join(wrap, b)))
 	}
-	return result, nil
+	return result
 }

--- a/internal/pipe/scoop/scoop_test.go
+++ b/internal/pipe/scoop/scoop_test.go
@@ -150,14 +150,28 @@ func Test_doRun(t *testing.T) {
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
-				{Name: "foo_1.0.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64", Goamd64: "v1", Path: file, Extra: map[string]any{
-					artifact.ExtraID:       "id1",
-					artifact.ExtraBinaries: []string{"bin1", "bin2"},
-				}},
-				{Name: "foos_1.0.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64", Goamd64: "v1", Path: file, Extra: map[string]any{
-					artifact.ExtraID:       "id2",
-					artifact.ExtraBinaries: []string{"bin4", "bin3"},
-				}},
+				{
+					Name:    "foo_1.0.1_windows_amd64.tar.gz",
+					Goos:    "windows",
+					Goarch:  "amd64",
+					Goamd64: "v1",
+					Path:    file,
+					Extra: map[string]any{
+						artifact.ExtraID:       "id1",
+						artifact.ExtraBinaries: []string{"bin1", "bin2"},
+					},
+				},
+				{
+					Name:    "foos_1.0.1_windows_amd64.tar.gz",
+					Goos:    "windows",
+					Goarch:  "amd64",
+					Goamd64: "v1",
+					Path:    file,
+					Extra: map[string]any{
+						artifact.ExtraID:       "id2",
+						artifact.ExtraBinaries: []string{"bin4", "bin3"},
+					},
+				},
 			},
 			shouldNotErr,
 			shouldNotErr,
@@ -193,8 +207,25 @@ func Test_doRun(t *testing.T) {
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
-				{Name: "foo_1.0.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64", Goamd64: "v1", Path: file},
-				{Name: "foo_1.0.1_windows_386.tar.gz", Goos: "windows", Goarch: "386", Path: file},
+				{
+					Name:    "foo_1.0.1_windows_amd64.tar.gz",
+					Goos:    "windows",
+					Goarch:  "amd64",
+					Goamd64: "v1",
+					Path:    file,
+					Extra: map[string]any{
+						artifact.ExtraBinaries: []string{"foo"},
+					},
+				},
+				{
+					Name:   "foo_1.0.1_windows_386.tar.gz",
+					Goos:   "windows",
+					Goarch: "386",
+					Path:   file,
+					Extra: map[string]any{
+						artifact.ExtraBinaries: []string{"foo"},
+					},
+				},
 			},
 			shouldNotErr,
 			shouldNotErr,
@@ -234,8 +265,25 @@ func Test_doRun(t *testing.T) {
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
-				{Name: "foo_1.0.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64", Goamd64: "v1", Path: file},
-				{Name: "foo_1.0.1_windows_386.tar.gz", Goos: "windows", Goarch: "386", Path: file},
+				{
+					Name:    "foo_1.0.1_windows_amd64.tar.gz",
+					Goos:    "windows",
+					Goarch:  "amd64",
+					Goamd64: "v1",
+					Path:    file,
+					Extra: map[string]any{
+						artifact.ExtraBinaries: []string{"foo"},
+					},
+				},
+				{
+					Name:   "foo_1.0.1_windows_386.tar.gz",
+					Goos:   "windows",
+					Goarch: "386",
+					Path:   file,
+					Extra: map[string]any{
+						artifact.ExtraBinaries: []string{"foo"},
+					},
+				},
 			},
 			shouldNotErr,
 			shouldNotErr,
@@ -281,7 +329,8 @@ func Test_doRun(t *testing.T) {
 					Goamd64: "v1",
 					Path:    file,
 					Extra: map[string]any{
-						"Wrap": "foo_1.0.1_windows_amd64",
+						artifact.ExtraWrappedIn: "foo_1.0.1_windows_amd64",
+						artifact.ExtraBinaries:  []string{"foo"},
 					},
 				},
 				{
@@ -290,7 +339,8 @@ func Test_doRun(t *testing.T) {
 					Goarch: "386",
 					Path:   file,
 					Extra: map[string]any{
-						"Wrap": "foo_1.0.1_windows_386",
+						artifact.ExtraWrappedIn: "foo_1.0.1_windows_386",
+						artifact.ExtraBinaries:  []string{"foo"},
 					},
 				},
 			},
@@ -323,8 +373,25 @@ func Test_doRun(t *testing.T) {
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
-				{Name: "foo_1.0.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64", Goamd64: "v1", Path: file},
-				{Name: "foo_1.0.1_windows_386.tar.gz", Goos: "windows", Goarch: "386", Path: file},
+				{
+					Name:    "foo_1.0.1_windows_amd64.tar.gz",
+					Goos:    "windows",
+					Goarch:  "amd64",
+					Goamd64: "v1",
+					Path:    file,
+					Extra: map[string]any{
+						artifact.ExtraBinaries: []string{"foo"},
+					},
+				},
+				{
+					Name:   "foo_1.0.1_windows_386.tar.gz",
+					Goos:   "windows",
+					Goarch: "386",
+					Path:   file,
+					Extra: map[string]any{
+						artifact.ExtraBinaries: []string{"foo"},
+					},
+				},
 			},
 			shouldNotErr,
 			shouldNotErr,
@@ -363,12 +430,18 @@ func Test_doRun(t *testing.T) {
 					Goarch:  "amd64",
 					Goamd64: "v1",
 					Path:    file,
+					Extra: map[string]any{
+						artifact.ExtraBinaries: []string{"foo"},
+					},
 				},
 				{
 					Name:   "foo_1.0.1_windows_386.tar.gz",
 					Goos:   "windows",
 					Goarch: "386",
 					Path:   file,
+					Extra: map[string]any{
+						artifact.ExtraBinaries: []string{"foo"},
+					},
 				},
 			},
 			shouldNotErr,
@@ -406,12 +479,18 @@ func Test_doRun(t *testing.T) {
 					Goarch:  "amd64",
 					Goamd64: "v1",
 					Path:    file,
+					Extra: map[string]any{
+						artifact.ExtraBinaries: []string{"foo"},
+					},
 				},
 				{
 					Name:   "foo_1.0.1_windows_386.tar.gz",
 					Goos:   "windows",
 					Goarch: "386",
 					Path:   file,
+					Extra: map[string]any{
+						artifact.ExtraBinaries: []string{"foo"},
+					},
 				},
 			},
 			shouldNotErr,
@@ -472,8 +551,25 @@ func Test_doRun(t *testing.T) {
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
-				{Name: "foo_1.0.1-pre.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64", Goamd64: "v1", Path: file},
-				{Name: "foo_1.0.1-pre.1_windows_386.tar.gz", Goos: "windows", Goarch: "386", Path: file},
+				{
+					Name:    "foo_1.0.1-pre.1_windows_amd64.tar.gz",
+					Goos:    "windows",
+					Goarch:  "amd64",
+					Goamd64: "v1",
+					Path:    file,
+					Extra: map[string]any{
+						artifact.ExtraBinaries: []string{"foo"},
+					},
+				},
+				{
+					Name:   "foo_1.0.1-pre.1_windows_386.tar.gz",
+					Goos:   "windows",
+					Goarch: "386",
+					Path:   file,
+					Extra: map[string]any{
+						artifact.ExtraBinaries: []string{"foo"},
+					},
+				},
 			},
 			shouldNotErr,
 			shouldErr("release is prerelease"),
@@ -504,8 +600,25 @@ func Test_doRun(t *testing.T) {
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
-				{Name: "foo_1.0.1-pre.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64", Goamd64: "v1", Path: file},
-				{Name: "foo_1.0.1-pre.1_windows_386.tar.gz", Goos: "windows", Goarch: "386", Path: file},
+				{
+					Name:    "foo_1.0.1-pre.1_windows_amd64.tar.gz",
+					Goos:    "windows",
+					Goarch:  "amd64",
+					Goamd64: "v1",
+					Path:    file,
+					Extra: map[string]any{
+						artifact.ExtraBinaries: []string{"foo"},
+					},
+				},
+				{
+					Name:   "foo_1.0.1-pre.1_windows_386.tar.gz",
+					Goos:   "windows",
+					Goarch: "386",
+					Path:   file,
+					Extra: map[string]any{
+						artifact.ExtraBinaries: []string{"foo"},
+					},
+				},
 			},
 			shouldNotErr,
 			shouldErr("scoop.skip_upload is true"),
@@ -680,7 +793,16 @@ func Test_doRun(t *testing.T) {
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
-				{Name: "foo_1.0.1-pre.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64", Goamd64: "v1", Path: file},
+				{
+					Name:    "foo_1.0.1-pre.1_windows_amd64.tar.gz",
+					Goos:    "windows",
+					Goarch:  "amd64",
+					Goamd64: "v1",
+					Path:    file,
+					Extra: map[string]any{
+						artifact.ExtraBinaries: []string{"foo"},
+					},
+				},
 			},
 			testlib.RequireTemplateError,
 			shouldNotErr,
@@ -711,7 +833,16 @@ func Test_doRun(t *testing.T) {
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
-				{Name: "foo_1.0.1_windows_amd64.tar.gz", Goos: "windows", Goarch: "amd64", Goamd64: "v1", Path: file},
+				{
+					Name:    "foo_1.0.1_windows_amd64.tar.gz",
+					Goos:    "windows",
+					Goarch:  "amd64",
+					Goamd64: "v1",
+					Path:    file,
+					Extra: map[string]any{
+						artifact.ExtraBinaries: []string{"foo"},
+					},
+				},
 			},
 			shouldNotErr,
 			shouldNotErr,
@@ -771,9 +902,9 @@ func TestRunPipePullRequest(t *testing.T) {
 		Goarch: "amd64",
 		Type:   artifact.UploadableArchive,
 		Extra: map[string]any{
-			artifact.ExtraID:     "foo",
-			artifact.ExtraFormat: "tar.gz",
-			artifact.ExtraBinary: "foo",
+			artifact.ExtraID:       "foo",
+			artifact.ExtraFormat:   "tar.gz",
+			artifact.ExtraBinaries: []string{"foo"},
 		},
 	})
 
@@ -1022,8 +1153,9 @@ func getScoopPipeSkipCtx(directory string) (*context.Context, string) {
 		Goamd64: "v1",
 		Type:    artifact.UploadableArchive,
 		Extra: map[string]any{
-			artifact.ExtraID:     "foo",
-			artifact.ExtraFormat: "tar.gz",
+			artifact.ExtraID:       "foo",
+			artifact.ExtraFormat:   "tar.gz",
+			artifact.ExtraBinaries: []string{"foo"},
 		},
 	})
 	ctx.Artifacts.Add(&artifact.Artifact{
@@ -1034,8 +1166,9 @@ func getScoopPipeSkipCtx(directory string) (*context.Context, string) {
 		Goamd64: "v3",
 		Type:    artifact.UploadableArchive,
 		Extra: map[string]any{
-			artifact.ExtraID:     "foo",
-			artifact.ExtraFormat: "tar.gz",
+			artifact.ExtraID:       "foo",
+			artifact.ExtraFormat:   "tar.gz",
+			artifact.ExtraBinaries: []string{"foo"},
 		},
 	})
 

--- a/internal/pipe/scoop/testdata/TestRunPipePullRequest.json.golden
+++ b/internal/pipe/scoop/testdata/TestRunPipePullRequest.json.golden
@@ -3,7 +3,9 @@
     "architecture": {
         "64bit": {
             "url": "https://dummyhost/download/v1.2.1/foo_windows_amd64.tar.gz",
-            "bin": null,
+            "bin": [
+                "foo"
+            ],
             "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         }
     },

--- a/internal/pipe/scoop/testdata/Test_doRun/git_remote.json.golden
+++ b/internal/pipe/scoop/testdata/Test_doRun/git_remote.json.golden
@@ -3,12 +3,16 @@
     "architecture": {
         "32bit": {
             "url": "https://dummyhost/download/v1.0.1/foo_1.0.1_windows_386.tar.gz",
-            "bin": null,
+            "bin": [
+                "foo"
+            ],
             "hash": "5e2bf57d3f40c4b6df69daf1936cb766f832374b4fc0259a7cbff06e2f70f269"
         },
         "64bit": {
             "url": "https://dummyhost/download/v1.0.1/foo_1.0.1_windows_amd64.tar.gz",
-            "bin": null,
+            "bin": [
+                "foo"
+            ],
             "hash": "5e2bf57d3f40c4b6df69daf1936cb766f832374b4fc0259a7cbff06e2f70f269"
         }
     },

--- a/internal/pipe/scoop/testdata/Test_doRun/valid_public_github.json.golden
+++ b/internal/pipe/scoop/testdata/Test_doRun/valid_public_github.json.golden
@@ -3,12 +3,16 @@
     "architecture": {
         "32bit": {
             "url": "https://dummyhost/download/v1.0.1/foo_1.0.1_windows_386.tar.gz",
-            "bin": null,
+            "bin": [
+                "foo"
+            ],
             "hash": "5e2bf57d3f40c4b6df69daf1936cb766f832374b4fc0259a7cbff06e2f70f269"
         },
         "64bit": {
             "url": "https://dummyhost/download/v1.0.1/foo_1.0.1_windows_amd64.tar.gz",
-            "bin": null,
+            "bin": [
+                "foo"
+            ],
             "hash": "5e2bf57d3f40c4b6df69daf1936cb766f832374b4fc0259a7cbff06e2f70f269"
         }
     },

--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -450,7 +450,7 @@ const (
 
 func push(ctx *context.Context, snap *artifact.Artifact) error {
 	log := log.WithField("snap", snap.Name)
-	releases := artifact.ExtraOr(*snap, releasesExtra, []string{})
+	releases := artifact.MustExtra[[]string](*snap, releasesExtra)
 	/* #nosec */
 	cmd := exec.CommandContext(ctx, "snapcraft", "upload", "--release="+strings.Join(releases, ","), snap.Path)
 	log.WithField("args", cmd.Args).Info("pushing snap")

--- a/internal/pipe/universalbinary/universalbinary_test.go
+++ b/internal/pipe/universalbinary/universalbinary_test.go
@@ -274,7 +274,7 @@ func TestRun(t *testing.T) {
 		unis := ctx1.Artifacts.Filter(artifact.ByType(artifact.UniversalBinary)).List()
 		require.Len(t, unis, 1)
 		checkUniversalBinary(t, unis[0])
-		require.True(t, artifact.ExtraOr(*unis[0], artifact.ExtraReplaces, false))
+		require.True(t, artifact.MustExtra[bool](*unis[0], artifact.ExtraReplaces))
 	})
 
 	t.Run("keeping", func(t *testing.T) {
@@ -283,7 +283,7 @@ func TestRun(t *testing.T) {
 		unis := ctx2.Artifacts.Filter(artifact.ByType(artifact.UniversalBinary)).List()
 		require.Len(t, unis, 1)
 		checkUniversalBinary(t, unis[0])
-		require.False(t, artifact.ExtraOr(*unis[0], artifact.ExtraReplaces, true))
+		require.False(t, artifact.MustExtra[bool](*unis[0], artifact.ExtraReplaces))
 	})
 
 	t.Run("bad template", func(t *testing.T) {

--- a/internal/pipe/winget/winget.go
+++ b/internal/pipe/winget/winget.go
@@ -406,7 +406,7 @@ func repoFileID(tp artifact.Type) string {
 func installerItemFilesFor(archive artifact.Artifact) []InstallerItemFile {
 	var files []InstallerItemFile
 	folder := artifact.ExtraOr(archive, artifact.ExtraWrappedIn, ".")
-	for _, bin := range artifact.ExtraOr(archive, artifact.ExtraBinaries, []string{}) {
+	for _, bin := range artifact.MustExtra[[]string](archive, artifact.ExtraBinaries) {
 		files = append(files, InstallerItemFile{
 			RelativeFilePath:     strings.ReplaceAll(filepath.Join(folder, bin), "/", "\\"),
 			PortableCommandAlias: strings.TrimSuffix(filepath.Base(bin), ".exe"),

--- a/internal/pipe/winget/winget.go
+++ b/internal/pipe/winget/winget.go
@@ -273,11 +273,7 @@ func (p Pipe) publishAll(ctx *context.Context, cli client.Client) error {
 }
 
 func doPublish(ctx *context.Context, cl client.Client, wingets []*artifact.Artifact) error {
-	winget, err := artifact.Extra[config.Winget](*wingets[0], wingetConfigExtra)
-	if err != nil {
-		return err
-	}
-
+	winget := artifact.MustExtra[config.Winget](*wingets[0], wingetConfigExtra)
 	if strings.TrimSpace(winget.SkipUpload) == "true" {
 		return errSkipUpload
 	}
@@ -459,18 +455,19 @@ func makeInstaller(ctx *context.Context, winget config.Winget, archives []*artif
 			InstallerSha256: sha256,
 			UpgradeBehavior: "uninstallPrevious",
 		}
-		if archive.Format() == "zip" {
+		switch archive.Type {
+		case artifact.UploadableArchive:
+			if archive.Format() != "zip" {
+				continue
+			}
 			zipCount++
 			installer.InstallerType = "zip"
 			item.NestedInstallerType = "portable"
 			item.NestedInstallerFiles = installerItemFilesFor(*archive)
-		} else {
+		case artifact.UploadableBinary:
 			binaryCount++
 			installer.InstallerType = "portable"
-			cmd, err := artifact.Extra[string](*archive, artifact.ExtraBinary)
-			if err != nil {
-				cmd = winget.Name
-			}
+			cmd := artifact.MustExtra[string](*archive, artifact.ExtraBinary)
 			installer.Commands = []string{cmd}
 		}
 		installer.Installers = append(installer.Installers, item)

--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -207,7 +207,7 @@ func (t *Template) WithArtifact(a *artifact.Artifact) *Template {
 		target:       a.Target,
 		binary:       artifact.ExtraOr(*a, binary, t.fields[projectName].(string)),
 		artifactName: a.Name,
-		artifactExt:  artifact.ExtraOr(*a, artifact.ExtraExt, ""),
+		artifactExt:  a.Ext(),
 		artifactPath: a.Path,
 	})
 }


### PR DESCRIPTION
- a lot of places `ExtraOr` is being used we actually expect the key to be there
- similarly, the previous `Extra` behavior was kind of the same of `ExtraOr` in some situations

This PR:

- improves `ExtraOr` by only returning `or` if the key doesn't exist, and panics if it cannot be cast into the expected type - which is the intended usage
- removes the `Extra` function
- adds a `MustExtra` function which panics if the key doesn't exist, or if it cannot be cast to the expected type