### PR TITLE
fix: set GOMAXPROCS=1 on each go build

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -320,6 +320,7 @@ func (*Builder) Build(ctx *context.Context, build config.Build, options api.Opti
 	if v := os.Getenv("GOCACHEPROG"); v != "" {
 		env = append(env, "GOCACHEPROG="+v)
 	}
+	env = append(env, "GOMAXPROCS=1")
 
 	if len(testEnvs) > 0 {
 		a.Extra["testEnvs"] = testEnvs


### PR DESCRIPTION
By default, we'll run goreleaser with `--parallelism=$GOMAXPROCS`, and then run `go build` for each target, which will also have `GOMAXPROCS` set.

This makes `--parallelism` actually not be respected, as it would create `GOMAXPROCS*GOMAXPROCS` threads.

This sets `GOMAXPROCS=1` in the `go build` process to address that.