### PR TITLE
fix: upx properly handle skips

### DIFF
--- a/internal/pipe/upx/testdata/fakeupx
+++ b/internal/pipe/upx/testdata/fakeupx
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+touch "${*: -1}.ran"
+echo "Fake compressed: ${*: -1}"

--- a/internal/pipe/upx/testdata/fakeupx.bat
+++ b/internal/pipe/upx/testdata/fakeupx.bat
@@ -1,0 +1,12 @@
+@echo off
+setlocal enabledelayedexpansion
+
+rem Get the last argument
+set args=%*
+for %%a in (%*) do set last=%%a
+
+rem Create empty file with .ran extension
+type nul > "%last%.ran"
+
+rem Output message
+echo Fake compressed: %last%

--- a/internal/pipe/upx/upx_test.go
+++ b/internal/pipe/upx/upx_test.go
@@ -51,8 +51,6 @@ func TestRun(t *testing.T) {
 	fakeupx, err := filepath.Abs("./testdata/fakeupx")
 	require.NoError(t, err)
 
-	t.Log(fakeupx)
-
 	ctx := testctx.NewWithCfg(config.Project{
 		UPXs: []config.UPX{
 			{

--- a/internal/pipe/upx/upx_test.go
+++ b/internal/pipe/upx/upx_test.go
@@ -48,7 +48,11 @@ func TestSkip(t *testing.T) {
 }
 
 func TestRun(t *testing.T) {
-	fakeupx, err := filepath.Abs("./testdata/fakeupx")
+	bin := "./testdata/fakeupx"
+	if testlib.IsWindows() {
+		bin += "+.bat"
+	}
+	fakeupx, err := filepath.Abs(bin)
 	require.NoError(t, err)
 
 	ctx := testctx.NewWithCfg(config.Project{

--- a/internal/pipe/upx/upx_test.go
+++ b/internal/pipe/upx/upx_test.go
@@ -50,7 +50,7 @@ func TestSkip(t *testing.T) {
 func TestRun(t *testing.T) {
 	bin := "./testdata/fakeupx"
 	if testlib.IsWindows() {
-		bin += "+.bat"
+		bin += ".bat"
 	}
 	fakeupx, err := filepath.Abs(bin)
 	require.NoError(t, err)

--- a/internal/pipe/upx/upx_test.go
+++ b/internal/pipe/upx/upx_test.go
@@ -109,7 +109,6 @@ func TestRun(t *testing.T) {
 				continue
 			}
 			for i := 1; i <= 5; i++ {
-				sid := strconv.Itoa(i)
 				path := filepath.Join(tmp, fmt.Sprintf("bin_%d_%s_%s%s", i, goos, goarch, ext))
 				require.NoError(t, os.WriteFile(path, []byte("fake bin"), 0o755))
 				expect = append(expect, path)
@@ -120,7 +119,7 @@ func TestRun(t *testing.T) {
 					Goarch: goarch,
 					Type:   artifact.Binary,
 					Extra: map[string]any{
-						artifact.ExtraID: sid,
+						artifact.ExtraID: strconv.Itoa(i),
 					},
 				})
 			}

--- a/internal/pipe/upx/upx_test.go
+++ b/internal/pipe/upx/upx_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
@@ -47,40 +48,55 @@ func TestSkip(t *testing.T) {
 }
 
 func TestRun(t *testing.T) {
-	testlib.CheckPath(t, "upx")
+	fakeupx, err := filepath.Abs("./testdata/fakeupx")
+	require.NoError(t, err)
+
+	t.Log(fakeupx)
+
 	ctx := testctx.NewWithCfg(config.Project{
 		UPXs: []config.UPX{
 			{
 				Enabled: "true",
 				IDs:     []string{"1"},
+				Binary:  fakeupx,
+			},
+			{
+				Enabled: "false",
 			},
 			{
 				Enabled:  "true",
 				IDs:      []string{"2"},
 				Compress: "best",
+				Binary:   fakeupx,
 			},
 			{
 				Enabled:  "true",
 				IDs:      []string{"3"},
 				Compress: "9",
+				Binary:   fakeupx,
 			},
 			{
 				Enabled:  "true",
 				IDs:      []string{"4"},
 				Compress: "8",
 				LZMA:     true,
+				Binary:   fakeupx,
+			},
+			{
+				Enabled: "false",
 			},
 			{
 				Enabled: `{{ eq .Env.UPX "1" }}`,
 				IDs:     []string{"5"},
 				Brute:   true,
+				Binary:  fakeupx,
 			},
 		},
 	}, testctx.WithEnv(map[string]string{"UPX": "1"}))
 
 	tmp := t.TempDir()
-	main := filepath.Join(tmp, "main.go")
-	require.NoError(t, os.WriteFile(main, []byte("package main\nfunc main(){ println(1) }"), 0o644))
+
+	var expect []string
 
 	for _, goos := range []string{"linux", "windows", "darwin"} {
 		for _, goarch := range []string{"386", "amd64", "arm64"} {
@@ -88,19 +104,17 @@ func TestRun(t *testing.T) {
 			if goos == "windows" {
 				ext = ".exe"
 			}
-			path := filepath.Join(tmp, fmt.Sprintf("bin_%s_%s%s", goos, goarch, ext))
-			cmd := exec.Command("go", "build", "-o", path, main)
-			cmd.Env = append([]string{
-				"CGO_ENABLED=0",
-				"GOOS=" + goos,
-				"GOARCH=" + goarch,
-			}, cmd.Environ()...)
-			if cmd.Run() != nil {
-				// ignore unsupported arches
+			if goos == "darwin" && goarch == "386" {
 				continue
 			}
-
+			if goos == "windows" && goarch == "arm64" {
+				continue
+			}
 			for i := 1; i <= 5; i++ {
+				sid := strconv.Itoa(i)
+				path := filepath.Join(tmp, fmt.Sprintf("bin_%d_%s_%s%s", i, goos, goarch, ext))
+				require.NoError(t, os.WriteFile(path, []byte("fake bin"), 0o755))
+				expect = append(expect, path)
 				ctx.Artifacts.Add(&artifact.Artifact{
 					Name:   "bin",
 					Path:   path,
@@ -108,7 +122,7 @@ func TestRun(t *testing.T) {
 					Goarch: goarch,
 					Type:   artifact.Binary,
 					Extra: map[string]any{
-						artifact.ExtraID: fmt.Sprintf("%d", i),
+						artifact.ExtraID: sid,
 					},
 				})
 			}
@@ -116,7 +130,11 @@ func TestRun(t *testing.T) {
 	}
 
 	require.NoError(t, Pipe{}.Default(ctx))
-	require.NoError(t, Pipe{}.Run(ctx))
+	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
+
+	for _, path := range expect {
+		require.FileExists(t, path+".ran")
+	}
 }
 
 func TestEnabled(t *testing.T) {

--- a/www/docs/static/schema-pro.json
+++ b/www/docs/static/schema-pro.json
@@ -755,6 +755,8 @@
 							"c-archive",
 							"c-shared",
 							"pie",
+							"wheel",
+							"sdist",
 							""
 						],
 						"default": ""
@@ -835,6 +837,8 @@
 							"c-archive",
 							"c-shared",
 							"pie",
+							"wheel",
+							"sdist",
 							""
 						],
 						"default": ""


### PR DESCRIPTION
closes #5719

- the actual skips were not being run inside the skip-aware context
- improved tests so we actually check it ran for all the binaries we want
- make tests faster by avoiding running `upx` for real and `go build`
