### PR TITLE
fix: group by platform should consider abi if available

### DIFF
--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -435,19 +435,23 @@ func (artifacts *Artifacts) GroupByPlatform() map[string][]*Artifact {
 	goamd64s := map[string]struct{}{}
 	gomipses := map[string]struct{}{}
 	goarms := map[string]struct{}{}
+	abis := map[string]struct{}{}
 	for _, a := range artifacts.List() {
 		plat := a.Goos + a.Goarch
-		fullplat := plat + a.Goarm + a.Gomips + a.Goamd64
+		abi := ExtraOr(*a, "Abi", "")
+		fullplat := plat + abi + a.Goarm + a.Gomips + a.Goamd64
 		goamd64s[a.Goamd64] = struct{}{}
 		gomipses[a.Gomips] = struct{}{}
 		goarms[a.Goarm] = struct{}{}
+		abis[abi] = struct{}{}
 		simpleResult[plat] = append(simpleResult[plat], a)
 		specificResult[fullplat] = append(specificResult[fullplat], a)
 	}
 
 	if len(nonEmpty(goamd64s)) > 1 ||
 		len(nonEmpty(gomipses)) > 1 ||
-		len(nonEmpty(goarms)) > 1 {
+		len(nonEmpty(goarms)) > 1 ||
+		len(nonEmpty(abis)) > 1 {
 		return specificResult
 	}
 

--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -380,6 +380,35 @@ func TestGroupByPlatform_mixingBuilders(t *testing.T) {
 	require.Len(t, groups["linuxarm"], 2)
 }
 
+func TestGroupByPlatform_abi(t *testing.T) {
+	data := []*Artifact{
+		{
+			Name:   "foo",
+			Goos:   "linux",
+			Goarch: "amd64",
+			Extra: map[string]any{
+				"Abi": "musl",
+			},
+		},
+		{
+			Name:   "foo",
+			Goos:   "linux",
+			Goarch: "amd64",
+			Extra: map[string]any{
+				"Abi": "gnu",
+			},
+		},
+	}
+	artifacts := New()
+	for _, a := range data {
+		artifacts.Add(a)
+	}
+	groups := artifacts.GroupByPlatform()
+	require.Len(t, groups, 2)
+	require.Len(t, groups["linuxamd64musl"], 1)
+	require.Len(t, groups["linuxamd64gnu"], 1)
+}
+
 func TestChecksum(t *testing.T) {
 	folder := t.TempDir()
 	file := filepath.Join(folder, "subject")

--- a/internal/builders/deno/build.go
+++ b/internal/builders/deno/build.go
@@ -95,6 +95,7 @@ func (b *Builder) Build(ctx *context.Context, build config.Build, options api.Op
 			artifact.ExtraExt:     options.Ext,
 			artifact.ExtraID:      build.ID,
 			artifact.ExtraBuilder: "deno",
+			keyAbi:                t.Abi,
 		},
 	}
 

--- a/internal/builders/deno/build_test.go
+++ b/internal/builders/deno/build_test.go
@@ -126,6 +126,7 @@ func TestBuild(t *testing.T) {
 			artifact.ExtraBuilder: "deno",
 			artifact.ExtraExt:     "",
 			artifact.ExtraID:      "default",
+			keyAbi:                "",
 		},
 	}, *bin)
 

--- a/internal/builders/deno/targets.go
+++ b/internal/builders/deno/targets.go
@@ -11,6 +11,8 @@ import (
 	api "github.com/goreleaser/goreleaser/v2/pkg/build"
 )
 
+const keyAbi = "Abi"
+
 // https://docs.deno.com/runtime/reference/cli/compile/#supported-targets
 var (
 	//go:embed targets.txt
@@ -34,7 +36,7 @@ func (t Target) Fields() map[string]string {
 		tmpl.KeyOS:   t.Os,
 		tmpl.KeyArch: t.Arch,
 		"Vendor":     t.Vendor,
-		"Abi":        t.Abi,
+		keyAbi:       t.Abi,
 	}
 }
 

--- a/internal/builders/zig/build.go
+++ b/internal/builders/zig/build.go
@@ -127,6 +127,7 @@ func (b *Builder) Build(ctx *context.Context, build config.Build, options api.Op
 			artifact.ExtraExt:     options.Ext,
 			artifact.ExtraID:      build.ID,
 			artifact.ExtraBuilder: "zig",
+			keyAbi:                t.Abi,
 		},
 	}
 

--- a/internal/builders/zig/build_test.go
+++ b/internal/builders/zig/build_test.go
@@ -164,6 +164,7 @@ func TestBuild(t *testing.T) {
 			artifact.ExtraBuilder: "zig",
 			artifact.ExtraExt:     "",
 			artifact.ExtraID:      "default",
+			keyAbi:                "",
 		},
 	}, *bin)
 

--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -132,7 +132,7 @@ func (Pipe) Run(ctx *context.Context) error {
 			return fmt.Errorf("invalid archive: %d: %w", i, ErrArchiveDifferentBinaryCount)
 		}
 		for group, artifacts := range artifacts {
-			log.Debugf("group %s has %d binaries", group, len(artifacts))
+			log.Infof("group %s has %d binaries", group, len(artifacts))
 			formats := packageFormats(archive, artifacts[0].Goos)
 			for _, format := range formats {
 				switch format {


### PR DESCRIPTION
closes https://github.com/goreleaser/goreleaser/issues/5722
