### PR TITLE
docs: use recommended SPDX SBOM filename in example

### DIFF
--- a/www/docs/customization/sbom.md
+++ b/www/docs/customization/sbom.md
@@ -42,7 +42,7 @@ sboms:
     #   Otherwise:       ["{{ .ArtifactName }}.sbom.json"]
     # Templates: allowed.
     documents:
-      - "${artifact}.spdx.sbom.json"
+      - "${artifact}.spdx.json"
 
     # Path to the SBOM generator command
     #


### PR DESCRIPTION
https://github.com/ossf/sbom-everywhere/blob/main/reference/sbom_naming.md#consistent-naming-conventions