### PR TITLE
fix(init): handle CRLF line endings in gitignore

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -115,16 +115,26 @@ func newInitCmd() *initCmd {
 	return root
 }
 
+
 func setupGitignore(path string, lines []string) (bool, error) {
 	ignored, _ := os.ReadFile(path)
+	content := strings.ReplaceAll(string(ignored), "\r\n", "\n")
+
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
 	if err != nil {
 		return false, err
 	}
 	defer f.Close()
+
+	if len(content) > 0 && !strings.HasSuffix(content, "\n") {
+		if _, err := f.WriteString("\n"); err != nil {
+			return false, err
+		}
+	}
+
 	var modified bool
 	for _, line := range lines {
-		if !strings.Contains(string(ignored), line+"\n") {
+		if !strings.Contains(content, line+"\n") {
 			if !modified {
 				line = "# Added by goreleaser init:\n" + line
 				modified = true

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -115,7 +115,6 @@ func newInitCmd() *initCmd {
 	return root
 }
 
-
 func setupGitignore(path string, lines []string) (bool, error) {
 	ignored, _ := os.ReadFile(path)
 	content := strings.ReplaceAll(string(ignored), "\r\n", "\n")

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -200,7 +200,6 @@ func TestSetupGitignore(t *testing.T) {
 		name           string
 		existing       string
 		lines          []string
-		expectModified bool
 		expectContent  string
 	}{
 		{

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -201,24 +201,56 @@ func TestSetupGitignore(t *testing.T) {
 		existing       string
 		lines          []string
 		expectContent  string
+		expectModified bool
 	}{
 		{
 			name:           "empty file",
 			existing:       "",
 			lines:          []string{"dist/"},
 			expectContent:  "# Added by goreleaser init:\ndist/\n",
+			expectModified: true,
 		},
 		{
 			name:           "no newline at end",
 			existing:       "foo",
 			lines:          []string{"dist/"},
 			expectContent:  "foo\n# Added by goreleaser init:\ndist/\n",
+			expectModified: true,
 		},
 		{
 			name:           "no newline at end with CRLF",
 			existing:       "foo\r\nbar",
 			lines:          []string{"dist/"},
 			expectContent:  "foo\r\nbar\n# Added by goreleaser init:\ndist/\n",
+			expectModified: true,
+		},
+		{
+			name:           "file already contains line",
+			existing:       "dist/\n",
+			lines:          []string{"dist/"},
+			expectContent:  "dist/\n",
+			expectModified: false,
+		},
+		{
+			name:           "multiple lines",
+			existing:       "",
+			lines:          []string{"dist/", "target/", "build/"},
+			expectContent:  "# Added by goreleaser init:\ndist/\ntarget/\nbuild/\n",
+			expectModified: true,
+		},
+		{
+			name:           "partial existing lines",
+			existing:       "dist/\n",
+			lines:          []string{"dist/", "target/", "build/"},
+			expectContent:  "dist/\n# Added by goreleaser init:\ntarget/\nbuild/\n",
+			expectModified: true,
+		},
+		{
+			name:           "no newline at end with multiple lines",
+			existing:       "foo",
+			lines:          []string{"dist/", "target/", "build/"},
+			expectContent:  "foo\n# Added by goreleaser init:\ndist/\ntarget/\nbuild/\n",
+			expectModified: true,
 		},
 	}
 
@@ -231,11 +263,36 @@ func TestSetupGitignore(t *testing.T) {
 
 			modified, err := setupGitignore(path, tt.lines)
 			require.NoError(t, err)
-			require.True(t, modified)
+			require.Equal(t, tt.expectModified, modified)
 
 			content, err := os.ReadFile(path)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectContent, string(content))
 		})
 	}
+
+	t.Run("write error", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "gitignore")
+		require.NoError(t, os.WriteFile(path, []byte(""), 0o444))
+
+		_, err := setupGitignore(path, []string{"dist/"})
+		require.Error(t, err)
+	})
+
+	t.Run("read error", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "gitignore")
+		require.NoError(t, os.WriteFile(path, []byte(""), 0o444))
+		require.NoError(t, os.Chmod(path, 0o000))
+
+		_, err := setupGitignore(path, []string{"dist/"})
+		require.Error(t, err)
+	})
+
+	t.Run("write newline error", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "gitignore")
+		require.NoError(t, os.WriteFile(path, []byte("foo"), 0o444))
+
+		_, err := setupGitignore(path, []string{"dist/"})
+		require.Error(t, err)
+	})
 }


### PR DESCRIPTION
This PR fixes two issues with the `goreleaser init` command when modifying `.gitignore` files:

1. When a `.gitignore` file contains CRLF line endings, the command would incorrectly add duplicate `dist/` entries
2. When a `.gitignore` file doesn't end with a newline, the new entries would be appended on the same line, causing incorrect formatting
