### PR TITLE
fix(gitlab): use CI_SERVER_VERSION when available

### DIFF
--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -78,12 +78,16 @@ func newGitLab(ctx *context.Context, token string, opts ...gitlab.ClientOptionFu
 }
 
 func isV17(client *gitlab.Client) bool {
-	v, _, err := client.Version.GetVersion(nil)
-	if err != nil {
-		log.WithError(err).Warn("could not get gitlab version")
-		return false
+	v := os.Getenv("CI_SERVER_VERSION")
+	if v == "" {
+		gitlabVersion, _, err := client.Version.GetVersion(nil)
+		if err != nil {
+			log.WithError(err).Warn("could not get gitlab version")
+			return false
+		}
+		v = gitlabVersion.Version
 	}
-	vv, err := semver.NewVersion(v.Version)
+	vv, err := semver.NewVersion(v)
 	if err != nil {
 		log.WithError(err).Warn("could not parse gitlab version")
 		return false


### PR DESCRIPTION
In some cases (e.g. security reasons), the CI triggerer may not have permission to access the GitLab Version API (401 Unauthorized), and we should prioritize reading from the CI value

This problem seems to be common in self-hosted instances (but official instances sometimes have problems)
