### PR TITLE
fix(dep): update gitlab, fix use of removed function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	github.com/ulikunitz/xz v0.5.12
-	gitlab.com/gitlab-org/api/client-go v0.128.0
+	gitlab.com/gitlab-org/api/client-go v0.129.0
 	gocloud.dev v0.41.0
 	golang.org/x/crypto v0.38.0
 	golang.org/x/oauth2 v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -937,8 +937,8 @@ github.com/zalando/go-keyring v0.2.3 h1:v9CUu9phlABObO4LPWycf+zwMG7nlbb3t/B5wa97
 github.com/zalando/go-keyring v0.2.3/go.mod h1:HL4k+OXQfJUWaMnqyuSOc0drfGPX2b51Du6K+MRgZMk=
 gitlab.com/digitalxero/go-conventional-commit v1.0.7 h1:8/dO6WWG+98PMhlZowt/YjuiKhqhGlOCwlIV8SqqGh8=
 gitlab.com/digitalxero/go-conventional-commit v1.0.7/go.mod h1:05Xc2BFsSyC5tKhK0y+P3bs0AwUtNuTp+mTpbCU/DZ0=
-gitlab.com/gitlab-org/api/client-go v0.128.0 h1:Wvy1UIuluKemubao2k8EOqrl3gbgJ1PVifMIQmg2Da4=
-gitlab.com/gitlab-org/api/client-go v0.128.0/go.mod h1:bYC6fPORKSmtuPRyD9Z2rtbAjE7UeNatu2VWHRf4/LE=
+gitlab.com/gitlab-org/api/client-go v0.129.0 h1:o9KLn6fezmxBQWYnQrnilwyuOjlx4206KP0bUn3HuBE=
+gitlab.com/gitlab-org/api/client-go v0.129.0/go.mod h1:ZhSxLAWadqP6J9lMh40IAZOlOxBLPRh7yFOXR/bMJWM=
 go.mongodb.org/mongo-driver v1.17.3 h1:TQyXhnsWfWtgAhMtOgtYHMTkZIfBTpMTsMnd9ZBeHxQ=
 go.mongodb.org/mongo-driver v1.17.3/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=

--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -531,7 +531,7 @@ func (c *gitlabClient) Upload(
 		linkURL = c.client.BaseURL().String() + baseLinkURL
 	} else {
 		log.WithField("file", file.Name()).Debug("uploading file as attachment")
-		projectFile, _, err := c.client.Projects.UploadFile(
+		projectFile, _, err := c.client.ProjectMarkdownUploads.UploadProjectMarkdown(
 			projectID,
 			file,
 			filepath.Base(file.Name()),


### PR DESCRIPTION
apparently this is what we're supposed to use now - looks like it does the same thing under the hood

closes #5778 
see: https://gitlab.com/gitlab-org/api/client-go/-/releases/v0.129.0