### PR TITLE
feat(ko): allow configuration of local domain to allow publishing to other local registries (e.g. kind)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,6 +25,6 @@ jobs:
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v4
         with:
           go-version: stable
-      - uses: github/codeql-action/init@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3
-      - uses: github/codeql-action/autobuild@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3
-      - uses: github/codeql-action/analyze@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3
+      - uses: github/codeql-action/init@fca7ace96b7d713c7035871441bd52efbe39e27e # v3
+      - uses: github/codeql-action/autobuild@fca7ace96b7d713c7035871441bd52efbe39e27e # v3
+      - uses: github/codeql-action/analyze@fca7ace96b7d713c7035871441bd52efbe39e27e # v3

--- a/internal/pipe/ko/ko.go
+++ b/internal/pipe/ko/ko.go
@@ -271,6 +271,14 @@ func (o *buildOptions) makeBuilder(ctx *context.Context) (*build.Caching, error)
 	return build.NewCaching(b)
 }
 
+func getLocalDomain(ko config.Ko) string {
+	localDomain := "goreleaser.ko.local"
+	if ko.LocalDomain != "" {
+		localDomain = ko.LocalDomain
+	}
+	return localDomain
+}
+
 func doBuild(ctx *context.Context, ko config.Ko) error {
 	opts, err := buildBuildOptions(ctx, ko)
 	if err != nil {
@@ -286,11 +294,6 @@ func doBuild(ctx *context.Context, ko config.Ko) error {
 		return fmt.Errorf("build: %w", err)
 	}
 
-	localDomain := "goreleaser.ko.local"
-	if ko.LocalDomain != "" {
-		localDomain = ko.LocalDomain
-	}
-
 	po := &options.PublishOptions{
 		DockerRepo:          opts.imageRepos[0],
 		Bare:                opts.bare,
@@ -298,7 +301,7 @@ func doBuild(ctx *context.Context, ko config.Ko) error {
 		BaseImportPaths:     opts.baseImportPaths,
 		Tags:                opts.tags,
 		Local:               ctx.Snapshot,
-		LocalDomain:         localDomain,
+		LocalDomain:         getLocalDomain(ko),
 	}
 	var p publish.Interface
 	if ctx.Snapshot {

--- a/internal/pipe/ko/ko.go
+++ b/internal/pipe/ko/ko.go
@@ -286,6 +286,11 @@ func doBuild(ctx *context.Context, ko config.Ko) error {
 		return fmt.Errorf("build: %w", err)
 	}
 
+	localDomain := "goreleaser.ko.local"
+	if ko.LocalDomain != "" {
+		localDomain = ko.LocalDomain
+	}
+
 	po := &options.PublishOptions{
 		DockerRepo:          opts.imageRepos[0],
 		Bare:                opts.bare,
@@ -293,7 +298,7 @@ func doBuild(ctx *context.Context, ko config.Ko) error {
 		BaseImportPaths:     opts.baseImportPaths,
 		Tags:                opts.tags,
 		Local:               ctx.Snapshot,
-		LocalDomain:         "goreleaser.ko.local",
+		LocalDomain:         localDomain,
 	}
 	var p publish.Interface
 	if ctx.Snapshot {

--- a/internal/pipe/ko/ko_test.go
+++ b/internal/pipe/ko/ko_test.go
@@ -191,7 +191,7 @@ func TestPublishPipeSuccess(t *testing.T) {
 		Tags                []string
 		CreationTime        string
 		KoDataCreationTime  string
-		Local               string
+		LocalDomain         string
 	}{
 		{
 			// Must be first as others add an SBOM for the same image

--- a/internal/pipe/ko/ko_test.go
+++ b/internal/pipe/ko/ko_test.go
@@ -722,6 +722,7 @@ func TestApplyTemplate(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
 func TestGetLocalDomain(t *testing.T) {
 	t.Run("default local domain", func(t *testing.T) {
 		ko := config.Ko{}

--- a/internal/pipe/ko/ko_test.go
+++ b/internal/pipe/ko/ko_test.go
@@ -191,6 +191,7 @@ func TestPublishPipeSuccess(t *testing.T) {
 		Tags                []string
 		CreationTime        string
 		KoDataCreationTime  string
+		Local               string
 	}{
 		{
 			// Must be first as others add an SBOM for the same image

--- a/internal/pipe/ko/ko_test.go
+++ b/internal/pipe/ko/ko_test.go
@@ -722,6 +722,19 @@ func TestApplyTemplate(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+func TestGetLocalDomain(t *testing.T) {
+	t.Run("default local domain", func(t *testing.T) {
+		ko := config.Ko{}
+		got := getLocalDomain(ko)
+		require.Equal(t, "goreleaser.ko.local", got)
+	})
+
+	t.Run("custom local domain", func(t *testing.T) {
+		ko := config.Ko{LocalDomain: "custom.domain"}
+		got := getLocalDomain(ko)
+		require.Equal(t, "custom.domain", got)
+	})
+}
 
 func mergeMaps(ms ...map[string]string) map[string]string {
 	result := map[string]string{}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -392,6 +392,7 @@ type Ko struct {
 	Bare                bool              `yaml:"bare,omitempty" json:"bare,omitempty"`
 	PreserveImportPaths bool              `yaml:"preserve_import_paths,omitempty" json:"preserve_import_paths,omitempty"`
 	BaseImportPaths     bool              `yaml:"base_import_paths,omitempty" json:"base_import_paths,omitempty"`
+	LocalDomain         string            `yaml:"local_domain,omitempty" json:"local_domain,omitempty"`
 
 	// v2.7+
 	Disable string `yaml:"disable,omitempty" json:"disable,omitempty" jsonschema:"oneof_type=string;boolean"`

--- a/www/docs/customization/ko.md
+++ b/www/docs/customization/ko.md
@@ -107,6 +107,13 @@ kos:
     #
     # Default: unset - no SBOM written to filesystem (but still uploaded to oci repository).
     sbom_directory: "out/sbom"
+    
+    # Ko publishes images to the local Docker daemon
+    # when Goreleaser is executed with the --snapshot flag. 
+    # Use the local_domain attribute to configure the local registry (e.g. kind.local). 
+    # 
+    # Default "goreleaser.ko.local" - local docker registry is used
+    local_domain: "goreleaser.ko.local"
 
     # Ldflags to use on build.
     #

--- a/www/docs/static/schema-pro.json
+++ b/www/docs/static/schema-pro.json
@@ -2402,6 +2402,9 @@
 					"sbom_directory": {
 						"type": "string"
 					},
+					"local_domain": {
+						"type": "string"
+					},
 					"ldflags": {
 						"items": {
 							"type": "string"

--- a/www/docs/static/schema-pro.json
+++ b/www/docs/static/schema-pro.json
@@ -1925,9 +1925,6 @@
 							}
 						]
 					},
-					"url_template": {
-						"type": "string"
-					},
 					"custom_block": {
 						"type": "string"
 					},
@@ -1945,6 +1942,9 @@
 					},
 					"manpage": {
 						"type": "string"
+					},
+					"url": {
+						"$ref": "#/$defs/HomebrewCaskURL"
 					},
 					"completions": {
 						"$ref": "#/$defs/HomebrewCaskCompletions"
@@ -2041,6 +2041,45 @@
 					},
 					"post": {
 						"$ref": "#/$defs/HomebrewCaskHook"
+					}
+				},
+				"additionalProperties": false,
+				"type": "object"
+			},
+			"HomebrewCaskURL": {
+				"properties": {
+					"template": {
+						"type": "string"
+					},
+					"verified": {
+						"type": "string"
+					},
+					"using": {
+						"type": "string"
+					},
+					"cookies": {
+						"additionalProperties": {
+							"type": "string"
+						},
+						"type": "object"
+					},
+					"referer": {
+						"type": "string"
+					},
+					"headers": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"user_agent": {
+						"type": "string"
+					},
+					"data": {
+						"additionalProperties": {
+							"type": "string"
+						},
+						"type": "object"
 					}
 				},
 				"additionalProperties": false,

--- a/www/docs/static/schema.json
+++ b/www/docs/static/schema.json
@@ -1860,6 +1860,9 @@
 					"sbom_directory": {
 						"type": "string"
 					},
+					"local_domain": {
+						"type": "string"
+					},
 					"ldflags": {
 						"items": {
 							"type": "string"


### PR DESCRIPTION
If applied, this commit will make the localDomain for `ko` builds configurable and add tests for the new configuration option.

This change allows users to specify a custom localDomain for ko builds, increasing flexibility for local image publishing scenarios.

https://ko.build/configuration/#local-publishing-options

closes https://github.com/orgs/goreleaser/discussions/5808