### PR TITLE
feat: add signed commits capabilities

### DIFF
--- a/internal/commitauthor/author.go
+++ b/internal/commitauthor/author.go
@@ -22,7 +22,26 @@ func Get(ctx *context.Context, og config.CommitAuthor) (config.CommitAuthor, err
 		return author, err
 	}
 	author.Email, err = tmpl.New(ctx).Apply(og.Email)
-	return author, err
+	if err != nil {
+		return author, err
+	}
+
+	// Apply templates to signing configuration
+	author.Signing.Enabled = og.Signing.Enabled
+	author.Signing.Key, err = tmpl.New(ctx).Apply(og.Signing.Key)
+	if err != nil {
+		return author, err
+	}
+	author.Signing.Program, err = tmpl.New(ctx).Apply(og.Signing.Program)
+	if err != nil {
+		return author, err
+	}
+	author.Signing.Format, err = tmpl.New(ctx).Apply(og.Signing.Format)
+	if err != nil {
+		return author, err
+	}
+
+	return author, nil
 }
 
 // Default sets the default commit author name and email.
@@ -33,5 +52,11 @@ func Default(og config.CommitAuthor) config.CommitAuthor {
 	if og.Email == "" {
 		og.Email = defaultEmail
 	}
+
+	// set default signing format if enabled but format not specified
+	if og.Signing.Enabled && og.Signing.Format == "" {
+		og.Signing.Format = "openpgp"
+	}
+
 	return og
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -421,8 +421,16 @@ type Scoop struct {
 
 // CommitAuthor is the author of a Git commit.
 type CommitAuthor struct {
-	Name  string `yaml:"name,omitempty" json:"name,omitempty"`
-	Email string `yaml:"email,omitempty" json:"email,omitempty"`
+	Name    string `yaml:"name,omitempty" json:"name,omitempty"`
+	Email   string `yaml:"email,omitempty" json:"email,omitempty"`
+	Signing CommitSigning `yaml:"signing,omitempty" json:"signing,omitempty"`
+}
+
+type CommitSigning struct {
+	Enabled   bool   `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	Key       string `yaml:"key,omitempty" json:"key,omitempty"`
+	Program   string `yaml:"program,omitempty" json:"program,omitempty"`
+	Format    string `yaml:"format,omitempty" json:"format,omitempty" jsonschema:"enum=openpgp,enum=x509,enum=ssh,default=openpgp"`
 }
 
 // BuildHooks define actions to run before and/or after something.


### PR DESCRIPTION
If applied, this commit will add the signing commits feature to goreleaser.

...

This change is being made in an attempt to guarantee that commits are not altered and are coming from a trusted source.

...

n/a
...
