### PR TITLE
fix: skip empty image_templates in docker_manifests

### DIFF
--- a/internal/pipe/docker/manifest.go
+++ b/internal/pipe/docker/manifest.go
@@ -143,7 +143,10 @@ func manifestImages(ctx *context.Context, manifest config.DockerManifest) ([]str
 		if err != nil {
 			return []string{}, err
 		}
-		imgs = append(imgs, withDigest(str, artifacts))
+
+		if str != "" {
+			imgs = append(imgs, withDigest(str, artifacts))
+		}
 	}
 	if strings.TrimSpace(strings.Join(manifest.ImageTemplates, "")) == "" {
 		return imgs, pipe.Skip("manifest has no images")

--- a/internal/pipe/docker/manifest_test.go
+++ b/internal/pipe/docker/manifest_test.go
@@ -1,8 +1,13 @@
 package docker
 
 import (
+	"slices"
+	"strings"
 	"testing"
 
+	"github.com/goreleaser/goreleaser/v2/internal/artifact"
+	"github.com/goreleaser/goreleaser/v2/pkg/config"
+	"github.com/goreleaser/goreleaser/v2/pkg/context"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,6 +28,124 @@ func TestValidateManifester(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+		})
+	}
+}
+
+func Test_manifestImages(t *testing.T) {
+	const someImage = "repo/image:tag"
+
+	tests := []struct {
+		name        string
+		artifacts   []*artifact.Artifact
+		templates   []string
+		want        []string
+		errContains string
+		wantErr     bool
+	}{
+		{
+			name:        "no templates",
+			want:        []string{},
+			wantErr:     true,
+			errContains: "manifest has no images",
+		},
+		{
+			name:        "empty template string",
+			templates:   []string{""},
+			want:        []string{},
+			wantErr:     true,
+			errContains: "manifest has no images",
+		},
+		{
+			name: "single image with digest",
+			artifacts: []*artifact.Artifact{
+				{
+					Type:  artifact.DockerImage,
+					Name:  someImage,
+					Extra: map[string]any{artifact.ExtraDigest: "sha256:123"},
+				},
+			},
+			templates: []string{someImage},
+			want:      []string{someImage + "@sha256:123"},
+		},
+		{
+			name: "single image without digest",
+			artifacts: []*artifact.Artifact{
+				{
+					Type:  artifact.DockerImage,
+					Name:  someImage,
+					Extra: map[string]any{},
+				},
+			},
+			templates: []string{someImage},
+			want:      []string{someImage},
+		},
+		{
+			name: "template with no matching artifact",
+			artifacts: []*artifact.Artifact{
+				{
+					Type:  artifact.DockerImage,
+					Name:  "other/image:tag",
+					Extra: map[string]any{artifact.ExtraDigest: "sha"},
+				},
+			},
+			templates: []string{someImage},
+			want:      []string{someImage},
+		},
+		{
+			name: "multiple templates with some empty",
+			artifacts: []*artifact.Artifact{
+				{
+					Type:  artifact.DockerImage,
+					Name:  "a:1",
+					Extra: map[string]any{artifact.ExtraDigest: "d1"},
+				},
+				{
+					Type:  artifact.DockerImage,
+					Name:  "b:2",
+					Extra: map[string]any{},
+				},
+			},
+			templates: []string{
+				"a:1",
+				`{{ if contains "aa" "a" }}{{""}}{{ else }}{{ "fail" }}{{ end }}`,
+				"b:2",
+				"",
+			},
+			want: []string{"a:1@d1", "b:2"},
+		},
+		{
+			name:        "incorrect template",
+			templates:   []string{"{{ if eq (INCORRECT true) }}"},
+			wantErr:     true,
+			errContains: "template: failed to apply",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.New(config.Project{})
+			for _, art := range tt.artifacts {
+				ctx.Artifacts.Add(art)
+			}
+
+			manifest := config.DockerManifest{
+				ImageTemplates: tt.templates,
+			}
+
+			got, err := manifestImages(ctx, manifest)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Fatalf("expected error to contain %q, got: %v", tt.errContains, err)
+				}
+			} else {
+				require.NoError(t, err)
+				if !slices.Equal(got, tt.want) {
+					t.Fatalf("unexpected output: want: %v, got: %v", tt.want, got)
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
Skips empty strings of the given `image_templates` from the `docker_manifests` section after evaluation.

This allows usage of conditionals for some of the filtered `dockers` builds (e.g. by `ids`), such as:

```yaml
builds:
  - id: amd_build
    goos:
      - linux
    goarch:
      - amd64

  - id: arm_build
    goos:
      - linux
    goarch:
      - arm64
    skip: >-
      {{ if skip }}{{ true }}{{ else }}false{{ end }}

dockers:
  - image_templates:
      - repo/image:tag-amd64
    ids:
      - amd_build
    use: buildx
    build_flag_templates:
      - --platform=linux/amd64

  - image_templates:
      - repo/image:tag-arm64
    ids:
      - arm_build
    goarch: arm64
    use: buildx
    build_flag_templates:
      - --platform=linux/arm64/v8

docker_manifests:
  - name_template: "repo/image:tag"
    image_templates:
      - "repo/image:tag-amd64"
      - >- 
        {{ if skip }}{{""}}{{ else }}repo/image:tag-arm64{{ end }}
```


Fixes #5824 
