### PR TITLE
fix(casks): binary packages need to rename to binary

### DIFF
--- a/internal/pipe/cask/template.go
+++ b/internal/pipe/cask/template.go
@@ -17,6 +17,7 @@ type templateData struct {
 	LinuxPackages        []releasePackage
 	MacOSPackages        []releasePackage
 	HasOnlyAmd64MacOsPkg bool
+	HasOnlyBinaryPkgs    bool
 }
 
 type releasePackage struct {
@@ -24,6 +25,8 @@ type releasePackage struct {
 	OS     string
 	Arch   string
 	URL    downloadURL
+	Name   string
+	Binary string
 }
 
 type downloadURL struct {

--- a/internal/pipe/cask/templates/cask.rb
+++ b/internal/pipe/cask/templates/cask.rb
@@ -8,7 +8,7 @@ cask "{{ .Name }}" do
     skip "Auto-generated on release."
   end
 
-  {{ with .Binary }}
+  {{ with and (not .HasOnlyBinaryPkgs) .Binary }}
   binary "{{ .}}"
   {{- end }}
   {{- with .Manpage }}

--- a/internal/pipe/cask/templates/linux_packages.rb
+++ b/internal/pipe/cask/templates/linux_packages.rb
@@ -7,6 +7,9 @@
   {{- end }}
     url "{{ $element.URL.Download }}"{{- include "additional_url_params" $element.URL }}
     sha256 "{{ $element.SHA256 }}"
+    {{- if .Binary }}
+    binary "{{ .Name }}", target: "{{ .Binary }}"
+    {{- end }}
   end
 {{- end }}
 {{- end }}

--- a/internal/pipe/cask/templates/macos_packages.rb
+++ b/internal/pipe/cask/templates/macos_packages.rb
@@ -3,6 +3,9 @@
   {{- if eq $element.Arch "all" }}
   url "{{ $element.URL.Download }}"{{- include "additional_url_params" $element.URL }}
   sha256 "{{ $element.SHA256 }}"
+  {{- if .Binary }}
+  binary "{{ .Name }}", target: "{{ .Binary }}"
+  {{- end }}
 
   {{- else }}
   {{- if eq $element.Arch "amd64" }}
@@ -13,6 +16,9 @@
   {{- end }}
     url "{{ $element.URL.Download }}"{{- include "additional_url_params" $element.URL }}
     sha256 "{{ $element.SHA256 }}"
+    {{- if .Binary }}
+    binary "{{ .Name }}", target: "{{ .Binary }}"
+    {{- end }}
   end
   {{- end }}
 

--- a/internal/pipe/cask/testdata/TestRunPipeBinaryRelease.rb.golden
+++ b/internal/pipe/cask/testdata/TestRunPipeBinaryRelease.rb.golden
@@ -8,12 +8,12 @@ cask "foo" do
     skip "Auto-generated on release."
   end
 
-  binary "foo"
   manpage "./man/foo.1.gz"
 
   on_macos do
     url "https://dummyhost/download/v1.2.1/foo_macos"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    binary "foo_macos", target: "foo"
   end
 
   # No zap stanza required

--- a/internal/pipe/cask/testdata/TestRunPipePullRequest.rb.golden
+++ b/internal/pipe/cask/testdata/TestRunPipePullRequest.rb.golden
@@ -13,6 +13,7 @@ cask "foo" do
   on_macos do
     url "https://dummyhost/download/v1.2.1/foo_macos"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    binary "foo_macos", target: "foo"
   end
 
   # No zap stanza required


### PR DESCRIPTION
this should fix the issue reported by @dorianm at https://github.com/orgs/goreleaser/discussions/5563#discussioncomment-13497346