### PR TITLE
feat(semver): allow to template tag before processing

### DIFF
--- a/internal/pipe/semver/semver.go
+++ b/internal/pipe/semver/semver.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/caarlos0/log"
+	"github.com/goreleaser/goreleaser/v2/internal/tmpl"
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
 )
 
@@ -16,11 +18,28 @@ func (Pipe) String() string {
 	return "parsing tag"
 }
 
+func getTag(ctx *context.Context) (string, error) {
+	if ctx.Config.Semver.Version == "" {
+		return ctx.Git.CurrentTag, nil
+	}
+	tag, err := tmpl.New(ctx).Apply(ctx.Config.Semver.Version)
+	if err != nil {
+		return "", fmt.Errorf("semver.process: %w", err)
+	}
+	log.Infof("using %q instead of %q", tag, ctx.Git.CurrentTag)
+	return tag, nil
+}
+
 // Run executes the hooks.
 func (Pipe) Run(ctx *context.Context) error {
-	sv, err := semver.NewVersion(ctx.Git.CurrentTag)
+	tag, err := getTag(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to parse tag '%s' as semver: %w", ctx.Git.CurrentTag, err)
+		return err
+	}
+
+	sv, err := semver.NewVersion(tag)
+	if err != nil {
+		return fmt.Errorf("failed to parse tag '%s' as semver: %w", tag, err)
 	}
 	ctx.Semver = context.Semver{
 		Major:      sv.Major(),

--- a/internal/pipe/semver/semver_test.go
+++ b/internal/pipe/semver/semver_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
+	"github.com/goreleaser/goreleaser/v2/pkg/config"
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
 	"github.com/stretchr/testify/require"
 )
@@ -14,6 +15,21 @@ func TestDescription(t *testing.T) {
 
 func TestValidSemver(t *testing.T) {
 	ctx := testctx.New(testctx.WithCurrentTag("v1.5.2-rc1"))
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, context.Semver{
+		Major:      1,
+		Minor:      5,
+		Patch:      2,
+		Prerelease: "rc1",
+	}, ctx.Semver)
+}
+
+func TestInvalidSemverProcess(t *testing.T) {
+	ctx := testctx.NewWithCfg(config.Project{
+		Semver: config.Semver{
+			Version: `{{ trimprefix .Tag "aaaa" }}`,
+		},
+	}, testctx.WithCurrentTag("aaaav1.5.2-rc1"))
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Equal(t, context.Semver{
 		Major:      1,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,11 @@ type Git struct {
 	IgnoreTags       []string `yaml:"ignore_tags,omitempty" json:"ignore_tags,omitempty"`
 }
 
+// Semver configs.
+type Semver struct {
+	Version string `yaml:"version_template,omitempty" json:"version_template,omitempty"`
+}
+
 // GitHubURLs holds the URLs to be used when using github enterprise.
 type GitHubURLs struct {
 	API           string `yaml:"api,omitempty" json:"api,omitempty"`
@@ -1179,6 +1184,7 @@ type Project struct {
 	SBOMs           []SBOM           `yaml:"sboms,omitempty" json:"sboms,omitempty"`
 	Chocolateys     []Chocolatey     `yaml:"chocolateys,omitempty" json:"chocolateys,omitempty"`
 	Git             Git              `yaml:"git,omitempty" json:"git,omitempty"`
+	Semver          Semver           `yaml:"semver,omitempty" json:"semver,omitempty"`
 	ReportSizes     bool             `yaml:"report_sizes,omitempty" json:"report_sizes,omitempty"`
 	Metadata        ProjectMetadata  `yaml:"metadata,omitempty" json:"metadata,omitempty"`
 

--- a/www/docs/customization/semver.md
+++ b/www/docs/customization/semver.md
@@ -1,0 +1,20 @@
+# SemVer
+
+<!-- md:version v2.11-unreleased -->
+
+This allows you to change some [SemVer][] behavior.
+
+```yaml title=".goreleaser.yaml"
+semver:
+  # This allows you to use a template output as your version.
+  # You can use this to trim a prefix, for example, or to hard-code some version
+  # for any reason.
+  # The result of this expression should be a valid semver.
+  #
+  # Templates: allowed.
+  version_template: '{{ trimPrefix .Tag "myprefix/" }}'
+```
+
+[SemVer]: http://semver.org
+
+<!-- md:templates -->

--- a/www/mkdocs.yml
+++ b/www/mkdocs.yml
@@ -121,6 +121,7 @@ nav:
           - customization/dist.md
           - customization/project.md
           - customization/git.md
+          - customization/semver.md
           - Split & Merge: customization/partial.md
       - Build:
           - customization/builds/index.md


### PR DESCRIPTION
this would allow to do some processing with the tag before trying to parse it as a semver.

This theoretically allows projects that don't use Semver to run goreleaser as well, as they can force a valid Semver in there.

see https://github.com/orgs/goreleaser/discussions/5833