### PR TITLE
fix: artifact.Checksum should set artifact.Extra field

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -60,6 +60,7 @@ linters:
         - name: errorf
         - name: increment-decrement
         - name: indent-error-flow
+        - name: modifies-value-receiver
         - name: range
         - name: receiver-naming
         - name: redefines-builtin-id

--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -303,10 +303,10 @@ func ExtraOr[T any](a Artifact, key string, or T) T {
 	return t
 }
 
-// Checksum calculates the checksum of the artifact.
+// Checksum calculates the checksum of the artifact and sets it's Extra field.
 //
 //nolint:gosec
-func (a Artifact) Checksum(algorithm string) (string, error) {
+func (a *Artifact) Checksum(algorithm string) (string, error) {
 	log.Debugf("calculating checksum for %s", a.Path)
 	file, err := os.Open(a.Path)
 	if err != nil {

--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -447,6 +447,21 @@ func TestChecksum(t *testing.T) {
 	}
 }
 
+func TestChecksumSetArtifactExtra(t *testing.T) {
+	folder := t.TempDir()
+	file := filepath.Join(folder, "subject")
+	require.NoError(t, os.WriteFile(file, []byte("lorem ipsum"), 0o644))
+	artifact := Artifact{
+		Path:  file,
+		Extra: nil,
+	}
+
+	sum, err := artifact.Checksum("crc32")
+	require.NoError(t, err)
+	require.Equal(t, "72d7748e", sum)
+	require.Equal(t, Extras{ExtraChecksum: "crc32:72d7748e"}, artifact.Extra)
+}
+
 func TestChecksumFileDoesntExist(t *testing.T) {
 	file := filepath.Join(t.TempDir(), "nope")
 	artifact := Artifact{


### PR DESCRIPTION
`revive.modifies-value-receiver` reports that `artifact.Checksum` doesn't set the `artifact.Extra` field due to the use of a value receiver in:
```go
func (a Artifact) Checksum(algorithm string) (string, error)
```

Golangci-lint output:

```console
$ golangci-lint run
internal/artifact/artifact.go:359:3: modifies-value-receiver: suspicious assignment to a by-value method receiver (revive)
                a.Extra = make(Extras)
                ^
1 issues:
* revive: 1
```

I believe this is a bug. If it’s not, we can remove the following lines (added in #4707), since they have no effect on the original `Artifact`:

```go
if a.Extra == nil {
	a.Extra = make(Extras)
}
a.Extra[ExtraChecksum] = fmt.Sprintf("%s:%s", algorithm, check)
```