### PR TITLE
refactor: simplify tests with require.ErrorContains

### DIFF
--- a/internal/client/git_test.go
+++ b/internal/client/git_test.go
@@ -329,9 +329,7 @@ func TestGitClientWithSigning(t *testing.T) {
 		)
 		// We expect this to fail in CI environments without GPG setup
 		// The important part is that it tries to sign (not just config error)
-		if err != nil {
-			require.Contains(t, err.Error(), "gpg")
-		}
+		require.ErrorContains(t, err, "gpg")
 	})
 
 	t.Run("commit signing disabled", func(t *testing.T) {
@@ -397,9 +395,7 @@ func TestGitClientWithSigning(t *testing.T) {
 		)
 		// We expect this to fail in CI environments without proper SSH key setup
 		// The important part is that it tries to sign with SSH format
-		if err != nil {
-			require.Contains(t, err.Error(), "public key")
-		}
+		require.ErrorContains(t, err, "public key")
 	})
 }
 

--- a/internal/pipe/gomod/gomod_proxy_test.go
+++ b/internal/pipe/gomod/gomod_proxy_test.go
@@ -222,16 +222,14 @@ func TestErrors(t *testing.T) {
 	ogerr := errors.New("fake")
 	t.Run("detailed", func(t *testing.T) {
 		err := newDetailedErrProxy(ogerr, "some details")
-		require.NotEmpty(t, err.Error())
-		require.Contains(t, err.Error(), "failed to proxy module")
-		require.Contains(t, err.Error(), "details")
+		require.ErrorContains(t, err, "failed to proxy module")
+		require.ErrorContains(t, err, "details")
 		require.ErrorIs(t, err, ogerr)
 	})
 
 	t.Run("normal", func(t *testing.T) {
 		err := newErrProxy(ogerr)
-		require.NotEmpty(t, err.Error())
-		require.Contains(t, err.Error(), "failed to proxy module")
+		require.ErrorContains(t, err, "failed to proxy module")
 		require.ErrorIs(t, err, ogerr)
 	})
 }

--- a/internal/pipe/ko/ko_test.go
+++ b/internal/pipe/ko/ko_test.go
@@ -704,8 +704,7 @@ func TestPublishPipeError(t *testing.T) {
 		ctx := makeCtx()
 		require.NoError(t, Pipe{}.Default(ctx))
 		err := Pipe{}.Publish(ctx)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), `Get "https://fakerepo:8080/v2/": dial tcp:`)
+		require.ErrorContains(t, err, `Get "https://fakerepo:8080/v2/": dial tcp:`)
 	})
 }
 


### PR DESCRIPTION
`require.Error(t, err)` is not needed because `require.ErrorContains` fails if `err` is nil or `err.Error()` is empty.