### PR TITLE
fix(rust): properly group binaries by platform

### DIFF
--- a/internal/builders/rust/build.go
+++ b/internal/builders/rust/build.go
@@ -75,7 +75,7 @@ func (b *Builder) Parse(target string) (api.Target, error) {
 	}
 
 	if len(parts) > 3 {
-		t.Environment = parts[3]
+		t.Abi = parts[3]
 	}
 
 	return t, nil
@@ -155,6 +155,7 @@ func (b *Builder) Build(ctx *context.Context, build config.Build, options api.Op
 			artifact.ExtraExt:     options.Ext,
 			artifact.ExtraID:      build.ID,
 			artifact.ExtraBuilder: "rust",
+			keyAbi:                t.Abi,
 		},
 	}
 

--- a/internal/builders/rust/targets.go
+++ b/internal/builders/rust/targets.go
@@ -21,27 +21,27 @@ var (
 )
 
 const (
-	keyVendor      = "Vendor"
-	keyEnvironment = "Environment"
+	keyVendor = "Vendor"
+	keyAbi    = "Abi"
 )
 
 // Target is a Rust build target.
 type Target struct {
 	// The Rust formatted target (arch-vendor-os-env).
-	Target      string
-	Os          string
-	Arch        string
-	Vendor      string
-	Environment string
+	Target string
+	Os     string
+	Arch   string
+	Vendor string
+	Abi    string
 }
 
 // Fields implements build.Target.
 func (t Target) Fields() map[string]string {
 	return map[string]string{
-		tmpl.KeyOS:     t.Os,
-		tmpl.KeyArch:   t.Arch,
-		keyEnvironment: t.Environment,
-		keyVendor:      t.Vendor,
+		tmpl.KeyOS:   t.Os,
+		tmpl.KeyArch: t.Arch,
+		keyAbi:       t.Abi,
+		keyVendor:    t.Vendor,
 	}
 }
 


### PR DESCRIPTION
The `GroupByPlatform()` method used in archives already considers the `Abi` extra field.
For some reason, in the Rust builder, it was being called environment instead.
Changed it to `Abi` so it works the same as Zig et al.
Also updated the tests.

With this patch, the reproducible works as expected:

```console
# ...
  • building binaries
    • building                                       binary=dist/archive-bug-mre_x86_64-unknown-linux-gnu/archive-bug-mre
    • cargo zigbuild
      output=
      │    Compiling archive-bug-mre v0.1.0 (/private/tmp/archive-bug-mre)
      │     Finished `release` profile [optimized] target(s) in 1.52s
    • building                                       binary=dist/archive-bug-mre_x86_64-unknown-linux-musl/archive-bug-mre
    • cargo zigbuild
      output=
      │    Compiling archive-bug-mre v0.1.0 (/private/tmp/archive-bug-mre)
      │     Finished `release` profile [optimized] target(s) in 6.34s
    • took: 15s
  • archives
    • archiving                                      name=dist/archive-bug-mre_Linux_x86_64.tar.gz
    • archiving                                      name=dist/archive-bug-mre_Linux_x86_64_musl.tar.gz
  • calculating checksums
# ...
```

closes #5865
