### PR TITLE
fix(nix): improve nix-hash check

### DIFF
--- a/internal/pipe/nix/nix_test.go
+++ b/internal/pipe/nix/nix_test.go
@@ -690,7 +690,7 @@ func linuxDep(s string) config.NixDependency {
 
 type unavailableHasher struct{}
 
-func (m unavailableHasher) Hash(path string) (string, error) {
+func (m unavailableHasher) Hash(string) (string, error) {
 	return "", errors.New("unavailable hasher")
 }
 func (m unavailableHasher) Available() bool { return false }


### PR DESCRIPTION
currently, it would give a warning when running goreleaser hc, but wouldn't actually fail the check, as the pipe was being skipped if nix-hash wasn't available.

this fixes it, so it checks on run instead.
