### PR TITLE
fix(cask): invalid string quoting in uninstall/zap arrays

### DIFF
--- a/internal/pipe/cask/template.go
+++ b/internal/pipe/cask/template.go
@@ -56,10 +56,10 @@ func dependsString(dependencies []config.HomebrewCaskDependency) string {
 	var formulas []string
 	for _, dependency := range dependencies {
 		if dependency.Cask != "" {
-			casks = append(casks, quote(dependency.Cask))
+			casks = append(casks, dependency.Cask)
 		}
 		if dependency.Formula != "" {
-			formulas = append(formulas, quote(dependency.Formula))
+			formulas = append(formulas, dependency.Formula)
 		}
 	}
 	sort.Strings(casks)
@@ -80,10 +80,10 @@ func conflictsString(conflicts []config.HomebrewCaskConflict) string {
 	var formulas []string
 	for _, conflict := range conflicts {
 		if conflict.Cask != "" {
-			casks = append(casks, quote(conflict.Cask))
+			casks = append(casks, conflict.Cask)
 		}
 		if conflict.Formula != "" {
-			formulas = append(formulas, quote(conflict.Formula))
+			formulas = append(formulas, conflict.Formula)
 		}
 	}
 	sort.Strings(casks)
@@ -150,10 +150,8 @@ func groupToS(name string, lines []string) string {
 	var sb strings.Builder
 	sb.WriteString(name + ": [\n")
 	for _, l := range lines {
-		sb.WriteString("      " + l + ",\n")
+		sb.WriteString("      " + fmt.Sprintf("%q", l) + ",\n")
 	}
 	sb.WriteString("    ]")
 	return sb.String()
 }
-
-func quote(s string) string { return fmt.Sprintf("%q", s) }

--- a/internal/pipe/cask/testdata/TestFullPipe/uninstall.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/uninstall.rb.golden
@@ -56,29 +56,29 @@ cask "uninstall" do
   service "foo.plist"
 
   uninstall launchctl: [
-      launchctl1,
-      launchctl2,
-      launchctl3,
+      "launchctl1",
+      "launchctl2",
+      "launchctl3",
     ],
     quit: [
-      quit1,
-      quit2,
-      quit3,
+      "quit1",
+      "quit2",
+      "quit3",
     ],
     login_item: [
-      loginitem1,
-      loginitem2,
-      loginitem3,
+      "loginitem1",
+      "loginitem2",
+      "loginitem3",
     ],
     delete: [
-      delete1,
-      delete2,
-      delete3,
+      "delete1",
+      "delete2",
+      "delete3",
     ],
     trash: [
-      trash1,
-      trash2,
-      trash3,
+      "trash1",
+      "trash2",
+      "trash3",
     ]
 
   # No zap stanza required

--- a/internal/pipe/cask/testdata/TestFullPipe/zap.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/zap.rb.golden
@@ -56,29 +56,29 @@ cask "zap" do
   service "foo.plist"
 
   zap launchctl: [
-      launchctl1,
-      launchctl2,
-      launchctl3,
+      "launchctl1",
+      "launchctl2",
+      "launchctl3",
     ],
     quit: [
-      quit1,
-      quit2,
-      quit3,
+      "quit1",
+      "quit2",
+      "quit3",
     ],
     login_item: [
-      loginitem1,
-      loginitem2,
-      loginitem3,
+      "loginitem1",
+      "loginitem2",
+      "loginitem3",
     ],
     delete: [
-      delete1,
-      delete2,
-      delete3,
+      "delete1",
+      "delete2",
+      "delete3",
     ],
     trash: [
-      trash1,
-      trash2,
-      trash3,
+      "trash1",
+      "trash2",
+      "trash3",
     ]
 
 end


### PR DESCRIPTION
## What this commit does

Fixes improper string quoting in Homebrew cask `zap` arrays to ensure valid Ruby syntax in generated cask files.

Previously, installing a cask with a `zap` stanza would result in an error due to unquoted strings.

### Example configuration

GoReleaser config (valid YAML):

```yaml
zap:
  trash:
    - "~/.moley/config.yml"
```

Generated cask (invalid Ruby):

```ruby
zap trash: [
    ~/.moley/config.yml,
  ]
```

This results in a syntax error when running:

```sh
brew install --cask moley.rb
```

Error:

```sh
➜  mole git:(main) ✗ brew install --cask moley.rb
Warning: Cask 'moley' is unreadable: /Users/kilianhoupeurt/Documents/git/mole/mole/moley.rb:36: syntax errors found
  34 |
  35 |   zap trash: [
> 36 |       ~/.moley/config.yml,
     |               ^~~~~~~ unknown regexp options - cfg
  37 |     ],
  48 |
```

### Actual fix

The fix updates the `groupToS` function to ensure all string values in the `zap` array are properly quoted using `fmt.Sprintf("%q", l)`.

Correct output:

```ruby
zap trash: [
    "~/.moley/config.yml",
  ]
```

With this fix, the cask installs correctly:

```sh
➜  mole git:(main) ✗ brew install --cask moley.rb
==> Downloading https://github.com/stupside/moley/releases/download/v1.1.2/moley_1.1.2_darwin_arm64.tar.gz
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/1010395208/c4459
########################################################################################################### 100.0%
==> Installing Cask moley
==> Linking Binary 'moley' to '/opt/homebrew/bin/moley'
🍺  moley was successfully installed!
```

## Why this change is necessary

Unquoted strings in Ruby array literals are treated as variables or invalid expressions, leading to syntax errors.

This change ensures:

* All zap entries are quoted strings
* Generated Ruby is syntactically valid
* Casks using zap can be installed without manual intervention

## Additional details

* Consolidates quoting logic in `groupToS`
* Updates test golden files accordingly

---

Fixes generation bug in Homebrew cask `zap` stanza

References:

* [GoReleaser homebrew\_casks docs](https://goreleaser.com/customization/homebrew_casks/#homebrew-casks)
* [[Problematic cask](https://github.com/stupside/homebrew-tap/blob/main/Casks/moley.rb#L35-L40)](https://github.com/stupside/homebrew-tap/blob/main/Casks/moley.rb#L35-L40)
* [[GoReleaser config](https://github.com/stupside/moley/blob/main/.goreleaser.yml#L44-L48)](https://github.com/stupside/moley/blob/main/.goreleaser.yml#L44-L48)