### PR TITLE
fix(nix): snapshot builds can now hash files as well

### DIFF
--- a/internal/pipe/nix/nix.go
+++ b/internal/pipe/nix/nix.go
@@ -50,13 +50,8 @@ var (
 	errInvalidLicense = errors.New("nix.license is invalid")
 )
 
-// NewBuild returns a pipe to be used in the build phase.
-func NewBuild() Pipe {
-	return Pipe{zeroHasher}
-}
-
-// NewPublish returns a pipe to be used in the publish phase.
-func NewPublish() Pipe {
+// New returns a pipe to be used in the publish phase.
+func New() Pipe {
 	return Pipe{realHasher}
 }
 
@@ -548,20 +543,9 @@ type fileHasher interface {
 	Available() bool
 }
 
-const (
-	zeroHash   = "0000000000000000000000000000000000000000000000000000"
-	nixHashBin = "nix-hash"
-)
+const nixHashBin = "nix-hash"
 
-var (
-	zeroHasher fileHasher = alwaysZeroHasher{}
-	realHasher fileHasher = nixHasher{bin: nixHashBin}
-)
-
-type alwaysZeroHasher struct{}
-
-func (alwaysZeroHasher) Hash(string) (string, error) { return zeroHash, nil }
-func (alwaysZeroHasher) Available() bool             { return true }
+var realHasher fileHasher = nixHasher{bin: nixHashBin}
 
 type nixHasher struct{ bin string }
 

--- a/internal/pipe/publish/publish.go
+++ b/internal/pipe/publish/publish.go
@@ -53,7 +53,7 @@ func New() Pipe {
 			// This should be one of the last steps
 			release.Pipe{},
 			// brew et al use the release URL, so, they should be last
-			nix.NewPublish(),
+			nix.New(),
 			winget.Pipe{},
 			brew.Pipe{},
 			cask.Pipe{},

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -136,7 +136,7 @@ var Pipeline = append(
 	// create arch linux aur pkgbuild (sources)
 	aursources.Pipe{},
 	// create nixpkgs
-	nix.NewBuild(),
+	nix.New(),
 	// winget installers
 	winget.Pipe{},
 	// homebrew formula

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -37,7 +37,7 @@ var Healthcheckers = []Healthchecker{
 	docker.Pipe{},
 	docker.ManifestPipe{},
 	chocolatey.Pipe{},
-	nix.NewPublish(),
+	nix.New(),
 }
 
 type system struct{}


### PR DESCRIPTION
Historically, we used to use `nix-prefetch-url`, so it could only calculate the hashes after the artifacts were pushed, so when using `--snapshot`, hashes would always be `0000...`.

Rather recently, we've changed it to use `nix-hash` instead, so we could also have changed it so it uses real hashes all the time.

This PR does that.

---

This pull request refactors the `nix` package by consolidating the `NewBuild` and `NewPublish` functions into a single `New` function, simplifying the hasher implementation, and updating tests and references accordingly.

### Refactoring and Simplification:

* Consolidated the `NewBuild` and `NewPublish` functions in `internal/pipe/nix/nix.go` into a single `New` function that uses the `realHasher` for all cases. (`[internal/pipe/nix/nix.goL53-R54](diffhunk://#diff-dcfa7e53a1ea2c45bc0c58928c8b59f135bc6860b0830a467df927f3cf148db0L53-R54)`)
* Removed the `alwaysZeroHasher` implementation and the associated `zeroHash` constant, as they are no longer needed. (`[[1]](diffhunk://#diff-dcfa7e53a1ea2c45bc0c58928c8b59f135bc6860b0830a467df927f3cf148db0L551-R548)`, `[[2]](diffhunk://#diff-be1bd23c510099bb46e6ea193cf0548eaa22bcbf9dd9f2ffb8c1ca7437dde312L693-R696)`)

### Updates to Tests:

* Updated test cases in `internal/pipe/nix/nix_test.go` to replace calls to `NewBuild` and `NewPublish` with `New`. Adjusted test logic to account for the removal of `alwaysZeroHasher`. (`[[1]](diffhunk://#diff-be1bd23c510099bb46e6ea193cf0548eaa22bcbf9dd9f2ffb8c1ca7437dde312L36-R43)`, `[[2]](diffhunk://#diff-be1bd23c510099bb46e6ea193cf0548eaa22bcbf9dd9f2ffb8c1ca7437dde312L52-R53)`, `[[3]](diffhunk://#diff-be1bd23c510099bb46e6ea193cf0548eaa22bcbf9dd9f2ffb8c1ca7437dde312L71-L76)`, `[[4]](diffhunk://#diff-be1bd23c510099bb46e6ea193cf0548eaa22bcbf9dd9f2ffb8c1ca7437dde312L524-R514)`)

### Updates to Pipeline and Healthcheck References:

* Replaced references to `nix.NewBuild` and `nix.NewPublish` with `nix.New` in `internal/pipeline/pipeline.go`, `internal/pipe/publish/publish.go`, and `pkg/healthcheck/healthcheck.go`. (`[[1]](diffhunk://#diff-f1ba43fd395a7dba28b0c238f66a8c5cb6edf8608820e8cfe0df1f36a5e4f5dcL56-R56)`, `[[2]](diffhunk://#diff-907bfb94a8c2367197d5b3de95c34ecd5cdab2944988165c644bd985722a3c56L139-R139)`, `[[3]](diffhunk://#diff-2c565121f665a1bc64eef7d8aeb4c3c406473167bb5fb93426755d18c98fa204L40-R40)`)