### PR TITLE
docs: update required workflow permissions in attestations.md

### DIFF
--- a/www/docs/customization/attestations.md
+++ b/www/docs/customization/attestations.md
@@ -8,6 +8,7 @@ do add the following to your release workflow:
 permissions:
   # ...
   # Give the workflow permission to write attestations.
+  id-token: write
   attestations: write
 
 jobs:
@@ -23,6 +24,18 @@ jobs:
         with:
           subject-checksums: ./dist/checksums.txt
 ```
+
+You will also want to adjust your Goreleaser configuration to produce the
+checksum file at a predictable filename matching the release workflow.
+```yaml title=".goreleaser.yaml"
+# ...
+
+# config the checksum filename
+# https://goreleaser.com/customization/checksum
+checksum:
+  name_template: "checksums.txt"
+```
+
 
 Users can then verify it with:
 


### PR DESCRIPTION
This updates the documentation regarding attestations to address two issues I hit when following the docs.

1. Adds `id-token: write` permissions to the Github Actions workflow.  Without this, the signature will fail.  See https://github.com/actions/attest-build-provenance?tab=readme-ov-file#usage for reference.
2. Show the goreleaser configuration file checksum filename modified to match the predictable filename in the actions workflow.