### PR TITLE
fix: exec.CommandContext

### DIFF
--- a/internal/builders/bun/build_test.go
+++ b/internal/builders/bun/build_test.go
@@ -83,7 +83,7 @@ func TestWithDefaults(t *testing.T) {
 func TestBuild(t *testing.T) {
 	testlib.CheckPath(t, "bun")
 	folder := testlib.Mktmp(t)
-	_, err := exec.Command("bun", "init", "--yes").CombinedOutput()
+	_, err := exec.CommandContext(t.Context(), "bun", "init", "--yes").CombinedOutput()
 	require.NoError(t, err)
 
 	modTime := time.Now().AddDate(-1, 0, 0).Round(time.Second).UTC()

--- a/internal/builders/deno/build_test.go
+++ b/internal/builders/deno/build_test.go
@@ -73,7 +73,7 @@ func TestWithDefaults(t *testing.T) {
 func TestBuild(t *testing.T) {
 	testlib.CheckPath(t, "deno")
 	folder := testlib.Mktmp(t)
-	_, err := exec.Command("deno", "init").CombinedOutput()
+	_, err := exec.CommandContext(t.Context(), "deno", "init").CombinedOutput()
 	require.NoError(t, err)
 
 	modTime := time.Now().AddDate(-1, 0, 0).Round(time.Second).UTC()

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -906,7 +906,7 @@ func TestBuildTests(t *testing.T) {
 
 func TestRunPipeWithProxiedRepo(t *testing.T) {
 	folder := testlib.Mktmp(t)
-	out, err := exec.Command("git", "clone", "https://github.com/goreleaser/test-mod", "-b", "v0.1.1", "--depth=1", ".").CombinedOutput()
+	out, err := exec.CommandContext(t.Context(), "git", "clone", "https://github.com/goreleaser/test-mod", "-b", "v0.1.1", "--depth=1", ".").CombinedOutput()
 	require.NoError(t, err, string(out))
 
 	proxied := filepath.Join(folder, "dist/proxy/default")
@@ -926,7 +926,7 @@ import _ "github.com/goreleaser/test-mod"
 		0o666,
 	))
 
-	cmd := exec.Command("go", "mod", "tidy")
+	cmd := exec.CommandContext(t.Context(), "go", "mod", "tidy")
 	cmd.Dir = proxied
 	out, err = cmd.CombinedOutput()
 	require.NoError(t, err, string(out))

--- a/internal/builders/poetry/build_test.go
+++ b/internal/builders/poetry/build_test.go
@@ -82,7 +82,7 @@ func TestBuild(t *testing.T) {
 	testlib.CheckPath(t, "poetry")
 
 	folder := testlib.Mktmp(t)
-	cmd := exec.Command("poetry", "new", "proj")
+	cmd := exec.CommandContext(t.Context(), "poetry", "new", "proj")
 	cmd.Dir = folder
 	_, err := cmd.CombinedOutput()
 	require.NoError(t, err)
@@ -176,7 +176,7 @@ func TestBuildSpecificModes(t *testing.T) {
 	testlib.CheckPath(t, "poetry")
 
 	folder := testlib.Mktmp(t)
-	cmd := exec.Command("poetry", "new", "proj")
+	cmd := exec.CommandContext(t.Context(), "poetry", "new", "proj")
 	cmd.Dir = folder
 	_, err := cmd.CombinedOutput()
 	require.NoError(t, err)

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -59,7 +59,7 @@ func TestBuild(t *testing.T) {
 	testlib.CheckPath(t, "cargo-zigbuild")
 
 	folder := testlib.Mktmp(t)
-	_, err := exec.Command("cargo", "init", "--bin", "--name=proj").CombinedOutput()
+	_, err := exec.CommandContext(t.Context(), "cargo", "init", "--bin", "--name=proj").CombinedOutput()
 	require.NoError(t, err)
 
 	modTime := time.Now().AddDate(-1, 0, 0).Round(time.Second).UTC()

--- a/internal/builders/uv/build_test.go
+++ b/internal/builders/uv/build_test.go
@@ -82,7 +82,7 @@ func TestBuild(t *testing.T) {
 	testlib.CheckPath(t, "uv")
 
 	folder := testlib.Mktmp(t)
-	cmd := exec.Command("uv", "init", "--name", "proj")
+	cmd := exec.CommandContext(t.Context(), "uv", "init", "--name", "proj")
 	cmd.Dir = folder
 	_, err := cmd.CombinedOutput()
 	require.NoError(t, err)
@@ -174,7 +174,7 @@ func TestBuildSpecificModes(t *testing.T) {
 	testlib.CheckPath(t, "uv")
 
 	folder := testlib.Mktmp(t)
-	cmd := exec.Command("uv", "init", "--name", "proj")
+	cmd := exec.CommandContext(t.Context(), "uv", "init", "--name", "proj")
 	cmd.Dir = folder
 	_, err := cmd.CombinedOutput()
 	require.NoError(t, err)

--- a/internal/builders/zig/build_test.go
+++ b/internal/builders/zig/build_test.go
@@ -99,7 +99,7 @@ func TestBuild(t *testing.T) {
 	folder := testlib.Mktmp(t)
 	folder = filepath.Join(folder, "proj")
 	require.NoError(t, os.MkdirAll(folder, 0o755))
-	cmd := exec.Command("zig", "init")
+	cmd := exec.CommandContext(t.Context(), "zig", "init")
 	cmd.Dir = folder
 	_, err := cmd.CombinedOutput()
 	require.NoError(t, err)

--- a/internal/pipe/blob/blob_minio_test.go
+++ b/internal/pipe/blob/blob_minio_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	stdctx "context"
+
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/internal/testlib"
@@ -29,7 +31,7 @@ const (
 var listen string
 
 func TestMain(m *testing.M) {
-	if !testlib.InPath("docker") || testlib.IsWindows() || !testlib.IsDockerRunning() {
+	if !testlib.InPath("docker") || testlib.IsWindows() || !testlib.IsDockerRunning(stdctx.Background()) {
 		// there's no minio windows image
 		m.Run()
 		return

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -56,7 +56,7 @@ func TestRunPipe(t *testing.T) {
 		return func(t *testing.T, _ string) {
 			t.Helper()
 			for _, filter := range filters {
-				cmd := exec.Command("docker", "images", "-q", "--filter", "reference=*/"+image, "--filter", filter)
+				cmd := exec.CommandContext(t.Context(), "docker", "images", "-q", "--filter", "reference=*/"+image, "--filter", filter)
 				// t.Log("running", cmd)
 				output, err := cmd.CombinedOutput()
 				require.NoError(t, err, string(output))
@@ -1033,7 +1033,7 @@ func TestRunPipe(t *testing.T) {
 				}
 
 				rmi := func(img string) error {
-					return exec.Command("docker", "rmi", "--force", img).Run()
+					return exec.CommandContext(t.Context(), "docker", "rmi", "--force", img).Run()
 				}
 
 				// this might fail as the image doesnt exist yet, so lets ignore the error

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -149,7 +149,8 @@ func TestShallowClone(t *testing.T) {
 	folder := testlib.Mktmp(t)
 	require.NoError(
 		t,
-		exec.Command(
+		exec.CommandContext(
+			t.Context(),
 			"git", "clone",
 			"--depth", "1",
 			"--branch", "v0.160.0",

--- a/internal/pipe/gomod/gomod_proxy_test.go
+++ b/internal/pipe/gomod/gomod_proxy_test.go
@@ -43,7 +43,7 @@ func TestCheckGoMod(t *testing.T) {
 		}, testctx.Snapshot, withTestModulePath)
 
 		fakeGoModAndSum(t, ctx.ModulePath)
-		require.NoError(t, exec.Command("go", "mod", "edit", "-replace", "foo=../bar").Run())
+		require.NoError(t, exec.CommandContext(t.Context(), "go", "mod", "edit", "-replace", "foo=../bar").Run())
 		require.NoError(t, CheckGoModPipe{}.Run(ctx))
 	})
 	t.Run("no go mod", func(t *testing.T) {
@@ -89,7 +89,7 @@ func TestCheckGoMod(t *testing.T) {
 		}, withTestModulePath)
 
 		fakeGoModAndSum(t, ctx.ModulePath)
-		require.NoError(t, exec.Command("go", "mod", "edit", "-replace", "foo=../bar").Run())
+		require.NoError(t, exec.CommandContext(t.Context(), "go", "mod", "edit", "-replace", "foo=../bar").Run())
 		require.ErrorIs(t, CheckGoModPipe{}.Run(ctx), ErrReplaceWithProxy)
 	})
 }

--- a/internal/pipe/gomod/gomod_test.go
+++ b/internal/pipe/gomod/gomod_test.go
@@ -64,7 +64,7 @@ func TestRunGoWork(t *testing.T) {
 		[]byte("use (\n\t.\n\tb\n)"),
 		0o666,
 	))
-	out, err := exec.Command("go", "list", "-m").CombinedOutput()
+	out, err := exec.CommandContext(t.Context(), "go", "list", "-m").CombinedOutput()
 	require.NoError(t, err)
 	require.Equal(t, "a\na/b", strings.TrimSpace(string(out)))
 	ctx := testctx.New()

--- a/internal/pipe/nix/nix.go
+++ b/internal/pipe/nix/nix.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"text/template"
 
+	stdctx "context"
+
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/client"
@@ -283,7 +285,7 @@ func preparePkg(
 
 	platforms := map[string]bool{}
 	for _, art := range archives {
-		sha, err := hasher.Hash(art.Path)
+		sha, err := hasher.Hash(ctx, art.Path)
 		if err != nil {
 			return "", err
 		}
@@ -539,7 +541,7 @@ func depNames(deps []config.NixDependency) []string {
 }
 
 type fileHasher interface {
-	Hash(name string) (string, error)
+	Hash(ctx stdctx.Context, name string) (string, error)
 	Available() bool
 }
 
@@ -554,9 +556,10 @@ func (p nixHasher) Available() bool {
 	return err == nil
 }
 
-func (p nixHasher) Hash(name string) (string, error) {
+func (p nixHasher) Hash(ctx stdctx.Context, name string) (string, error) {
 	// $ nix-hash --type sha256 --flat --base32 <(echo test)
-	out, err := exec.Command(
+	out, err := exec.CommandContext(
+		ctx,
 		p.bin,
 		"--type", "sha256",
 		"--flat",

--- a/internal/pipe/project/project.go
+++ b/internal/pipe/project/project.go
@@ -29,7 +29,7 @@ func (Pipe) Default(ctx *context.Context) error {
 		ctx.Config.Release.GitHub.Name,
 		ctx.Config.Release.GitLab.Name,
 		ctx.Config.Release.Gitea.Name,
-		moduleName(),
+		moduleName(ctx),
 		gitRemote(ctx),
 	} {
 		if candidate == "" {
@@ -53,8 +53,8 @@ func cargoName() string {
 	return ""
 }
 
-func moduleName() string {
-	bts, err := exec.Command("go", "list", "-m").CombinedOutput()
+func moduleName(ctx *context.Context) string {
+	bts, err := exec.CommandContext(ctx, "go", "list", "-m").CombinedOutput()
 	if err != nil {
 		return ""
 	}

--- a/internal/pipe/project/project_test.go
+++ b/internal/pipe/project/project_test.go
@@ -72,7 +72,7 @@ func TestEmptyProjectName_DefaultsToGiteaRelease(t *testing.T) {
 func TestEmptyProjectName_DefaultsToGoModPath(t *testing.T) {
 	_ = testlib.Mktmp(t)
 	ctx := testctx.New()
-	require.NoError(t, exec.Command("go", "mod", "init", "github.com/foo/bar").Run())
+	require.NoError(t, exec.CommandContext(t.Context(), "go", "mod", "init", "github.com/foo/bar").Run())
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "bar", ctx.Config.ProjectName)
 }

--- a/internal/pipe/sign/sign_test.go
+++ b/internal/pipe/sign/sign_test.go
@@ -726,7 +726,7 @@ func verifySignature(tb testing.TB, ctx *context.Context, sig string, user strin
 	artifact = strings.TrimSuffix(artifact, "."+fakeGPGKeyID)
 
 	// verify signature was made with key for user 'nopass'
-	cmd := exec.Command("gpg", "--homedir", keyring, "--verify", filepath.Join(ctx.Config.Dist, sig), filepath.Join(ctx.Config.Dist, artifact))
+	cmd := exec.CommandContext(tb.Context(), "gpg", "--homedir", keyring, "--verify", filepath.Join(ctx.Config.Dist, sig), filepath.Join(ctx.Config.Dist, artifact))
 	out, err := cmd.CombinedOutput()
 	require.NoError(tb, err, string(out))
 

--- a/internal/pipe/universalbinary/universalbinary_test.go
+++ b/internal/pipe/universalbinary/universalbinary_test.go
@@ -223,7 +223,7 @@ func TestRun(t *testing.T) {
 	})
 
 	for arch, path := range paths {
-		cmd := exec.Command("go", "build", "-o", path, src)
+		cmd := exec.CommandContext(t.Context(), "go", "build", "-o", path, src)
 		cmd.Env = append(os.Environ(), "GOOS=darwin", "GOARCH="+arch)
 		_, err := cmd.CombinedOutput()
 		require.NoError(t, err)

--- a/internal/pipe/upx/upx_test.go
+++ b/internal/pipe/upx/upx_test.go
@@ -218,7 +218,7 @@ func TestFindBinaries(t *testing.T) {
 				}
 			}
 			path := filepath.Join(tmp, fmt.Sprintf("bin_%s_%s%s", goos, goarch, ext))
-			cmd := exec.Command("go", "build", "-o", path, main)
+			cmd := exec.CommandContext(t.Context(), "go", "build", "-o", path, main)
 			cmd.Env = append([]string{
 				"CGO_ENABLED=0",
 				"GOOS=" + goos,

--- a/internal/testlib/docker.go
+++ b/internal/testlib/docker.go
@@ -1,6 +1,7 @@
 package testlib
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"sync"
@@ -20,17 +21,17 @@ var (
 func CheckDocker(tb testing.TB) {
 	tb.Helper()
 	CheckPath(tb, "docker")
-	if !IsDockerRunning() {
+	if !IsDockerRunning(tb.Context()) {
 		tb.Skip("could not run 'docker ps'")
 	}
 }
 
 // IsDockerRunning executes a `docker ps` and returns true if it succeeds.
-func IsDockerRunning() bool {
+func IsDockerRunning(ctx context.Context) bool {
 	if os.Getenv("CI") == "true" {
 		return true
 	}
-	return exec.Command("docker", "ps", "-q").Run() == nil
+	return exec.CommandContext(ctx, "docker", "ps", "-q").Run() == nil
 }
 
 // MustDockerPool gets a single dockertet.Pool.

--- a/internal/testlib/git.go
+++ b/internal/testlib/git.go
@@ -140,7 +140,8 @@ func CatFileFromBareRepository(tb testing.TB, url, name string) []byte {
 func CatFileFromBareRepositoryOnBranch(tb testing.TB, url, branch, name string) []byte {
 	tb.Helper()
 
-	out, err := exec.Command(
+	out, err := exec.CommandContext(
+		tb.Context(),
 		"git",
 		"-C", url,
 		"show",


### PR DESCRIPTION
fixed some `exec.Command` calls to pass the context within.