### PR TITLE
ci: release loong64 archives

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,6 +38,7 @@ builds:
       - amd64
       - arm
       - arm64
+      - loong64
       - ppc64
       - riscv64
     goarm:


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

This commit could release loong64 archives.

<!-- Why is this change being made? -->

I need to use gorelease to build binaries and then use these binaries to build a container image for the loong64 architecture.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

https://github.com/goreleaser/goreleaser/pull/3277
