### PR TITLE
add .github/goreleaser.yaml

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -50,6 +50,8 @@ func loadConfigCheck(path string) (config.Project, string, error) {
 		".goreleaser.yaml",
 		"goreleaser.yml",
 		"goreleaser.yaml",
+		".github/goreleaser.yml",
+		".github/goreleaser.yaml",
 	} {
 		proj, err := config.Load(f)
 		if err != nil && errors.Is(err, fs.ErrNotExist) {

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -17,6 +17,8 @@ func TestConfigFlagNotSetButExists(t *testing.T) {
 		".goreleaser.yaml",
 		"goreleaser.yml",
 		"goreleaser.yaml",
+		".github/goreleaser.yml",
+		".github/goreleaser.yaml",
 	} {
 		t.Run(name, func(t *testing.T) {
 			folder := setup(t)

--- a/www/docs/customization/index.md
+++ b/www/docs/customization/index.md
@@ -69,6 +69,8 @@ for `__VERSION__` (latest):
     - `.goreleaser.yaml`
     - `goreleaser.yml`
     - `goreleaser.yaml`
+    - `.github/goreleaser.yml`
+    - `.github/goreleaser.yaml`
 
 [jsonschema]: http://json-schema.org/draft/2020-12/json-schema-validation.html
 [schema]: ../cmd/goreleaser_jsonschema.md


### PR DESCRIPTION
This commit adds `.github` directory as a search path for the config. 

This is for use with GitHub actions, it keeps the repo root cleaner. (Since you already need to have the .github directory for actions anyways)

Alternatives:
- add this logic to the GitHub action
- if goreleaser is not running interactively, check all first-level directories for an *unambiguous* goreleaser config (ie only use the config if it's the only one found).
  - Probably also add a parameter to skip this function in case there's a config but the user doesn't want to use any configs on this run.

I didn't bother to create an issue for this, as it seems simple enough to just add it.