### PR TITLE
fix: make brews deprecation "soft"

### DIFF
--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -12,14 +12,15 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"text/template"
 
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/client"
 	"github.com/goreleaser/goreleaser/v2/internal/commitauthor"
-	"github.com/goreleaser/goreleaser/v2/internal/deprecate"
 	"github.com/goreleaser/goreleaser/v2/internal/experimental"
+	"github.com/goreleaser/goreleaser/v2/internal/logext"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe"
 	"github.com/goreleaser/goreleaser/v2/internal/skips"
 	"github.com/goreleaser/goreleaser/v2/internal/tmpl"
@@ -56,8 +57,21 @@ func (Pipe) Skip(ctx *context.Context) bool {
 }
 
 func (Pipe) Default(ctx *context.Context) error {
+	var warnOnce sync.Once
 	for i := range ctx.Config.Brews {
-		deprecate.Notice(ctx, "brews")
+		// TODO: add this back at some point:
+		// deprecate.Notice(ctx, "brews")
+		warnOnce.Do(func() {
+			log.Warn(
+				logext.Keyword("brews") +
+					logext.Warning(" is being phased out in favor of ") +
+					logext.Keyword("homebrew_casks") +
+					logext.Warning(", check ") +
+					logext.URL("https://goreleaser.com/deprecations#brews") +
+					logext.Warning(" for more info"),
+			)
+		})
+
 		brew := &ctx.Config.Brews[i]
 
 		brew.CommitAuthor = commitauthor.Default(brew.CommitAuthor)

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -1256,9 +1256,10 @@ func TestDefault(t *testing.T) {
 	require.NotEmpty(t, ctx.Config.Brews[0].CommitAuthor.Email)
 	require.NotEmpty(t, ctx.Config.Brews[0].CommitMessageTemplate)
 	require.Equal(t, repo, ctx.Config.Brews[0].Repository)
-	require.True(t, ctx.Deprecated)
-	_, ok := ctx.NotifiedDeprecations["brews"]
-	require.True(t, ok, "Brews should be deprecated")
+	// TODO: add this back at some point:
+	// require.True(t, ctx.Deprecated)
+	// _, ok := ctx.NotifiedDeprecations["brews"]
+	// require.True(t, ok, "Brews should be deprecated")
 }
 
 func TestGHFolder(t *testing.T) {


### PR DESCRIPTION
it's not too easy to remove/switch this, and if someone runs `goreleaser check` in their CI, this will make it fail.

eventually we could add a better mechanism for this, but since this is a one-off thing for now, added a warning for it.