### PR TITLE
ci: link announcement in the release notes

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -403,6 +403,11 @@ milestones:
 
 release:
   name_template: "v{{ .Version }}"
+  header: |
+    ## Announcement
+
+    Read the official announcement: [Announcing GoReleaser v{{.Major}}.{{.Minor}}](https://goreleaser.com/blog/goreleaser-v{{.Major}}.{{.Minor}}/).
+
   footer: |
     **Full Changelog**: https://github.com/goreleaser/goreleaser/compare/{{ .PreviousTag }}...{{ if .IsNightly }}nightly{{ else }}{{ .Tag }}{{ end }}
 


### PR DESCRIPTION
will add a header to every release linking to the announcement.