### PR TITLE
fix(shell): prevent panic on empty commands

### DIFF
--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -18,6 +18,11 @@ import (
 
 // Run a shell command with given arguments and envs
 func Run(ctx *context.Context, dir string, command, env []string, output bool) error {
+	if len(command) == 0 {
+		log.Warn("skipping empty command")
+		return nil
+	}
+
 	/* #nosec */
 	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
 	cmd.Env = env

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -23,6 +23,16 @@ func TestRunCommand(t *testing.T) {
 		))
 	})
 
+	t.Run("empty command", func(t *testing.T) {
+		require.NoError(t, shell.Run(
+			testctx.New(),
+			"",
+			[]string{},
+			[]string{},
+			false,
+		))
+	})
+
 	t.Run("cmd failed", func(t *testing.T) {
 		require.Error(t, shell.Run(
 			testctx.New(),


### PR DESCRIPTION
it might happen that the string is templated, but it evals to empty, in which case shell was panicking.

this should fix it

https://github.com/orgs/goreleaser/discussions/5928