### PR TITLE
feat(tmpl): readFile and mustReadFile

### DIFF
--- a/internal/tmpl/testdata/file_a.txt
+++ b/internal/tmpl/testdata/file_a.txt
@@ -1,0 +1,2 @@
+this is the content of a file
+

--- a/internal/tmpl/tmpl_test.go
+++ b/internal/tmpl/tmpl_test.go
@@ -427,6 +427,46 @@ func TestChecksum(t *testing.T) {
 	}
 }
 
+func TestMustReadFile(t *testing.T) {
+	tpl := New(testctx.New())
+
+	t.Run("file exists", func(t *testing.T) {
+		got, err := tpl.Apply(`{{ mustReadFile "./testdata/file_a.txt" }}`)
+		require.NoError(t, err)
+		require.Equal(t, "this is the content of a file", got)
+	})
+	t.Run("file don't exist", func(t *testing.T) {
+		got, err := tpl.Apply(`{{ mustReadFile "./testdata/nope.txt" }}`)
+		require.ErrorAs(t, err, &Error{})
+		require.Empty(t, got)
+	})
+	t.Run("file at ~", func(t *testing.T) {
+		got, err := tpl.Apply(`{{ mustReadFile "~/.nope" }}`)
+		require.ErrorAs(t, err, &Error{})
+		require.Empty(t, got)
+	})
+}
+
+func TestReadFile(t *testing.T) {
+	tpl := New(testctx.New())
+
+	t.Run("file exists", func(t *testing.T) {
+		got, err := tpl.Apply(`{{ readFile "./testdata/file_a.txt" }}`)
+		require.NoError(t, err)
+		require.Equal(t, "this is the content of a file", got)
+	})
+	t.Run("file don't exist", func(t *testing.T) {
+		got, err := tpl.Apply(`{{ readFile "./testdata/nope.txt" }}`)
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+	t.Run("file at ~", func(t *testing.T) {
+		got, err := tpl.Apply(`{{ readFile "~/.nope" }}`)
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+}
+
 func TestApplyAll(t *testing.T) {
 	tpl := New(testctx.New()).WithEnvS([]string{
 		"FOO=bar",

--- a/www/docs/customization/templates.md
+++ b/www/docs/customization/templates.md
@@ -175,6 +175,8 @@ On all fields, you have these available functions:
 | `sha3_384 .ArtifactPath`          | `sha3_384` checksum of the artifact. See [SHA3-384](https://pkg.go.dev/golang.org/x/crypto/sha3) (since v2.9)             |
 | `sha3_256 .ArtifactPath`          | `sha3_256` checksum of the artifact. See [SHA3-256](https://pkg.go.dev/golang.org/x/crypto/sha3) (since v2.9)             |
 | `sha3_512 .ArtifactPath`          | `sha3_512` checksum of the artifact. See [SHA3-512](https://pkg.go.dev/golang.org/x/crypto/sha3) (since v2.9)             |
+| `mustReadFile "/foo/bar.txt"`     | reads the file contents or fails if it can't be read (since v2.12-unreleased)                                             |
+| `readFile "/foo/bar.txt"`         | reads the file contents if it it can be read, or return empty string (since v2.12-unreleased)                             |
 
 ## Functions (Pro)
 


### PR DESCRIPTION
This should allow users to manually read secrets from files whilst configuring something, e.g.:

```go
env:
  FOO_SECRET: '{{ mustReadFile "./secret.txt" }}'
```