### PR TITLE
feat(golang): update allowed targets

### DIFF
--- a/internal/builders/golang/targets.go
+++ b/internal/builders/golang/targets.go
@@ -87,31 +87,31 @@ func listTargets(build config.Build) ([]string, error) {
 	//nolint:prealloc
 	var result []string
 	for _, target := range allBuildTargets(build) {
-		if !contains(target.Goos, validGoos) {
+		if !slices.Contains(validGoos, target.Goos) {
 			return result, fmt.Errorf("invalid goos: %s", target.Goos)
 		}
-		if !contains(target.Goarch, validGoarch) {
+		if !slices.Contains(validGoarch, target.Goarch) {
 			return result, fmt.Errorf("invalid goarch: %s", target.Goarch)
 		}
-		if target.Goamd64 != "" && !contains(target.Goamd64, validGoamd64) {
+		if target.Goamd64 != "" && !slices.Contains(validGoamd64, target.Goamd64) {
 			return result, fmt.Errorf("invalid goamd64: %s", target.Goamd64)
 		}
-		if target.Go386 != "" && !contains(target.Go386, validGo386) {
+		if target.Go386 != "" && !slices.Contains(validGo386, target.Go386) {
 			return result, fmt.Errorf("invalid go386: %s", target.Go386)
 		}
-		if target.Goarm != "" && !contains(target.Goarm, validGoarm) {
+		if target.Goarm != "" && !slices.Contains(validGoarm, target.Goarm) {
 			return result, fmt.Errorf("invalid goarm: %s", target.Goarm)
 		}
 		if target.Goarm64 != "" && !validGoarm64.MatchString(target.Goarm64) {
 			return result, fmt.Errorf("invalid goarm64: %s", target.Goarm64)
 		}
-		if target.Gomips != "" && !contains(target.Gomips, validGomips) {
+		if target.Gomips != "" && !slices.Contains(validGomips, target.Gomips) {
 			return result, fmt.Errorf("invalid gomips: %s", target.Gomips)
 		}
-		if target.Goppc64 != "" && !contains(target.Goppc64, validGoppc64) {
+		if target.Goppc64 != "" && !slices.Contains(validGoppc64, target.Goppc64) {
 			return result, fmt.Errorf("invalid goppc64: %s", target.Goppc64)
 		}
-		if target.Goriscv64 != "" && !contains(target.Goriscv64, validGoriscv64) {
+		if target.Goriscv64 != "" && !slices.Contains(validGoriscv64, target.Goriscv64) {
 			return result, fmt.Errorf("invalid goriscv64: %s", target.Goriscv64)
 		}
 		if !valid(target) {
@@ -240,11 +240,22 @@ func ignored(build config.Build, target Target) bool {
 }
 
 func valid(target Target) bool {
-	return contains(target.Goos+target.Goarch, validTargets)
-}
+	t := target.Goos + target.Goarch
+	if slices.Contains(validTargets, t) {
+		return true
+	}
 
-func contains(s string, ss []string) bool {
-	return slices.Contains(ss, s)
+	if slices.Contains(experimentalTargets, t) {
+		log.WithField("target", target).Warn("experimental target, use at your own risk")
+		return true
+	}
+
+	if slices.Contains(brokenTargets, t) {
+		log.WithField("target", target).Error("broken target, use at your own risk")
+		return true
+	}
+
+	return false
 }
 
 // lists from https://go.dev/doc/install/source#environment
@@ -295,10 +306,17 @@ var (
 		"solarisamd64",
 		"solarissparc",
 		"solarissparc64",
-		"windowsarm",
 		"windowsarm64",
 		"windows386",
 		"windowsamd64",
+	}
+
+	experimentalTargets = []string{
+		"openbsdriscv64", // https://golang.google.cn/doc/go1.23#openbsd
+	}
+
+	brokenTargets = []string{
+		"windowsarm", // broken: https://golang.google.cn/doc/go1.24#windows , https://golang.google.cn/doc/go1.25#windows
 	}
 
 	validGoos = []string{
@@ -344,5 +362,5 @@ var (
 	validGoarm64   = regexp.MustCompile(`(v8\.[0-9]|v9\.[0-5])((,lse|,crypto)?)+`)
 	validGomips    = []string{"hardfloat", "softfloat"}
 	validGoppc64   = []string{"power8", "power9", "power10"}
-	validGoriscv64 = []string{"rva20u64", "rva22u64"}
+	validGoriscv64 = []string{"rva20u64", "rva22u64", "rva23u64"}
 )

--- a/internal/builders/golang/targets_test.go
+++ b/internal/builders/golang/targets_test.go
@@ -148,6 +148,7 @@ func TestAllBuildTargets(t *testing.T) {
 			"openbsd_amd64_v3",
 			"openbsd_amd64_v4",
 			"openbsd_arm64_v9.0",
+			"openbsd_riscv64_rva22u64",
 			"windows_386_softfloat",
 			"windows_amd64_v2",
 			"windows_amd64_v3",
@@ -260,6 +261,10 @@ func TestGoosGoarchCombos(t *testing.T) {
 		{"windows", "arm", true},
 		{"windows", "arm64", true},
 		{"js", "wasm", true},
+		// experimental targets:
+		{os: "openbsd", arch: "riscv64", valid: true},
+		// broken/to-be-removed:
+		{os: "windows", arch: "arm", valid: true},
 		// invalid targets
 		{"darwin", "386", false},
 		{"darwin", "arm", false},


### PR DESCRIPTION
- add the concept of experimental and broken targets
- added openbsd/riscv64 as an experimental target (added in go1.23)
- moved windows/arm into the broken target list (marked in go1.25, will be removed in go1.27)
- added `rva23u64` to `GORISCV64` (added in go1.26)

closes https://github.com/orgs/goreleaser/discussions/5939

