### PR TITLE
ci: use go-version-file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
-          go-version: stable
+          go-version-file: go.mod
       - uses: mlugg/setup-zig@v2
         with:
           version: 0.14.0 # https://github.com/ziglang/zig/issues/23977

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v4
         with:
-          go-version: stable
+          go-version-file: go.mod
       - uses: github/codeql-action/init@76621b61decf072c1cee8dd1ce2d2a82d33c17ed # v3
       - uses: github/codeql-action/autobuild@76621b61decf072c1cee8dd1ce2d2a82d33c17ed # v3
       - uses: github/codeql-action/analyze@76621b61decf072c1cee8dd1ce2d2a82d33c17ed # v3

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ secrets.GH_PAT }}
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v4
         with:
-          go-version: stable
+          go-version-file: go.mod
           cache: true
       - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v1
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v4
         with:
-          go-version: stable
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:

--- a/.github/workflows/nightly-oss.yml
+++ b/.github/workflows/nightly-oss.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v4
         with:
-          go-version: stable
+          go-version-file: go.mod
       - uses: sigstore/cosign-installer@v3.9.2
       - uses: anchore/sbom-action/download-syft@v0.20.4
       - uses: crazy-max/ghaction-upx@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
         run: sudo snap install snapcraft --classic
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v4
         with:
-          go-version: stable
+          go-version-file: go.mod
       - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         with:
           path: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/goreleaser/goreleaser/v2
 
-go 1.24.0
+go 1.24.6
 
 require (
 	code.gitea.io/sdk/gitea v0.21.0


### PR DESCRIPTION
this prevents breaking CI when a new Go version is out.