### PR TITLE
feat: retry docker manifest, retry configurations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/agnivade/levenshtein v1.2.1
 	github.com/anchore/quill v0.5.1
 	github.com/atc0005/go-teams-notify/v2 v2.13.0
+	github.com/avast/retry-go/v4 v4.6.1
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.10.1
 	github.com/bluesky-social/indigo v0.0.0-20240813042137-4006c0eca043
 	github.com/caarlos0/env/v11 v11.3.1

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3d
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/atc0005/go-teams-notify/v2 v2.13.0 h1:nbDeHy89NjYlF/PEfLVF6lsserY9O5SnN1iOIw3AxXw=
 github.com/atc0005/go-teams-notify/v2 v2.13.0/go.mod h1:WSv9moolRsBcpZbwEf6gZxj7h0uJlJskJq5zkEWKO8Y=
+github.com/avast/retry-go/v4 v4.6.1 h1:VkOLRubHdisGrHnTu89g08aQEWEgRU7LVEop3GbIcMk=
+github.com/avast/retry-go/v4 v4.6.1/go.mod h1:V6oF8njAwxJ5gRo1Q7Cxab24xs5NCWZBeaHHBklR8mA=
 github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
 github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aws/aws-sdk-go-v2 v1.37.2 h1:xkW1iMYawzcmYFYEV0UCMxc8gSsjCGEhBXQkdQywVbo=

--- a/internal/client/git.go
+++ b/internal/client/git.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/avast/retry-go/v4"
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/internal/git"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe"
@@ -86,7 +87,7 @@ func (g *gitClient) CreateFiles(
 			return fmt.Errorf("git: failed to create parent: %w", err)
 		}
 
-		if err := cloneRepoWithRetries(ctx, parent, url, name, env); err != nil {
+		if err := cloneRepo(ctx, parent, url, name, env); err != nil {
 			return err
 		}
 
@@ -219,29 +220,22 @@ func isPasswordError(err error) bool {
 	return errors.As(err, &kerr)
 }
 
-func cloneRepoWithRetries(ctx *context.Context, parent, url, name string, env []string) error {
-	var try int
-	for try < 10 {
-		try++
-		err := runGitCmds(ctx, parent, env, [][]string{{"clone", url, name}})
-		if err == nil {
-			return nil
-		}
-		if isRetriableCloneError(err) {
-			log.WithField("try", try).
-				WithField("image", name).
-				WithError(err).
-				Warnf("failed to push image, will retry")
-			time.Sleep(time.Duration(try*10) * time.Second)
-			continue
-		}
+func cloneRepo(ctx *context.Context, parent, url, name string, env []string) error {
+	if err := retry.Do(
+		func() error {
+			log.WithField("url", url).Infof("cloning %s", name)
+			return runGitCmds(ctx, parent, env, [][]string{{"clone", url, name}})
+		},
+		retry.RetryIf(func(err error) bool {
+			return strings.Contains(err.Error(), "Connection reset")
+		}),
+		retry.Attempts(10),
+		retry.Delay(time.Second),
+		retry.LastErrorOnly(true),
+	); err != nil {
 		return fmt.Errorf("failed to clone local repository: %w", err)
 	}
-	return fmt.Errorf("failed to push %s after %d tries", name, try)
-}
-
-func isRetriableCloneError(err error) bool {
-	return strings.Contains(err.Error(), "Connection reset")
+	return nil
 }
 
 func runGitCmds(ctx *context.Context, cwd string, env []string, cmds [][]string) error {

--- a/internal/pipe/docker/api_docker.go
+++ b/internal/pipe/docker/api_docker.go
@@ -3,9 +3,7 @@ package docker
 import (
 	"fmt"
 	"regexp"
-	"strings"
 
-	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
 )
 
@@ -18,15 +16,9 @@ func init() {
 	})
 }
 
-const maxRetries = 10
-
 type dockerManifester struct{}
 
 func (m dockerManifester) Create(ctx *context.Context, manifest string, images, flags []string) error {
-	return m.tryCreate(ctx, manifest, images, flags, 0)
-}
-
-func (m dockerManifester) tryCreate(ctx *context.Context, manifest string, images, flags []string, try int) error {
 	_ = runCommand(ctx, ".", "docker", "manifest", "rm", manifest)
 
 	args := []string{"manifest", "create", manifest}
@@ -34,18 +26,6 @@ func (m dockerManifester) tryCreate(ctx *context.Context, manifest string, image
 	args = append(args, flags...)
 
 	if err := runCommand(ctx, ".", "docker", args...); err != nil {
-		if strings.Contains(err.Error(), "manifest verification failed for digest") && try < maxRetries {
-			// this error happens every so often for some reason... retry
-			log.WithField("try", try+1).
-				WithField("maxRetries", maxRetries).
-				WithField("manifest", manifest).
-				WithField("images", images).
-				WithField("flags", flags).
-				WithError(err).
-				Warn("got an error while creating the manifest, will retry")
-			return m.tryCreate(ctx, manifest, images, flags, try+1)
-		}
-
 		return fmt.Errorf("failed to create %s: %w", manifest, err)
 	}
 	return nil

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe"
@@ -1052,6 +1053,8 @@ func TestRunPipe(t *testing.T) {
 					manifest.PushFlags = []string{"--insecure"}
 					manifest.CreateFlags = []string{"--insecure"}
 				}
+				require.NoError(t, Pipe{}.Default(ctx))
+				require.NoError(t, ManifestPipe{}.Default(ctx))
 				err = Pipe{}.Run(ctx)
 				docker.assertError(t, err)
 				if err == nil {
@@ -1166,11 +1169,20 @@ func TestDefault(t *testing.T) {
 	require.Equal(t, useDocker, docker.Use)
 	docker = ctx.Config.Dockers[1]
 	require.Equal(t, useBuildx, docker.Use)
+	require.Equal(t, uint(10), docker.Retry.Attempts)
+	require.Equal(t, 10*time.Second, docker.Retry.Delay)
+	require.Equal(t, 5*time.Minute, docker.Retry.MaxDelay)
 
 	require.NoError(t, ManifestPipe{}.Default(ctx))
 	require.Len(t, ctx.Config.DockerManifests, 2)
 	require.Equal(t, useDocker, ctx.Config.DockerManifests[0].Use)
 	require.Equal(t, useDocker, ctx.Config.DockerManifests[1].Use)
+
+	for _, manifest := range ctx.Config.DockerManifests {
+		require.Equal(t, uint(10), manifest.Retry.Attempts)
+		require.Equal(t, 10*time.Second, manifest.Retry.Delay)
+		require.Equal(t, 5*time.Minute, manifest.Retry.MaxDelay)
+	}
 }
 
 func TestDefaultDuplicateID(t *testing.T) {

--- a/internal/pipe/docker/manifest.go
+++ b/internal/pipe/docker/manifest.go
@@ -123,7 +123,7 @@ func (ManifestPipe) Publish(ctx *context.Context) error {
 					log.WithField("manifest", name).Info("pushing manifest")
 					return manifester.Push(ctx, name, manifest.PushFlags)
 				},
-				retry.RetryIf(isRetriableManifestCreate),
+				retry.RetryIf(isRetriablePush),
 				retry.Attempts(manifest.Retry.Attempts),
 				retry.Delay(manifest.Retry.Delay),
 				retry.MaxDelay(manifest.Retry.MaxDelay),

--- a/internal/pipe/release/release.go
+++ b/internal/pipe/release/release.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/avast/retry-go/v4"
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/client"
@@ -181,7 +182,10 @@ func doPublish(ctx *context.Context, client client.Client) error {
 	g := semerrgroup.New(ctx.Parallelism)
 	for _, artifact := range ctx.Artifacts.Filter(filters).List() {
 		g.Go(func() error {
-			return upload(ctx, client, releaseID, artifact)
+			if err := upload(ctx, client, releaseID, artifact); err != nil {
+				return fmt.Errorf("failed to upload %s: %w", artifact.Name, err)
+			}
+			return nil
 		})
 	}
 	if err := g.Wait(); err != nil {
@@ -192,37 +196,21 @@ func doPublish(ctx *context.Context, client client.Client) error {
 }
 
 func upload(ctx *context.Context, cli client.Client, releaseID string, artifact *artifact.Artifact) error {
-	var try int
-	tryUpload := func() error {
-		try++
-		file, err := os.Open(artifact.Path)
-		if err != nil {
-			return err
-		}
-		defer file.Close()
-		log.WithField("file", file.Name()).WithField("name", artifact.Name).Info("uploading to release")
-		if err := cli.Upload(ctx, releaseID, artifact, file); err != nil {
-			log.WithField("try", try).
-				WithField("artifact", artifact.Name).
-				WithError(err).
-				Warn("failed to upload artifact, will retry")
-			return err
-		}
-		return nil
-	}
-
-	var err error
-	for try < 10 {
-		err = tryUpload()
-		if err == nil {
-			return nil
-		}
-		if errors.As(err, &client.RetriableError{}) {
-			time.Sleep(time.Duration(try*50) * time.Millisecond)
-			continue
-		}
-		break
-	}
-
-	return fmt.Errorf("failed to upload %s after %d tries: %w", artifact.Name, try, err)
+	return retry.Do(
+		func() error {
+			log.WithField("file", artifact.Path).
+				WithField("name", artifact.Name).
+				Info("uploading to release")
+			file, err := os.Open(artifact.Path)
+			if err != nil {
+				return err
+			}
+			defer file.Close()
+			return cli.Upload(ctx, releaseID, artifact, file)
+		},
+		retry.Attempts(10),
+		retry.Delay(50*time.Millisecond),
+		retry.LastErrorOnly(true),
+		retry.RetryIf(func(err error) bool { return errors.As(err, &client.RetriableError{}) }),
+	)
 }

--- a/internal/pipe/release/release_test.go
+++ b/internal/pipe/release/release_test.go
@@ -275,7 +275,7 @@ func TestRunPipeUploadFailure(t *testing.T) {
 	client := &client.Mock{
 		FailToUpload: true,
 	}
-	require.EqualError(t, doPublish(ctx, client), "failed to upload bin.tar.gz after 1 tries: upload failed")
+	require.EqualError(t, doPublish(ctx, client), "failed to upload bin.tar.gz: upload failed")
 	require.True(t, client.CreatedRelease)
 	require.False(t, client.UploadedFile)
 	require.False(t, client.ReleasePublished)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1014,6 +1014,14 @@ type Checksum struct {
 	ExtraFiles   []ExtraFile `yaml:"extra_files,omitempty" json:"extra_files,omitempty"`
 }
 
+// Retry config for operations that support retries.
+// Added in v2.12.
+type Retry struct {
+	Attempts uint          `yaml:"attempts,omitempty" json:"attempts,omitempty"`
+	Delay    time.Duration `yaml:"delay,omitempty" json:"delay,omitempty"`
+	MaxDelay time.Duration `yaml:"max_delay,omitempty" json:"max_delay,omitempty"`
+}
+
 // Docker image config.
 type Docker struct {
 	ID                 string   `yaml:"id,omitempty" json:"id,omitempty"`
@@ -1029,6 +1037,7 @@ type Docker struct {
 	BuildFlagTemplates []string `yaml:"build_flag_templates,omitempty" json:"build_flag_templates,omitempty"`
 	PushFlags          []string `yaml:"push_flags,omitempty" json:"push_flags,omitempty"`
 	Use                string   `yaml:"use,omitempty" json:"use,omitempty" jsonschema:"enum=docker,enum=buildx,default=docker"`
+	Retry              Retry    `yaml:"retry,omitempty" json:"retry,omitempty"`
 }
 
 // DockerManifest config.
@@ -1040,6 +1049,7 @@ type DockerManifest struct {
 	CreateFlags    []string `yaml:"create_flags,omitempty" json:"create_flags,omitempty"`
 	PushFlags      []string `yaml:"push_flags,omitempty" json:"push_flags,omitempty"`
 	Use            string   `yaml:"use,omitempty" json:"use,omitempty"`
+	Retry          Retry    `yaml:"retry,omitempty" json:"retry,omitempty"`
 }
 
 // Filters config.

--- a/www/docs/customization/docker.md
+++ b/www/docs/customization/docker.md
@@ -182,7 +182,7 @@ dockers:
       # Maximum delay between retry attempts.
       #
       # Default: 5m.
-      max_interval: 2m
+      max_delay: 2m
 
     # If your Dockerfile copies files other than binaries and packages,
     # you should list them here as well.

--- a/www/docs/customization/docker.md
+++ b/www/docs/customization/docker.md
@@ -165,6 +165,25 @@ dockers:
     push_flags:
       - --tls-verify=false
 
+    # Retry configuration for push operations.
+    #
+    # <!-- md:inline_version v2.12-unreleased -->.
+    retry:
+      # Attempts of retry.
+      #
+      # Default: 10.
+      attempts: 5
+
+      # Delay between retry attempts.
+      #
+      # Default: 10s.
+      delay: 5s
+
+      # Maximum delay between retry attempts.
+      #
+      # Default: 5m.
+      max_interval: 2m
+
     # If your Dockerfile copies files other than binaries and packages,
     # you should list them here as well.
     # Note that GoReleaser will create the same structure inside a temporary

--- a/www/docs/customization/docker_manifest.md
+++ b/www/docs/customization/docker_manifest.md
@@ -51,6 +51,25 @@ docker_manifests:
     push_flags:
       - --insecure
 
+    # Retry configuration for manifest operations.
+    #
+    # <!-- md:inline_version v2.12-unreleased -->.
+    retry:
+      # Attempts of retry.
+      #
+      # Default: 10.
+      attempts: 5
+
+      # Delay between retry attempts.
+      #
+      # Default: 10s.
+      delay: 5s
+
+      # Maximum delay between retry attempts.
+      #
+      # Default: 5m.
+      max_interval: 2m
+
     # Skips the Docker manifest.
     # If you set this to `false` or `auto` on your source Docker configuration,
     #  you'll probably want to do the same here.

--- a/www/docs/customization/docker_manifest.md
+++ b/www/docs/customization/docker_manifest.md
@@ -68,7 +68,7 @@ docker_manifests:
       # Maximum delay between retry attempts.
       #
       # Default: 5m.
-      max_interval: 2m
+      max_delay: 2m
 
     # Skips the Docker manifest.
     # If you set this to `false` or `auto` on your source Docker configuration,


### PR DESCRIPTION
- adds avast/retry in favor of our manual retries here and there
- makes retries configurable for docker images and manifests
- use retries in docker manifest create and push

closes #5967
fixes #5853

