### PR TITLE
fix(brew): use && instead of and

### DIFF
--- a/internal/pipe/brew/templates/linux_packages.rb
+++ b/internal/pipe/brew/templates/linux_packages.rb
@@ -1,11 +1,11 @@
 {{- define "linux_packages" }}
 {{- range $element := .LinuxPackages }}
   {{- if eq $element.Arch "amd64" }}
-  if Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
+  if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
   {{- else if eq $element.Arch "arm64" }}
-  if Hardware::CPU.arm? and Hardware::CPU.is_64_bit?
+  if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
   {{- else if eq $element.Arch "arm" }}
-  if Hardware::CPU.arm? and !Hardware::CPU.is_64_bit?
+  if Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
   {{- end }}
     url "{{ $element.DownloadURL }}"
     {{- if .DownloadStrategy }}, using: {{ .DownloadStrategy }}{{- end }}

--- a/internal/pipe/brew/testdata/TestFullFormulae.rb.golden
+++ b/internal/pipe/brew/testdata/TestFullFormulae.rb.golden
@@ -30,21 +30,21 @@ class Test < Formula
   end
 
   on_linux do
-    if Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
+    if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Linux_x86_64.tar.gz"
       sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67"
       def install
         bin.install "test"
       end
     end
-    if Hardware::CPU.arm? and !Hardware::CPU.is_64_bit?
+    if Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
       url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Arm6.tar.gz"
       sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67"
       def install
         bin.install "test"
       end
     end
-    if Hardware::CPU.arm? and Hardware::CPU.is_64_bit?
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Arm64.tar.gz"
       sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67"
       def install

--- a/internal/pipe/brew/testdata/TestFullFormulaeLinuxOnly.rb.golden
+++ b/internal/pipe/brew/testdata/TestFullFormulaeLinuxOnly.rb.golden
@@ -8,21 +8,21 @@ class Test < Formula
   version "0.1.3"
   depends_on :linux
 
-  if Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
+  if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
     url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Linux_x86_64.tar.gz"
     sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67"
     def install
       bin.install "test"
     end
   end
-  if Hardware::CPU.arm? and !Hardware::CPU.is_64_bit?
+  if Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
     url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Arm6.tar.gz"
     sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67"
     def install
       bin.install "test"
     end
   end
-  if Hardware::CPU.arm? and Hardware::CPU.is_64_bit?
+  if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
     url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Arm64.tar.gz"
     sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67"
     def install

--- a/internal/pipe/brew/testdata/TestFullPipe/custom_block.rb.golden
+++ b/internal/pipe/brew/testdata/TestFullPipe/custom_block.rb.golden
@@ -33,7 +33,7 @@ class CustomBlock < Formula
   end
 
   on_linux do
-    if Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
+    if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/bin.tar.zst"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       def install

--- a/internal/pipe/brew/testdata/TestFullPipe/custom_download_strategy.rb.golden
+++ b/internal/pipe/brew/testdata/TestFullPipe/custom_download_strategy.rb.golden
@@ -33,7 +33,7 @@ class CustomDownloadStrategy < Formula
   end
 
   on_linux do
-    if Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
+    if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/bin.tar.zst", using: GitHubPrivateRepositoryReleaseDownloadStrategy
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       def install

--- a/internal/pipe/brew/testdata/TestFullPipe/custom_require.rb.golden
+++ b/internal/pipe/brew/testdata/TestFullPipe/custom_require.rb.golden
@@ -34,7 +34,7 @@ class CustomRequire < Formula
   end
 
   on_linux do
-    if Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
+    if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/bin.tar.zst", using: CustomDownloadStrategy
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       def install

--- a/internal/pipe/brew/testdata/TestFullPipe/default.rb.golden
+++ b/internal/pipe/brew/testdata/TestFullPipe/default.rb.golden
@@ -33,7 +33,7 @@ class Default < Formula
   end
 
   on_linux do
-    if Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
+    if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/bin.tar.zst"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       def install

--- a/internal/pipe/brew/testdata/TestFullPipe/default_gitlab.rb.golden
+++ b/internal/pipe/brew/testdata/TestFullPipe/default_gitlab.rb.golden
@@ -33,7 +33,7 @@ class DefaultGitlab < Formula
   end
 
   on_linux do
-    if Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
+    if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/bin.tar.zst"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       def install

--- a/internal/pipe/brew/testdata/TestFullPipe/git_remote.rb.golden
+++ b/internal/pipe/brew/testdata/TestFullPipe/git_remote.rb.golden
@@ -33,7 +33,7 @@ class GitRemote < Formula
   end
 
   on_linux do
-    if Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
+    if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/bin.tar.zst"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       def install

--- a/internal/pipe/brew/testdata/TestFullPipe/open_pr.rb.golden
+++ b/internal/pipe/brew/testdata/TestFullPipe/open_pr.rb.golden
@@ -33,7 +33,7 @@ class OpenPr < Formula
   end
 
   on_linux do
-    if Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
+    if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/bin.tar.zst"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       def install

--- a/internal/pipe/brew/testdata/TestFullPipe/valid_repository_templates.rb.golden
+++ b/internal/pipe/brew/testdata/TestFullPipe/valid_repository_templates.rb.golden
@@ -33,7 +33,7 @@ class ValidRepositoryTemplates < Formula
   end
 
   on_linux do
-    if Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
+    if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/bin.tar.zst"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       def install

--- a/internal/pipe/brew/testdata/TestFullPipe/with_header.rb.golden
+++ b/internal/pipe/brew/testdata/TestFullPipe/with_header.rb.golden
@@ -39,7 +39,7 @@ class WithHeader < Formula
   end
 
   on_linux do
-    if Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
+    if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/bin.tar.zst",
         headers: [
           "Authorization: bearer #{ENV["HOMEBREW_GITHUB_API_TOKEN"]}"

--- a/internal/pipe/brew/testdata/TestFullPipe/with_many_headers.rb.golden
+++ b/internal/pipe/brew/testdata/TestFullPipe/with_many_headers.rb.golden
@@ -41,7 +41,7 @@ class WithManyHeaders < Formula
   end
 
   on_linux do
-    if Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
+    if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/bin.tar.zst",
         headers: [
           "Accept: application/octet-stream",

--- a/internal/pipe/brew/testdata/TestRunPipeForMultipleAmd64Versions/v1.rb.golden
+++ b/internal/pipe/brew/testdata/TestRunPipeForMultipleAmd64Versions/v1.rb.golden
@@ -20,7 +20,7 @@ class V1 < Formula
   end
 
   on_linux do
-    if Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
+    if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/amd64v2.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       def install
@@ -28,7 +28,7 @@ class V1 < Formula
         man1.install "./man/foo.1.gz"
       end
     end
-    if Hardware::CPU.arm? and Hardware::CPU.is_64_bit?
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       def install

--- a/internal/pipe/brew/testdata/TestRunPipeForMultipleAmd64Versions/v2.rb.golden
+++ b/internal/pipe/brew/testdata/TestRunPipeForMultipleAmd64Versions/v2.rb.golden
@@ -20,7 +20,7 @@ class V2 < Formula
   end
 
   on_linux do
-    if Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
+    if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/amd64v2.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       def install
@@ -28,7 +28,7 @@ class V2 < Formula
         man1.install "./man/foo.1.gz"
       end
     end
-    if Hardware::CPU.arm? and Hardware::CPU.is_64_bit?
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       def install

--- a/internal/pipe/brew/testdata/TestRunPipeForMultipleAmd64Versions/v3.rb.golden
+++ b/internal/pipe/brew/testdata/TestRunPipeForMultipleAmd64Versions/v3.rb.golden
@@ -20,7 +20,7 @@ class V3 < Formula
   end
 
   on_linux do
-    if Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
+    if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/amd64v3.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       def install
@@ -28,7 +28,7 @@ class V3 < Formula
         man1.install "./man/foo.1.gz"
       end
     end
-    if Hardware::CPU.arm? and Hardware::CPU.is_64_bit?
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       def install

--- a/internal/pipe/brew/testdata/TestRunPipeForMultipleAmd64Versions/v4.rb.golden
+++ b/internal/pipe/brew/testdata/TestRunPipeForMultipleAmd64Versions/v4.rb.golden
@@ -20,7 +20,7 @@ class V4 < Formula
   end
 
   on_linux do
-    if Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
+    if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/amd64v3.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       def install
@@ -28,7 +28,7 @@ class V4 < Formula
         man1.install "./man/foo.1.gz"
       end
     end
-    if Hardware::CPU.arm? and Hardware::CPU.is_64_bit?
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       def install

--- a/internal/pipe/brew/testdata/TestRunPipeForMultipleArmVersions/multiple_armv5.rb.golden
+++ b/internal/pipe/brew/testdata/TestRunPipeForMultipleArmVersions/multiple_armv5.rb.golden
@@ -30,14 +30,14 @@ class MultipleArmv5 < Formula
   end
 
   on_linux do
-    if Hardware::CPU.arm? and !Hardware::CPU.is_64_bit?
+    if Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/armv5.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       def install
         bin.install "multiple_armv5"
       end
     end
-    if Hardware::CPU.arm? and Hardware::CPU.is_64_bit?
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       def install

--- a/internal/pipe/brew/testdata/TestRunPipeForMultipleArmVersions/multiple_armv6.rb.golden
+++ b/internal/pipe/brew/testdata/TestRunPipeForMultipleArmVersions/multiple_armv6.rb.golden
@@ -30,14 +30,14 @@ class MultipleArmv6 < Formula
   end
 
   on_linux do
-    if Hardware::CPU.arm? and !Hardware::CPU.is_64_bit?
+    if Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/armv6.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       def install
         bin.install "multiple_armv6"
       end
     end
-    if Hardware::CPU.arm? and Hardware::CPU.is_64_bit?
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       def install

--- a/internal/pipe/brew/testdata/TestRunPipeForMultipleArmVersions/multiple_armv7.rb.golden
+++ b/internal/pipe/brew/testdata/TestRunPipeForMultipleArmVersions/multiple_armv7.rb.golden
@@ -30,14 +30,14 @@ class MultipleArmv7 < Formula
   end
 
   on_linux do
-    if Hardware::CPU.arm? and !Hardware::CPU.is_64_bit?
+    if Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/armv7.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       def install
         bin.install "multiple_armv7"
       end
     end
-    if Hardware::CPU.arm? and Hardware::CPU.is_64_bit?
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       url "https://dummyhost/download/v1.0.1/arm64.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       def install


### PR DESCRIPTION
according to some users, linuxbrew might complain for the `and` syntax: https://github.com/orgs/goreleaser/discussions/5947
