### PR TITLE
feat: add makeself self-extracting archive format support

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/goreleaser/goreleaser/v2/pkg/archive/gzip"
+	"github.com/goreleaser/goreleaser/v2/pkg/archive/makeself"
 	"github.com/goreleaser/goreleaser/v2/pkg/archive/tar"
 	"github.com/goreleaser/goreleaser/v2/pkg/archive/targz"
 	"github.com/goreleaser/goreleaser/v2/pkg/archive/tarxz"
@@ -36,8 +37,25 @@ func New(w io.Writer, format string) (Archive, error) {
 		return tarzst.New(w), nil
 	case "zip":
 		return zip.New(w), nil
+	case "makeself":
+		return makeself.New(w), nil
 	}
 	return nil, fmt.Errorf("invalid archive format: %s", format)
+}
+
+// NewWithMakeselfConfig creates a makeself archive with custom configuration.
+func NewWithMakeselfConfig(w io.Writer, outputPath string, cfg config.MakeselfConfig) (Archive, error) {
+	makeselfCfg := makeself.MakeselfConfig{
+		OutputPath:        outputPath,
+		InstallScript:     cfg.InstallScript,
+		InstallScriptFile: cfg.InstallScriptFile,
+		Label:             cfg.Label,
+		Compression:       cfg.Compression,
+		ExtraArgs:         cfg.ExtraArgs,
+		LSMTemplate:       cfg.LSMTemplate,
+		LSMFile:           cfg.LSMFile,
+	}
+	return makeself.NewWithConfig(w, outputPath, makeselfCfg), nil
 }
 
 // Copy copies the source archive into a new one, which can be appended at.

--- a/pkg/archive/makeself/makeself.go
+++ b/pkg/archive/makeself/makeself.go
@@ -1,0 +1,336 @@
+// Package makeself implements the Archive interface providing makeself self-extracting
+// archive creation.
+package makeself
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/goreleaser/goreleaser/v2/pkg/config"
+)
+
+// Archive as makeself.
+type Archive struct {
+	tempDir    string
+	files      map[string]bool
+	target     io.Writer
+	outputPath string // Path where makeself should create the archive directly
+	closed     bool
+	config     MakeselfConfig // Configuration options for makeself
+}
+
+// MakeselfConfig holds configuration options for makeself archives.
+type MakeselfConfig struct {
+	OutputPath        string   // Optional: override output path
+	InstallScript     string   // Optional: custom install script content
+	InstallScriptFile string   // Optional: path to custom install script file (relative to archive contents)
+	Label             string   // Optional: custom label for the archive
+	Compression       string   // Optional: compression format (gzip, bzip2, xz, lzo, compress, none)
+	ExtraArgs         []string // Optional: extra command line arguments
+	LSMTemplate       string   // Optional: LSM file content template
+	LSMFile           string   // Optional: path to external LSM file
+}
+
+// New makeself archive.
+func New(target io.Writer) *Archive {
+	tempDir, err := os.MkdirTemp("", "makeself-*")
+	if err != nil {
+		panic(fmt.Sprintf("failed to create temp directory: %v", err))
+	}
+
+	// Target must be a file for makeself to work
+	file, ok := target.(*os.File)
+	if !ok {
+		panic("makeself archives require an *os.File target")
+	}
+
+	return &Archive{
+		tempDir:    tempDir,
+		files:      map[string]bool{},
+		target:     target,
+		outputPath: file.Name(),
+		closed:     false,
+	}
+}
+
+// NewWithInstallScript creates a makeself archive with a custom install script.
+func NewWithInstallScript(target io.Writer, installScript string) *Archive {
+	archive := New(target)
+
+	// Write custom install script
+	installPath := filepath.Join(archive.tempDir, "install.sh")
+	if err := os.WriteFile(installPath, []byte(installScript), 0o755); err != nil {
+		panic(fmt.Sprintf("failed to create install script: %v", err))
+	}
+
+	return archive
+}
+
+// NewWithConfig creates a makeself archive with full configuration options.
+func NewWithConfig(target io.Writer, outputPath string, cfg MakeselfConfig) *Archive {
+	archive := New(target)
+
+	// Override output path if provided
+	if cfg.OutputPath != "" {
+		archive.outputPath = cfg.OutputPath
+	} else if outputPath != "" {
+		archive.outputPath = outputPath
+	}
+
+	// Handle install script - defer validation for file-based scripts
+	if cfg.InstallScript != "" {
+		// Use provided script content
+		installPath := filepath.Join(archive.tempDir, "install.sh")
+		if err := os.WriteFile(installPath, []byte(cfg.InstallScript), 0o755); err != nil {
+			panic(fmt.Sprintf("failed to create install script: %v", err))
+		}
+	}
+
+	// Store configuration for use in Close()
+	archive.config = cfg
+
+	return archive
+}
+
+// Close creates the makeself archive and writes it to the target.
+func (a *Archive) Close() error {
+	if a.closed {
+		return nil // Idempotent close
+	}
+	a.closed = true
+
+	defer os.RemoveAll(a.tempDir)
+
+	// Check if makeself command is available
+	makeselfCmd := findMakeselfCommand()
+	if makeselfCmd == "" {
+		return fmt.Errorf("makeself command not found in PATH (tried 'makeself' and 'makeself.sh')")
+	}
+
+	// Determine the install script to use
+	var installScriptArg string
+	if a.config.InstallScriptFile != "" {
+		// Install script file path is relative to archive contents
+		scriptPath := filepath.Join(a.tempDir, a.config.InstallScriptFile)
+		if _, err := os.Stat(scriptPath); err != nil {
+			return fmt.Errorf("install script file %s not found in archive contents: %w", a.config.InstallScriptFile, err)
+		}
+		// Use relative path for makeself command, avoid double ./ prefix
+		if strings.HasPrefix(a.config.InstallScriptFile, "./") {
+			installScriptArg = a.config.InstallScriptFile
+		} else {
+			installScriptArg = "./" + a.config.InstallScriptFile
+		}
+	} else {
+		// Create a basic install script if none exists
+		installScript := filepath.Join(a.tempDir, "install.sh")
+		if _, err := os.Stat(installScript); os.IsNotExist(err) {
+			installContent := `#!/bin/bash
+# Default installation script for makeself archive
+# This script is executed after extraction
+
+# Make binaries executable
+find . -type f -perm -u+x -exec chmod +x {} \;
+
+echo "Archive extracted successfully to $(pwd)"
+echo "Files:"
+find . -type f | sort
+`
+			if err := os.WriteFile(installScript, []byte(installContent), 0o755); err != nil {
+				return fmt.Errorf("failed to create install script: %w", err)
+			}
+		}
+		installScriptArg = "./install.sh"
+	}
+
+	// Prepare the output file for makeself
+	outputPath := a.outputPath
+
+	// Truncate the target file to prepare for makeself to write to it
+	file := a.target.(*os.File)
+	if err := file.Truncate(0); err != nil {
+		return fmt.Errorf("failed to truncate target file: %w", err)
+	}
+	if _, err := file.Seek(0, 0); err != nil {
+		return fmt.Errorf("failed to seek to beginning of file: %w", err)
+	}
+
+	// Build makeself command with configuration
+	args := []string{"--quiet"} // Always run quietly
+
+	// Apply compression setting
+	switch strings.ToLower(a.config.Compression) {
+	case "none":
+		args = append(args, "--nocomp")
+	case "gzip", "gz":
+		args = append(args, "--gzip")
+	case "bzip2", "bz2":
+		args = append(args, "--bzip2")
+	case "xz":
+		args = append(args, "--xz")
+	case "lzo":
+		args = append(args, "--lzo")
+	case "compress":
+		args = append(args, "--compress")
+	case "":
+		// Default: let makeself choose its default (usually gzip)
+	default:
+		// For unknown compression types, log a warning but continue
+		fmt.Fprintf(os.Stderr, "Warning: unknown compression format '%s', using makeself default\n", a.config.Compression)
+	}
+
+	// Handle LSM configuration
+	var lsmFile string
+	var cleanupLSM bool
+	if a.config.LSMTemplate != "" {
+		// Create temporary LSM file from template
+		tmpFile, err := os.CreateTemp("", "lsm-*.txt")
+		if err != nil {
+			return fmt.Errorf("failed to create temporary LSM file: %w", err)
+		}
+		lsmFile = tmpFile.Name()
+		cleanupLSM = true
+
+		if _, err := tmpFile.WriteString(a.config.LSMTemplate); err != nil {
+			tmpFile.Close()
+			os.Remove(lsmFile)
+			return fmt.Errorf("failed to write LSM template to file: %w", err)
+		}
+		tmpFile.Close()
+	} else if a.config.LSMFile != "" {
+		// Use external LSM file
+		lsmFile = a.config.LSMFile
+		// Verify the file exists
+		if _, err := os.Stat(lsmFile); err != nil {
+			return fmt.Errorf("LSM file %s not found: %w", lsmFile, err)
+		}
+	}
+
+	// Clean up temporary LSM file when done
+	if cleanupLSM {
+		defer os.Remove(lsmFile)
+	}
+
+	// Add LSM file argument if specified
+	if lsmFile != "" {
+		args = append(args, "--lsm", lsmFile)
+	}
+
+	// Add any extra arguments from configuration
+	args = append(args, a.config.ExtraArgs...)
+
+	// Add required positional arguments
+	args = append(args, a.tempDir)  // Source directory
+	args = append(args, outputPath) // Output file
+
+	// Use custom label or default
+	label := "Self-extracting archive"
+	if a.config.Label != "" {
+		label = a.config.Label
+	}
+	args = append(args, label)
+
+	// Use the determined install script argument
+	args = append(args, installScriptArg)
+
+	// Create the makeself archive command
+	cmd := exec.Command(makeselfCmd, args...)
+
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("makeself failed: %w: %s", err, stderr.String())
+	}
+
+	// Make the archive executable like makeself normally does
+	if info, err := file.Stat(); err == nil {
+		// Add executable permission for user, group, and other
+		newMode := info.Mode() | 0o111
+		if err := file.Chmod(newMode); err != nil {
+			// Don't fail if we can't set permissions - just log it
+			fmt.Fprintf(os.Stderr, "Warning: failed to make makeself archive executable: %v\n", err)
+		}
+	}
+
+	return nil
+}
+
+// findMakeselfCommand finds the makeself command in PATH, trying both 'makeself' and 'makeself.sh'
+func findMakeselfCommand() string {
+	// Try 'makeself' first (common on some distributions)
+	if _, err := exec.LookPath("makeself"); err == nil {
+		return "makeself"
+	}
+	// Try 'makeself.sh' (traditional name)
+	if _, err := exec.LookPath("makeself.sh"); err == nil {
+		return "makeself.sh"
+	}
+	// Not found
+	return ""
+}
+
+// Add file to the archive.
+func (a *Archive) Add(f config.File) error {
+	if a.closed {
+		return fmt.Errorf("cannot add files to closed archive")
+	}
+	if _, ok := a.files[f.Destination]; ok {
+		return fmt.Errorf("file %s already exists in archive", f.Destination)
+	}
+
+	destPath := filepath.Join(a.tempDir, f.Destination)
+
+	// Create destination directory if it doesn't exist
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", filepath.Dir(destPath), err)
+	}
+
+	// Copy file to temp directory
+	src, err := os.Open(f.Source)
+	if err != nil {
+		return fmt.Errorf("failed to open source file %s: %w", f.Source, err)
+	}
+	defer src.Close()
+
+	srcInfo, err := src.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to stat source file %s: %w", f.Source, err)
+	}
+
+	if srcInfo.IsDir() {
+		return fmt.Errorf("directories are not supported in makeself archives: %s", f.Source)
+	}
+
+	dst, err := os.Create(destPath)
+	if err != nil {
+		return fmt.Errorf("failed to create destination file %s: %w", destPath, err)
+	}
+	defer dst.Close()
+
+	if _, err := io.Copy(dst, src); err != nil {
+		return fmt.Errorf("failed to copy file %s to %s: %w", f.Source, destPath, err)
+	}
+
+	// Set file permissions
+	mode := srcInfo.Mode()
+	if f.Info.Mode != 0 {
+		mode = f.Info.Mode
+	}
+	if err := os.Chmod(destPath, mode); err != nil {
+		return fmt.Errorf("failed to set permissions on %s: %w", destPath, err)
+	}
+
+	// Set modification time
+	if !f.Info.ParsedMTime.IsZero() {
+		if err := os.Chtimes(destPath, f.Info.ParsedMTime, f.Info.ParsedMTime); err != nil {
+			return fmt.Errorf("failed to set modification time on %s: %w", destPath, err)
+		}
+	}
+
+	a.files[f.Destination] = true
+	return nil
+}

--- a/pkg/archive/makeself/makeself_test.go
+++ b/pkg/archive/makeself/makeself_test.go
@@ -1,0 +1,530 @@
+package makeself
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/goreleaser/goreleaser/v2/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeselfArchive(t *testing.T) {
+	tmp := t.TempDir()
+	outputFile := filepath.Join(tmp, "test.run")
+
+	// Create mock makeself script that creates a simple archive
+	mockMakeselfScript := filepath.Join(tmp, "makeself")
+	mockScript := `#!/bin/bash
+# Mock makeself script for testing
+# Find the output path (the argument that ends with .run, whether file exists or not)
+for arg in "$@"; do
+    if [[ "$arg" == *.run ]]; then
+        OUTPUT_PATH="$arg"
+        break
+    fi
+done
+echo "Creating self-extracting archive: $OUTPUT_PATH"
+# Create a simple executable script as output
+cat > "$OUTPUT_PATH" << 'EOF'
+#!/bin/bash
+echo "Self-extracting archive created successfully"
+exit 0
+EOF
+chmod +x "$OUTPUT_PATH"
+`
+	require.NoError(t, os.WriteFile(mockMakeselfScript, []byte(mockScript), 0o755))
+
+	// Set PATH to include our mock script
+	originalPath := os.Getenv("PATH")
+	defer func() { os.Setenv("PATH", originalPath) }()
+	os.Setenv("PATH", tmp+":"+originalPath)
+
+	f, err := os.Create(outputFile)
+	require.NoError(t, err)
+	defer f.Close()
+
+	archive := New(f)
+	defer archive.Close()
+
+	// Test adding files
+	require.NoError(t, archive.Add(config.File{
+		Source:      "../testdata/foo.txt",
+		Destination: "foo.txt",
+	}))
+
+	// Test error handling for non-existent file
+	require.Error(t, archive.Add(config.File{
+		Source:      "../testdata/nope.txt",
+		Destination: "nope.txt",
+	}))
+
+	require.NoError(t, archive.Close())
+	require.NoError(t, f.Close())
+
+	// Verify the output file was created
+	_, err = os.Stat(outputFile)
+	require.NoError(t, err)
+}
+
+func TestMakeselfArchiveWithCustomInstallScript(t *testing.T) {
+	tmp := t.TempDir()
+	outputFile := filepath.Join(tmp, "test-custom.run")
+
+	// Create custom install script
+	customScript := "#!/bin/bash\necho 'Custom install script executed'\n"
+
+	// Create mock makeself script
+	mockMakeselfScript := filepath.Join(tmp, "makeself")
+	mockScript := `#!/bin/bash
+# Find the output path (the argument that ends with .run, whether file exists or not)
+for arg in "$@"; do
+    if [[ "$arg" == *.run ]]; then
+        OUTPUT_PATH="$arg"
+        break
+    fi
+done
+cat > "$OUTPUT_PATH" << 'EOF'
+#!/bin/bash
+echo "Archive with custom install script"
+exit 0
+EOF
+chmod +x "$OUTPUT_PATH"
+`
+	require.NoError(t, os.WriteFile(mockMakeselfScript, []byte(mockScript), 0o755))
+
+	// Set PATH to include our mock script
+	originalPath := os.Getenv("PATH")
+	defer func() { os.Setenv("PATH", originalPath) }()
+	os.Setenv("PATH", tmp+":"+originalPath)
+
+	f, err := os.Create(outputFile)
+	require.NoError(t, err)
+	defer f.Close()
+
+	archive := NewWithInstallScript(f, customScript)
+	defer archive.Close()
+
+	require.NoError(t, archive.Add(config.File{
+		Source:      "../testdata/foo.txt",
+		Destination: "foo.txt",
+	}))
+
+	require.NoError(t, archive.Close())
+	require.NoError(t, f.Close())
+
+	// Verify output file exists
+	_, err = os.Stat(outputFile)
+	require.NoError(t, err)
+}
+
+func TestMakeselfArchiveError(t *testing.T) {
+	tmp := t.TempDir()
+	outputFile := filepath.Join(tmp, "test-error.run")
+
+	// Create mock makeself script that fails
+	mockMakeselfScript := filepath.Join(tmp, "makeself")
+	mockScript := `#!/bin/bash
+echo "makeself.sh error" >&2
+exit 1
+`
+	require.NoError(t, os.WriteFile(mockMakeselfScript, []byte(mockScript), 0o755))
+
+	// Set PATH to include our mock script
+	originalPath := os.Getenv("PATH")
+	defer func() { os.Setenv("PATH", originalPath) }()
+	os.Setenv("PATH", tmp+":"+originalPath)
+
+	f, err := os.Create(outputFile)
+	require.NoError(t, err)
+	defer f.Close()
+
+	archive := New(f)
+
+	require.NoError(t, archive.Add(config.File{
+		Source:      "../testdata/foo.txt",
+		Destination: "foo.txt",
+	}))
+
+	// Close should fail because makeself returns error
+	err = archive.Close()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "makeself failed")
+}
+
+func TestMakeselfArchiveMissingMakeself(t *testing.T) {
+	tmp := t.TempDir()
+	outputFile := filepath.Join(tmp, "test-missing.run")
+
+	// Ensure makeself is not in PATH
+	originalPath := os.Getenv("PATH")
+	defer func() { os.Setenv("PATH", originalPath) }()
+	os.Setenv("PATH", "/nonexistent")
+
+	f, err := os.Create(outputFile)
+	require.NoError(t, err)
+	defer f.Close()
+
+	archive := New(f)
+
+	require.NoError(t, archive.Add(config.File{
+		Source:      "../testdata/foo.txt",
+		Destination: "foo.txt",
+	}))
+
+	// Close should fail because makeself is not found
+	err = archive.Close()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "makeself command not found")
+}
+
+func TestMakeselfWithConfig(t *testing.T) {
+	tmp := t.TempDir()
+	outputFile := filepath.Join(tmp, "test-config.run")
+
+	// Create mock makeself script
+	mockMakeselfScript := filepath.Join(tmp, "makeself")
+	mockScript := `#!/bin/bash
+# Find the output path (the argument that ends with .run, whether file exists or not)
+for arg in "$@"; do
+    if [[ "$arg" == *.run ]]; then
+        OUTPUT_PATH="$arg"
+        break
+    fi
+done
+cat > "$OUTPUT_PATH" << 'EOF'
+#!/bin/bash
+echo "Archive with configuration"
+exit 0
+EOF
+chmod +x "$OUTPUT_PATH"
+`
+	require.NoError(t, os.WriteFile(mockMakeselfScript, []byte(mockScript), 0o755))
+
+	// Set PATH to include our mock script
+	originalPath := os.Getenv("PATH")
+	defer func() { os.Setenv("PATH", originalPath) }()
+	os.Setenv("PATH", tmp+":"+originalPath)
+
+	f, err := os.Create(outputFile)
+	require.NoError(t, err)
+	defer f.Close()
+
+	cfg := MakeselfConfig{
+		Label:         "Test Archive",
+		InstallScript: "#!/bin/bash\necho 'Custom install'",
+		Compression:   "none",
+		ExtraArgs:     []string{"--notemp"},
+	}
+
+	archive := NewWithConfig(f, "", cfg)
+	defer archive.Close()
+
+	require.NoError(t, archive.Add(config.File{
+		Source:      "../testdata/foo.txt",
+		Destination: "foo.txt",
+	}))
+
+	require.NoError(t, archive.Close())
+	require.NoError(t, f.Close())
+
+	// Verify output file exists
+	_, err = os.Stat(outputFile)
+	require.NoError(t, err)
+}
+
+func TestFindMakeselfCommand(t *testing.T) {
+	// This test checks if findMakeselfCommand works correctly
+	// In real environments, it might find makeself or makeself.sh
+	cmd := findMakeselfCommand()
+
+	// The command might be found or not, depending on the test environment
+	// If found, it should be one of the expected commands
+	if cmd != "" {
+		require.Contains(t, []string{"makeself", "makeself.sh"}, cmd)
+
+		// Verify the command actually exists
+		_, err := exec.LookPath(cmd)
+		require.NoError(t, err)
+	}
+}
+
+func TestMakeselfWithLSMTemplate(t *testing.T) {
+	tmp := t.TempDir()
+	outputFile := filepath.Join(tmp, "test-lsm-template.run")
+
+	// Create mock makeself script that accepts LSM flag
+	mockMakeselfScript := filepath.Join(tmp, "makeself")
+	mockScript := `#!/bin/bash
+# Mock makeself script that accepts LSM flag
+for arg in "$@"; do
+    if [[ "$arg" == "--lsm" ]]; then
+        echo "LSM flag detected"
+    fi
+done
+# Find the output path (the argument that ends with .run, whether file exists or not)
+for arg in "$@"; do
+    if [[ "$arg" == *.run ]]; then
+        OUTPUT_PATH="$arg"
+        break
+    fi
+done
+cat > "$OUTPUT_PATH" << 'EOF'
+#!/bin/bash
+echo "Archive with LSM template"
+exit 0
+EOF
+chmod +x "$OUTPUT_PATH"
+`
+	require.NoError(t, os.WriteFile(mockMakeselfScript, []byte(mockScript), 0o755))
+
+	// Set PATH to include our mock script
+	originalPath := os.Getenv("PATH")
+	defer func() { os.Setenv("PATH", originalPath) }()
+	os.Setenv("PATH", tmp+":"+originalPath)
+
+	f, err := os.Create(outputFile)
+	require.NoError(t, err)
+	defer f.Close()
+
+	lsmContent := `Begin4
+Title: Test Software
+Version: 1.0.0
+Description: A test software package
+Author: Test Author
+Maintained-by: test@example.com
+Platforms: Linux
+Copying-policy: MIT
+End`
+
+	cfg := MakeselfConfig{
+		Label:       "Test Archive with LSM Template",
+		LSMTemplate: lsmContent,
+	}
+
+	archive := NewWithConfig(f, "", cfg)
+	defer archive.Close()
+
+	require.NoError(t, archive.Add(config.File{
+		Source:      "../testdata/foo.txt",
+		Destination: "foo.txt",
+	}))
+
+	require.NoError(t, archive.Close())
+	require.NoError(t, f.Close())
+
+	// Verify output file exists
+	_, err = os.Stat(outputFile)
+	require.NoError(t, err)
+}
+
+func TestMakeselfWithLSMFile(t *testing.T) {
+	tmp := t.TempDir()
+	outputFile := filepath.Join(tmp, "test-lsm-file.run")
+
+	// Create a temporary LSM file
+	lsmFile := filepath.Join(tmp, "test.lsm")
+	lsmContent := `Begin4
+Title: External LSM Test
+Version: 2.0.0
+Description: Testing external LSM file
+Author: External Author
+Maintained-by: external@example.com
+Platforms: Linux
+Copying-policy: GPL
+End`
+	require.NoError(t, os.WriteFile(lsmFile, []byte(lsmContent), 0o644))
+
+	// Create mock makeself script that accepts LSM flag
+	mockMakeselfScript := filepath.Join(tmp, "makeself")
+	mockScript := `#!/bin/bash
+for arg in "$@"; do
+    if [[ "$arg" == "--lsm" ]]; then
+        echo "LSM flag detected with file: $2"
+    fi
+done
+# Find the output path (the argument that ends with .run, whether file exists or not)
+for arg in "$@"; do
+    if [[ "$arg" == *.run ]]; then
+        OUTPUT_PATH="$arg"
+        break
+    fi
+done
+cat > "$OUTPUT_PATH" << 'EOF'
+#!/bin/bash
+echo "Archive with external LSM file"
+exit 0
+EOF
+chmod +x "$OUTPUT_PATH"
+`
+	require.NoError(t, os.WriteFile(mockMakeselfScript, []byte(mockScript), 0o755))
+
+	// Set PATH to include our mock script
+	originalPath := os.Getenv("PATH")
+	defer func() { os.Setenv("PATH", originalPath) }()
+	os.Setenv("PATH", tmp+":"+originalPath)
+
+	f, err := os.Create(outputFile)
+	require.NoError(t, err)
+	defer f.Close()
+
+	cfg := MakeselfConfig{
+		Label:   "Test Archive with External LSM",
+		LSMFile: lsmFile,
+	}
+
+	archive := NewWithConfig(f, "", cfg)
+	defer archive.Close()
+
+	require.NoError(t, archive.Add(config.File{
+		Source:      "../testdata/foo.txt",
+		Destination: "foo.txt",
+	}))
+
+	require.NoError(t, archive.Close())
+	require.NoError(t, f.Close())
+
+	// Verify output file exists
+	_, err = os.Stat(outputFile)
+	require.NoError(t, err)
+}
+
+func TestMakeselfWithMissingLSMFile(t *testing.T) {
+	tmp := t.TempDir()
+	outputFile := filepath.Join(tmp, "test-missing-lsm.run")
+
+	// Create mock makeself script
+	mockMakeselfScript := filepath.Join(tmp, "makeself")
+	mockScript := `#!/bin/bash
+echo "This should not be reached"
+`
+	require.NoError(t, os.WriteFile(mockMakeselfScript, []byte(mockScript), 0o755))
+
+	// Set PATH to include our mock script
+	originalPath := os.Getenv("PATH")
+	defer func() { os.Setenv("PATH", originalPath) }()
+	os.Setenv("PATH", tmp+":"+originalPath)
+
+	f, err := os.Create(outputFile)
+	require.NoError(t, err)
+	defer f.Close()
+
+	cfg := MakeselfConfig{
+		Label:   "Test Archive with Missing LSM",
+		LSMFile: "/nonexistent/file.lsm",
+	}
+
+	archive := NewWithConfig(f, "", cfg)
+
+	require.NoError(t, archive.Add(config.File{
+		Source:      "../testdata/foo.txt",
+		Destination: "foo.txt",
+	}))
+
+	// Close should fail because LSM file doesn't exist
+	err = archive.Close()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "LSM file")
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestMakeselfInstallScriptPathHandling(t *testing.T) {
+	tmp := t.TempDir()
+	outputFile := filepath.Join(tmp, "test-script-path.run")
+
+	// Create install script files for testing
+	installScript1 := filepath.Join(tmp, "script.sh")
+	scriptContent := "#!/bin/bash\necho 'Custom install script executed'"
+	require.NoError(t, os.WriteFile(installScript1, []byte(scriptContent), 0o755))
+
+	// Create mock makeself script that captures the install script argument
+	mockMakeselfScript := filepath.Join(tmp, "makeself")
+	mockScript := `#!/bin/bash
+# Capture the install script argument (last argument)
+echo "Install script arg: ${@: -1}" > "` + tmp + `/captured_args.txt"
+# Find the output path (the argument that ends with .run, whether file exists or not)
+for arg in "$@"; do
+    if [[ "$arg" == *.run ]]; then
+        OUTPUT_PATH="$arg"
+        break
+    fi
+done
+if [[ -z "$OUTPUT_PATH" ]]; then
+    echo "Error: Could not find output path" >&2
+    exit 1
+fi
+cat > "$OUTPUT_PATH" << 'EOF'
+#!/bin/bash
+echo "Archive with install script path test"
+exit 0
+EOF
+chmod +x "$OUTPUT_PATH"
+`
+	require.NoError(t, os.WriteFile(mockMakeselfScript, []byte(mockScript), 0o755))
+
+	// Set PATH to include our mock script
+	originalPath := os.Getenv("PATH")
+	defer func() { os.Setenv("PATH", originalPath) }()
+	os.Setenv("PATH", tmp+":"+originalPath)
+
+	// Test 1: Install script file without ./ prefix
+	t.Run("without_dot_slash", func(t *testing.T) {
+		f, err := os.Create(outputFile + "_1.run")
+		require.NoError(t, err)
+		defer f.Close()
+
+		cfg := MakeselfConfig{
+			Label:             "Test Archive Path Without Dot Slash",
+			InstallScriptFile: "script.sh",
+		}
+
+		archive := NewWithConfig(f, "", cfg)
+		defer archive.Close()
+
+		require.NoError(t, archive.Add(config.File{
+			Source:      installScript1,
+			Destination: "script.sh",
+		}))
+
+		require.NoError(t, archive.Close())
+		require.NoError(t, f.Close())
+
+		// Check captured args
+		capturedArgsFile := filepath.Join(tmp, "captured_args.txt")
+		capturedArgs, err := os.ReadFile(capturedArgsFile)
+		require.NoError(t, err)
+		require.Contains(t, string(capturedArgs), "Install script arg: ./script.sh")
+	})
+
+	// Test 2: Install script file with ./ prefix already
+	t.Run("with_dot_slash", func(t *testing.T) {
+		f, err := os.Create(outputFile + "_2.run")
+		require.NoError(t, err)
+		defer f.Close()
+
+		cfg := MakeselfConfig{
+			Label:             "Test Archive Path With Dot Slash",
+			InstallScriptFile: "./script.sh",
+		}
+
+		archive := NewWithConfig(f, "", cfg)
+		defer archive.Close()
+
+		require.NoError(t, archive.Add(config.File{
+			Source:      installScript1,
+			Destination: "script.sh",
+		}))
+
+		require.NoError(t, archive.Close())
+		require.NoError(t, f.Close())
+
+		// Check captured args - should not have double ./
+		capturedArgsFile := filepath.Join(tmp, "captured_args.txt")
+		capturedArgs, err := os.ReadFile(capturedArgsFile)
+		require.NoError(t, err)
+		require.Contains(t, string(capturedArgs), "Install script arg: ./script.sh")
+		// Ensure there's no double ./
+		require.NotContains(t, string(capturedArgs), "Install script arg: .//")
+	})
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -543,10 +543,10 @@ type Hook struct {
 // FormatOverride is used to specify a custom format for a specific GOOS.
 type FormatOverride struct {
 	Goos    string      `yaml:"goos,omitempty" json:"goos,omitempty"`
-	Formats StringArray `yaml:"formats,omitempty" json:"formats,omitempty" jsonschema:"enum=tar,enum=tgz,enum=tar.gz,enum=zip,enum=gz,enum=tar.xz,enum=txz,enum=binary,enum=none,default=tar.gz"`
+	Formats StringArray `yaml:"formats,omitempty" json:"formats,omitempty" jsonschema:"enum=tar,enum=tgz,enum=tar.gz,enum=zip,enum=gz,enum=tar.xz,enum=txz,enum=binary,enum=makeself,enum=none,default=tar.gz"`
 
 	// Deprecated: use [Formats] instead.
-	Format string `yaml:"format,omitempty" json:"format,omitempty" jsonschema:"enum=tar,enum=tgz,enum=tar.gz,enum=zip,enum=gz,enum=tar.xz,enum=txz,enum=binary,enum=none,default=tar.gz"`
+	Format string `yaml:"format,omitempty" json:"format,omitempty" jsonschema:"enum=tar,enum=tgz,enum=tar.gz,enum=zip,enum=gz,enum=tar.xz,enum=txz,enum=binary,enum=makeself,enum=none,default=tar.gz"`
 }
 
 // File is a file inside an archive.
@@ -591,13 +591,25 @@ type UPX struct {
 	Brute    bool     `yaml:"brute,omitempty" json:"brute,omitempty"`
 }
 
+// makeself-specific configuration options.
+type MakeselfConfig struct {
+	Label             string   `yaml:"label,omitempty" json:"label,omitempty"`
+	InstallScript     string   `yaml:"install_script,omitempty" json:"install_script,omitempty"`
+	InstallScriptFile string   `yaml:"install_script_file,omitempty" json:"install_script_file,omitempty"`
+	Compression       string   `yaml:"compression,omitempty" json:"compression,omitempty"`
+	ExtraArgs         []string `yaml:"extra_args,omitempty" json:"extra_args,omitempty"`
+	LSMTemplate       string   `yaml:"lsm_template,omitempty" json:"lsm_template,omitempty"`
+	LSMFile           string   `yaml:"lsm_file,omitempty" json:"lsm_file,omitempty"`
+	Extension         string   `yaml:"extension,omitempty" json:"extension,omitempty"`
+}
+
 // Archive config used for the archive.
 type Archive struct {
 	ID                        string           `yaml:"id,omitempty" json:"id,omitempty"`
 	IDs                       []string         `yaml:"ids,omitempty" json:"ids,omitempty"`
 	BuildsInfo                FileInfo         `yaml:"builds_info,omitempty" json:"builds_info,omitempty"`
 	NameTemplate              string           `yaml:"name_template,omitempty" json:"name_template,omitempty"`
-	Formats                   StringArray      `yaml:"formats,omitempty" json:"formats,omitempty" jsonschema:"enum=tar,enum=tgz,enum=tar.gz,enum=zip,enum=gz,enum=tar.xz,enum=txz,enum=binary,default=tar.gz"`
+	Formats                   StringArray      `yaml:"formats,omitempty" json:"formats,omitempty" jsonschema:"enum=tar,enum=tgz,enum=tar.gz,enum=zip,enum=gz,enum=tar.xz,enum=txz,enum=binary,enum=makeself,default=tar.gz"`
 	FormatOverrides           []FormatOverride `yaml:"format_overrides,omitempty" json:"format_overrides,omitempty"`
 	WrapInDirectory           string           `yaml:"wrap_in_directory,omitempty" json:"wrap_in_directory,omitempty" jsonschema:"oneof_type=string;boolean"`
 	StripBinaryDirectory      bool             `yaml:"strip_binary_directory,omitempty" json:"strip_binary_directory,omitempty"`
@@ -605,8 +617,11 @@ type Archive struct {
 	Meta                      bool             `yaml:"meta,omitempty" json:"meta,omitempty"`
 	AllowDifferentBinaryCount bool             `yaml:"allow_different_binary_count,omitempty" json:"allow_different_binary_count,omitempty"`
 
+	// Only used when format includes 'makeself'.
+	Makeself MakeselfConfig `yaml:"makeself,omitempty" json:"makeself,omitempty"`
+
 	// Deprecated: use [Formats] instead.
-	Format string `yaml:"format,omitempty" json:"format,omitempty" jsonschema:"enum=tar,enum=tgz,enum=tar.gz,enum=zip,enum=gz,enum=tar.xz,enum=txz,enum=binary,default=tar.gz"`
+	Format string `yaml:"format,omitempty" json:"format,omitempty" jsonschema:"enum=tar,enum=tgz,enum=tar.gz,enum=zip,enum=gz,enum=tar.xz,enum=txz,enum=binary,enum=makeself,default=tar.gz"`
 
 	// Deprecated: use [IDs] instead.
 	Builds []string `yaml:"builds,omitempty" json:"builds,omitempty"`

--- a/www/docs/customization/archive.md
+++ b/www/docs/customization/archive.md
@@ -36,6 +36,7 @@ archives:
     # - `tar`
     # - `gz`
     # - `zip`
+    # - `makeself` # <!-- md:inline_version v2.12 -->.
     # - `binary`
     #
     # Default: ['tar.gz'].
@@ -105,6 +106,7 @@ archives:
         # - `tar`
         # - `gz`
         # - `zip`
+        # - `makeself` # <!-- md:inline_version v2.12 -->.
         # - `binary` # be extra-cautious with the file name template in this case!
         # - `none`   # skips this archive
         #
@@ -316,3 +318,117 @@ archives:
 
 You can then set a custom `name_template`, which will be the name used when
 uploading the binary to the release, for example.
+
+## Makeself Self-Extracting Archives
+
+Makeself creates self-extracting archives that can be executed to automatically extract and optionally install their contents. This is particularly useful for distributing software that needs to be easily installable without requiring users to manually extract archives.
+
+!!! note
+
+    The `makeself` format requires the `makeself` or `makeself.sh` command to be available in your system PATH. You can install it from your system package manager or from [the makeself project](https://github.com/megastep/makeself).
+
+### Makeself Configuration
+
+When using the `makeself` format, you can configure additional options:
+
+```yaml title=".goreleaser.yaml"
+archives:
+  - formats: ["makeself"]
+    
+    # Makeself-specific configuration
+    makeself:
+      # Custom file extension for the self-extracting archive.
+      # Default: '.run'
+      # Templates: allowed.
+      extension: ".run"
+      
+      # Custom label/description for the archive.
+      # Default: 'Self-extracting archive'
+      # Templates: allowed.
+      label: "{{ .ProjectName }} v{{ .Version }} Installer"
+      
+      # Compression format to use.
+      # Valid options: gzip, bzip2, xz, lzo, compress, none
+      # Default: gzip (makeself default)
+      # Templates: allowed.
+      compression: "gzip"
+      
+      # Inline install script content.
+      # This script will be executed after extraction.
+      # Templates: allowed.
+      install_script: |
+        #!/bin/bash
+        echo "Installing {{ .ProjectName }}..."
+        chmod +x {{ .Binary }}
+        cp {{ .Binary }} /usr/local/bin/
+        echo "Installation complete!"
+      
+      # Path to install script file within the archive.
+      # Alternative to install_script for external script files.
+      # Templates: allowed.
+      install_script_file: "install.sh"
+      
+      # Additional command-line arguments to pass to makeself.
+      # Templates: allowed.
+      extra_args:
+        - "--notemp"
+        - "--needroot"  # Requires root privileges to run
+      
+      # Linux Software Map (LSM) template content.
+      # Templates: allowed.
+      lsm_template: |
+        Begin4
+        Title: {{ .ProjectName }}
+        Version: {{ .Version }}
+        Description: {{ .ProjectName }} self-extracting installer
+        Author: Your Name
+        Maintained-by: your-email@example.com
+        Primary-site: https://github.com/youruser/yourproject
+        Platforms: Linux
+        Copying-policy: MIT
+        End
+      
+      # Path to external LSM file.
+      # Alternative to lsm_template for external LSM files.
+      # Templates: allowed.
+      lsm_file: "project.lsm"
+```
+
+### Simple Makeself Example
+
+Here's a minimal example to create a self-extracting installer:
+
+```yaml title=".goreleaser.yaml"
+archives:
+  - id: installer
+    formats: ["makeself"]
+    makeself:
+      label: "{{ .ProjectName }} v{{ .Version }} Installer"
+      extra_args:
+        - "--needroot"  # Ensures installer runs as root
+      install_script: |
+        #!/bin/bash
+        echo "Installing {{ .ProjectName }}..."
+        chmod +x {{ .Binary }}
+        cp {{ .Binary }} /usr/local/bin/
+        echo "{{ .ProjectName }} installed successfully!"
+```
+
+This will create a `.run` file that users can execute with `./yourproject_1.0.0_linux_amd64.run`. The `--needroot` flag ensures the installer automatically requests root privileges, so the install script can assume it's running as root (no `sudo` needed in the script).
+
+### Advanced Makeself Features
+
+- **Custom Extensions**: Use templated extensions like `.{{ .Os }}.run` for platform-specific naming
+- **LSM Support**: Include Linux Software Map information for software catalogs
+- **Flexible Install Scripts**: Use either inline scripts or external script files from your repository
+- **Compression Options**: Choose from multiple compression formats based on size vs. speed trade-offs
+- **Integration with Files**: Add documentation, licenses, and other files that will be available to the install script
+- **Root Privileges**: Use `--needroot` in `extra_args` to ensure the installer runs with root privileges, simplifying system-wide installations
+
+!!! tip
+
+    The install script has access to all files included in the archive, so you can reference documentation, configuration files, or other assets in your installation logic.
+
+!!! tip "Root Privileges"
+
+    When using `--needroot` in `extra_args`, the makeself installer will automatically prompt for root privileges when executed. This allows your install script to assume root access without using `sudo` commands, making the script simpler and more reliable. Users will be prompted like: `"This installer requires root privileges. Please enter your password when prompted."``


### PR DESCRIPTION
Add "makeself" archive format with configurable install scripts, compression options, LSM support, and custom extensions.

Features include inline/file-based install scripts, custom labels, multiple compression formats, and comprehensive error handling.

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

Add makself archive support to goreleaser

<!-- Why is this change being made? -->

.This is an itch I wanted to scratch because we were developing a tool that we wanted to distribute using makeself and the only way to integrate it into the release process was to add a pre-release hook, which was still not the right solution since it needed to untar the archives and re-package it as makeself and we would still end up publishing both the tarballs and the .run makself archives. This fixes that and provides us a clean pipeline to publish self extracting archives for platforms that support makeself.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

Makeself is documented [here](https://makeself.io/)