### PR TITLE
feat(nfpm): add `Prefix` template variable for termux

### DIFF
--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -154,7 +154,10 @@ func mergeOverrides(fpm config.NFPM, format string) (*config.NFPMOverridables, e
 	return &overridden, nil
 }
 
-const termuxFormat = "termux.deb"
+const (
+	termuxFormat = "termux.deb"
+	termuxData   = "/data/data/com.termux/files"
+)
 
 func isSupportedTermuxArch(goos, goarch string) bool {
 	if goos != "android" {
@@ -296,8 +299,13 @@ func create(ctx *context.Context, fpm config.NFPM, format string, artifacts []*a
 	// We cannot use t.ApplyAll on the following fields as they are shared
 	// across multiple nfpms.
 	//
+	prefix := ""
+	if format == termuxFormat {
+		prefix = termuxData
+	}
 	t = t.WithExtraFields(tmpl.Fields{
 		"Format": format,
+		"Prefix": prefix,
 	})
 
 	debKeyFile, err := t.Apply(overridden.Deb.Signature.KeyFile)
@@ -631,7 +639,7 @@ func termuxPrefixedDir(dir string) string {
 	if dir == "" {
 		return ""
 	}
-	return filepath.Join("/data/data/com.termux/files", dir)
+	return filepath.Join(termuxData, dir)
 }
 
 func artifactPackageDir(bindir string, libdirs config.Libdirs, art *artifact.Artifact) string {

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -173,7 +173,7 @@ func TestRunPipe(t *testing.T) {
 						},
 						{
 							Source:      "./testdata/testfile.txt",
-							Destination: "/etc/nope.conf",
+							Destination: "{{.Prefix}}/etc/nope.conf",
 							Type:        "config",
 							FileInfo:    fileInfo,
 						},
@@ -485,21 +485,24 @@ func TestRunPipe(t *testing.T) {
 				cshared = "/usr/lib64/c-shareds"
 			}
 		}
+		prefix := ""
 		if format == termuxFormat {
-			bin = filepath.Join("/data/data/com.termux/files", bin)
-			header = filepath.Join("/data/data/com.termux/files", header)
-			cshared = filepath.Join("/data/data/com.termux/files", cshared)
-			carchive = filepath.Join("/data/data/com.termux/files", carchive)
+			prefix = "/data/data/com.termux/files"
+			bin = filepath.Join(prefix, bin)
+			header = filepath.Join(prefix, header)
+			cshared = filepath.Join(prefix, cshared)
+			carchive = filepath.Join(prefix, carchive)
 		}
 		bin = filepath.ToSlash(filepath.Join(bin, "mybin"))
 		header = filepath.ToSlash(filepath.Join(header, "foo.h"))
 		cshared = filepath.ToSlash(filepath.Join(cshared, "foo.so"))
 		carchive = filepath.ToSlash(filepath.Join(carchive, "foo.a"))
+
 		require.ElementsMatch(t, []string{
 			"/var/log/foobar",
 			"/usr/share/testfile.txt",
 			"/etc/mydir",
-			"/etc/nope.conf",
+			prefix + "/etc/nope.conf",
 			"/etc/nope-rpm.conf",
 			"/etc/nope2.conf",
 			"/etc/nope3_mybin.conf",


### PR DESCRIPTION
It'll be empty in all formats but `termux.deb`, this way users can properly put the files in the right places.

Not sure about the name of the variable, though.