### PR TITLE
feat(makeself): move from archive format to standalone pipeline

### DIFF
--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -105,6 +105,8 @@ const (
 	PySdist
 	// Metadata is an internal goreleaser metadata JSON file.
 	Metadata
+	// MakeselfPackage is a makeself self-extracting archive.
+	MakeselfPackage
 	// lastMarker is used in tests to denote the last valid type.
 	// always add new types before this one.
 	lastMarker
@@ -182,6 +184,8 @@ func (t Type) String() string {
 		return "Wheel"
 	case PySdist:
 		return "Source Dist"
+	case MakeselfPackage:
+		return "Makeself Package"
 	default:
 		return "unknown"
 	}

--- a/internal/pipe/makeself/makeself.go
+++ b/internal/pipe/makeself/makeself.go
@@ -1,0 +1,528 @@
+// Package makeself implements the Pipe interface providing makeself self-extracting archive support.
+package makeself
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/caarlos0/log"
+	"github.com/goreleaser/goreleaser/v2/internal/archivefiles"
+	"github.com/goreleaser/goreleaser/v2/internal/artifact"
+	"github.com/goreleaser/goreleaser/v2/internal/ids"
+	"github.com/goreleaser/goreleaser/v2/internal/pipe"
+	"github.com/goreleaser/goreleaser/v2/internal/semerrgroup"
+	"github.com/goreleaser/goreleaser/v2/internal/skips"
+	"github.com/goreleaser/goreleaser/v2/internal/tmpl"
+	"github.com/goreleaser/goreleaser/v2/pkg/config"
+	"github.com/goreleaser/goreleaser/v2/pkg/context"
+)
+
+const (
+	defaultNameTemplate = `{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}`
+	extraFiles          = "Files"
+)
+
+// Pipe for makeself packaging.
+type Pipe struct{}
+
+func (Pipe) String() string { return "makeself packages" }
+func (Pipe) Skip(ctx *context.Context) bool {
+	return skips.Any(ctx, skips.Makeself) || len(ctx.Config.Makeselfs) == 0
+}
+
+// Default sets the pipe defaults.
+func (Pipe) Default(ctx *context.Context) error {
+	ids := ids.New("makeselfs")
+	for i := range ctx.Config.Makeselfs {
+		makeself := &ctx.Config.Makeselfs[i]
+		if makeself.ID == "" {
+			makeself.ID = "default"
+		}
+		if makeself.NameTemplate == "" {
+			makeself.NameTemplate = defaultNameTemplate
+		}
+		if makeself.Extension == "" {
+			makeself.Extension = ".run"
+		}
+		ids.Inc(makeself.ID)
+	}
+	return ids.Validate()
+}
+
+// Run the pipe.
+func (Pipe) Run(ctx *context.Context) error {
+	skips := pipe.SkipMemento{}
+	for _, makeself := range ctx.Config.Makeselfs {
+		err := doRun(ctx, makeself)
+		if pipe.IsSkip(err) {
+			skips.Remember(err)
+			continue
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return skips.Evaluate()
+}
+
+func doRun(ctx *context.Context, makeselfCfg config.MakeselfPackage) error {
+	// Handle meta packages - they don't need binaries
+	if makeselfCfg.Meta {
+		return create(ctx, makeselfCfg, nil)
+	}
+
+	filters := []artifact.Filter{
+		artifact.Or(
+			artifact.ByType(artifact.Binary),
+			artifact.ByType(artifact.UniversalBinary),
+			artifact.ByType(artifact.Header),
+			artifact.ByType(artifact.CArchive),
+			artifact.ByType(artifact.CShared),
+		),
+	}
+	if len(makeselfCfg.IDs) > 0 {
+		filters = append(filters, artifact.ByIDs(makeselfCfg.IDs...))
+	}
+
+	// Add platform filtering
+	log.Debugf("makeself config %s: goos=%v, goarch=%v", makeselfCfg.ID, makeselfCfg.Goos, makeselfCfg.Goarch)
+	if len(makeselfCfg.Goos) > 0 {
+		goosFilters := make([]artifact.Filter, len(makeselfCfg.Goos))
+		for i, goos := range makeselfCfg.Goos {
+			goosFilters[i] = artifact.ByGoos(goos)
+		}
+		filters = append(filters, artifact.Or(goosFilters...))
+		log.Debugf("makeself config %s: added goos filtering for %v", makeselfCfg.ID, makeselfCfg.Goos)
+	} else {
+		log.Warnf("makeself config %s: NO goos filtering - will process ALL platforms!", makeselfCfg.ID)
+	}
+	if len(makeselfCfg.Goarch) > 0 {
+		goarchFilters := make([]artifact.Filter, len(makeselfCfg.Goarch))
+		for i, goarch := range makeselfCfg.Goarch {
+			goarchFilters[i] = artifact.ByGoarch(goarch)
+		}
+		filters = append(filters, artifact.Or(goarchFilters...))
+		log.Debugf("makeself config %s: added goarch filtering for %v", makeselfCfg.ID, makeselfCfg.Goarch)
+	}
+
+	binaries := ctx.Artifacts.
+		Filter(artifact.And(filters...)).
+		GroupByPlatform()
+	if len(binaries) == 0 {
+		return fmt.Errorf("no binaries found for builds %v with goos %v goarch %v", makeselfCfg.IDs, makeselfCfg.Goos, makeselfCfg.Goarch)
+	}
+
+	g := semerrgroup.New(ctx.Parallelism)
+	for _, artifacts := range binaries {
+		g.Go(func() error {
+			return create(ctx, makeselfCfg, artifacts)
+		})
+	}
+	return g.Wait()
+}
+
+func create(ctx *context.Context, makeselfCfg config.MakeselfPackage, binaries []*artifact.Artifact) error {
+	template := tmpl.New(ctx)
+	if len(binaries) > 0 {
+		template = template.WithArtifact(binaries[0])
+	}
+
+	// Check if disabled
+	if makeselfCfg.Disable != "" {
+		disable, err := template.Apply(makeselfCfg.Disable)
+		if err != nil {
+			return err
+		}
+		if disable == "true" {
+			return nil // Return nil instead of skip error for disabled packages
+		}
+	}
+
+	var packageName string
+	var err error
+
+	// For meta packages without binaries, use a simpler name template if the default is being used
+	if makeselfCfg.Meta && len(binaries) == 0 && makeselfCfg.NameTemplate == defaultNameTemplate {
+		// Use a meta-package friendly name template
+		metaTemplate := `{{ .ProjectName }}_{{ .Version }}_meta`
+		packageName, err = template.Apply(metaTemplate)
+	} else {
+		packageName, err = template.Apply(makeselfCfg.NameTemplate)
+	}
+	if err != nil {
+		return err
+	}
+
+	// Apply templates to all configuration fields
+	label := makeselfCfg.Label
+	if label != "" {
+		label, err = template.Apply(label)
+		if err != nil {
+			return fmt.Errorf("failed to apply template to label: %w", err)
+		}
+	}
+
+	installScript := makeselfCfg.InstallScript
+	if installScript != "" {
+		installScript, err = template.Apply(installScript)
+		if err != nil {
+			return fmt.Errorf("failed to apply template to install_script: %w", err)
+		}
+	}
+
+	installScriptFile := makeselfCfg.InstallScriptFile
+	if installScriptFile != "" {
+		installScriptFile, err = template.Apply(installScriptFile)
+		if err != nil {
+			return fmt.Errorf("failed to apply template to install_script_file: %w", err)
+		}
+	}
+
+	compression := makeselfCfg.Compression
+	if compression != "" {
+		compression, err = template.Apply(compression)
+		if err != nil {
+			return fmt.Errorf("failed to apply template to compression: %w", err)
+		}
+	}
+
+	lsmTemplate := makeselfCfg.LSMTemplate
+	if lsmTemplate != "" {
+		lsmTemplate, err = template.Apply(lsmTemplate)
+		if err != nil {
+			return fmt.Errorf("failed to apply template to lsm_template: %w", err)
+		}
+	}
+
+	lsmFile := makeselfCfg.LSMFile
+	if lsmFile != "" {
+		lsmFile, err = template.Apply(lsmFile)
+		if err != nil {
+			return fmt.Errorf("failed to apply template to lsm_file: %w", err)
+		}
+	}
+
+	extension := makeselfCfg.Extension
+	if extension != "" {
+		extension, err = template.Apply(extension)
+		if err != nil {
+			return fmt.Errorf("failed to apply template to extension: %w", err)
+		}
+	}
+
+	// Ensure we always have an extension - fallback to .run if empty
+	if extension == "" {
+		extension = ".run"
+	}
+
+	// Apply templates to extra args
+	extraArgs := make([]string, len(makeselfCfg.ExtraArgs))
+	for i, arg := range makeselfCfg.ExtraArgs {
+		extraArgs[i], err = template.Apply(arg)
+		if err != nil {
+			return fmt.Errorf("failed to apply template to extra_args[%d]: %w", i, err)
+		}
+	}
+
+	// Ensure extension starts with a dot
+	if extension != "" && !strings.HasPrefix(extension, ".") {
+		extension = "." + extension
+	}
+
+	packageFilename := packageName + extension
+	packagePath := filepath.Join(ctx.Config.Dist, packageFilename)
+
+	log := log.WithField("package", packageName).WithField("path", packagePath).WithField("extension", extension)
+	log.Info("creating makeself package")
+
+	// Ensure the filename has the correct extension for debugging
+	log.Debugf("Final package filename: %s (name=%s, ext=%s)", packageFilename, packageName, extension)
+
+	// Create makeself package directly using makeself command
+	err = createMakeselfPackage(ctx, packagePath, binaries, makeselfCfg, template, label, installScript, installScriptFile, compression, lsmTemplate, lsmFile, extraArgs)
+	if err != nil {
+		return fmt.Errorf("failed to create makeself package: %w", err)
+	}
+
+	bins := []string{}
+	if !makeselfCfg.Meta {
+		for _, binary := range binaries {
+			bins = append(bins, binary.Name)
+			log.WithField("binary", binary.Name).Debug("added binary to makeself package")
+		}
+	}
+
+	// Add extra files
+	files, err := archivefiles.Eval(template, makeselfCfg.Files)
+	if err != nil {
+		return fmt.Errorf("failed to find files to archive: %w", err)
+	}
+
+	// Create artifact
+	art := &artifact.Artifact{
+		Type: artifact.MakeselfPackage,
+		Name: packageFilename,
+		Path: packagePath,
+		Extra: map[string]any{
+			artifact.ExtraID:       makeselfCfg.ID,
+			artifact.ExtraFormat:   "makeself",
+			artifact.ExtraExt:      extension,
+			artifact.ExtraBinaries: bins,
+			extraFiles:             files,
+		},
+	}
+
+	if len(binaries) > 0 {
+		art.Goos = binaries[0].Goos
+		art.Goarch = binaries[0].Goarch
+		art.Goamd64 = binaries[0].Goamd64
+		art.Go386 = binaries[0].Go386
+		art.Goarm = binaries[0].Goarm
+		art.Goarm64 = binaries[0].Goarm64
+		art.Gomips = binaries[0].Gomips
+		art.Goppc64 = binaries[0].Goppc64
+		art.Goriscv64 = binaries[0].Goriscv64
+		art.Target = binaries[0].Target
+		if rep, ok := binaries[0].Extra[artifact.ExtraReplaces]; ok {
+			art.Extra[artifact.ExtraReplaces] = rep
+		}
+	}
+
+	ctx.Artifacts.Add(art)
+	return nil
+}
+
+func createMakeselfPackage(ctx *context.Context, packagePath string, binaries []*artifact.Artifact, makeselfCfg config.MakeselfPackage, template *tmpl.Template, label, installScript, installScriptFile, compression, lsmTemplate, lsmFile string, extraArgs []string) error {
+	// Create the package directory if it doesn't exist
+	packageDir := filepath.Dir(packagePath)
+	log.Debugf("creating package directory: %s", packageDir)
+	if err := os.MkdirAll(packageDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", packageDir, err)
+	}
+
+	// Verify directory was created
+	if _, err := os.Stat(packageDir); os.IsNotExist(err) {
+		return fmt.Errorf("package directory %s was not created successfully", packageDir)
+	}
+	log.Debugf("package directory verified: %s", packageDir)
+
+	// Check if makeself command is available
+	makeselfCmd := findMakeselfCommand()
+	if makeselfCmd == "" {
+		return fmt.Errorf("makeself command not found in PATH (tried 'makeself' and 'makeself.sh')")
+	}
+
+	// Create temporary directory for files to be archived
+	tempDir, err := os.MkdirTemp("", "makeself-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Add binaries unless it's a meta package
+	if !makeselfCfg.Meta {
+		for _, binary := range binaries {
+			// Preserve binary directory structure by default (matches archive pipeline behavior)
+			var dst string
+			if makeselfCfg.StripBinaryDirectory {
+				dst = filepath.Join(tempDir, filepath.Base(binary.Name))
+			} else {
+				dst = filepath.Join(tempDir, binary.Name)
+				// Ensure parent directory exists for nested binary paths
+				if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+					return fmt.Errorf("failed to create directory for %s: %w", binary.Name, err)
+				}
+			}
+
+			if err := copyFile(binary.Path, dst); err != nil {
+				return fmt.Errorf("failed to copy binary %s: %w", binary.Name, err)
+			}
+			// Make binary executable
+			if err := os.Chmod(dst, 0o755); err != nil {
+				return fmt.Errorf("failed to make binary executable %s: %w", dst, err)
+			}
+		}
+	}
+
+	// Add extra files
+	files, err := archivefiles.Eval(template, makeselfCfg.Files)
+	if err != nil {
+		return fmt.Errorf("failed to find files to archive: %w", err)
+	}
+	if makeselfCfg.Meta && len(files) == 0 {
+		return fmt.Errorf("no files found for meta package")
+	}
+
+	for _, f := range files {
+		dst := filepath.Join(tempDir, f.Destination)
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return fmt.Errorf("failed to create directory for %s: %w", f.Destination, err)
+		}
+		if err := copyFile(f.Source, dst); err != nil {
+			return fmt.Errorf("failed to copy file %s: %w", f.Source, err)
+		}
+	}
+
+	// Create install script if provided
+	var installScriptPath string
+	if installScript != "" {
+		installScriptPath = filepath.Join(tempDir, "install.sh")
+		if err := os.WriteFile(installScriptPath, []byte(installScript), 0o755); err != nil {
+			return fmt.Errorf("failed to write install script: %w", err)
+		}
+		installScriptFile = "install.sh"
+	} else if installScriptFile != "" {
+		// Use relative path for makeself command, avoid double ./ prefix
+		if strings.HasPrefix(installScriptFile, "./") {
+			installScriptFile = installScriptFile[2:]
+		}
+	} else {
+		// Create default install script
+		installScriptPath = filepath.Join(tempDir, "install.sh")
+		installContent := `#!/bin/bash
+# Default installation script for makeself archive
+# This script is executed after extraction
+echo "Files extracted to: $PWD"
+echo "Installation complete."
+`
+		if err := os.WriteFile(installScriptPath, []byte(installContent), 0o755); err != nil {
+			return fmt.Errorf("failed to write default install script: %w", err)
+		}
+		installScriptFile = "install.sh"
+	}
+
+	// Create LSM file if LSM template is provided
+	var lsmFilePath string
+	if lsmTemplate != "" {
+		lsmFilePath = filepath.Join(tempDir, "package.lsm")
+		if err := os.WriteFile(lsmFilePath, []byte(lsmTemplate), 0o644); err != nil {
+			return fmt.Errorf("failed to write LSM file: %w", err)
+		}
+		lsmFile = lsmFilePath
+	}
+
+	// Build makeself command with configuration
+	args := []string{"--quiet"} // Always run quietly
+
+	// Add compression argument
+	switch compression {
+	case "gzip":
+		args = append(args, "--gzip")
+	case "bzip2":
+		args = append(args, "--bzip2")
+	case "xz":
+		args = append(args, "--xz")
+	case "lzo":
+		args = append(args, "--lzo")
+	case "compress":
+		args = append(args, "--compress")
+	case "none":
+		args = append(args, "--nocomp")
+	case "":
+		// Default: let makeself choose its default (usually gzip)
+	default:
+		// For unknown compression types, log a warning but continue
+		log.Warnf("unknown compression format '%s', using makeself default", compression)
+	}
+
+	// Add LSM file if specified
+	if lsmFile != "" {
+		args = append(args, "--lsm", lsmFile)
+	}
+
+	// Add extra arguments
+	for _, arg := range extraArgs {
+		if arg != "" {
+			args = append(args, arg)
+		}
+	}
+
+	// Add required arguments: directory, package, label, startup_script
+	args = append(args, tempDir, packagePath)
+
+	if label == "" {
+		label = "Self-extracting archive"
+	}
+	args = append(args, label)
+
+	if installScriptFile != "" {
+		args = append(args, installScriptFile)
+	}
+
+	// Create the makeself archive command - execute from original working directory
+	cmd := exec.Command(makeselfCmd, args...)
+
+	// Debug: Log the full command being executed
+	log.Debugf("executing makeself command: %s %v", makeselfCmd, args)
+
+	// Capture stderr for error reporting
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("makeself failed: %w: %s", err, string(output))
+	}
+
+	// Debug: Log makeself output and check if file was created
+	log.Debugf("makeself output: %s", string(output))
+	_, err = os.Stat(packagePath)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("makeself command completed but output file was not created at %s", packagePath)
+	}
+
+	// Stat failed for some other reason
+	if err != nil {
+		return fmt.Errorf("makeself command completed but stat on file %s failed with: %w", packagePath, err)
+	}
+
+	// Make the archive executable
+	if err := os.Chmod(packagePath, 0o755); err != nil {
+		// Don't fail if we can't set permissions - just log it
+		log.Warnf("failed to make makeself archive executable: %v", err)
+	}
+
+	return nil
+}
+
+// findMakeselfCommand finds the makeself command in PATH, trying both 'makeself' and 'makeself.sh'
+func findMakeselfCommand() string {
+	// Try 'makeself' first (common on some distributions)
+	if _, err := exec.LookPath("makeself"); err == nil {
+		return "makeself"
+	}
+	// Try 'makeself.sh' (traditional name)
+	if _, err := exec.LookPath("makeself.sh"); err == nil {
+		return "makeself.sh"
+	}
+	return ""
+}
+
+// copyFile copies a file from src to dst, preserving permissions
+func copyFile(src, dst string) error {
+	// Get source file info to preserve permissions
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	input, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer input.Close()
+
+	output, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer output.Close()
+
+	_, err = output.ReadFrom(input)
+	if err != nil {
+		return err
+	}
+
+	// Preserve source file permissions
+	return os.Chmod(dst, srcInfo.Mode())
+}

--- a/internal/pipe/makeself/makeself_test.go
+++ b/internal/pipe/makeself/makeself_test.go
@@ -1,0 +1,935 @@
+package makeself
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/goreleaser/goreleaser/v2/internal/artifact"
+	"github.com/goreleaser/goreleaser/v2/internal/skips"
+	"github.com/goreleaser/goreleaser/v2/internal/testctx"
+	"github.com/goreleaser/goreleaser/v2/internal/testlib"
+	"github.com/goreleaser/goreleaser/v2/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescription(t *testing.T) {
+	require.Equal(t, "makeself packages", Pipe{}.String())
+}
+
+func TestSkip(t *testing.T) {
+	t.Run("skip", func(t *testing.T) {
+		ctx := testctx.New(testctx.Skip(skips.Makeself))
+		require.True(t, Pipe{}.Skip(ctx))
+	})
+
+	t.Run("dont skip", func(t *testing.T) {
+		ctx := testctx.NewWithCfg(config.Project{
+			Makeselfs: []config.MakeselfPackage{{}},
+		})
+		require.False(t, Pipe{}.Skip(ctx))
+	})
+
+	t.Run("skip no makeselfs", func(t *testing.T) {
+		ctx := testctx.New()
+		require.True(t, Pipe{}.Skip(ctx))
+	})
+}
+
+func TestDefault(t *testing.T) {
+	ctx := testctx.NewWithCfg(config.Project{
+		Makeselfs: []config.MakeselfPackage{
+			{},
+			{
+				ID:           "custom",
+				NameTemplate: "custom_{{.Os}}_{{.Arch}}",
+				Extension:    ".bin",
+			},
+		},
+	})
+
+	require.NoError(t, Pipe{}.Default(ctx))
+
+	require.Equal(t, "default", ctx.Config.Makeselfs[0].ID)
+	require.Equal(t, defaultNameTemplate, ctx.Config.Makeselfs[0].NameTemplate)
+	require.Equal(t, ".run", ctx.Config.Makeselfs[0].Extension)
+
+	require.Equal(t, "custom", ctx.Config.Makeselfs[1].ID)
+	require.Equal(t, "custom_{{.Os}}_{{.Arch}}", ctx.Config.Makeselfs[1].NameTemplate)
+	require.Equal(t, ".bin", ctx.Config.Makeselfs[1].Extension)
+}
+
+func TestDefaultDuplicateID(t *testing.T) {
+	ctx := testctx.NewWithCfg(config.Project{
+		Makeselfs: []config.MakeselfPackage{
+			{ID: "test"},
+			{ID: "test"},
+		},
+	})
+
+	require.EqualError(t, Pipe{}.Default(ctx), "found 2 makeselfs with the ID 'test', please fix your config")
+}
+
+func createFakeBinary(t *testing.T, dist, platform, binary string) string {
+	t.Helper()
+	path := filepath.Join(dist, platform, binary)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	return path
+}
+
+func createMockMakeself(t *testing.T, folder string) {
+	t.Helper()
+	mockMakeselfScript := filepath.Join(folder, "makeself")
+	mockScript := `#!/bin/bash
+# Mock makeself script for testing
+
+# Handle --help flag separately (don't log it)
+if [[ "$1" == "--help" ]]; then
+	   echo "makeself version 2.4.0"
+	   echo "Usage: makeself [args] source_dir target_file label startup_script"
+	   exit 0
+fi
+
+# Create minimal self-extracting archive
+# Args: [flags...] source_dir target_file label startup_script
+# Find the target file (second to last argument, or argument that looks like a path)
+target=""
+for arg in "$@"; do
+	   if [[ "$arg" == *".run" ]] || [[ "$arg" == *".bin" ]] || [[ "$arg" == *"/"* ]] && [[ "$arg" != "--"* ]]; then
+	       if [[ -n "$arg" ]] && [[ "$arg" != *" "* ]]; then
+	           target="$arg"
+	       fi
+	   fi
+done
+
+if [[ -n "$target" ]]; then
+	   cat > "$target" << 'EOF'
+#!/bin/bash
+echo "Test makeself archive"
+exit 0
+EOF
+	   chmod +x "$target"
+fi
+
+# Log the actual makeself command arguments (not --help calls)
+echo "$@" > "` + folder + `/makeself_args.log"`
+	require.NoError(t, os.WriteFile(mockMakeselfScript, []byte(mockScript), 0o755))
+
+	// Set PATH to include our mock makeself
+	originalPath := os.Getenv("PATH")
+	t.Cleanup(func() { os.Setenv("PATH", originalPath) })
+	os.Setenv("PATH", folder+":"+originalPath)
+}
+
+func TestRunPipe(t *testing.T) {
+	folder := testlib.Mktmp(t)
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+
+	createFakeBinary(t, dist, "linux386", "bin/mybin")
+	createFakeBinary(t, dist, "linuxamd64", "bin/mybin")
+	createMockMakeself(t, folder)
+
+	// Create some extra files for the package
+	require.NoError(t, os.MkdirAll(filepath.Join(folder, "docs"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(folder, "README.md"), []byte("# Test"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(folder, "docs/manual.txt"), []byte("Manual"), 0o644))
+
+	ctx := testctx.NewWithCfg(
+		config.Project{
+			Dist:        dist,
+			ProjectName: "testapp",
+			Makeselfs: []config.MakeselfPackage{
+				{
+					ID:           "default",
+					IDs:          []string{"build1"},
+					NameTemplate: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}",
+					Label:        "{{ .ProjectName }} v{{ .Version }} Installer",
+					InstallScript: `#!/bin/bash
+echo "Installing {{ .ProjectName }}"
+cp mybin /usr/local/bin/`,
+					Compression: "gzip",
+					Files: []config.File{
+						{Source: "README.md"},
+						{Source: "docs/*"},
+					},
+				},
+			},
+		},
+		testctx.WithVersion("1.0.0"),
+		testctx.WithCurrentTag("v1.0.0"),
+	)
+
+	// Add binary artifacts
+	linux386Build := &artifact.Artifact{
+		Goos:   "linux",
+		Goarch: "386",
+		Name:   "bin/mybin",
+		Path:   filepath.Join(dist, "linux386", "bin", "mybin"),
+		Type:   artifact.Binary,
+		Extra: map[string]any{
+			artifact.ExtraBinary: "bin/mybin",
+			artifact.ExtraID:     "build1",
+		},
+	}
+	linuxAmd64Build := &artifact.Artifact{
+		Goos:   "linux",
+		Goarch: "amd64",
+		Name:   "bin/mybin",
+		Path:   filepath.Join(dist, "linuxamd64", "bin", "mybin"),
+		Type:   artifact.Binary,
+		Extra: map[string]any{
+			artifact.ExtraBinary: "bin/mybin",
+			artifact.ExtraID:     "build1",
+		},
+	}
+	ctx.Artifacts.Add(linux386Build)
+	ctx.Artifacts.Add(linuxAmd64Build)
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Run(ctx))
+
+	// Verify artifacts were created
+	artifacts := ctx.Artifacts.Filter(artifact.ByType(artifact.MakeselfPackage)).List()
+	require.Len(t, artifacts, 2) // One for each platform
+
+	for _, art := range artifacts {
+		require.Equal(t, "default", art.ID())
+		require.Equal(t, "makeself", art.Format())
+		require.Equal(t, ".run", art.Ext())
+		require.Contains(t, art.Name, "testapp_1.0.0_linux_")
+		require.True(t, strings.HasSuffix(art.Name, ".run"))
+
+		// Verify artifact file exists
+		require.FileExists(t, art.Path)
+
+		// Check binaries were included
+		binaries := artifact.MustExtra[[]string](*art, artifact.ExtraBinaries)
+		require.Contains(t, binaries, "bin/mybin")
+	}
+
+	// Verify makeself was called with correct arguments
+	argsFile := filepath.Join(folder, "makeself_args.log")
+	args, err := os.ReadFile(argsFile)
+	require.NoError(t, err)
+	argsStr := string(args)
+	require.Contains(t, argsStr, "testapp v1.0.0 Installer")
+	require.Contains(t, argsStr, "--gzip")
+}
+
+func TestRunPipeNoBinaries(t *testing.T) {
+	folder := testlib.Mktmp(t)
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+	createMockMakeself(t, folder)
+
+	ctx := testctx.NewWithCfg(
+		config.Project{
+			Dist: dist,
+			Makeselfs: []config.MakeselfPackage{
+				{
+					IDs: []string{"nonexistent"},
+				},
+			},
+		},
+		testctx.WithVersion("1.0.0"),
+	)
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	err := Pipe{}.Run(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no binaries found for builds")
+}
+
+func TestRunPipeDisabled(t *testing.T) {
+	folder := testlib.Mktmp(t)
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+	createFakeBinary(t, dist, "linux386", "bin/mybin")
+	createMockMakeself(t, folder)
+
+	ctx := testctx.NewWithCfg(
+		config.Project{
+			Dist: dist,
+			Makeselfs: []config.MakeselfPackage{
+				{
+					IDs:     []string{"build1"},
+					Disable: "true",
+				},
+			},
+		},
+		testctx.WithVersion("1.0.0"),
+	)
+
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Goos:   "linux",
+		Goarch: "386",
+		Name:   "bin/mybin",
+		Path:   filepath.Join(dist, "linux386", "bin", "mybin"),
+		Type:   artifact.Binary,
+		Extra: map[string]any{
+			artifact.ExtraBinary: "bin/mybin",
+			artifact.ExtraID:     "build1",
+		},
+	})
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Run(ctx))
+
+	// Should have no makeself artifacts
+	artifacts := ctx.Artifacts.Filter(artifact.ByType(artifact.MakeselfPackage)).List()
+	require.Empty(t, artifacts)
+}
+
+func TestRunPipeMetaPackage(t *testing.T) {
+	folder := testlib.Mktmp(t)
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+	createMockMakeself(t, folder)
+
+	// Create some files for meta package
+	require.NoError(t, os.WriteFile(filepath.Join(folder, "config.conf"), []byte("config"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(folder, "scripts.sh"), []byte("#!/bin/bash\necho test"), 0o755))
+
+	ctx := testctx.NewWithCfg(
+		config.Project{
+			Dist:        dist,
+			ProjectName: "configs",
+			Makeselfs: []config.MakeselfPackage{
+				{
+					ID:           "meta",
+					NameTemplate: "{{ .ProjectName }}_{{ .Version }}_meta",
+					Meta:         true,
+					Files: []config.File{
+						{Source: "config.conf"},
+						{Source: "scripts.sh"},
+					},
+				},
+			},
+		},
+		testctx.WithVersion("1.0.0"),
+	)
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Run(ctx))
+
+	// Verify meta package was created
+	artifacts := ctx.Artifacts.Filter(artifact.ByType(artifact.MakeselfPackage)).List()
+	require.Len(t, artifacts, 1)
+	require.Equal(t, "configs_1.0.0_meta.run", artifacts[0].Name)
+
+	// Should have no binaries
+	binaries := artifact.MustExtra[[]string](*artifacts[0], artifact.ExtraBinaries)
+	require.Empty(t, binaries)
+}
+
+func TestRunPipeMetaPackageNoFiles(t *testing.T) {
+	folder := testlib.Mktmp(t)
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+	createMockMakeself(t, folder)
+
+	ctx := testctx.NewWithCfg(
+		config.Project{
+			Dist: dist,
+			Makeselfs: []config.MakeselfPackage{
+				{
+					Meta: true,
+				},
+			},
+		},
+		testctx.WithVersion("1.0.0"),
+	)
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	err := Pipe{}.Run(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no files found for meta package")
+}
+
+func TestRunPipeTemplateError(t *testing.T) {
+	folder := testlib.Mktmp(t)
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+	createFakeBinary(t, dist, "linux386", "bin/mybin")
+	createMockMakeself(t, folder)
+
+	ctx := testctx.NewWithCfg(
+		config.Project{
+			Dist: dist,
+			Makeselfs: []config.MakeselfPackage{
+				{
+					IDs:          []string{"build1"},
+					NameTemplate: "{{ .InvalidField }}",
+				},
+			},
+		},
+		testctx.WithVersion("1.0.0"),
+	)
+
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Goos:   "linux",
+		Goarch: "386",
+		Name:   "bin/mybin",
+		Path:   filepath.Join(dist, "linux386", "bin", "mybin"),
+		Type:   artifact.Binary,
+		Extra: map[string]any{
+			artifact.ExtraBinary: "bin/mybin",
+			artifact.ExtraID:     "build1",
+		},
+	})
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	err := Pipe{}.Run(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "InvalidField")
+}
+
+func TestRunPipeCustomExtension(t *testing.T) {
+	folder := testlib.Mktmp(t)
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+	createFakeBinary(t, dist, "linux386", "bin/mybin")
+	createMockMakeself(t, folder)
+
+	testCases := []struct {
+		name              string
+		extension         string
+		expectedExtension string
+	}{
+		{
+			name:              "default",
+			extension:         "",
+			expectedExtension: ".run",
+		},
+		{
+			name:              "custom_with_dot",
+			extension:         ".installer",
+			expectedExtension: ".installer",
+		},
+		{
+			name:              "custom_without_dot",
+			extension:         "bin",
+			expectedExtension: ".bin",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testctx.NewWithCfg(
+				config.Project{
+					Dist:        dist,
+					ProjectName: "testapp",
+					Makeselfs: []config.MakeselfPackage{
+						{
+							IDs:       []string{"build1"},
+							Extension: tc.extension,
+						},
+					},
+				},
+				testctx.WithVersion("1.0.0"),
+			)
+
+			ctx.Artifacts.Add(&artifact.Artifact{
+				Goos:   "linux",
+				Goarch: "386",
+				Name:   "bin/mybin",
+				Path:   filepath.Join(dist, "linux386", "bin", "mybin"),
+				Type:   artifact.Binary,
+				Extra: map[string]any{
+					artifact.ExtraBinary: "bin/mybin",
+					artifact.ExtraID:     "build1",
+				},
+			})
+
+			require.NoError(t, Pipe{}.Default(ctx))
+			require.NoError(t, Pipe{}.Run(ctx))
+
+			artifacts := ctx.Artifacts.Filter(artifact.ByType(artifact.MakeselfPackage)).List()
+			require.Len(t, artifacts, 1)
+			require.True(t, strings.HasSuffix(artifacts[0].Name, tc.expectedExtension))
+		})
+	}
+}
+
+func TestRunPipeWithLSMTemplate(t *testing.T) {
+	folder := testlib.Mktmp(t)
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+	createFakeBinary(t, dist, "linux386", "bin/mybin")
+	createMockMakeself(t, folder)
+
+	ctx := testctx.NewWithCfg(
+		config.Project{
+			Dist:        dist,
+			ProjectName: "myapp",
+			Env:         []string{"AUTHOR=Test Author"},
+			Makeselfs: []config.MakeselfPackage{
+				{
+					IDs:         []string{"build1"},
+					Label:       "{{ .ProjectName }} Installer",
+					LSMTemplate: `Begin3\nTitle: {{ .ProjectName }}\nAuthor: {{ .Env.AUTHOR }}\nEnd`,
+				},
+			},
+		},
+		testctx.WithVersion("1.0.0"),
+	)
+
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Goos:   "linux",
+		Goarch: "386",
+		Name:   "bin/mybin",
+		Path:   filepath.Join(dist, "linux386", "bin", "mybin"),
+		Type:   artifact.Binary,
+		Extra: map[string]any{
+			artifact.ExtraBinary: "bin/mybin",
+			artifact.ExtraID:     "build1",
+		},
+	})
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Run(ctx))
+
+	// Check that makeself was called with LSM flag
+	argsFile := filepath.Join(folder, "makeself_args.log")
+	args, err := os.ReadFile(argsFile)
+	require.NoError(t, err)
+	require.Contains(t, string(args), "--lsm")
+}
+
+func TestRunPipeWithLSMFile(t *testing.T) {
+	folder := testlib.Mktmp(t)
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+	createFakeBinary(t, dist, "linux386", "bin/mybin")
+	createMockMakeself(t, folder)
+
+	// Create LSM file
+	lsmFile := filepath.Join(folder, "app.lsm")
+	require.NoError(t, os.WriteFile(lsmFile, []byte("Begin3\nTitle: Test\nEnd"), 0o644))
+
+	ctx := testctx.NewWithCfg(
+		config.Project{
+			Dist: dist,
+			Makeselfs: []config.MakeselfPackage{
+				{
+					IDs:     []string{"build1"},
+					LSMFile: lsmFile,
+				},
+			},
+		},
+		testctx.WithVersion("1.0.0"),
+	)
+
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Goos:   "linux",
+		Goarch: "386",
+		Name:   "bin/mybin",
+		Path:   filepath.Join(dist, "linux386", "bin", "mybin"),
+		Type:   artifact.Binary,
+		Extra: map[string]any{
+			artifact.ExtraBinary: "bin/mybin",
+			artifact.ExtraID:     "build1",
+		},
+	})
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Run(ctx))
+
+	// Check that makeself was called with LSM file
+	argsFile := filepath.Join(folder, "makeself_args.log")
+	args, err := os.ReadFile(argsFile)
+	require.NoError(t, err)
+	argsStr := string(args)
+	require.Contains(t, argsStr, "--lsm")
+	require.Contains(t, argsStr, lsmFile)
+}
+
+func TestRunPipeWithExtraArgs(t *testing.T) {
+	folder := testlib.Mktmp(t)
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+	createFakeBinary(t, dist, "linux386", "bin/mybin")
+	createMockMakeself(t, folder)
+
+	ctx := testctx.NewWithCfg(
+		config.Project{
+			Dist:        dist,
+			ProjectName: "testapp",
+			Makeselfs: []config.MakeselfPackage{
+				{
+					IDs: []string{"build1"},
+					ExtraArgs: []string{
+						"--needroot",
+						"--keep",
+						"--copy",
+					},
+				},
+			},
+		},
+		testctx.WithVersion("1.0.0"),
+	)
+
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Goos:   "linux",
+		Goarch: "386",
+		Name:   "bin/mybin",
+		Path:   filepath.Join(dist, "linux386", "bin", "mybin"),
+		Type:   artifact.Binary,
+		Extra: map[string]any{
+			artifact.ExtraBinary: "bin/mybin",
+			artifact.ExtraID:     "build1",
+		},
+	})
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Run(ctx))
+
+	// Check that makeself was called with extra args
+	argsFile := filepath.Join(folder, "makeself_args.log")
+	args, err := os.ReadFile(argsFile)
+	require.NoError(t, err)
+	argsStr := string(args)
+	require.Contains(t, argsStr, "--needroot")
+	require.Contains(t, argsStr, "--keep")
+	require.Contains(t, argsStr, "--copy")
+}
+
+func TestRunPipeMultipleMakeselfs(t *testing.T) {
+	folder := testlib.Mktmp(t)
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+	createFakeBinary(t, dist, "linux386", "bin/mybin")
+	createMockMakeself(t, folder)
+
+	ctx := testctx.NewWithCfg(
+		config.Project{
+			Dist:        dist,
+			ProjectName: "testapp",
+			Makeselfs: []config.MakeselfPackage{
+				{
+					ID:           "full",
+					IDs:          []string{"build1"},
+					NameTemplate: "{{ .ProjectName }}_full_{{ .Version }}_{{ .Os }}_{{ .Arch }}",
+					Label:        "Full {{ .ProjectName }} Installer",
+				},
+				{
+					ID:           "minimal",
+					IDs:          []string{"build1"},
+					NameTemplate: "{{ .ProjectName }}_minimal_{{ .Version }}_{{ .Os }}_{{ .Arch }}",
+					Label:        "Minimal {{ .ProjectName }} Installer",
+					Extension:    ".bin",
+				},
+			},
+		},
+		testctx.WithVersion("1.0.0"),
+	)
+
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Goos:   "linux",
+		Goarch: "386",
+		Name:   "bin/mybin",
+		Path:   filepath.Join(dist, "linux386", "bin", "mybin"),
+		Type:   artifact.Binary,
+		Extra: map[string]any{
+			artifact.ExtraBinary: "bin/mybin",
+			artifact.ExtraID:     "build1",
+		},
+	})
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Run(ctx))
+
+	artifacts := ctx.Artifacts.Filter(artifact.ByType(artifact.MakeselfPackage)).List()
+	require.Len(t, artifacts, 2)
+
+	// Check both packages were created
+	var fullPackage, minimalPackage *artifact.Artifact
+	for _, art := range artifacts {
+		if art.ID() == "full" {
+			fullPackage = art
+		} else if art.ID() == "minimal" {
+			minimalPackage = art
+		}
+	}
+
+	require.NotNil(t, fullPackage)
+	require.NotNil(t, minimalPackage)
+	require.Contains(t, fullPackage.Name, "testapp_full_1.0.0_linux_386.run")
+	require.Contains(t, minimalPackage.Name, "testapp_minimal_1.0.0_linux_386.bin")
+}
+
+func TestBinaryPathPreservation(t *testing.T) {
+	tests := []struct {
+		name                 string
+		stripBinaryDirectory bool
+		binaryName           string
+		expectedPath         string
+	}{
+		{
+			name:                 "preserve directory structure by default",
+			stripBinaryDirectory: false,
+			binaryName:           "bin/agent",
+			expectedPath:         "bin/agent",
+		},
+		{
+			name:                 "strip directory when configured",
+			stripBinaryDirectory: true,
+			binaryName:           "bin/agent",
+			expectedPath:         "agent",
+		},
+		{
+			name:                 "handle nested directories",
+			stripBinaryDirectory: false,
+			binaryName:           "usr/local/bin/tool",
+			expectedPath:         "usr/local/bin/tool",
+		},
+		{
+			name:                 "strip nested directories",
+			stripBinaryDirectory: true,
+			binaryName:           "usr/local/bin/tool",
+			expectedPath:         "tool",
+		},
+		{
+			name:                 "handle single level binary",
+			stripBinaryDirectory: false,
+			binaryName:           "myapp",
+			expectedPath:         "myapp",
+		},
+		{
+			name:                 "strip single level binary",
+			stripBinaryDirectory: true,
+			binaryName:           "myapp",
+			expectedPath:         "myapp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			makeselfCfg := config.MakeselfPackage{
+				StripBinaryDirectory: tt.stripBinaryDirectory,
+			}
+
+			// Simulate the binary path logic from the implementation
+			var dst string
+			if makeselfCfg.StripBinaryDirectory {
+				dst = filepath.Join(tempDir, filepath.Base(tt.binaryName))
+			} else {
+				dst = filepath.Join(tempDir, tt.binaryName)
+			}
+
+			// Extract the relative path within tempDir
+			relPath, err := filepath.Rel(tempDir, dst)
+			require.NoError(t, err)
+
+			// Normalize path separators for comparison
+			expectedPath := filepath.FromSlash(tt.expectedPath)
+			require.Equal(t, expectedPath, relPath)
+		})
+	}
+}
+
+func TestStripBinaryDirectoryInMakeself(t *testing.T) {
+	folder := testlib.Mktmp(t)
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+	createFakeBinary(t, dist, "linux386", "bin/mybin")
+	createFakeBinary(t, dist, "linux386", "bin/tool")
+	createMockMakeself(t, folder)
+
+	tests := []struct {
+		name                 string
+		stripBinaryDirectory bool
+		expectedBinaries     []string
+	}{
+		{
+			name:                 "preserve binary paths by default",
+			stripBinaryDirectory: false,
+			expectedBinaries:     []string{"bin/mybin", "bin/tool"},
+		},
+		{
+			name:                 "strip binary paths when configured",
+			stripBinaryDirectory: true,
+			expectedBinaries:     []string{"bin/mybin", "bin/tool"}, // Artifact.Name remains same, only internal path changes
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := testctx.NewWithCfg(
+				config.Project{
+					Dist:        dist,
+					ProjectName: "testapp",
+					Makeselfs: []config.MakeselfPackage{
+						{
+							ID:                   "test",
+							IDs:                  []string{"build1"},
+							StripBinaryDirectory: tt.stripBinaryDirectory,
+						},
+					},
+				},
+				testctx.WithVersion("1.0.0"),
+			)
+
+			// Add binary artifacts
+			ctx.Artifacts.Add(&artifact.Artifact{
+				Goos:   "linux",
+				Goarch: "386",
+				Name:   "bin/mybin",
+				Path:   filepath.Join(dist, "linux386", "bin", "mybin"),
+				Type:   artifact.Binary,
+				Extra: map[string]any{
+					artifact.ExtraBinary: "bin/mybin",
+					artifact.ExtraID:     "build1",
+				},
+			})
+			ctx.Artifacts.Add(&artifact.Artifact{
+				Goos:   "linux",
+				Goarch: "386",
+				Name:   "bin/tool",
+				Path:   filepath.Join(dist, "linux386", "bin", "tool"),
+				Type:   artifact.Binary,
+				Extra: map[string]any{
+					artifact.ExtraBinary: "bin/tool",
+					artifact.ExtraID:     "build1",
+				},
+			})
+
+			require.NoError(t, Pipe{}.Default(ctx))
+			require.NoError(t, Pipe{}.Run(ctx))
+
+			// Verify artifacts were created
+			artifacts := ctx.Artifacts.Filter(artifact.ByType(artifact.MakeselfPackage)).List()
+			require.Len(t, artifacts, 1)
+
+			// Check binaries were included
+			binaries := artifact.MustExtra[[]string](*artifacts[0], artifact.ExtraBinaries)
+			require.ElementsMatch(t, tt.expectedBinaries, binaries)
+		})
+	}
+}
+
+func TestCopyFilePreservesPermissions(t *testing.T) {
+	tempDir := t.TempDir()
+
+	tests := []struct {
+		name         string
+		sourceMode   os.FileMode
+		expectedMode os.FileMode
+	}{
+		{
+			name:         "executable script",
+			sourceMode:   0o755,
+			expectedMode: 0o755,
+		},
+		{
+			name:         "regular file",
+			sourceMode:   0o644,
+			expectedMode: 0o644,
+		},
+		{
+			name:         "read-only file",
+			sourceMode:   0o444,
+			expectedMode: 0o444,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create source file with specific permissions
+			srcPath := filepath.Join(tempDir, "source_"+tt.name)
+			require.NoError(t, os.WriteFile(srcPath, []byte("test content"), tt.sourceMode))
+
+			// Verify source file has expected permissions
+			srcInfo, err := os.Stat(srcPath)
+			require.NoError(t, err)
+			require.Equal(t, tt.sourceMode, srcInfo.Mode().Perm())
+
+			// Copy file using copyFile function
+			dstPath := filepath.Join(tempDir, "dest_"+tt.name)
+			require.NoError(t, copyFile(srcPath, dstPath))
+
+			// Verify destination file has same permissions as source
+			dstInfo, err := os.Stat(dstPath)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedMode, dstInfo.Mode().Perm())
+
+			// Verify content was copied correctly
+			content, err := os.ReadFile(dstPath)
+			require.NoError(t, err)
+			require.Equal(t, "test content", string(content))
+		})
+	}
+}
+
+func TestMakeselfPreservesScriptPermissions(t *testing.T) {
+	folder := testlib.Mktmp(t)
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+	createFakeBinary(t, dist, "linux386", "bin/mybin")
+	createMockMakeself(t, folder)
+
+	// Create executable script file in source
+	scriptDir := filepath.Join(folder, "scripts")
+	require.NoError(t, os.MkdirAll(scriptDir, 0o755))
+	scriptPath := filepath.Join(scriptDir, "activate.sh")
+	scriptContent := `#!/bin/bash
+echo "Activating application"
+chmod +x bin/*
+`
+	require.NoError(t, os.WriteFile(scriptPath, []byte(scriptContent), 0o755))
+
+	// Verify source script is executable
+	scriptInfo, err := os.Stat(scriptPath)
+	require.NoError(t, err)
+	require.True(t, scriptInfo.Mode().Perm()&0o111 != 0, "source script should be executable")
+
+	ctx := testctx.NewWithCfg(
+		config.Project{
+			Dist:        dist,
+			ProjectName: "testapp",
+			Makeselfs: []config.MakeselfPackage{
+				{
+					ID:  "default",
+					IDs: []string{"build1"},
+					Files: []config.File{
+						{Source: "scripts/activate.sh", Destination: "scripts/activate.sh"},
+					},
+				},
+			},
+		},
+		testctx.WithVersion("1.0.0"),
+	)
+
+	// Add binary artifact
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Goos:   "linux",
+		Goarch: "386",
+		Name:   "bin/mybin",
+		Path:   filepath.Join(dist, "linux386", "bin", "mybin"),
+		Type:   artifact.Binary,
+		Extra: map[string]any{
+			artifact.ExtraBinary: "bin/mybin",
+			artifact.ExtraID:     "build1",
+		},
+	})
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Run(ctx))
+
+	// Verify makeself package was created
+	artifacts := ctx.Artifacts.Filter(artifact.ByType(artifact.MakeselfPackage)).List()
+	require.Len(t, artifacts, 1)
+	require.FileExists(t, artifacts[0].Path)
+
+	// The test verifies that the copyFile function preserves permissions
+	// The actual verification of permissions within the makeself archive
+	// would require extracting and testing the archive, which is beyond
+	// the scope of this unit test. The copyFile test above covers the
+	// core functionality.
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -24,6 +24,7 @@ import (
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/gomod"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/ko"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/krew"
+	"github.com/goreleaser/goreleaser/v2/internal/pipe/makeself"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/metadata"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/nfpm"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/nix"
@@ -123,6 +124,8 @@ var Pipeline = append(
 	sourcearchive.Pipe{},
 	// archive via fpm (deb, rpm) using "native" go impl
 	nfpm.Pipe{},
+	// create makeself self-extracting archives
+	makeself.Pipe{},
 	// archive via snapcraft (snap)
 	snapcraft.Pipe{},
 	// create SBOMs of artifacts

--- a/internal/skips/skips.go
+++ b/internal/skips/skips.go
@@ -31,6 +31,7 @@ const (
 	AUR            Key = "aur"
 	AURSource      Key = "aur-source"
 	NFPM           Key = "nfpm"
+	Makeself       Key = "makeself"
 	Chocolatey     Key = "chocolatey"
 	Notarize       Key = "notarize"
 	Archive        Key = "archive"
@@ -123,6 +124,7 @@ var Release = Keys{
 	AUR,
 	AURSource,
 	NFPM,
+	Makeself,
 	Before,
 	Notarize,
 	Archive,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1160,48 +1160,49 @@ type Source struct {
 
 // Project includes all project configuration.
 type Project struct {
-	Version         int              `yaml:"version,omitempty" json:"version,omitempty" jsonschema:"enum=2,default=2"`
-	Pro             bool             `yaml:"pro,omitempty" json:"pro,omitempty"`
-	ProjectName     string           `yaml:"project_name,omitempty" json:"project_name,omitempty"`
-	Env             []string         `yaml:"env,omitempty" json:"env,omitempty"`
-	Release         Release          `yaml:"release,omitempty" json:"release,omitempty"`
-	Milestones      []Milestone      `yaml:"milestones,omitempty" json:"milestones,omitempty"`
-	Casks           []HomebrewCask   `yaml:"homebrew_casks,omitempty" json:"homebrew_casks,omitempty"`
-	Nix             []Nix            `yaml:"nix,omitempty" json:"nix,omitempty"`
-	Winget          []Winget         `yaml:"winget,omitempty" json:"winget,omitempty"`
-	AURs            []AUR            `yaml:"aurs,omitempty" json:"aurs,omitempty"`
-	AURSources      []AURSource      `yaml:"aur_sources,omitempty" json:"aur_sources,omitempty"`
-	Krews           []Krew           `yaml:"krews,omitempty" json:"krews,omitempty"`
-	Kos             []Ko             `yaml:"kos,omitempty" json:"kos,omitempty"`
-	Scoops          []Scoop          `yaml:"scoops,omitempty" json:"scoops,omitempty"`
-	Builds          []Build          `yaml:"builds,omitempty" json:"builds,omitempty"`
-	Archives        []Archive        `yaml:"archives,omitempty" json:"archives,omitempty"`
-	NFPMs           []NFPM           `yaml:"nfpms,omitempty" json:"nfpms,omitempty"`
-	Snapcrafts      []Snapcraft      `yaml:"snapcrafts,omitempty" json:"snapcrafts,omitempty"`
-	Snapshot        Snapshot         `yaml:"snapshot,omitempty" json:"snapshot,omitempty"`
-	Checksum        Checksum         `yaml:"checksum,omitempty" json:"checksum,omitempty"`
-	Dockers         []Docker         `yaml:"dockers,omitempty" json:"dockers,omitempty"`
-	DockerManifests []DockerManifest `yaml:"docker_manifests,omitempty" json:"docker_manifests,omitempty"`
-	Artifactories   []Upload         `yaml:"artifactories,omitempty" json:"artifactories,omitempty"`
-	Uploads         []Upload         `yaml:"uploads,omitempty" json:"uploads,omitempty"`
-	Blobs           []Blob           `yaml:"blobs,omitempty" json:"blobs,omitempty"`
-	Publishers      []Publisher      `yaml:"publishers,omitempty" json:"publishers,omitempty"`
-	Changelog       Changelog        `yaml:"changelog,omitempty" json:"changelog,omitempty"`
-	Dist            string           `yaml:"dist,omitempty" json:"dist,omitempty"`
-	Signs           []Sign           `yaml:"signs,omitempty" json:"signs,omitempty"`
-	Notarize        Notarize         `yaml:"notarize,omitempty" json:"notarize,omitempty"`
-	DockerSigns     []Sign           `yaml:"docker_signs,omitempty" json:"docker_signs,omitempty"`
-	BinarySigns     []Sign           `yaml:"binary_signs,omitempty" json:"binary_signs,omitempty"`
-	EnvFiles        EnvFiles         `yaml:"env_files,omitempty" json:"env_files,omitempty"`
-	Before          Before           `yaml:"before,omitempty" json:"before,omitempty"`
-	Source          Source           `yaml:"source,omitempty" json:"source,omitempty"`
-	GoMod           GoMod            `yaml:"gomod,omitempty" json:"gomod,omitempty"`
-	Announce        Announce         `yaml:"announce,omitempty" json:"announce,omitempty"`
-	SBOMs           []SBOM           `yaml:"sboms,omitempty" json:"sboms,omitempty"`
-	Chocolateys     []Chocolatey     `yaml:"chocolateys,omitempty" json:"chocolateys,omitempty"`
-	Git             Git              `yaml:"git,omitempty" json:"git,omitempty"`
-	ReportSizes     bool             `yaml:"report_sizes,omitempty" json:"report_sizes,omitempty"`
-	Metadata        ProjectMetadata  `yaml:"metadata,omitempty" json:"metadata,omitempty"`
+	Version         int               `yaml:"version,omitempty" json:"version,omitempty" jsonschema:"enum=2,default=2"`
+	Pro             bool              `yaml:"pro,omitempty" json:"pro,omitempty"`
+	ProjectName     string            `yaml:"project_name,omitempty" json:"project_name,omitempty"`
+	Env             []string          `yaml:"env,omitempty" json:"env,omitempty"`
+	Release         Release           `yaml:"release,omitempty" json:"release,omitempty"`
+	Milestones      []Milestone       `yaml:"milestones,omitempty" json:"milestones,omitempty"`
+	Casks           []HomebrewCask    `yaml:"homebrew_casks,omitempty" json:"homebrew_casks,omitempty"`
+	Nix             []Nix             `yaml:"nix,omitempty" json:"nix,omitempty"`
+	Winget          []Winget          `yaml:"winget,omitempty" json:"winget,omitempty"`
+	AURs            []AUR             `yaml:"aurs,omitempty" json:"aurs,omitempty"`
+	AURSources      []AURSource       `yaml:"aur_sources,omitempty" json:"aur_sources,omitempty"`
+	Krews           []Krew            `yaml:"krews,omitempty" json:"krews,omitempty"`
+	Kos             []Ko              `yaml:"kos,omitempty" json:"kos,omitempty"`
+	Scoops          []Scoop           `yaml:"scoops,omitempty" json:"scoops,omitempty"`
+	Builds          []Build           `yaml:"builds,omitempty" json:"builds,omitempty"`
+	Archives        []Archive         `yaml:"archives,omitempty" json:"archives,omitempty"`
+	NFPMs           []NFPM            `yaml:"nfpms,omitempty" json:"nfpms,omitempty"`
+	Makeselfs       []MakeselfPackage `yaml:"makeselfs,omitempty" json:"makeselfs,omitempty"`
+	Snapcrafts      []Snapcraft       `yaml:"snapcrafts,omitempty" json:"snapcrafts,omitempty"`
+	Snapshot        Snapshot          `yaml:"snapshot,omitempty" json:"snapshot,omitempty"`
+	Checksum        Checksum          `yaml:"checksum,omitempty" json:"checksum,omitempty"`
+	Dockers         []Docker          `yaml:"dockers,omitempty" json:"dockers,omitempty"`
+	DockerManifests []DockerManifest  `yaml:"docker_manifests,omitempty" json:"docker_manifests,omitempty"`
+	Artifactories   []Upload          `yaml:"artifactories,omitempty" json:"artifactories,omitempty"`
+	Uploads         []Upload          `yaml:"uploads,omitempty" json:"uploads,omitempty"`
+	Blobs           []Blob            `yaml:"blobs,omitempty" json:"blobs,omitempty"`
+	Publishers      []Publisher       `yaml:"publishers,omitempty" json:"publishers,omitempty"`
+	Changelog       Changelog         `yaml:"changelog,omitempty" json:"changelog,omitempty"`
+	Dist            string            `yaml:"dist,omitempty" json:"dist,omitempty"`
+	Signs           []Sign            `yaml:"signs,omitempty" json:"signs,omitempty"`
+	Notarize        Notarize          `yaml:"notarize,omitempty" json:"notarize,omitempty"`
+	DockerSigns     []Sign            `yaml:"docker_signs,omitempty" json:"docker_signs,omitempty"`
+	BinarySigns     []Sign            `yaml:"binary_signs,omitempty" json:"binary_signs,omitempty"`
+	EnvFiles        EnvFiles          `yaml:"env_files,omitempty" json:"env_files,omitempty"`
+	Before          Before            `yaml:"before,omitempty" json:"before,omitempty"`
+	Source          Source            `yaml:"source,omitempty" json:"source,omitempty"`
+	GoMod           GoMod             `yaml:"gomod,omitempty" json:"gomod,omitempty"`
+	Announce        Announce          `yaml:"announce,omitempty" json:"announce,omitempty"`
+	SBOMs           []SBOM            `yaml:"sboms,omitempty" json:"sboms,omitempty"`
+	Chocolateys     []Chocolatey      `yaml:"chocolateys,omitempty" json:"chocolateys,omitempty"`
+	Git             Git               `yaml:"git,omitempty" json:"git,omitempty"`
+	ReportSizes     bool              `yaml:"report_sizes,omitempty" json:"report_sizes,omitempty"`
+	Metadata        ProjectMetadata   `yaml:"metadata,omitempty" json:"metadata,omitempty"`
 
 	UniversalBinaries []UniversalBinary `yaml:"universal_binaries,omitempty" json:"universal_binaries,omitempty"`
 	UPXs              []UPX             `yaml:"upx,omitempty" json:"upx,omitempty"`

--- a/pkg/config/makeself.go
+++ b/pkg/config/makeself.go
@@ -1,0 +1,35 @@
+// Package config contains makeself-specific configuration structures.
+package config
+
+// MakeselfPackage represents a makeself self-extracting archive configuration.
+type MakeselfPackage struct {
+	ID           string   `yaml:"id,omitempty" json:"id,omitempty"`
+	IDs          []string `yaml:"ids,omitempty" json:"ids,omitempty"`
+	NameTemplate string   `yaml:"name_template,omitempty" json:"name_template,omitempty"`
+
+	// Makeself-specific configuration
+	Label             string   `yaml:"label,omitempty" json:"label,omitempty"`
+	InstallScript     string   `yaml:"install_script,omitempty" json:"install_script,omitempty"`
+	InstallScriptFile string   `yaml:"install_script_file,omitempty" json:"install_script_file,omitempty"`
+	Compression       string   `yaml:"compression,omitempty" json:"compression,omitempty"`
+	ExtraArgs         []string `yaml:"extra_args,omitempty" json:"extra_args,omitempty"`
+	LSMTemplate       string   `yaml:"lsm_template,omitempty" json:"lsm_template,omitempty"`
+	LSMFile           string   `yaml:"lsm_file,omitempty" json:"lsm_file,omitempty"`
+	Extension         string   `yaml:"extension,omitempty" json:"extension,omitempty"`
+
+	// Binary path handling - matches archive pipeline behavior
+	StripBinaryDirectory bool `yaml:"strip_binary_directory,omitempty" json:"strip_binary_directory,omitempty"`
+
+	// Platform filtering
+	Goos   []string `yaml:"goos,omitempty" json:"goos,omitempty"`
+	Goarch []string `yaml:"goarch,omitempty" json:"goarch,omitempty"`
+
+	// Files to include in the package (in addition to binaries)
+	Files []File `yaml:"files,omitempty" json:"files,omitempty"`
+
+	// Meta package - no binaries, only files
+	Meta bool `yaml:"meta,omitempty" json:"meta,omitempty"`
+
+	// Control options
+	Disable string `yaml:"disable,omitempty" json:"disable,omitempty" jsonschema:"oneof_type=string;boolean"`
+}

--- a/www/docs/customization/makeself.md
+++ b/www/docs/customization/makeself.md
@@ -1,0 +1,320 @@
+# Makeself Self-Extracting Archives
+
+Makeself creates self-extracting archives that can be executed to automatically extract and optionally install their contents. This is particularly useful for distributing software that needs to be easily installable without requiring users to manually extract archives. Typically this supports Linux, MacOS and any other platform that makeself runs on. See the makeself
+link below.
+
+!!! note
+
+    The `makeself` command requires the `makeself` or `makeself.sh` command to be available in your system PATH. You can install it from your system package manager or from [the makeself project](https://github.com/megastep/makeself).
+
+Here is a commented `makeselfs` section with all fields specified:
+
+```yaml title=".goreleaser.yaml"
+makeselfs:
+  - #
+    # ID of this makeself package.
+    #
+    # Default: 'default'.
+    id: my-installer
+
+    # IDs of the builds which should be packaged in this makeself archive.
+    #
+    # Default: empty (include all).
+    ids:
+      - my-binary
+
+    # Archive name template.
+    #
+    # Default: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
+    # Templates: allowed.
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+    # Custom file extension for the self-extracting archive.
+    #
+    # Default: '.run'
+    # Templates: allowed.
+    extension: ".run"
+
+    # Custom label/description for the archive shown during execution.
+    #
+    # Default: 'Self-extracting archive'
+    # Templates: allowed.
+    label: "{{ .ProjectName }} v{{ .Version }} Installer"
+
+    # Compression format to use.
+    #
+    # Valid options: gzip, bzip2, xz, lzo, compress, none
+    # Default: gzip (makeself default)
+    # Templates: allowed.
+    # note: none translates to makeslef's --nocomp flag
+    compression: "gzip"
+
+    # Inline install script content.
+    # This script will be executed after extraction.
+    # Templates: allowed.
+    install_script: |
+      #!/bin/bash
+      echo "Installing {{ .ProjectName }}..."
+      chmod +x {{ .Binary }}
+      cp {{ .Binary }} /usr/local/bin/
+      echo "Installation complete!"
+
+    # Path to install script file within the archive.
+    # Alternative to install_script for external script files.
+    # Templates: allowed.
+    install_script_file: "install.sh"
+
+    # Additional command-line arguments to pass to makeself.
+    # Templates: allowed.
+    extra_args:
+      - "--notemp"     # Don't use a temporary directory for extraction
+      - "--needroot"   # Requires root privileges to run
+      - "--keep"       # Don't remove extracted files after execution
+      - "--copy"       # Copy files to temporary directory instead of extracting in place
+
+    # Linux Software Map (LSM) template content.
+    # Templates: allowed.
+    lsm_template: |
+      Begin4
+      Title: {{ .ProjectName }}
+      Version: {{ .Version }}
+      Description: {{ .ProjectName }} self-extracting installer
+      Author: Your Name
+      Maintained-by: your-email@example.com
+      Primary-site: https://github.com/youruser/yourproject
+      Platforms: Linux
+      Copying-policy: MIT
+      End
+
+    # Path to external LSM file.
+    # Alternative to lsm_template for external LSM files.
+    # Templates: allowed.
+    lsm_file: "project.lsm"
+
+    # Additional files/globs you want to add to the makeself package.
+    # These files will be available to the install script.
+    #
+    # Default: [ 'LICENSE*', 'README*', 'CHANGELOG', 'license*', 'readme*', 'changelog'].
+    # Templates: allowed.
+    files:
+      - LICENSE.txt
+      - README_{{.Os}}.md
+      - CHANGELOG.md
+      - configs/*
+      - scripts/*.sh
+      # a more complete example
+      - src: "*.md"
+        dst: docs
+
+        # Strip parent directories when adding files to the archive.
+        strip_parent: true
+
+        # File info.
+        info:
+          # Templates: allowed.
+          owner: root
+
+          # Templates: allowed.
+          group: root
+
+          # Must be in time.RFC3339Nano format.
+          # Templates: allowed.
+          mtime: "{{ .CommitDate }}"
+
+          # File mode.
+          mode: 0644
+
+    # This will create a package without any binaries, only the files are there.
+    # Useful for configuration packages or system setup packages.
+    # The name template must not contain any references to `Os`, `Arch` etc, since the package will be meta.
+    #
+    # Templates: allowed.
+    meta: false
+
+    # Disable this makeself package.
+    # Templates: allowed.
+    disable: "{{ .Env.SKIP_MAKESELF }}"
+
+    # Deprecated: use 'ids' instead.
+    builds:
+      - default
+```
+
+## Simple Makeself Example
+
+Here's a minimal example to create a self-extracting installer:
+
+```yaml title=".goreleaser.yaml"
+makeselfs:
+  - id: installer
+    ids:
+      - default
+    label: "{{ .ProjectName }} v{{ .Version }} Installer"
+    extra_args:
+      - "--needroot"  # Ensures installer runs as root
+    install_script: |
+      #!/bin/bash
+      echo "Installing {{ .ProjectName }}..."
+      chmod +x {{ .Binary }}
+      cp {{ .Binary }} /usr/local/bin/
+      echo "{{ .ProjectName }} installed successfully!"
+```
+
+This will create a `.run` file that users can execute with `./yourproject_1.0.0_linux_amd64.run`. The `--needroot` flag ensures the installer automatically requests root privileges, so the install script can assume it's running as root (no `sudo` needed in the script).
+
+## Advanced Examples
+
+### Multiple Package Types
+
+You can create multiple makeself packages with different configurations:
+
+```yaml title=".goreleaser.yaml"
+makeselfs:
+  # Full installer with all components
+  - id: full
+    ids:
+      - default
+    name_template: "{{ .ProjectName }}_full_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    label: "{{ .ProjectName }} Full Installer"
+    files:
+      - configs/*
+      - scripts/*
+      - docs/*
+    extra_args:
+      - "--needroot"
+    install_script: |
+      #!/bin/bash
+      echo "Installing {{ .ProjectName }} (Full)..."
+      chmod +x {{ .Binary }}
+      cp {{ .Binary }} /usr/local/bin/
+      mkdir -p /etc/{{ .ProjectName }}
+      cp configs/* /etc/{{ .ProjectName }}/
+      echo "Full installation complete!"
+
+  # Minimal installer with just the binary
+  - id: minimal
+    ids:
+      - default
+    name_template: "{{ .ProjectName }}_minimal_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    label: "{{ .ProjectName }} Minimal Installer"
+    extension: ".bin"
+    files:
+      - none*  # Don't include default files
+    install_script: |
+      #!/bin/bash
+      echo "Installing {{ .ProjectName }} (Minimal)..."
+      chmod +x {{ .Binary }}
+      cp {{ .Binary }} /usr/local/bin/
+      echo "Minimal installation complete!"
+```
+
+### Meta Packages
+
+Create configuration-only packages without binaries:
+
+```yaml title=".goreleaser.yaml"
+makeselfs:
+  - id: config
+    meta: true  # No binaries included
+    name_template: "{{ .ProjectName }}_config_{{ .Version }}"
+    label: "{{ .ProjectName }} Configuration Package"
+    files:
+      - configs/*
+      - scripts/*
+    install_script: |
+      #!/bin/bash
+      echo "Installing {{ .ProjectName }} configurations..."
+      mkdir -p /etc/{{ .ProjectName }}
+      cp configs/* /etc/{{ .ProjectName }}/
+      chmod +x scripts/*.sh
+      cp scripts/*.sh /usr/local/bin/
+      echo "Configuration installed!"
+```
+
+### Using External Install Scripts
+
+Instead of inline scripts, you can reference external files:
+
+```yaml title=".goreleaser.yaml"
+makeselfs:
+  - id: installer
+    ids:
+      - default
+    label: "{{ .ProjectName }} v{{ .Version }} Installer"
+    install_script_file: "scripts/install.sh"
+    files:
+      - scripts/install.sh
+      - scripts/uninstall.sh
+      - configs/*
+```
+
+Create `scripts/install.sh`:
+```bash
+#!/bin/bash
+set -e
+
+echo "Installing {{ .ProjectName }}..."
+
+# Install binary
+chmod +x {{ .Binary }}
+cp {{ .Binary }} /usr/local/bin/
+
+# Install configurations
+mkdir -p /etc/{{ .ProjectName }}
+cp configs/* /etc/{{ .ProjectName }}/
+
+# Install uninstaller
+chmod +x scripts/uninstall.sh
+cp scripts/uninstall.sh /usr/local/bin/{{ .ProjectName }}-uninstall
+
+echo "{{ .ProjectName }} installed successfully!"
+echo "Run '{{ .ProjectName }}' to get started"
+echo "Run '{{ .ProjectName }}-uninstall' to remove"
+```
+
+## Makeself Features Supported
+
+- **Custom Extensions**: Use templated extensions like `.{{ .Os }}.run` for platform-specific naming
+- **LSM Support**: Include Linux Software Map information for software catalogs
+- **Flexible Install Scripts**: Use either inline scripts or external script files from your repository
+- **Compression Options**: Choose from multiple compression formats based on size vs. speed trade-offs
+- **Integration with Files**: Add documentation, licenses, and other files that will be available to the install script
+- **Root Privileges**: Use `--needroot` in `extra_args` to ensure the installer runs with root privileges, simplifying system-wide installations
+- **Meta Packages**: Create configuration-only packages without binaries
+
+## Available Template Variables
+
+All standard GoReleaser template variables are available, including:
+
+- `{{ .ProjectName }}` - Project name
+- `{{ .Version }}` - Version being released
+- `{{ .Tag }}` - Git tag
+- `{{ .Binary }}` - Binary name (useful in install scripts)
+- `{{ .Os }}` - Operating system
+- `{{ .Arch }}` - Architecture
+- `{{ .Env.VARIABLE_NAME }}` - Environment variables
+
+## Makeself Arguments
+
+Common `extra_args` options:
+
+- `--needroot` - Requires root privileges to run the installer
+- `--keep` - Keep extracted files after execution (useful for debugging)
+- `--notemp` - Don't use a temporary directory for extraction
+- `--copy` - Copy files to temp directory instead of extracting in place
+- `--current` - Files will be extracted to the current directory
+- `--nooverwrite` - Don't overwrite existing files
+
+!!! tip
+
+    The install script has access to all files included in the package, so you can reference documentation, configuration files, or other assets in your installation logic.
+
+!!! tip "Root Privileges"
+
+    When using `--needroot` in `extra_args`, the makeself installer will automatically prompt for root privileges when executed. This allows your install script to assume root access without using `sudo` commands, making the script simpler and more reliable. Users will be prompted like: `"This installer requires root privileges. Please enter your password when prompted."`
+
+!!! warning
+
+    Makeself packages are platform-specific (typically Linux and macos) and create executable files. Make sure your target users can execute them on their systems.
+
+<!-- md:templates -->

--- a/www/mkdocs.yml
+++ b/www/mkdocs.yml
@@ -141,6 +141,7 @@ nav:
           - customization/archive.md
           - customization/source.md
           - Linux Packages: customization/nfpm.md
+          - Self-Extracting Archives: customization/makeself.md
           - customization/app_bundles.md
           - customization/dmg.md
           - customization/msi.md


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->

Add makeself support to goreleaser to create self-extracting archives/installers.

<!-- Why is this change being made? -->

This is to scratch an itch I had with the current goreleaser implementation that I was using where I needed to create makeself archives but the current workaround using pre-release hooks was inelegent and inefficient. I wanted to add first class support for makeself to goreleaser.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

Documentation about makeself available [here](https://makeself.io/)