### PR TITLE
fix(docker/v2): do not warn skip docker/v2 on production builds

### DIFF
--- a/internal/pipe/docker/v2/docker_integration_test.go
+++ b/internal/pipe/docker/v2/docker_integration_test.go
@@ -55,8 +55,8 @@ func TestRun(t *testing.T) {
 		})
 	}
 
-	require.NoError(t, Pipe{}.Default(ctx))
-	err := Pipe{}.Run(ctx)
+	require.NoError(t, Base{}.Default(ctx))
+	err := Snapshot{}.Run(ctx)
 	require.NoError(t, err, "message: %s, output: %v", gerrors.MessageOf(err), gerrors.DetailsOf(err))
 
 	images := ctx.Artifacts.Filter(
@@ -144,9 +144,8 @@ func TestPublish(t *testing.T) {
 		})
 	}
 
-	require.NoError(t, Pipe{}.Default(ctx))
-	testlib.AssertSkipped(t, Pipe{}.Run(ctx)) // should be skipped in non-snapshot builds
-	err := Pipe{}.Publish(ctx)
+	require.NoError(t, Base{}.Default(ctx))
+	err := Publish{}.Publish(ctx)
 	require.NoError(t, err, "message: %s, output: %v", gerrors.MessageOf(err), gerrors.DetailsOf(err))
 
 	images := ctx.Artifacts.Filter(artifact.ByType(artifact.DockerImageV2)).List()

--- a/internal/pipe/docker/v2/docker_test.go
+++ b/internal/pipe/docker/v2/docker_test.go
@@ -17,11 +17,11 @@ import (
 )
 
 func TestString(t *testing.T) {
-	require.NotEmpty(t, Pipe{}.String())
+	require.NotEmpty(t, Base{}.String())
 }
 
 func TestDependencies(t *testing.T) {
-	require.Equal(t, []string{"docker buildx"}, Pipe{}.Dependencies(nil))
+	require.Equal(t, []string{"docker buildx"}, Base{}.Dependencies(nil))
 }
 
 func TestSkip(t *testing.T) {
@@ -29,17 +29,29 @@ func TestSkip(t *testing.T) {
 		ctx := testctx.NewWithCfg(config.Project{
 			DockersV2: []config.DockerV2{{}},
 		}, testctx.Skip(skips.Docker))
-		require.True(t, Pipe{}.Skip(ctx))
+		require.True(t, Base{}.Skip(ctx))
 	})
 	t.Run("no dockers", func(t *testing.T) {
 		ctx := testctx.NewWithCfg(config.Project{})
-		require.True(t, Pipe{}.Skip(ctx))
+		require.True(t, Base{}.Skip(ctx))
 	})
 	t.Run("don't skip", func(t *testing.T) {
 		ctx := testctx.NewWithCfg(config.Project{
 			DockersV2: []config.DockerV2{{}},
 		})
-		require.False(t, Pipe{}.Skip(ctx))
+		require.False(t, Base{}.Skip(ctx))
+	})
+	t.Run("snapshot don't skip snapshot", func(t *testing.T) {
+		ctx := testctx.NewWithCfg(config.Project{
+			DockersV2: []config.DockerV2{{}},
+		}, testctx.Snapshot)
+		require.False(t, Snapshot{}.Skip(ctx))
+	})
+	t.Run("snapshot skip non snapshot", func(t *testing.T) {
+		ctx := testctx.NewWithCfg(config.Project{
+			DockersV2: []config.DockerV2{{}},
+		})
+		require.True(t, Snapshot{}.Skip(ctx))
 	})
 }
 
@@ -48,7 +60,7 @@ func TestDefault(t *testing.T) {
 		ProjectName: "dockerv2",
 		DockersV2:   []config.DockerV2{{}},
 	})
-	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Base{}.Default(ctx))
 	d := ctx.Config.DockersV2[0]
 	require.NotEmpty(t, d.ID)
 	require.NotEmpty(t, d.Dockerfile)

--- a/internal/pipe/publish/publish.go
+++ b/internal/pipe/publish/publish.go
@@ -49,7 +49,7 @@ func New() Pipe {
 			artifactory.Pipe{},
 			docker.Pipe{},
 			docker.ManifestPipe{},
-			dockerv2.Pipe{},
+			dockerv2.Publish{},
 			dockerdigest.Pipe{},
 			ko.Pipe{},
 			sign.DockerPipe{},

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -157,7 +157,7 @@ var Pipeline = append(
 	reportsizes.Pipe{},
 	// create and push docker images
 	docker.Pipe{},
-	dockerv2.Pipe{},
+	dockerv2.Snapshot{},
 	// create and push docker images using ko
 	ko.Pipe{},
 	// publishes artifacts

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -90,7 +90,7 @@ var Defaulters = []Defaulter{
 	sign.DockerPipe{},
 	sbom.Pipe{},
 	docker.Pipe{},
-	dockerv2.Pipe{},
+	dockerv2.Base{},
 	docker.ManifestPipe{},
 	dockerdigest.Pipe{},
 	artifactory.Pipe{},

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -37,7 +37,7 @@ var Healthcheckers = []Healthchecker{
 	sbom.Pipe{},
 	docker.Pipe{},
 	docker.ManifestPipe{},
-	dockerv2.Pipe{},
+	dockerv2.Base{},
 	chocolatey.Pipe{},
 	nix.New(),
 }


### PR DESCRIPTION
It is a bit confusing.

Resolved by splitting the pipes into two, one that is automatically skipped in non-snapshot builds, so it doesn't log anything.
