### PR TITLE
fix(docker/v2): properly set manifest annotations

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -133,6 +133,8 @@ dockers_v2:
       "org.opencontainers.image.revision": "{{.FullCommit}}"
       "org.opencontainers.image.version": "{{.Version}}"
       "org.opencontainers.image.source": "{{.GitURL}}"
+    annotations:
+      "org.opencontainers.image.description": "Release engineering, simplified"
 
 archives:
   - name_template: >-

--- a/internal/pipe/docker/v2/docker.go
+++ b/internal/pipe/docker/v2/docker.go
@@ -228,6 +228,11 @@ func makeArgs(ctx *context.Context, d config.DockerV2, extraArgs []string) ([]st
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid annotations: %w", err)
 	}
+	if len(d.Platforms) > 1 {
+		for i := 1; i < len(annotationFlags); i += 2 {
+			annotationFlags[i] = "index:" + strings.TrimPrefix(annotationFlags[i], "index:")
+		}
+	}
 
 	buildFlags, err := tplMapFlags(tpl, "--build-arg", d.BuildArgs)
 	if err != nil {

--- a/internal/pipe/docker/v2/docker_test.go
+++ b/internal/pipe/docker/v2/docker_test.go
@@ -166,9 +166,10 @@ func TestMakeArgs(t *testing.T) {
 				"name":    "{{.ProjectName}}",
 			},
 			Annotations: map[string]string{
-				"ignored": "  ",
-				"  ":      "also ignored",
-				"foo":     "{{.ProjectName}}",
+				"ignored":   "  ",
+				"  ":        "also ignored",
+				"foo":       "{{.ProjectName}}",
+				"index:zaz": "zaz",
 			},
 			Platforms: []string{"linux/amd64", "linux/arm64"},
 			BuildArgs: map[string]string{
@@ -193,7 +194,8 @@ func TestMakeArgs(t *testing.T) {
 				"--iidfile=id.txt",
 				"--label", "date=2025-08-19T00:00:00Z",
 				"--label", "name=dockerv2",
-				"--annotation", "foo=dockerv2",
+				"--annotation", "index:foo=dockerv2",
+				"--annotation", "index:zaz=zaz",
 				"--build-arg", "FOO=bar",
 				"--ulimit=1000",
 				".",


### PR DESCRIPTION
When we build a manifest, we need to prefix the annotation key with `index:`.

This does it automatically :) 