### PR TITLE
fix(schema): Introduce BinarySign struct to fix schema bug

### DIFF
--- a/internal/pipe/sign/sign_binary.go
+++ b/internal/pipe/sign/sign_binary.go
@@ -9,6 +9,7 @@ import (
 	"github.com/goreleaser/goreleaser/v2/internal/pipe"
 	"github.com/goreleaser/goreleaser/v2/internal/semerrgroup"
 	"github.com/goreleaser/goreleaser/v2/internal/skips"
+	"github.com/goreleaser/goreleaser/v2/pkg/config"
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
 )
 
@@ -80,8 +81,24 @@ func (BinaryPipe) Run(ctx *context.Context) error {
 			if len(cfg.IDs) > 0 {
 				filters = append(filters, artifact.ByIDs(cfg.IDs...))
 			}
-			return sign(ctx, cfg, ctx.Artifacts.Filter(artifact.And(filters...)).List())
+			return sign(ctx, toSign(cfg), ctx.Artifacts.Filter(artifact.And(filters...)).List())
 		})
 	}
 	return g.Wait()
+}
+
+func toSign(b config.BinarySign) config.Sign {
+	return config.Sign{
+		ID:          b.ID,
+		Cmd:         b.Cmd,
+		Args:        b.Args,
+		Signature:   b.Signature,
+		Artifacts:   b.Artifacts,
+		IDs:         b.IDs,
+		Stdin:       b.Stdin,
+		StdinFile:   b.StdinFile,
+		Env:         b.Env,
+		Certificate: b.Certificate,
+		Output:      b.Output,
+	}
 }

--- a/internal/pipe/sign/sign_binary_test.go
+++ b/internal/pipe/sign/sign_binary_test.go
@@ -19,7 +19,7 @@ func TestBinarySignDescription(t *testing.T) {
 
 func TestBinarySignDefault(t *testing.T) {
 	ctx := testctx.NewWithCfg(config.Project{
-		BinarySigns: []config.Sign{{}},
+		BinarySigns: []config.BinarySign{{}},
 	})
 	err := BinaryPipe{}.Default(ctx)
 	require.NoError(t, err)
@@ -31,7 +31,7 @@ func TestBinarySignDefault(t *testing.T) {
 
 func TestBinarySignDisabled(t *testing.T) {
 	ctx := testctx.NewWithCfg(config.Project{
-		BinarySigns: []config.Sign{
+		BinarySigns: []config.BinarySign{
 			{Artifacts: "none"},
 		},
 	})
@@ -41,7 +41,7 @@ func TestBinarySignDisabled(t *testing.T) {
 
 func TestBinarySignInvalidOption(t *testing.T) {
 	ctx := testctx.NewWithCfg(config.Project{
-		BinarySigns: []config.Sign{
+		BinarySigns: []config.BinarySign{
 			{Artifacts: "archive"},
 		},
 	})
@@ -61,7 +61,7 @@ func TestBinarySkip(t *testing.T) {
 
 	t.Run("dont skip", func(t *testing.T) {
 		ctx := testctx.NewWithCfg(config.Project{
-			BinarySigns: []config.Sign{
+			BinarySigns: []config.BinarySign{
 				{},
 			},
 		})
@@ -71,7 +71,7 @@ func TestBinarySkip(t *testing.T) {
 
 func TestBinaryDependencies(t *testing.T) {
 	ctx := testctx.NewWithCfg(config.Project{
-		BinarySigns: []config.Sign{
+		BinarySigns: []config.BinarySign{
 			{Cmd: "cosign"},
 			{Cmd: "gpg2"},
 		},
@@ -82,12 +82,12 @@ func TestBinaryDependencies(t *testing.T) {
 func TestBinarySign(t *testing.T) {
 	testlib.CheckPath(t, "gpg")
 	testlib.SkipIfWindows(t, "tries to use /usr/bin/gpg-agent")
-	doTest := func(tb testing.TB, sign config.Sign) []*artifact.Artifact {
+	doTest := func(tb testing.TB, sign config.BinarySign) []*artifact.Artifact {
 		tb.Helper()
 		tmpdir := tb.TempDir()
 
 		ctx := testctx.NewWithCfg(config.Project{
-			BinarySigns: []config.Sign{sign},
+			BinarySigns: []config.BinarySign{sign},
 		})
 
 		require.NoError(tb, os.WriteFile(filepath.Join(tmpdir, "bin1"), []byte("foo"), 0o644))
@@ -128,12 +128,12 @@ func TestBinarySign(t *testing.T) {
 	}
 
 	t.Run("default", func(t *testing.T) {
-		sigs := doTest(t, config.Sign{})
+		sigs := doTest(t, config.BinarySign{})
 		require.Len(t, sigs, 2)
 	})
 
 	t.Run("templated-signature", func(t *testing.T) {
-		sigs := doTest(t, config.Sign{
+		sigs := doTest(t, config.BinarySign{
 			Signature: "prefix_{{ .Arch }}_suffix",
 			Cmd:       "/bin/sh",
 			Args: []string{
@@ -153,7 +153,7 @@ func TestBinarySign(t *testing.T) {
 	})
 
 	t.Run("filter", func(t *testing.T) {
-		sigs := doTest(t, config.Sign{
+		sigs := doTest(t, config.BinarySign{
 			ID:  "bar",
 			IDs: []string{"bar"},
 		})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -893,6 +893,21 @@ type Sign struct {
 	Output      bool     `yaml:"output,omitempty" json:"output,omitempty"`
 }
 
+// BinarySign config.
+type BinarySign struct {
+	ID          string   `yaml:"id,omitempty" json:"id,omitempty"`
+	Cmd         string   `yaml:"cmd,omitempty" json:"cmd,omitempty"`
+	Args        []string `yaml:"args,omitempty" json:"args,omitempty"`
+	Signature   string   `yaml:"signature,omitempty" json:"signature,omitempty"`
+	Artifacts   string   `yaml:"artifacts,omitempty" json:"artifacts,omitempty" jsonschema:"enum=binary","enum=none"`
+	IDs         []string `yaml:"ids,omitempty" json:"ids,omitempty"`
+	Stdin       *string  `yaml:"stdin,omitempty" json:"stdin,omitempty"`
+	StdinFile   string   `yaml:"stdin_file,omitempty" json:"stdin_file,omitempty"`
+	Env         []string `yaml:"env,omitempty" json:"env,omitempty"`
+	Certificate string   `yaml:"certificate,omitempty" json:"certificate,omitempty"`
+	Output      bool     `yaml:"output,omitempty" json:"output,omitempty"`
+}
+
 type Notarize struct {
 	MacOS []MacOSSignNotarize `yaml:"macos" json:"macos"`
 }
@@ -1219,7 +1234,7 @@ type Project struct {
 	Signs           []Sign           `yaml:"signs,omitempty" json:"signs,omitempty"`
 	Notarize        Notarize         `yaml:"notarize,omitempty" json:"notarize,omitempty"`
 	DockerSigns     []Sign           `yaml:"docker_signs,omitempty" json:"docker_signs,omitempty"`
-	BinarySigns     []Sign           `yaml:"binary_signs,omitempty" json:"binary_signs,omitempty"`
+	BinarySigns     []BinarySign     `yaml:"binary_signs,omitempty" json:"binary_signs,omitempty"`
 	EnvFiles        EnvFiles         `yaml:"env_files,omitempty" json:"env_files,omitempty"`
 	Before          Before           `yaml:"before,omitempty" json:"before,omitempty"`
 	Source          Source           `yaml:"source,omitempty" json:"source,omitempty"`


### PR DESCRIPTION
This PR fixes the bug discussed in [discussion#6057](https://github.com/orgs/goreleaser/discussions/6057).

The schema & schema-pro incorrectly return 9 valid options for `binary_signs` -> `artifacts` instead of two supported: `none | binary`. As a result, language servers report 9 valid options, and `gorelease check` succeeeds but actual signing fails.
Language server incorrect values:
<img width="206" height="293" alt="Screenshot 2025-09-08 at 16 40 44" src="https://github.com/user-attachments/assets/de4e5511-36a4-4323-a350-0851bb8858c3" />

check passes, signing fails:
```
$ goreleaser check
  • checking                                  path=.goreleaser.yaml
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!
...
  • signing binaries
invalid list of artifacts to sign: all
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.12.0/x64/goreleaser' failed with exit code 1
```


If applied, this commit will introduce `BinarySign` to resolve the bug in the schema, to align with the documentation & actual behaviour of the code.

tests updated in `internal/pipe/sign/sign_binary_test.go` and a small `toSign` wrapper to ensure backwards compatibility with existing `sign()`.

Build succeeds locally:
```
go build -o goreleaser .  
➜  goreleaser git:(fix/binary_sign) ./goreleaser --version
  ____       ____      _
 / ___| ___ |  _ \ ___| | ___  __ _ ___  ___ _ __
| |  _ / _ \| |_) / _ \ |/ _ \/ _` / __|/ _ \ '__|
| |_| | (_) |  _ <  __/ |  __/ (_| \__ \  __/ |
 \____|\___/|_| \_\___|_|\___|\__,_|___/\___|_|
goreleaser: Release engineering, simplified.
https://goreleaser.com

GitVersion:    v2.12.1-0.20250908073636-c8b464ad5be4
GitCommit:     c8b464ad5be4972e5daec0678cef317e6a89de01
GitTreeState:  clean
BuildDate:     2025-09-08T07:36:36
BuiltBy:       unknown
GoVersion:     go1.25.1
Compiler:      gc
ModuleSum:     unknown
Platform:      darwin/arm64
```

`task ci` fails due to what seems like an unrelated error? 
```
--- FAIL: TestBuild (1.17s)
    build_test.go:123:
        	Error Trace:	./goreleaser/internal/builders/poetry/build_test.go:123
        	Error:      	Received unexpected error:
        	            	chtimes: dist/proj-all-all/--py3-none-any.whl: chtimes dist/proj-all-all/--py3-none-any.whl: no such file or directory
        	Test:       	TestBuild
FAIL
```