### PR TITLE
docs: fix typo in signs config section

### DIFF
--- a/www/docs/customization/sign.md
+++ b/www/docs/customization/sign.md
@@ -63,7 +63,7 @@ signs:
     # - diskimage:  macOS DMG disk images (Pro only)
     # - archive:    archives from archive pipe
     # - sbom:       any SBOMs generated for other artifacts
-    # - binary:     binaries (only when `archives.format` is 'binary', use binaries_sign otherwise)
+    # - binary:     binaries (only when `archives.format` is 'binary', use binary_signs otherwise)
     #
     # Default: 'none'.
     artifacts: all


### PR DESCRIPTION
The comment said to use `binaries_sign`, but the actual value should be `binary_signs`.

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

...

<!-- Why is this change being made? -->

...

<!-- # Provide links to any relevant tickets, URLs or other resources -->

...
