### PR TITLE
docs: fix inconsistency about symlink in nfpm.md

### DIFF
--- a/www/docs/customization/nfpm.md
+++ b/www/docs/customization/nfpm.md
@@ -215,7 +215,7 @@ nfpms:
         type: config
 
       # Simple symlink.
-      # Corresponds to `ln -s /sbin/foo /usr/local/bin/foo`
+      # Corresponds to `ln -s /sbin/foo /usr/bin/foo`
       - src: /sbin/foo
         dst: /usr/bin/foo
         type: "symlink"


### PR DESCRIPTION
This PR fixs inconsistency between comment and actual configuration in nfpm symlink example.