### PR TITLE
Fedora move exclude to repo config

### DIFF
--- a/www/docs/install.md
+++ b/www/docs/install.md
@@ -129,8 +129,9 @@ You can see the instructions for each of them below.
     name=GoReleaser
     baseurl=https://repo.goreleaser.com/yum/
     enabled=1
-    gpgcheck=0' | sudo tee /etc/yum.repos.d/goreleaser.repo
-    sudo yum --exclude=goreleaser-pro install goreleaser
+    gpgcheck=0
+    exclude=goreleaser-pro' | sudo tee /etc/yum.repos.d/goreleaser.repo
+    sudo yum install goreleaser
     ```
 
 === "Pro"
@@ -140,8 +141,9 @@ You can see the instructions for each of them below.
     name=GoReleaser
     baseurl=https://repo.goreleaser.com/yum/
     enabled=1
-    gpgcheck=0' | sudo tee /etc/yum.repos.d/goreleaser.repo
-    sudo yum --exclude=goreleaser install goreleaser-pro
+    gpgcheck=0
+    exclude=goreleaser' | sudo tee /etc/yum.repos.d/goreleaser.repo
+    sudo yum install goreleaser-pro
     ```
 
 ## AUR


### PR DESCRIPTION
Fedora: Move the OSS/Pro exclude config to the repo config That way it works even with yum update later on

**If applied, this commit will...**
Provide a better outcome for people using goreleaser on Fedora (like me)

**Why is this change being made?**
The install instructions are not optimal and I keep getting goreleaser-pro installed when I do yum update
