### PR TITLE
docs: fix duplicated packages comments

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,6 +8,7 @@ linters:
     - depguard
     - forbidigo
     - gocritic
+    - godoclint
     - misspell
     - noctx
     - nolintlint

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -1,4 +1,3 @@
-// Package cmd provides the command line interface for goreleaser.
 package cmd
 
 import (

--- a/cmd/doc.go
+++ b/cmd/doc.go
@@ -1,0 +1,2 @@
+// Package cmd provides the command line interface for goreleaser.
+package cmd

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,4 +1,3 @@
-// Package cmd provides the command line interface for goreleaser.
 package cmd
 
 import (

--- a/internal/pipe/blob/blob.go
+++ b/internal/pipe/blob/blob.go
@@ -1,4 +1,3 @@
-// Package blob provides the pipe implementation that uploads files to "blob" providers, such as s3, gcs and azure.
 package blob
 
 import (

--- a/internal/pipe/blob/doc.go
+++ b/internal/pipe/blob/doc.go
@@ -1,2 +1,2 @@
-// Package blob provides a Pipe that push artifacts to blob supported by Go CDK
+// Package blob provides the pipe implementation that uploads files to "blob" providers, such as s3, gcs and azure.
 package blob

--- a/internal/pipe/chocolatey/chocolatey.go
+++ b/internal/pipe/chocolatey/chocolatey.go
@@ -1,4 +1,3 @@
-// Package chocolatey publishes chocolatey packages.
 package chocolatey
 
 import (

--- a/internal/pipe/chocolatey/doc.go
+++ b/internal/pipe/chocolatey/doc.go
@@ -1,0 +1,2 @@
+// Package chocolatey publishes chocolatey packages.
+package chocolatey

--- a/internal/pipe/chocolatey/nuspec.go
+++ b/internal/pipe/chocolatey/nuspec.go
@@ -1,4 +1,3 @@
-// Package chocolatey creates chocolatey packages.
 package chocolatey
 
 import (

--- a/internal/pipe/gomod/gomod_proxy.go
+++ b/internal/pipe/gomod/gomod_proxy.go
@@ -1,5 +1,3 @@
-// Package gomod provides go modules utilities, such as template variables and the ability to proxy the module from
-// proxy.golang.org.
 package gomod
 
 import (

--- a/internal/pipe/linkedin/client.go
+++ b/internal/pipe/linkedin/client.go
@@ -1,4 +1,3 @@
-// Package linkedin announces releases on LinkedIn.
 package linkedin
 
 import (

--- a/internal/pipe/linkedin/doc.go
+++ b/internal/pipe/linkedin/doc.go
@@ -1,0 +1,2 @@
+// Package linkedin announces releases on LinkedIn.
+package linkedin

--- a/internal/pipe/linkedin/linkedin.go
+++ b/internal/pipe/linkedin/linkedin.go
@@ -1,4 +1,3 @@
-// Package linkedin announces releases on LinkedIn.
 package linkedin
 
 import (

--- a/internal/pipe/winget/doc.go
+++ b/internal/pipe/winget/doc.go
@@ -1,0 +1,2 @@
+// Package winget creates winget manifests.
+package winget

--- a/internal/pipe/winget/template.go
+++ b/internal/pipe/winget/template.go
@@ -1,4 +1,3 @@
-// Package winget creates winget manifests.
 package winget
 
 import (

--- a/internal/pipe/winget/winget.go
+++ b/internal/pipe/winget/winget.go
@@ -1,4 +1,3 @@
-// Package winget creates winget manifests.
 package winget
 
 import (


### PR DESCRIPTION
This PR fixes [`godoclint`](https://golangci-lint.run/docs/linters/configuration/#godoclint) issues that reports about duplicated package comments:

```console
❯ golangci-lint run --enable-only godoclint
cmd/build.go:1:1: package has more than one godoc ("cmd") (godoclint)
// Package cmd provides the command line interface for goreleaser.
^
cmd/init.go:1:1: package has more than one godoc ("cmd") (godoclint)
// Package cmd provides the command line interface for goreleaser.
^
internal/pipe/blob/blob.go:1:1: package has more than one godoc ("blob") (godoclint)
// Package blob provides the pipe implementation that uploads files to "blob" providers, such as s3, gcs and azure.
^
internal/pipe/blob/doc.go:1:1: package has more than one godoc ("blob") (godoclint)
// Package blob provides a Pipe that push artifacts to blob supported by Go CDK
^
internal/pipe/chocolatey/chocolatey.go:1:1: package has more than one godoc ("chocolatey") (godoclint)
// Package chocolatey publishes chocolatey packages.
^
internal/pipe/chocolatey/nuspec.go:1:1: package has more than one godoc ("chocolatey") (godoclint)
// Package chocolatey creates chocolatey packages.
^
internal/pipe/gomod/doc.go:1:1: package has more than one godoc ("gomod") (godoclint)
// Package gomod provides go modules utilities, such as template variables and the ability to proxy the module from
^
internal/pipe/gomod/gomod_proxy.go:1:1: package has more than one godoc ("gomod") (godoclint)
// Package gomod provides go modules utilities, such as template variables and the ability to proxy the module from
^
internal/pipe/linkedin/client.go:1:1: package has more than one godoc ("linkedin") (godoclint)
// Package linkedin announces releases on LinkedIn.
^
internal/pipe/linkedin/linkedin.go:1:1: package has more than one godoc ("linkedin") (godoclint)
// Package linkedin announces releases on LinkedIn.
^
internal/pipe/winget/template.go:1:1: package has more than one godoc ("winget") (godoclint)
// Package winget creates winget manifests.
^
internal/pipe/winget/winget.go:1:1: package has more than one godoc ("winget") (godoclint)
// Package winget creates winget manifests.
^
12 issues:
* godoclint: 12
```

Before (see the text in "Overview"):

<img width="835" height="680" alt="image" src="https://github.com/user-attachments/assets/a19f7574-3c8c-45da-be80-c1c57ceb413e" />

After:

<img width="998" height="566" alt="image" src="https://github.com/user-attachments/assets/ae6ca863-3d52-4907-8634-26271f3ef7de" />
