### PR TITLE
docs: add default value for wrap directory

### DIFF
--- a/www/docs/customization/archive.md
+++ b/www/docs/customization/archive.md
@@ -73,6 +73,7 @@ archives:
     # you'll get a directory 'goreleaser_Linux_arm64'.
     # If set to false, all files are extracted separately.
     # You can also set it to a custom directory name (templating is supported).
+    # Default: false.
     wrap_in_directory: true
 
     # If set to true, will strip the parent directories away from binary files.


### PR DESCRIPTION
Some of the keys for "archives" list defaults, some don't. This one didn't and I assume it was 'true' given the example. The default is actually 'false'. I figured I'd document it for future me and others.