### PR TITLE
refactor(homebrew): replace Binary with Binaries slice in HomebrewCask

### DIFF
--- a/internal/pipe/cask/cask.go
+++ b/internal/pipe/cask/cask.go
@@ -67,8 +67,12 @@ func (Pipe) Default(ctx *context.Context) error {
 		if brew.Directory != "Casks" {
 			log.Warnf("%q might not work properly for your end users, for reference, the default is \"Casks\"", brew.Directory)
 		}
-		if brew.Binary == "" {
-			brew.Binary = brew.Name
+		if len(brew.Binaries) == 0 || brew.Binaries[0] == "" {
+			brew.Binaries = []string{brew.Name}
+		}
+		if brew.Binary != "" {
+			deprecate.Notice(ctx, "homebrew_casks.binary")
+			brew.Binaries = append(brew.Binaries, brew.Binary)
 		}
 		if brew.Manpage != "" {
 			deprecate.Notice(ctx, "homebrew_casks.manpage")
@@ -238,6 +242,10 @@ func doRun(ctx *context.Context, brew config.HomebrewCask, cl client.ReleaseURLT
 		&brew.Completions.Fish,
 		&brew.SkipUpload,
 	); err != nil {
+		return err
+	}
+
+	if err := tmpl.New(ctx).ApplySlice(&brew.Binaries); err != nil {
 		return err
 	}
 

--- a/internal/pipe/cask/cask_test.go
+++ b/internal/pipe/cask/cask_test.go
@@ -59,7 +59,7 @@ var defaultTemplateData = templateData{
 	HomebrewCask: config.HomebrewCask{
 		Description: "Some desc",
 		Homepage:    "https://google.com",
-		Binary:      "mybin",
+		Binaries:    []string{"mybin"},
 		Completions: config.HomebrewCaskCompletions{
 			Fish: "mybin.fish",
 			Bash: "mybin.bash",
@@ -432,7 +432,7 @@ func TestFullPipe(t *testing.T) {
 									Install: "system \"echo\"\ntouch \"/tmp/hi\"",
 								},
 							},
-							Binary: "{{.ProjectName}}",
+							Binaries: []string{"{{.ProjectName}}"},
 						},
 					},
 					Env: []string{"FOO=foo_is_bar"},
@@ -556,7 +556,7 @@ func TestRunPipeNameTemplate(t *testing.T) {
 					Name:        "foo_{{ .Env.FOO_BAR }}",
 					Description: "Foo bar",
 					Homepage:    "https://goreleaser.com",
-					Binary:      "foo",
+					Binaries:    []string{"foo"},
 					Repository: config.RepoRef{
 						Owner: "foo",
 						Name:  "bar",
@@ -824,7 +824,7 @@ func TestRunPipeBinaryRelease(t *testing.T) {
 						Owner: "foo",
 						Name:  "bar",
 					},
-					Binary:   "foo",
+					Binaries: []string{"foo"},
 					Manpages: []string{"./man/foo.1.gz"},
 				},
 			},
@@ -1040,7 +1040,7 @@ func TestDefault(t *testing.T) {
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.True(t, ctx.Deprecated)
 	require.Equal(t, ctx.Config.ProjectName, ctx.Config.Casks[0].Name)
-	require.Equal(t, ctx.Config.ProjectName, ctx.Config.Casks[0].Binary)
+	require.Equal(t, ctx.Config.ProjectName, ctx.Config.Casks[0].Binaries[0])
 	require.NotEmpty(t, ctx.Config.Casks[0].CommitAuthor.Name)
 	require.NotEmpty(t, ctx.Config.Casks[0].CommitAuthor.Email)
 	require.NotEmpty(t, ctx.Config.Casks[0].CommitMessageTemplate)
@@ -1102,7 +1102,7 @@ func TestRunPipeUniversalBinary(t *testing.T) {
 					IDs: []string{
 						"unibin",
 					},
-					Binary: "unibin",
+					Binaries: []string{"unibin"},
 				},
 			},
 		},
@@ -1157,7 +1157,7 @@ func TestRunPipeUniversalBinaryNotReplacing(t *testing.T) {
 					IDs: []string{
 						"unibin",
 					},
-					Binary: "unibin",
+					Binaries: []string{"unibin"},
 				},
 			},
 		},

--- a/internal/pipe/cask/templates/cask.rb
+++ b/internal/pipe/cask/templates/cask.rb
@@ -15,8 +15,10 @@ cask "{{ .Name }}" do
     skip "Auto-generated on release."
   end
 
-  {{ with and (not .HasOnlyBinaryPkgs) .Binary }}
-  binary "{{ .}}"
+  {{ with and (not .HasOnlyBinaryPkgs) .Binaries }}
+  {{- range . }}
+  binary "{{ . }}"
+  {{- end }}
   {{- end }}
   {{- range .Manpages }}
   manpage "{{ .}}"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -231,7 +231,7 @@ type HomebrewCask struct {
 	Service               string       `yaml:"service,omitempty" json:"service,omitempty"`
 
 	// Cask only:
-	Binary       string                   `yaml:"binary,omitempty" json:"binary,omitempty"`
+	Binaries     []string                 `yaml:"binaries,omitempty" json:"binaries,omitempty"`
 	Manpages     []string                 `yaml:"manpages,omitempty" json:"manpages,omitempty"`
 	URL          HomebrewCaskURL          `yaml:"url,omitempty" json:"url,omitempty"`
 	Completions  HomebrewCaskCompletions  `yaml:"completions,omitempty" json:"completions,omitempty"`
@@ -243,6 +243,9 @@ type HomebrewCask struct {
 
 	// Deprecated: use [HomebrewCask.Manpages] instead.
 	Manpage string `yaml:"manpage,omitempty" json:"manpage,omitempty"`
+
+	// Deprecated: use [HomebrewCask.Binaries] instead.
+	Binary string `yaml:"binary,omitempty" json:"binary,omitempty"`
 }
 
 type HomebrewCaskURL struct {

--- a/www/docs/customization/homebrew_casks.md
+++ b/www/docs/customization/homebrew_casks.md
@@ -40,7 +40,9 @@ homebrew_casks:
     #
     # Default: the cask name.
     # Templates: allowed.
-    binary: myapp
+    binaries:
+      - myapp
+      - myapp2
 
     # App to use instead of the binary.
     # This will then make GoReleaser use only the DMG files instead of archives.


### PR DESCRIPTION
This will align goreleaser to specification from https://docs.brew.sh/Cask-Cookbook#at-least-one-artifact-stanza-is-also-required where multiple `binary` items are permitted.