### PR TITLE
Add Flyte to the list of users

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -38,6 +38,7 @@ Here's a running list of some organizations using GoReleaser[^1]:
 1. [Fleet for osquery](https://fleetdm.com)
 1. [Flipt](https://www.flipt.io)
 1. [FluxCD](https://fluxcd.io)
+1. [Flyte](https://flyte.org)
 1. [Gaia Pipeline](https://github.com/gaia-pipeline)
 1. [GitGuardian](https://gitguardian.com)
 1. [GitHub](https://github.com)


### PR DESCRIPTION



<!-- If applied, this commit will... -->

Add Flyte to the list of projects that rely on goreleaser (as can be evidenced by https://github.com/flyteorg/flyte/blob/master/.github/workflows/create_release.yml#L181C19-L187)

<!-- Why is this change being made? -->

Flyte has been relying on goreleaser since the beginning of the project and it's using the pro version for the last 2 years without any issues.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

N/A
