### PR TITLE
fix(dcos): typo in nfpm.md from 'headers' to 'header'

### DIFF
--- a/www/docs/customization/nfpm.md
+++ b/www/docs/customization/nfpm.md
@@ -122,7 +122,7 @@ nfpms:
     # Templates: allowed.
     libdirs:
       # Default: '/usr/include'.
-      headers: /usr/include/something
+      header: /usr/include/something
 
       # Default: '/usr/lib'.
       cshared: /usr/lib/foo


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->

Fix docs, ref:

https://github.com/goreleaser/goreleaser/blob/23b03dad313594d9b49d7952ee29f71cf7dabe32/pkg/config/config.go#L696