### PR TITLE
fix: add template keys

### DIFF
--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"net/url"
-	"os"
+	sys "os" // renamed import
 	"os/user"
 	"path/filepath"
 	"regexp"
@@ -50,6 +50,7 @@ const (
 	rawVersion      = "RawVersion"
 	tag             = "Tag"
 	previousTag     = "PreviousTag"
+	arch            = "Arch"
 	branch          = "Branch"
 	commit          = "Commit"
 	shortCommit     = "ShortCommit"
@@ -67,6 +68,7 @@ const (
 	gitTreeState    = "GitTreeState"
 	major           = "Major"
 	minor           = "Minor"
+	os              = "Os"
 	patch           = "Patch"
 	prerelease      = "Prerelease"
 	isSnapshot      = "IsSnapshot"
@@ -112,6 +114,8 @@ func New(ctx *context.Context) *Template {
 		projectName:     ctx.Config.ProjectName,
 		modulePath:      ctx.ModulePath,
 		version:         ctx.Version,
+		arch:            ctx.Runtime.Goarch,
+		os:              ctx.Runtime.Goos,
 		rawVersion:      rawVersionV,
 		summary:         ctx.Git.Summary,
 		tag:             ctx.Git.CurrentTag,
@@ -534,7 +538,7 @@ func mustReadFile(path string) (string, error) {
 		}
 		path = user.HomeDir + path[1:]
 	}
-	bts, err := os.ReadFile(path)
+	bts, err := sys.ReadFile(path)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## If applied, this commit will...

Allow the `system_command` under `homebrew_casks` -> `hooks` -> `post` -> `install` to use:
* `{{ .Os }}`
* `{{ .Arch }}`
* (please let me know if I need to add any more missing keys)

Let me know if you do not like the renaming of the `os` module to `sys` and I can update it per your guidance.

## Why is this change being made?

In my `.goreleaser.yaml` file, I want to use `wrap_in_directory: true` which means that the full path to the binary must also be used in the `system_command`.


## Provide links to any relevant tickets, URLs or other resources

https://github.com/orgs/goreleaser/discussions/6212

## Testing

I was able to run my patched version with `goreleaser release --clean` to publish an updated homebrew cask ruby file, which then emitted the correct `system_command`:

```yaml
system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}/wrapline"]
```

