### PR TITLE
feat: update Go to 1.25.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/goreleaser/goreleaser/v2
 
-go 1.25.3
+go 1.25.4
 
 require (
 	code.gitea.io/sdk/gitea v0.22.1

--- a/internal/pipe/ko/testdata/app/go.mod
+++ b/internal/pipe/ko/testdata/app/go.mod
@@ -1,3 +1,3 @@
 module testapp
 
-go 1.25.3
+go 1.25.4

--- a/internal/pipe/universalbinary/testdata/fake/go.mod
+++ b/internal/pipe/universalbinary/testdata/fake/go.mod
@@ -1,3 +1,3 @@
 module fake
 
-go 1.25.3
+go 1.25.4


### PR DESCRIPTION
Update to latest and greatest, follows what's been done for Go 1.25.3 in https://github.com/goreleaser/goreleaser/pull/6223.
