### PR TITLE
fix: dynamically use announcer names in errors

### DIFF
--- a/internal/pipe/bluesky/bluesky.go
+++ b/internal/pipe/bluesky/bluesky.go
@@ -44,12 +44,12 @@ func (Pipe) Default(ctx *context.Context) error {
 func (p Pipe) Announce(ctx *context.Context) error {
 	msg, err := tmpl.New(ctx).Apply(ctx.Config.Announce.Bluesky.MessageTemplate)
 	if err != nil {
-		return fmt.Errorf("bluesky: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	var cfg Config
 	if err = env.Parse(&cfg); err != nil {
-		return fmt.Errorf("bluesky: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	post := bsky.FeedPost{

--- a/internal/pipe/discord/discord.go
+++ b/internal/pipe/discord/discord.go
@@ -55,24 +55,24 @@ func (p Pipe) Default(ctx *context.Context) error {
 func (p Pipe) Announce(ctx *context.Context) error {
 	msg, err := tmpl.New(ctx).Apply(ctx.Config.Announce.Discord.MessageTemplate)
 	if err != nil {
-		return fmt.Errorf("discord: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	cfg, err := env.ParseAs[Config]()
 	if err != nil {
-		return fmt.Errorf("discord: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	log.Infof("posting: '%s'", msg)
 
 	color, err := strconv.Atoi(ctx.Config.Announce.Discord.Color)
 	if err != nil {
-		return fmt.Errorf("discord: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	u, err := url.Parse(cfg.API)
 	if err != nil {
-		return fmt.Errorf("discord: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 	u = u.JoinPath("webhooks", cfg.WebhookID, cfg.WebhookToken)
 
@@ -89,23 +89,23 @@ func (p Pipe) Announce(ctx *context.Context) error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("discord: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(bts))
 	if err != nil {
-		return fmt.Errorf("discord: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("discord: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 204 && resp.StatusCode != 200 {
-		return fmt.Errorf("discord: %s", resp.Status)
+		return fmt.Errorf("%s: %s", p, resp.Status)
 	}
 
 	return nil

--- a/internal/pipe/linkedin/linkedin.go
+++ b/internal/pipe/linkedin/linkedin.go
@@ -31,15 +31,15 @@ func (Pipe) Default(ctx *context.Context) error {
 	return nil
 }
 
-func (Pipe) Announce(ctx *context.Context) error {
+func (p Pipe) Announce(ctx *context.Context) error {
 	message, err := tmpl.New(ctx).Apply(ctx.Config.Announce.LinkedIn.MessageTemplate)
 	if err != nil {
-		return fmt.Errorf("linkedin: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	cfg, err := env.ParseAs[Config]()
 	if err != nil {
-		return fmt.Errorf("linkedin: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	c, err := createLinkedInClient(oauthClientConfig{
@@ -47,12 +47,12 @@ func (Pipe) Announce(ctx *context.Context) error {
 		AccessToken: cfg.AccessToken,
 	})
 	if err != nil {
-		return fmt.Errorf("linkedin: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	url, err := c.Share(ctx, message)
 	if err != nil {
-		return fmt.Errorf("linkedin: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	log.Infof("The text post is available at: %s\n", url)

--- a/internal/pipe/mastodon/mastodon.go
+++ b/internal/pipe/mastodon/mastodon.go
@@ -35,15 +35,15 @@ func (Pipe) Default(ctx *context.Context) error {
 	return nil
 }
 
-func (Pipe) Announce(ctx *context.Context) error {
+func (p Pipe) Announce(ctx *context.Context) error {
 	msg, err := tmpl.New(ctx).Apply(ctx.Config.Announce.Mastodon.MessageTemplate)
 	if err != nil {
-		return fmt.Errorf("mastodon: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	cfg, err := env.ParseAs[Config]()
 	if err != nil {
-		return fmt.Errorf("mastodon: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	client := mastodon.NewClient(&mastodon.Config{
@@ -57,7 +57,7 @@ func (Pipe) Announce(ctx *context.Context) error {
 	if _, err := client.PostStatus(ctx, &mastodon.Toot{
 		Status: msg,
 	}); err != nil {
-		return fmt.Errorf("mastodon: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 	return nil
 }

--- a/internal/pipe/mattermost/mattermost.go
+++ b/internal/pipe/mattermost/mattermost.go
@@ -52,20 +52,20 @@ func (Pipe) Default(ctx *context.Context) error {
 	return nil
 }
 
-func (Pipe) Announce(ctx *context.Context) error {
+func (p Pipe) Announce(ctx *context.Context) error {
 	msg, err := tmpl.New(ctx).Apply(ctx.Config.Announce.Mattermost.MessageTemplate)
 	if err != nil {
-		return fmt.Errorf("mattermost: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	title, err := tmpl.New(ctx).Apply(ctx.Config.Announce.Mattermost.TitleTemplate)
 	if err != nil {
-		return fmt.Errorf("teams: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	cfg, err := env.ParseAs[Config]()
 	if err != nil {
-		return fmt.Errorf("mattermost: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	log.Infof("posting: %q", msg)
@@ -86,7 +86,7 @@ func (Pipe) Announce(ctx *context.Context) error {
 
 	err = postWebhook(ctx, cfg.Webhook, wm)
 	if err != nil {
-		return fmt.Errorf("mattermost: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	return nil

--- a/internal/pipe/opencollective/opencollective.go
+++ b/internal/pipe/opencollective/opencollective.go
@@ -42,30 +42,30 @@ func (Pipe) Default(ctx *context.Context) error {
 	return nil
 }
 
-func (Pipe) Announce(ctx *context.Context) error {
+func (p Pipe) Announce(ctx *context.Context) error {
 	title, err := tmpl.New(ctx).Apply(ctx.Config.Announce.OpenCollective.TitleTemplate)
 	if err != nil {
-		return fmt.Errorf("opencollective: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 	html, err := tmpl.New(ctx).Apply(ctx.Config.Announce.OpenCollective.MessageTemplate)
 	if err != nil {
-		return fmt.Errorf("opencollective: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	cfg, err := env.ParseAs[Config]()
 	if err != nil {
-		return fmt.Errorf("opencollective: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	log.Infof("posting: %q | %q", title, html)
 
 	id, err := createUpdate(ctx, title, html, ctx.Config.Announce.OpenCollective.Slug, cfg.Token)
 	if err != nil {
-		return fmt.Errorf("opencollective: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	if err := publishUpdate(ctx, id, cfg.Token); err != nil {
-		return fmt.Errorf("opencollective: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	return nil

--- a/internal/pipe/reddit/reddit.go
+++ b/internal/pipe/reddit/reddit.go
@@ -41,15 +41,15 @@ func (Pipe) Default(ctx *context.Context) error {
 	return nil
 }
 
-func (Pipe) Announce(ctx *context.Context) error {
+func (p Pipe) Announce(ctx *context.Context) error {
 	title, err := tmpl.New(ctx).Apply(ctx.Config.Announce.Reddit.TitleTemplate)
 	if err != nil {
-		return fmt.Errorf("reddit: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	url, err := tmpl.New(ctx).Apply(ctx.Config.Announce.Reddit.URLTemplate)
 	if err != nil {
-		return fmt.Errorf("reddit: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	linkRequest := reddit.SubmitLinkRequest{
@@ -60,18 +60,18 @@ func (Pipe) Announce(ctx *context.Context) error {
 
 	cfg, err := env.ParseAs[Config]()
 	if err != nil {
-		return fmt.Errorf("reddit: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	credentials := reddit.Credentials{ID: ctx.Config.Announce.Reddit.ApplicationID, Secret: cfg.Secret, Username: ctx.Config.Announce.Reddit.Username, Password: cfg.Password}
 	client, err := reddit.NewClient(credentials)
 	if err != nil {
-		return fmt.Errorf("reddit: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	post, _, err := client.Post.SubmitLink(ctx, linkRequest)
 	if err != nil {
-		return fmt.Errorf("reddit: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	log.Infof("The text post is available at: %s\n", post.URL)

--- a/internal/pipe/slack/slack.go
+++ b/internal/pipe/slack/slack.go
@@ -40,15 +40,15 @@ func (Pipe) Default(ctx *context.Context) error {
 	return nil
 }
 
-func (Pipe) Announce(ctx *context.Context) error {
+func (p Pipe) Announce(ctx *context.Context) error {
 	msg, err := tmpl.New(ctx).Apply(ctx.Config.Announce.Slack.MessageTemplate)
 	if err != nil {
-		return fmt.Errorf("slack: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	cfg, err := env.ParseAs[Config]()
 	if err != nil {
-		return fmt.Errorf("slack: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	log.Infof("posting: '%s'", msg)
@@ -73,7 +73,7 @@ func (Pipe) Announce(ctx *context.Context) error {
 
 	err = slack.PostWebhook(cfg.Webhook, wm)
 	if err != nil {
-		return fmt.Errorf("slack: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	return nil

--- a/internal/pipe/smtp/smtp.go
+++ b/internal/pipe/smtp/smtp.go
@@ -46,15 +46,15 @@ func (Pipe) Default(ctx *context.Context) error {
 	return nil
 }
 
-func (Pipe) Announce(ctx *context.Context) error {
+func (p Pipe) Announce(ctx *context.Context) error {
 	subject, err := tmpl.New(ctx).Apply(ctx.Config.Announce.SMTP.SubjectTemplate)
 	if err != nil {
-		return fmt.Errorf("SMTP: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	body, err := tmpl.New(ctx).Apply(ctx.Config.Announce.SMTP.BodyTemplate)
 	if err != nil {
-		return fmt.Errorf("SMTP: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	m := gomail.NewMessage()
@@ -86,7 +86,7 @@ func (Pipe) Announce(ctx *context.Context) error {
 
 	// Now send E-Mail
 	if err := d.DialAndSend(m); err != nil {
-		return fmt.Errorf("SMTP: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	log.Infof("The mail has been send from %s to %s\n", ctx.Config.Announce.SMTP.From, receivers)

--- a/internal/pipe/teams/teams.go
+++ b/internal/pipe/teams/teams.go
@@ -50,17 +50,17 @@ func (p Pipe) Default(ctx *context.Context) error {
 func (p Pipe) Announce(ctx *context.Context) error {
 	title, err := tmpl.New(ctx).Apply(ctx.Config.Announce.Teams.TitleTemplate)
 	if err != nil {
-		return fmt.Errorf("teams: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	msg, err := tmpl.New(ctx).Apply(ctx.Config.Announce.Teams.MessageTemplate)
 	if err != nil {
-		return fmt.Errorf("teams: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	cfg, err := env.ParseAs[Config]()
 	if err != nil {
-		return fmt.Errorf("teams: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	log.Infof("posting: '%s'", msg)
@@ -77,11 +77,11 @@ func (p Pipe) Announce(ctx *context.Context) error {
 	messageCardSection.ActivityImage = ctx.Config.Announce.Teams.IconURL
 	err = msgCard.AddSection(messageCardSection)
 	if err != nil {
-		return fmt.Errorf("teams: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 	err = client.Send(cfg.Webhook, msgCard)
 	if err != nil {
-		return fmt.Errorf("teams: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 	return nil
 }

--- a/internal/pipe/telegram/telegram.go
+++ b/internal/pipe/telegram/telegram.go
@@ -43,7 +43,7 @@ func (Pipe) Default(ctx *context.Context) error {
 	return nil
 }
 
-func (Pipe) Announce(ctx *context.Context) error {
+func (p Pipe) Announce(ctx *context.Context) error {
 	msg, chatID, err := getMessageDetails(ctx)
 	if err != nil {
 		return err
@@ -51,20 +51,20 @@ func (Pipe) Announce(ctx *context.Context) error {
 
 	cfg, err := env.ParseAs[Config]()
 	if err != nil {
-		return fmt.Errorf("telegram: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	log.Infof("posting: '%s'", msg)
 	bot, err := api.NewBotAPI(cfg.ConsumerToken)
 	if err != nil {
-		return fmt.Errorf("telegram: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	tm := api.NewMessage(chatID, msg)
 	tm.ParseMode = "MarkdownV2"
 	_, err = bot.Send(tm)
 	if err != nil {
-		return fmt.Errorf("telegram: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 	log.Debug("message sent")
 	return nil

--- a/internal/pipe/twitter/twitter.go
+++ b/internal/pipe/twitter/twitter.go
@@ -36,15 +36,15 @@ func (Pipe) Default(ctx *context.Context) error {
 	return nil
 }
 
-func (Pipe) Announce(ctx *context.Context) error {
+func (p Pipe) Announce(ctx *context.Context) error {
 	msg, err := tmpl.New(ctx).Apply(ctx.Config.Announce.Twitter.MessageTemplate)
 	if err != nil {
-		return fmt.Errorf("twitter: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	cfg, err := env.ParseAs[Config]()
 	if err != nil {
-		return fmt.Errorf("twitter: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	log.Infof("posting: '%s'", msg)
@@ -52,7 +52,7 @@ func (Pipe) Announce(ctx *context.Context) error {
 	token := oauth1.NewToken(cfg.AccessToken, cfg.AccessSecret)
 	client := twitter.NewClient(config.Client(oauth1.NoContext, token))
 	if _, _, err := client.Statuses.Update(msg, nil); err != nil {
-		return fmt.Errorf("twitter: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 	return nil
 }

--- a/internal/pipe/webhook/webhook.go
+++ b/internal/pipe/webhook/webhook.go
@@ -3,7 +3,6 @@ package webhook
 
 import (
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -59,28 +58,28 @@ func (p Pipe) Default(ctx *context.Context) error {
 func (p Pipe) Announce(ctx *context.Context) error {
 	cfg, err := env.ParseAs[Config]()
 	if err != nil {
-		return fmt.Errorf("webhook: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	endpointURLConfig, err := tmpl.New(ctx).Apply(ctx.Config.Announce.Webhook.EndpointURL)
 	if err != nil {
-		return fmt.Errorf("webhook: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 	if len(endpointURLConfig) == 0 {
-		return errors.New("webhook: no endpoint url")
+		return fmt.Errorf("%s: no endpoint url", p)
 	}
 
 	if _, err := url.ParseRequestURI(endpointURLConfig); err != nil {
-		return fmt.Errorf("webhook: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 	endpointURL, err := url.Parse(endpointURLConfig)
 	if err != nil {
-		return fmt.Errorf("webhook: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	msg, err := tmpl.New(ctx).Apply(ctx.Config.Announce.Webhook.MessageTemplate)
 	if err != nil {
-		return fmt.Errorf("webhook: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 
 	log.Infof("posting: '%s'", msg)
@@ -96,7 +95,7 @@ func (p Pipe) Announce(ctx *context.Context) error {
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL.String(), strings.NewReader(msg))
 	if err != nil {
-		return fmt.Errorf("webhook: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 	req.Header.Add(ContentTypeHeaderKey, ctx.Config.Announce.Webhook.ContentType)
 	req.Header.Add(UserAgentHeaderKey, UserAgentHeaderValue)
@@ -115,7 +114,7 @@ func (p Pipe) Announce(ctx *context.Context) error {
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("webhook: %w", err)
+		return fmt.Errorf("%s: %w", p, err)
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
This PR uses this setup in announcer error messages. It also fixes an error where the Mattermost announcer mistakenly refers to itself as Teams. Creating this PR was brought up in #6199.