### PR TITLE
fix(github): more details if sync and create ref fail

### DIFF
--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -727,7 +727,7 @@ func githubErrLogger(resp *github.Response, err error) *log.Entry {
 }
 
 func bodyOf(resp *github.Response) string {
-	if resp == nil {
+	if resp == nil || resp.Body == nil {
 		return "no response"
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
@andreynering reported an error in the go-task release process, and it's impossible to figure out what causes it.

this might help, I think.

https://github.com/go-task/task/actions/runs/19277377006/job/55120379540