### PR TITLE
fix(github): improve create/update file

### DIFF
--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -368,7 +368,9 @@ func (c *githubClient) CreateFile(
 		return fmt.Errorf("could not get %q: %w", path, err)
 	}
 
-	options.SHA = github.Ptr(file.GetSHA())
+	if file != nil {
+		options.SHA = file.SHA
+	}
 	if _, _, err := c.client.Repositories.UpdateFile(
 		ctx,
 		repo.Owner,

--- a/internal/client/github_test.go
+++ b/internal/client/github_test.go
@@ -761,6 +761,9 @@ func TestGitHubCreateFileHappyPathCreate(t *testing.T) {
 		}
 
 		if r.URL.Path == "/api/v3/repos/someone/something/contents/file.txt" && r.Method == http.MethodPut {
+			var data github.RepositoryContentFileOptions
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&data))
+			assert.Nil(t, data.SHA)
 			w.WriteHeader(http.StatusOK)
 			return
 		}
@@ -807,6 +810,9 @@ func TestGitHubCreateFileHappyPathUpdate(t *testing.T) {
 		}
 
 		if r.URL.Path == "/api/v3/repos/someone/something/contents/file.txt" && r.Method == http.MethodPut {
+			var data github.RepositoryContentFileOptions
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&data))
+			assert.Equal(t, "fake", data.GetSHA())
 			w.WriteHeader(http.StatusOK)
 			return
 		}


### PR DESCRIPTION
I've seen that since today GitHub API seems to be failing when creating new files through this endpoint, I think they changed something in their implementation, and, technically, I think we were sending an invalid request (empty SHA instead of `nil` SHA).

If the file don't yet exist, we should leave the SHA `nil` instead. 
If that's the reason, this should fix it.