### PR TITLE
fix(nix): use stdenvNoCC.hostPlatform.system instead of deprecated system parameter

### DIFF
--- a/internal/pipe/nix/testdata/TestRunPipe/deps_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/deps_build.nix.golden
@@ -12,7 +12,7 @@
   makeWrapper,
 }:
 let
-  system = stdenvNoCC.hostPlatform.system;
+  inherit (stdenvNoCC.hostPlatform) system;
   shaMap = {
     i686-linux = "0000000000000000000000000000000000000000000000000000";
     x86_64-linux = "0000000000000000000000000000000000000000000000000000";

--- a/internal/pipe/nix/testdata/TestRunPipe/deps_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/deps_publish.nix.golden
@@ -12,7 +12,7 @@
   makeWrapper,
 }:
 let
-  system = stdenvNoCC.hostPlatform.system;
+  inherit (stdenvNoCC.hostPlatform) system;
   shaMap = {
     i686-linux = "sha16";
     x86_64-linux = "sha1";

--- a/internal/pipe/nix/testdata/TestRunPipe/extra-install_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/extra-install_build.nix.golden
@@ -12,7 +12,7 @@
   makeWrapper,
 }:
 let
-  system = stdenvNoCC.hostPlatform.system;
+  inherit (stdenvNoCC.hostPlatform) system;
   shaMap = {
     i686-linux = "0000000000000000000000000000000000000000000000000000";
     x86_64-linux = "0000000000000000000000000000000000000000000000000000";

--- a/internal/pipe/nix/testdata/TestRunPipe/extra-install_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/extra-install_publish.nix.golden
@@ -12,7 +12,7 @@
   makeWrapper,
 }:
 let
-  system = stdenvNoCC.hostPlatform.system;
+  inherit (stdenvNoCC.hostPlatform) system;
   shaMap = {
     i686-linux = "sha16";
     x86_64-linux = "sha1";

--- a/internal/pipe/nix/testdata/TestRunPipe/minimal_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/minimal_build.nix.golden
@@ -7,7 +7,7 @@
   stdenvNoCC,
 }:
 let
-  system = stdenvNoCC.hostPlatform.system;
+  inherit (stdenvNoCC.hostPlatform) system;
   shaMap = {
     i686-linux = "0000000000000000000000000000000000000000000000000000";
     x86_64-linux = "0000000000000000000000000000000000000000000000000000";

--- a/internal/pipe/nix/testdata/TestRunPipe/minimal_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/minimal_publish.nix.golden
@@ -7,7 +7,7 @@
   stdenvNoCC,
 }:
 let
-  system = stdenvNoCC.hostPlatform.system;
+  inherit (stdenvNoCC.hostPlatform) system;
   shaMap = {
     i686-linux = "sha16";
     x86_64-linux = "sha1";

--- a/internal/pipe/nix/testdata/TestRunPipe/open-pr_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/open-pr_build.nix.golden
@@ -7,7 +7,7 @@
   stdenvNoCC,
 }:
 let
-  system = stdenvNoCC.hostPlatform.system;
+  inherit (stdenvNoCC.hostPlatform) system;
   shaMap = {
     i686-linux = "0000000000000000000000000000000000000000000000000000";
     x86_64-linux = "0000000000000000000000000000000000000000000000000000";

--- a/internal/pipe/nix/testdata/TestRunPipe/open-pr_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/open-pr_publish.nix.golden
@@ -7,7 +7,7 @@
   stdenvNoCC,
 }:
 let
-  system = stdenvNoCC.hostPlatform.system;
+  inherit (stdenvNoCC.hostPlatform) system;
   shaMap = {
     i686-linux = "sha16";
     x86_64-linux = "sha1";

--- a/internal/pipe/nix/testdata/TestRunPipe/partial_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/partial_build.nix.golden
@@ -7,7 +7,7 @@
   stdenvNoCC,
 }:
 let
-  system = stdenvNoCC.hostPlatform.system;
+  inherit (stdenvNoCC.hostPlatform) system;
   shaMap = {
     x86_64-linux = "0000000000000000000000000000000000000000000000000000";
     x86_64-darwin = "0000000000000000000000000000000000000000000000000000";

--- a/internal/pipe/nix/testdata/TestRunPipe/partial_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/partial_publish.nix.golden
@@ -7,7 +7,7 @@
   stdenvNoCC,
 }:
 let
-  system = stdenvNoCC.hostPlatform.system;
+  inherit (stdenvNoCC.hostPlatform) system;
   shaMap = {
     x86_64-linux = "sha1";
     x86_64-darwin = "sha3";

--- a/internal/pipe/nix/testdata/TestRunPipe/skip-upload-auto_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/skip-upload-auto_build.nix.golden
@@ -7,7 +7,7 @@
   stdenvNoCC,
 }:
 let
-  system = stdenvNoCC.hostPlatform.system;
+  inherit (stdenvNoCC.hostPlatform) system;
   shaMap = {
     i686-linux = "0000000000000000000000000000000000000000000000000000";
     x86_64-linux = "0000000000000000000000000000000000000000000000000000";

--- a/internal/pipe/nix/testdata/TestRunPipe/skip-upload_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/skip-upload_build.nix.golden
@@ -7,7 +7,7 @@
   stdenvNoCC,
 }:
 let
-  system = stdenvNoCC.hostPlatform.system;
+  inherit (stdenvNoCC.hostPlatform) system;
   shaMap = {
     i686-linux = "0000000000000000000000000000000000000000000000000000";
     x86_64-linux = "0000000000000000000000000000000000000000000000000000";

--- a/internal/pipe/nix/testdata/TestRunPipe/unibin-replaces_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/unibin-replaces_build.nix.golden
@@ -7,7 +7,7 @@
   stdenvNoCC,
 }:
 let
-  system = stdenvNoCC.hostPlatform.system;
+  inherit (stdenvNoCC.hostPlatform) system;
   shaMap = {
     i686-linux = "0000000000000000000000000000000000000000000000000000";
     x86_64-linux = "0000000000000000000000000000000000000000000000000000";

--- a/internal/pipe/nix/testdata/TestRunPipe/unibin-replaces_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/unibin-replaces_publish.nix.golden
@@ -7,7 +7,7 @@
   stdenvNoCC,
 }:
 let
-  system = stdenvNoCC.hostPlatform.system;
+  inherit (stdenvNoCC.hostPlatform) system;
   shaMap = {
     i686-linux = "sha16";
     x86_64-linux = "sha1";

--- a/internal/pipe/nix/testdata/TestRunPipe/wrapped-in-dir_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/wrapped-in-dir_build.nix.golden
@@ -7,7 +7,7 @@
   stdenvNoCC,
 }:
 let
-  system = stdenvNoCC.hostPlatform.system;
+  inherit (stdenvNoCC.hostPlatform) system;
   shaMap = {
     i686-linux = "0000000000000000000000000000000000000000000000000000";
     x86_64-linux = "0000000000000000000000000000000000000000000000000000";

--- a/internal/pipe/nix/testdata/TestRunPipe/wrapped-in-dir_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/wrapped-in-dir_publish.nix.golden
@@ -7,7 +7,7 @@
   stdenvNoCC,
 }:
 let
-  system = stdenvNoCC.hostPlatform.system;
+  inherit (stdenvNoCC.hostPlatform) system;
   shaMap = {
     i686-linux = "sha16";
     x86_64-linux = "sha1";

--- a/internal/pipe/nix/testdata/TestRunPipe/zip-and-tar_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip-and-tar_build.nix.golden
@@ -8,7 +8,7 @@
   unzip,
 }:
 let
-  system = stdenvNoCC.hostPlatform.system;
+  inherit (stdenvNoCC.hostPlatform) system;
   shaMap = {
     i686-linux = "0000000000000000000000000000000000000000000000000000";
     aarch64-linux = "0000000000000000000000000000000000000000000000000000";

--- a/internal/pipe/nix/testdata/TestRunPipe/zip-and-tar_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip-and-tar_publish.nix.golden
@@ -8,7 +8,7 @@
   unzip,
 }:
 let
-  system = stdenvNoCC.hostPlatform.system;
+  inherit (stdenvNoCC.hostPlatform) system;
   shaMap = {
     i686-linux = "sha16";
     aarch64-linux = "sha2";

--- a/internal/pipe/nix/testdata/TestRunPipe/zip-with-dependencies_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip-with-dependencies_build.nix.golden
@@ -10,7 +10,7 @@
   unzip,
 }:
 let
-  system = stdenvNoCC.hostPlatform.system;
+  inherit (stdenvNoCC.hostPlatform) system;
   shaMap = {
     i686-linux = "0000000000000000000000000000000000000000000000000000";
     x86_64-linux = "0000000000000000000000000000000000000000000000000000";

--- a/internal/pipe/nix/testdata/TestRunPipe/zip-with-dependencies_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip-with-dependencies_publish.nix.golden
@@ -10,7 +10,7 @@
   unzip,
 }:
 let
-  system = stdenvNoCC.hostPlatform.system;
+  inherit (stdenvNoCC.hostPlatform) system;
   shaMap = {
     i686-linux = "sha15";
     x86_64-linux = "sha8";

--- a/internal/pipe/nix/testdata/TestRunPipe/zip_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip_build.nix.golden
@@ -8,7 +8,7 @@
   unzip,
 }:
 let
-  system = stdenvNoCC.hostPlatform.system;
+  inherit (stdenvNoCC.hostPlatform) system;
   shaMap = {
     i686-linux = "0000000000000000000000000000000000000000000000000000";
     x86_64-linux = "0000000000000000000000000000000000000000000000000000";

--- a/internal/pipe/nix/testdata/TestRunPipe/zip_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip_publish.nix.golden
@@ -8,7 +8,7 @@
   unzip,
 }:
 let
-  system = stdenvNoCC.hostPlatform.system;
+  inherit (stdenvNoCC.hostPlatform) system;
   shaMap = {
     i686-linux = "sha15";
     x86_64-linux = "sha8";

--- a/internal/pipe/nix/tmpl.nix
+++ b/internal/pipe/nix/tmpl.nix
@@ -10,7 +10,7 @@
 {{- end }}
 }:
 let
-  system = stdenvNoCC.hostPlatform.system;
+  inherit (stdenvNoCC.hostPlatform) system;
   shaMap = {
     {{- with  .Archives.linux386.Sha }}
     i686-linux = "{{ . }}";


### PR DESCRIPTION
<!-- If applied, this commit will... -->

Fix the deprecation warning that appears on NixOS 24.11+ when using GoReleaser-generated nix packages:

```
evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'
```

The change:
- Removes the `system ? builtins.currentSystem` function parameter
- Derives `system` from `stdenvNoCC.hostPlatform.system` in the let block
- Reformats function parameters to use consistent Nix style
- Removes the redundant `system = system;` derivation attribute

<!-- Why is this change being made? -->

The old pattern had two issues:

1. **Function parameter**: `system ? builtins.currentSystem` — when `callPackage` passes arguments, it provides `pkgs.system` which is now a deprecated alias
2. **Derivation attribute**: `system = system;` — redundant since `stdenvNoCC.mkDerivation` already sets this via `stdenv.hostPlatform.system`

This change is safe because:
- The `system` variable remains available in the template for URL/SHA map lookups
- `stdenvNoCC.hostPlatform.system` is the canonical, non-deprecated way to access platform information
- This improves cross-compilation support (the original motivation for the deprecation)
- Tested on NixOS unstable — packages build and run correctly

<!-- Provide links to any relevant tickets, URLs or other resources -->

- [NixOS Discourse: How to fix the 'system' deprecation warning](https://discourse.nixos.org/t/how-to-fix-evaluation-warning-system-has-been-renamed-to-replaced-by-stdenv-hostplatform-system/72120)
- [Blog: Nix best practices for system handling](https://isabelroses.com/blog/im-not-mad-im-disappointed/)
- [nixpkgs Issue #27069: Reduce redundant ways to inspect platforms](https://github.com/NixOS/nixpkgs/issues/27069)
- [nixpkgs PR #209816: Deprecate toplevel platform attributes](https://github.com/NixOS/nixpkgs/pull/209816)

---

**Testing:**
- [x] All existing nix pipe tests pass locally
- [x] golangci-lint passes with 0 issues
- [x] `task build` succeeds
- [x] Manually tested generated packages (dagger, container-use) on NixOS unstable