### PR TITLE
refactor: fix deprecated method usage in tests 

### DIFF
--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -70,7 +70,7 @@ func TestSetupPipeline(t *testing.T) {
 		require.Equal(
 			t,
 			pipeline.BuildCmdPipeline,
-			setupPipeline(testctx.New(), buildOpts{}),
+			setupPipeline(testctx.Wrap(t.Context()), buildOpts{}),
 		)
 	})
 
@@ -78,7 +78,7 @@ func TestSetupPipeline(t *testing.T) {
 		require.Equal(
 			t,
 			pipeline.BuildCmdPipeline,
-			setupPipeline(testctx.New(), buildOpts{
+			setupPipeline(testctx.Wrap(t.Context()), buildOpts{
 				singleTarget: true,
 			}),
 		)
@@ -88,7 +88,7 @@ func TestSetupPipeline(t *testing.T) {
 		require.Equal(
 			t,
 			pipeline.BuildCmdPipeline,
-			setupPipeline(testctx.New(), buildOpts{
+			setupPipeline(testctx.Wrap(t.Context()), buildOpts{
 				singleTarget: true,
 				ids:          []string{"foo"},
 			}),
@@ -99,7 +99,7 @@ func TestSetupPipeline(t *testing.T) {
 		require.Equal(
 			t,
 			append(pipeline.BuildCmdPipeline, withOutputPipe{"foobar"}),
-			setupPipeline(testctx.New(), buildOpts{
+			setupPipeline(testctx.Wrap(t.Context()), buildOpts{
 				singleTarget: true,
 				ids:          []string{"foo"},
 				output:       ".",
@@ -112,9 +112,10 @@ func TestSetupPipeline(t *testing.T) {
 			t,
 			pipeline.BuildCmdPipeline,
 			setupPipeline(
-				testctx.NewWithCfg(config.Project{
+				testctx.WrapWithCfg(t.Context(), config.Project{
 					Builds: []config.Build{{}},
 				}),
+
 				buildOpts{
 					singleTarget: true,
 				},
@@ -127,7 +128,7 @@ func TestSetupPipeline(t *testing.T) {
 			t,
 			append(pipeline.BuildCmdPipeline, withOutputPipe{"foobar"}),
 			setupPipeline(
-				testctx.New(),
+				testctx.Wrap(t.Context()),
 				buildOpts{
 					singleTarget: true,
 					ids:          []string{"foo"},
@@ -142,9 +143,10 @@ func TestSetupPipeline(t *testing.T) {
 			t,
 			append(pipeline.BuildCmdPipeline, withOutputPipe{"zaz"}),
 			setupPipeline(
-				testctx.NewWithCfg(config.Project{
+				testctx.WrapWithCfg(t.Context(), config.Project{
 					Builds: []config.Build{{}},
 				}),
+
 				buildOpts{
 					singleTarget: true,
 					output:       "zaz",
@@ -156,7 +158,7 @@ func TestSetupPipeline(t *testing.T) {
 
 func TestBuildFlags(t *testing.T) {
 	setup := func(opts buildOpts) *context.Context {
-		ctx := testctx.New()
+		ctx := testctx.Wrap(t.Context())
 		require.NoError(t, setupBuildContext(ctx, opts))
 		return ctx
 	}
@@ -200,7 +202,7 @@ func TestBuildFlags(t *testing.T) {
 
 	t.Run("id", func(t *testing.T) {
 		t.Run("match", func(t *testing.T) {
-			ctx := testctx.NewWithCfg(config.Project{
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 				Builds: []config.Build{
 					{
 						ID: "default",
@@ -210,13 +212,14 @@ func TestBuildFlags(t *testing.T) {
 					},
 				},
 			})
+
 			require.NoError(t, setupBuildContext(ctx, buildOpts{
 				ids: []string{"foo"},
 			}))
 		})
 
 		t.Run("match-multiple", func(t *testing.T) {
-			ctx := testctx.NewWithCfg(config.Project{
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 				Builds: []config.Build{
 					{
 						ID: "default",
@@ -226,13 +229,14 @@ func TestBuildFlags(t *testing.T) {
 					},
 				},
 			})
+
 			require.NoError(t, setupBuildContext(ctx, buildOpts{
 				ids: []string{"foo", "default"},
 			}))
 		})
 
 		t.Run("match-partial", func(t *testing.T) {
-			ctx := testctx.NewWithCfg(config.Project{
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 				Builds: []config.Build{
 					{
 						ID: "default",
@@ -242,13 +246,14 @@ func TestBuildFlags(t *testing.T) {
 					},
 				},
 			})
+
 			require.NoError(t, setupBuildContext(ctx, buildOpts{
 				ids: []string{"foo", "notdefault"},
 			}))
 		})
 
 		t.Run("dont match", func(t *testing.T) {
-			ctx := testctx.NewWithCfg(config.Project{
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 				Builds: []config.Build{
 					{
 						ID: "foo",
@@ -258,26 +263,28 @@ func TestBuildFlags(t *testing.T) {
 					},
 				},
 			})
+
 			require.EqualError(t, setupBuildContext(ctx, buildOpts{
 				ids: []string{"bar", "fooz"},
 			}), "no builds with ids bar, fooz")
 		})
 
 		t.Run("default config", func(t *testing.T) {
-			ctx := testctx.New()
+			ctx := testctx.Wrap(t.Context())
 			require.NoError(t, setupBuildContext(ctx, buildOpts{
 				ids: []string{"aaa"},
 			}))
 		})
 
 		t.Run("single build config", func(t *testing.T) {
-			ctx := testctx.NewWithCfg(config.Project{
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 				Builds: []config.Build{
 					{
 						ID: "foo",
 					},
 				},
 			})
+
 			require.NoError(t, setupBuildContext(ctx, buildOpts{
 				ids: []string{"not foo but doesnt matter"},
 			}))

--- a/cmd/release_test.go
+++ b/cmd/release_test.go
@@ -58,7 +58,7 @@ func TestReleaseBrokenProject(t *testing.T) {
 func TestReleaseFlags(t *testing.T) {
 	setup := func(tb testing.TB, opts releaseOpts) *context.Context {
 		tb.Helper()
-		ctx := testctx.New()
+		ctx := testctx.Wrap(t.Context())
 		require.NoError(t, setupReleaseContext(ctx, opts))
 		return ctx
 	}
@@ -77,11 +77,12 @@ func TestReleaseFlags(t *testing.T) {
 		})
 
 		t.Run("set in config", func(t *testing.T) {
-			ctx := testctx.NewWithCfg(config.Project{
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 				Release: config.Release{
 					Draft: true,
 				},
 			})
+
 			require.NoError(t, setupReleaseContext(ctx, releaseOpts{}))
 			require.True(t, ctx.Config.Release.Draft)
 		})

--- a/internal/archivefiles/archivefiles_test.go
+++ b/internal/archivefiles/archivefiles_test.go
@@ -13,9 +13,10 @@ import (
 
 func TestEval(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Env: []string{"OWNER=carlos", "FOLDER=d"},
 	})
+
 	ctx.Git.CommitDate = now
 	tmpl := tmpl.New(ctx)
 

--- a/internal/builders/base/build_test.go
+++ b/internal/builders/base/build_test.go
@@ -85,7 +85,7 @@ func TestChTimes(t *testing.T) {
 		build := config.Build{
 			ModTimestamp: "{{.Env.A}}",
 		}
-		tpl := tmpl.New(testctx.New()).SetEnv("A=" + strconv.FormatInt(modTime.Unix(), 10))
+		tpl := tmpl.New(testctx.Wrap(t.Context())).SetEnv("A=" + strconv.FormatInt(modTime.Unix(), 10))
 		require.NoError(t, ChTimes(build, tpl, &artifact.Artifact{
 			Path: name,
 		}))
@@ -99,7 +99,7 @@ func TestChTimes(t *testing.T) {
 		build := config.Build{
 			ModTimestamp: "{{.Env.A}}",
 		}
-		tpl := tmpl.New(testctx.New())
+		tpl := tmpl.New(testctx.Wrap(t.Context()))
 		require.Error(t, ChTimes(build, tpl, &artifact.Artifact{
 			Path: name,
 		}))
@@ -109,7 +109,7 @@ func TestChTimes(t *testing.T) {
 		build := config.Build{
 			ModTimestamp: "invalid",
 		}
-		tpl := tmpl.New(testctx.New())
+		tpl := tmpl.New(testctx.Wrap(t.Context()))
 		require.Error(t, ChTimes(build, tpl, &artifact.Artifact{
 			Path: name,
 		}))
@@ -117,7 +117,7 @@ func TestChTimes(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		name := filepath.Join(t.TempDir(), "file")
 		build := config.Build{}
-		tpl := tmpl.New(testctx.New())
+		tpl := tmpl.New(testctx.Wrap(t.Context()))
 		require.NoError(t, ChTimes(build, tpl, &artifact.Artifact{
 			Path: name,
 		}))
@@ -140,7 +140,7 @@ func TestTemplateEnv(t *testing.T) {
 			},
 		},
 	}
-	tpl := tmpl.New(testctx.New()).SetEnv("FU=foobar").WithArtifact(&artifact.Artifact{
+	tpl := tmpl.New(testctx.Wrap(t.Context())).SetEnv("FU=foobar").WithArtifact(&artifact.Artifact{
 		Goos: "linux",
 	})
 
@@ -154,5 +154,5 @@ func TestTemplateEnv(t *testing.T) {
 }
 
 func TestExec(t *testing.T) {
-	require.NoError(t, Exec(testctx.New(), []string{"echo", "$FOO"}, []string{"FOO=foobar"}, "."))
+	require.NoError(t, Exec(testctx.Wrap(t.Context()), []string{"echo", "$FOO"}, []string{"FOO=foobar"}, "."))
 }

--- a/internal/builders/bun/build_test.go
+++ b/internal/builders/bun/build_test.go
@@ -113,7 +113,7 @@ func TestBuild(t *testing.T) {
 	require.NoError(t, err)
 
 	modTime := time.Now().AddDate(-1, 0, 0).Round(time.Second).UTC()
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        "dist",
 		ProjectName: "proj",
 		Builds: []config.Build{
@@ -124,6 +124,7 @@ func TestBuild(t *testing.T) {
 			},
 		},
 	})
+
 	build, err := Default.WithDefaults(ctx.Config.Builds[0])
 	require.NoError(t, err)
 

--- a/internal/builders/deno/build_test.go
+++ b/internal/builders/deno/build_test.go
@@ -77,7 +77,7 @@ func TestBuild(t *testing.T) {
 	require.NoError(t, err)
 
 	modTime := time.Now().AddDate(-1, 0, 0).Round(time.Second).UTC()
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        "dist",
 		ProjectName: "proj",
 		Builds: []config.Build{
@@ -88,6 +88,7 @@ func TestBuild(t *testing.T) {
 			},
 		},
 	})
+
 	build, err := Default.WithDefaults(ctx.Config.Builds[0])
 	require.NoError(t, err)
 

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -351,11 +351,12 @@ func TestWithDefaults(t *testing.T) {
 			if testcase.build.Tool != "" && testcase.build.Tool != "go" {
 				createFakeGoBinaryWithVersion(t, testcase.build.Tool, "go1.18")
 			}
-			ctx := testctx.NewWithCfg(config.Project{
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 				Builds: []config.Build{
 					testcase.build,
 				},
 			}, testctx.WithCurrentTag("5.6.7"))
+
 			build, err := Default.WithDefaults(ctx.Config.Builds[0])
 			require.NoError(t, err)
 			require.ElementsMatch(t, build.Targets, testcase.targets)
@@ -442,11 +443,12 @@ func TestInvalidTargets(t *testing.T) {
 		},
 	} {
 		t.Run(s, func(t *testing.T) {
-			ctx := testctx.NewWithCfg(config.Project{
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 				Builds: []config.Build{
 					tc.build,
 				},
 			})
+
 			_, err := Default.WithDefaults(ctx.Config.Builds[0])
 			require.EqualError(t, err, tc.expectedErr)
 		})
@@ -456,7 +458,7 @@ func TestInvalidTargets(t *testing.T) {
 func TestBuild(t *testing.T) {
 	folder := testlib.Mktmp(t)
 	writeGoodMain(t, folder)
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Env: []string{"GO_FLAGS=-v", "GOBIN=go"},
 		Builds: []config.Build{
 			{
@@ -500,6 +502,7 @@ func TestBuild(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v5.6.7"), testctx.WithVersion("v5.6.7"))
+
 	build := ctx.Config.Builds[0]
 	for _, target := range build.Targets {
 		var ext string
@@ -633,7 +636,7 @@ func TestBuild(t *testing.T) {
 func TestBuildInvalidEnv(t *testing.T) {
 	folder := testlib.Mktmp(t)
 	writeGoodMain(t, folder)
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds: []config.Build{
 			{
 				ID:     "foo",
@@ -649,6 +652,7 @@ func TestBuildInvalidEnv(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("5.6.7"))
+
 	build := ctx.Config.Builds[0]
 	err := Default.Build(ctx, build, api.Options{
 		Target: mustParse(t, runtimeTarget),
@@ -665,7 +669,7 @@ func TestBuildCodeInSubdir(t *testing.T) {
 	err := os.Mkdir(subdir, 0o755)
 	require.NoError(t, err)
 	writeGoodMain(t, subdir)
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds: []config.Build{
 			{
 				ID:     "foo",
@@ -682,6 +686,7 @@ func TestBuildCodeInSubdir(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("5.6.7"))
+
 	build := ctx.Config.Builds[0]
 	err = Default.Build(ctx, build, api.Options{
 		Target: mustParse(t, runtimeTarget),
@@ -696,7 +701,7 @@ func TestBuildWithDotGoDir(t *testing.T) {
 	folder := testlib.Mktmp(t)
 	require.NoError(t, os.Mkdir(filepath.Join(folder, ".go"), 0o755))
 	writeGoodMain(t, folder)
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds: []config.Build{
 			{
 				ID:      "foo",
@@ -710,6 +715,7 @@ func TestBuildWithDotGoDir(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("5.6.7"))
+
 	build := ctx.Config.Builds[0]
 	require.NoError(t, Default.Build(ctx, build, api.Options{
 		Target: mustParse(t, runtimeTarget),
@@ -722,7 +728,7 @@ func TestBuildWithDotGoDir(t *testing.T) {
 func TestBuildFailed(t *testing.T) {
 	folder := testlib.Mktmp(t)
 	writeGoodMain(t, folder)
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds: []config.Build{
 			{
 				ID: "buildid",
@@ -737,6 +743,7 @@ func TestBuildFailed(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("5.6.7"))
+
 	err := Default.Build(ctx, ctx.Config.Builds[0], api.Options{
 		Target: mustParse(t, "darwin_amd64"),
 	})
@@ -747,7 +754,7 @@ func TestBuildFailed(t *testing.T) {
 func TestRunInvalidAsmflags(t *testing.T) {
 	folder := testlib.Mktmp(t)
 	writeGoodMain(t, folder)
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds: []config.Build{
 			{
 				Binary: "nametest",
@@ -760,6 +767,7 @@ func TestRunInvalidAsmflags(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("5.6.7"))
+
 	err := Default.Build(ctx, ctx.Config.Builds[0], api.Options{
 		Target: mustParse(t, runtimeTarget),
 	})
@@ -769,7 +777,7 @@ func TestRunInvalidAsmflags(t *testing.T) {
 func TestRunInvalidGcflags(t *testing.T) {
 	folder := testlib.Mktmp(t)
 	writeGoodMain(t, folder)
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds: []config.Build{
 			{
 				Binary: "nametest",
@@ -782,6 +790,7 @@ func TestRunInvalidGcflags(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("5.6.7"))
+
 	err := Default.Build(ctx, ctx.Config.Builds[0], api.Options{
 		Target: mustParse(t, runtimeTarget),
 	})
@@ -791,7 +800,7 @@ func TestRunInvalidGcflags(t *testing.T) {
 func TestRunInvalidLdflags(t *testing.T) {
 	folder := testlib.Mktmp(t)
 	writeGoodMain(t, folder)
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds: []config.Build{
 			{
 				Binary: "nametest",
@@ -805,6 +814,7 @@ func TestRunInvalidLdflags(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("5.6.7"))
+
 	err := Default.Build(ctx, ctx.Config.Builds[0], api.Options{
 		Target: mustParse(t, runtimeTarget),
 	})
@@ -814,7 +824,7 @@ func TestRunInvalidLdflags(t *testing.T) {
 func TestRunInvalidFlags(t *testing.T) {
 	folder := testlib.Mktmp(t)
 	writeGoodMain(t, folder)
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds: []config.Build{
 			{
 				Binary: "nametest",
@@ -827,6 +837,7 @@ func TestRunInvalidFlags(t *testing.T) {
 			},
 		},
 	})
+
 	err := Default.Build(ctx, ctx.Config.Builds[0], api.Options{
 		Target: mustParse(t, runtimeTarget),
 	})
@@ -838,9 +849,10 @@ func TestRunPipeWithoutMainFunc(t *testing.T) {
 		t.Helper()
 		folder := testlib.Mktmp(t)
 		writeMainWithoutMainFunc(t, folder)
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Builds: []config.Build{{Binary: "no-main"}},
 		}, testctx.WithCurrentTag("5.6.7"))
+
 		return ctx
 	}
 	t.Run("empty", func(t *testing.T) {
@@ -887,7 +899,7 @@ func TestRunPipeWithoutMainFunc(t *testing.T) {
 func TestBuildTests(t *testing.T) {
 	folder := testlib.Mktmp(t)
 	writeTest(t, folder)
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds: []config.Build{{
 			Binary:  "foo.test",
 			Command: "test",
@@ -897,6 +909,7 @@ func TestBuildTests(t *testing.T) {
 			NoMainCheck: true,
 		}},
 	}, testctx.WithCurrentTag("5.6.7"))
+
 	build, err := Default.WithDefaults(ctx.Config.Builds[0])
 	require.NoError(t, err)
 	require.NoError(t, Default.Build(ctx, build, api.Options{
@@ -931,7 +944,7 @@ import _ "github.com/goreleaser/test-mod"
 	out, err = cmd.CombinedOutput()
 	require.NoError(t, err, string(out))
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		GoMod: config.GoMod{
 			Proxy: true,
 		},
@@ -963,7 +976,7 @@ func TestRunPipeWithMainFuncNotInMainGoFile(t *testing.T) {
 		[]byte("package main\nfunc main() {println(0)}"),
 		0o644,
 	))
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds: []config.Build{
 			{
 				Binary: "foo",
@@ -979,6 +992,7 @@ func TestRunPipeWithMainFuncNotInMainGoFile(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("5.6.7"))
+
 	t.Run("empty", func(t *testing.T) {
 		ctx.Config.Builds[0].Main = ""
 		require.NoError(t, Default.Build(ctx, ctx.Config.Builds[0], api.Options{
@@ -1002,14 +1016,14 @@ func TestRunPipeWithMainFuncNotInMainGoFile(t *testing.T) {
 func TestLdFlagsFullTemplate(t *testing.T) {
 	run := time.Now().UTC()
 	commit := time.Now().AddDate(-1, 0, 0)
-	ctx := testctx.New(
+	ctx := testctx.Wrap(t.Context(),
 		testctx.WithCurrentTag("v1.2.3"),
 		testctx.WithCommit("123"),
 		testctx.WithCommitDate(commit),
 		testctx.WithVersion("1.2.3"),
 		testctx.WithEnv(map[string]string{"FOO": "123"}),
-		testctx.WithDate(run),
-	)
+		testctx.WithDate(run))
+
 	artifact := &artifact.Artifact{Goarch: "amd64"}
 	flags, err := tmpl.New(ctx).WithArtifact(artifact).
 		Apply(`-s -w -X main.version={{.Version}} -X main.tag={{.Tag}} -X main.date={{.Date}} -X main.commit={{.Commit}} -X "main.foo={{.Env.FOO}}" -X main.time={{ time "20060102" }} -X main.arch={{.Arch}} -X main.commitDate={{.CommitDate}}`)
@@ -1031,7 +1045,7 @@ func TestInvalidTemplate(t *testing.T) {
 		"{{.Env.NOPE}}",
 	} {
 		t.Run(template, func(t *testing.T) {
-			ctx := testctx.New(testctx.WithCurrentTag("3.4.1"))
+			ctx := testctx.Wrap(t.Context(), testctx.WithCurrentTag("3.4.1"))
 			flags, err := tmpl.New(ctx).Apply(template)
 			testlib.RequireTemplateError(t, err)
 			require.Empty(t, flags)
@@ -1046,7 +1060,7 @@ func TestBuildModTimestamp(t *testing.T) {
 	folder := testlib.Mktmp(t)
 	writeGoodMain(t, folder)
 
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Env: []string{"GO_FLAGS=-v"},
 			Builds: []config.Build{{
@@ -1071,8 +1085,7 @@ func TestBuildModTimestamp(t *testing.T) {
 			}},
 		},
 		testctx.WithCurrentTag("v5.6.7"),
-		testctx.WithVersion("5.6.7"),
-	)
+		testctx.WithVersion("5.6.7"))
 
 	build := ctx.Config.Builds[0]
 	for _, target := range build.Targets {
@@ -1101,14 +1114,14 @@ func TestBuildModTimestamp(t *testing.T) {
 func TestBuildGoBuildLine(t *testing.T) {
 	requireEqualCmd := func(tb testing.TB, build config.Build, expected []string) {
 		tb.Helper()
-		ctx := testctx.NewWithCfg(
+		ctx := testctx.WrapWithCfg(t.Context(),
 			config.Project{
 				Builds: []config.Build{build},
 			},
 			testctx.WithVersion("1.2.3"),
 			testctx.WithGitInfo(context.GitInfo{Commit: "aaa"}),
-			testctx.WithEnv(map[string]string{"GOBIN": "go"}),
-		)
+			testctx.WithEnv(map[string]string{"GOBIN": "go"}))
+
 		options := api.Options{
 			Path:   ctx.Config.Builds[0].Binary,
 			Target: mustParse(t, "linux_amd64"),
@@ -1261,7 +1274,7 @@ func TestOverrides(t *testing.T) {
 	} {
 		t.Run("linux "+arch, func(t *testing.T) {
 			dets, err := withOverrides(
-				testctx.New(),
+				testctx.Wrap(t.Context()),
 				config.Build{
 					BuildDetails: config.BuildDetails{
 						Ldflags: []string{"original"},
@@ -1287,7 +1300,7 @@ func TestOverrides(t *testing.T) {
 
 	t.Run("single sided", func(t *testing.T) {
 		dets, err := withOverrides(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			config.Build{
 				BuildDetails: config.BuildDetails{},
 				BuildDetailsOverrides: []config.BuildDetailsOverride{
@@ -1316,7 +1329,7 @@ func TestOverrides(t *testing.T) {
 
 	t.Run("with template", func(t *testing.T) {
 		dets, err := withOverrides(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			config.Build{
 				BuildDetails: config.BuildDetails{
 					Ldflags:  []string{"original"},
@@ -1343,7 +1356,7 @@ func TestOverrides(t *testing.T) {
 
 	t.Run("with invalid template", func(t *testing.T) {
 		_, err := withOverrides(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			config.Build{
 				BuildDetailsOverrides: []config.BuildDetailsOverride{
 					{
@@ -1357,7 +1370,7 @@ func TestOverrides(t *testing.T) {
 
 	t.Run("with goarm64", func(t *testing.T) {
 		dets, err := withOverrides(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			config.Build{
 				BuildDetails: config.BuildDetails{
 					Ldflags: []string{"original"},
@@ -1383,7 +1396,7 @@ func TestOverrides(t *testing.T) {
 
 	t.Run("with goarm64 unspecified", func(t *testing.T) {
 		dets, err := withOverrides(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			config.Build{
 				BuildDetails: config.BuildDetails{
 					Ldflags: []string{"original"},
@@ -1408,7 +1421,7 @@ func TestOverrides(t *testing.T) {
 
 	t.Run("with goarm", func(t *testing.T) {
 		dets, err := withOverrides(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			config.Build{
 				BuildDetails: config.BuildDetails{
 					Ldflags: []string{"original"},
@@ -1434,7 +1447,7 @@ func TestOverrides(t *testing.T) {
 
 	t.Run("with goarm unspecified", func(t *testing.T) {
 		dets, err := withOverrides(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			config.Build{
 				BuildDetails: config.BuildDetails{
 					Ldflags: []string{"original"},
@@ -1459,7 +1472,7 @@ func TestOverrides(t *testing.T) {
 
 	t.Run("with gomips", func(t *testing.T) {
 		dets, err := withOverrides(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			config.Build{
 				BuildDetails: config.BuildDetails{
 					Ldflags: []string{"original"},
@@ -1485,7 +1498,7 @@ func TestOverrides(t *testing.T) {
 
 	t.Run("with gomips unspecified", func(t *testing.T) {
 		dets, err := withOverrides(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			config.Build{
 				BuildDetails: config.BuildDetails{
 					Ldflags: []string{"original"},
@@ -1510,7 +1523,7 @@ func TestOverrides(t *testing.T) {
 
 	t.Run("with goriscv64", func(t *testing.T) {
 		dets, err := withOverrides(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			config.Build{
 				BuildDetails: config.BuildDetails{
 					Ldflags: []string{"original"},
@@ -1536,7 +1549,7 @@ func TestOverrides(t *testing.T) {
 
 	t.Run("with goriscv64 unspecified", func(t *testing.T) {
 		dets, err := withOverrides(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			config.Build{
 				BuildDetails: config.BuildDetails{
 					Ldflags: []string{"original"},
@@ -1562,7 +1575,7 @@ func TestOverrides(t *testing.T) {
 
 	t.Run("with go386", func(t *testing.T) {
 		dets, err := withOverrides(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			config.Build{
 				BuildDetails: config.BuildDetails{
 					Ldflags: []string{"original"},
@@ -1588,7 +1601,7 @@ func TestOverrides(t *testing.T) {
 
 	t.Run("with go386 unspecified", func(t *testing.T) {
 		dets, err := withOverrides(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			config.Build{
 				BuildDetails: config.BuildDetails{
 					Ldflags: []string{"original"},
@@ -1649,7 +1662,7 @@ func TestInvalidGoBinaryTpl(t *testing.T) {
 	folder := testlib.Mktmp(t)
 	require.NoError(t, os.Mkdir(filepath.Join(folder, ".go"), 0o755))
 	writeGoodMain(t, folder)
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds: []config.Build{
 			{
 				Targets: []string{runtimeTarget},
@@ -1658,6 +1671,7 @@ func TestInvalidGoBinaryTpl(t *testing.T) {
 			},
 		},
 	})
+
 	build := ctx.Config.Builds[0]
 	testlib.RequireTemplateError(t, Default.Build(ctx, build, api.Options{
 		Target: mustParse(t, runtimeTarget),

--- a/internal/builders/poetry/build_test.go
+++ b/internal/builders/poetry/build_test.go
@@ -90,7 +90,7 @@ func TestBuild(t *testing.T) {
 	t.Chdir(filepath.Join(folder, "proj"))
 
 	modTime := time.Now().AddDate(-1, 0, 0).Round(time.Second).UTC()
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        filepath.Join(folder, "dist"),
 		ProjectName: "proj",
 		Builds: []config.Build{
@@ -184,7 +184,7 @@ func TestBuildSpecificModes(t *testing.T) {
 	t.Chdir(filepath.Join(folder, "proj"))
 
 	modTime := time.Now().AddDate(-1, 0, 0).Round(time.Second).UTC()
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        filepath.Join(folder, "dist"),
 		ProjectName: "proj",
 		Builds: []config.Build{

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -63,7 +63,7 @@ func TestBuild(t *testing.T) {
 	require.NoError(t, err)
 
 	modTime := time.Now().AddDate(-1, 0, 0).Round(time.Second).UTC()
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        "dist",
 		ProjectName: "proj",
 		Builds: []config.Build{
@@ -77,6 +77,7 @@ func TestBuild(t *testing.T) {
 			},
 		},
 	})
+
 	build, err := Default.WithDefaults(ctx.Config.Builds[0])
 	require.NoError(t, err)
 	require.NoError(t, Default.Prepare(ctx, build))

--- a/internal/builders/uv/build_test.go
+++ b/internal/builders/uv/build_test.go
@@ -88,7 +88,7 @@ func TestBuild(t *testing.T) {
 	require.NoError(t, err)
 
 	modTime := time.Now().AddDate(-1, 0, 0).Round(time.Second).UTC()
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        filepath.Join(folder, "dist"),
 		ProjectName: "proj",
 		Builds: []config.Build{
@@ -180,7 +180,7 @@ func TestBuildSpecificModes(t *testing.T) {
 	require.NoError(t, err)
 
 	modTime := time.Now().AddDate(-1, 0, 0).Round(time.Second).UTC()
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        filepath.Join(folder, "dist"),
 		ProjectName: "proj",
 		Builds: []config.Build{

--- a/internal/builders/zig/build_test.go
+++ b/internal/builders/zig/build_test.go
@@ -105,7 +105,7 @@ func TestBuild(t *testing.T) {
 	require.NoError(t, err)
 
 	modTime := time.Now().AddDate(-1, 0, 0).Round(time.Second).UTC()
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        "dist",
 		ProjectName: "proj",
 		Env: []string{
@@ -125,6 +125,7 @@ func TestBuild(t *testing.T) {
 			},
 		},
 	})
+
 	build, err := Default.WithDefaults(ctx.Config.Builds[0])
 	require.NoError(t, err)
 

--- a/internal/client/git_test.go
+++ b/internal/client/git_test.go
@@ -20,9 +20,10 @@ func TestGitClient(t *testing.T) {
 
 	t.Run("full", func(t *testing.T) {
 		url := testlib.GitMakeBareRepository(t)
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: t.TempDir(),
 		})
+
 		repo := Repo{
 			GitURL:     url,
 			PrivateKey: testlib.MakeNewSSHKey(t, ""),
@@ -55,9 +56,10 @@ func TestGitClient(t *testing.T) {
 
 	t.Run("with new branch", func(t *testing.T) {
 		url := testlib.GitMakeBareRepository(t)
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: t.TempDir(),
 		})
+
 		repo := Repo{
 			GitURL:     url,
 			PrivateKey: testlib.MakeNewSSHKey(t, ""),
@@ -102,9 +104,10 @@ func TestGitClient(t *testing.T) {
 
 	t.Run("no repo name", func(t *testing.T) {
 		url := testlib.GitMakeBareRepository(t)
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: t.TempDir(),
 		})
+
 		repo := Repo{
 			GitURL:     url,
 			PrivateKey: testlib.MakeNewSSHKey(t, ""),
@@ -129,9 +132,10 @@ func TestGitClient(t *testing.T) {
 		require.Equal(t, "fake content 2", string(testlib.CatFileFromBareRepository(t, url, "fake.txt")))
 	})
 	t.Run("bad url", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: t.TempDir(),
 		})
+
 		repo := Repo{
 			GitURL: "{{ .Nope }}",
 		}
@@ -146,9 +150,10 @@ func TestGitClient(t *testing.T) {
 		))
 	})
 	t.Run("clone fail", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: t.TempDir(),
 		})
+
 		repo := Repo{
 			GitURL:     "git@github.com:nope/nopenopenopenope",
 			PrivateKey: testlib.MakeNewSSHKey(t, ""),
@@ -165,9 +170,10 @@ func TestGitClient(t *testing.T) {
 		require.ErrorContains(t, err, "failed to clone")
 	})
 	t.Run("bad ssh cmd", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: t.TempDir(),
 		})
+
 		repo := Repo{
 			GitURL:        testlib.GitMakeBareRepository(t),
 			PrivateKey:    testlib.MakeNewSSHKey(t, ""),
@@ -184,9 +190,10 @@ func TestGitClient(t *testing.T) {
 		))
 	})
 	t.Run("empty url", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: t.TempDir(),
 		})
+
 		repo := Repo{}
 		cli := NewGitUploadClient(repo.Branch)
 		require.EqualError(t, cli.CreateFile(
@@ -199,9 +206,10 @@ func TestGitClient(t *testing.T) {
 		), "url is empty")
 	})
 	t.Run("bad ssh cmd", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: t.TempDir(),
 		})
+
 		repo := Repo{
 			GitURL:     testlib.GitMakeBareRepository(t),
 			PrivateKey: "{{.Foo}}",
@@ -217,9 +225,10 @@ func TestGitClient(t *testing.T) {
 		))
 	})
 	t.Run("bad key path", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: t.TempDir(),
 		})
+
 		repo := Repo{
 			GitURL:     testlib.GitMakeBareRepository(t),
 			PrivateKey: "./nope",
@@ -308,9 +317,10 @@ func TestGitClientWithSigning(t *testing.T) {
 		}
 
 		url := testlib.GitMakeBareRepository(t)
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: t.TempDir(),
 		})
+
 		repo := Repo{
 			GitURL:     url,
 			PrivateKey: testlib.MakeNewSSHKey(t, ""),
@@ -342,9 +352,10 @@ func TestGitClientWithSigning(t *testing.T) {
 		}
 
 		url := testlib.GitMakeBareRepository(t)
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: t.TempDir(),
 		})
+
 		repo := Repo{
 			GitURL:     url,
 			PrivateKey: testlib.MakeNewSSHKey(t, ""),
@@ -374,9 +385,10 @@ func TestGitClientWithSigning(t *testing.T) {
 		}
 
 		url := testlib.GitMakeBareRepository(t)
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: t.TempDir(),
 		})
+
 		repo := Repo{
 			GitURL:     url,
 			PrivateKey: testlib.MakeNewSSHKey(t, ""),

--- a/internal/client/gitea_test.go
+++ b/internal/client/gitea_test.go
@@ -28,7 +28,7 @@ type GetInstanceURLSuite struct {
 func (s *GetInstanceURLSuite) TestWithScheme() {
 	t := s.T()
 	rootURL := "https://gitea.com"
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		GiteaURLs: config.GiteaURLs{
 			API: rootURL + "/api/v1",
 		},
@@ -41,7 +41,7 @@ func (s *GetInstanceURLSuite) TestWithScheme() {
 
 func (s *GetInstanceURLSuite) TestParseError() {
 	t := s.T()
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		GiteaURLs: config.GiteaURLs{
 			API: "://wrong.gitea.com",
 		},
@@ -54,7 +54,7 @@ func (s *GetInstanceURLSuite) TestParseError() {
 
 func (s *GetInstanceURLSuite) TestNoScheme() {
 	t := s.T()
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		GiteaURLs: config.GiteaURLs{
 			API: "gitea.com",
 		},
@@ -67,7 +67,7 @@ func (s *GetInstanceURLSuite) TestNoScheme() {
 
 func (s *GetInstanceURLSuite) TestEmpty() {
 	t := s.T()
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		GiteaURLs: config.GiteaURLs{
 			API: "",
 		},
@@ -81,7 +81,7 @@ func (s *GetInstanceURLSuite) TestEmpty() {
 func (s *GetInstanceURLSuite) TestTemplate() {
 	t := s.T()
 	rootURL := "https://gitea.mycompany.com"
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Env: []string{
 			fmt.Sprintf("GORELEASER_TEST_GITAEA_URLS_API=%s", rootURL),
 		},
@@ -97,7 +97,7 @@ func (s *GetInstanceURLSuite) TestTemplate() {
 
 func (s *GetInstanceURLSuite) TestTemplateMissingValue() {
 	t := s.T()
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		GiteaURLs: config.GiteaURLs{
 			API: "{{ .Env.GORELEASER_NOT_EXISTS }}",
 		},
@@ -110,7 +110,7 @@ func (s *GetInstanceURLSuite) TestTemplateMissingValue() {
 
 func (s *GetInstanceURLSuite) TestTemplateInvalid() {
 	t := s.T()
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		GiteaURLs: config.GiteaURLs{
 			API: "{{.dddddddddd",
 		},
@@ -160,7 +160,8 @@ func (s *GiteaReleasesTestSuite) SetupTest() {
 	s.commit = "some commit hash"
 	s.isDraft = false
 	s.isPrerelease = true
-	s.ctx = testctx.NewWithCfg(
+	s.ctx = testctx.WrapWithCfg(
+		s.T().Context(),
 		config.Project{
 			ProjectName: "project",
 			Release: config.Release{
@@ -182,8 +183,8 @@ func (s *GiteaReleasesTestSuite) SetupTest() {
 		func(ctx *context.Context) {
 			ctx.PreRelease = s.isPrerelease
 		},
-		testctx.WithSemver(6, 6, 6, ""),
-	)
+		testctx.WithSemver(6, 6, 6, ""))
+
 	s.releaseID = 666
 	s.releaseURL = fmt.Sprintf("%v/%v", s.releasesURL, s.releaseID)
 	httpmock.RegisterResponder("GET", fmt.Sprintf("%s/api/v1/version", s.url), httpmock.NewStringResponder(200, "{\"version\":\"1.12.0\"}"))
@@ -507,7 +508,7 @@ func TestGiteaReleaseURLTemplate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := testctx.NewWithCfg(config.Project{
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 				Env: []string{
 					"GORELEASER_TEST_GITEA_URLS_DOWNLOAD=https://gitea.mycompany.com",
 				},
@@ -522,6 +523,7 @@ func TestGiteaReleaseURLTemplate(t *testing.T) {
 					},
 				},
 			})
+
 			client, err := newGitea(ctx, ctx.Token)
 			require.NoError(t, err)
 
@@ -553,11 +555,12 @@ func TestGiteaGetDefaultBranch(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		GiteaURLs: config.GiteaURLs{
 			API: srv.URL,
 		},
 	})
+
 	client, err := newGitea(ctx, "test-token")
 	require.NoError(t, err)
 	repo := Repo{
@@ -584,11 +587,12 @@ func TestGiteaGetDefaultBranchErr(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		GiteaURLs: config.GiteaURLs{
 			API: srv.URL,
 		},
 	})
+
 	client, err := newGitea(ctx, "test-token")
 	require.NoError(t, err)
 	repo := Repo{
@@ -642,11 +646,12 @@ func TestGiteaChangelog(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		GiteaURLs: config.GiteaURLs{
 			API: srv.URL,
 		},
 	})
+
 	client, err := newGitea(ctx, "test-token")
 	require.NoError(t, err)
 	repo := Repo{
@@ -673,11 +678,12 @@ func TestGiteaChangelog(t *testing.T) {
 }
 
 func TestGiteatGetInstanceURL(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		GiteaURLs: config.GiteaURLs{
 			API: "http://our.internal.gitea.media/api/v1",
 		},
 	})
+
 	url, err := getInstanceURL(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "http://our.internal.gitea.media", url)

--- a/internal/commitauthor/author_test.go
+++ b/internal/commitauthor/author_test.go
@@ -10,12 +10,14 @@ import (
 
 func TestGet(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
-		author, err := Get(testctx.NewWithCfg(config.Project{
+		author, err := Get(testctx.WrapWithCfg(t.Context(), config.Project{
 			Env: []string{"NAME=foo", "MAIL=foo@bar"},
-		}), config.CommitAuthor{
-			Name:  "{{.Env.NAME}}",
-			Email: "{{.Env.MAIL}}",
-		})
+		}),
+
+			config.CommitAuthor{
+				Name:  "{{.Env.NAME}}",
+				Email: "{{.Env.MAIL}}",
+			})
 		require.NoError(t, err)
 		require.Equal(t, config.CommitAuthor{
 			Name:  "foo",
@@ -24,18 +26,20 @@ func TestGet(t *testing.T) {
 	})
 
 	t.Run("valid with signing", func(t *testing.T) {
-		author, err := Get(testctx.NewWithCfg(config.Project{
+		author, err := Get(testctx.WrapWithCfg(t.Context(), config.Project{
 			Env: []string{"NAME=foo", "MAIL=foo@bar", "SIGNING_KEY=ABC123", "GPG_PROGRAM=/usr/bin/gpg"},
-		}), config.CommitAuthor{
-			Name:  "{{.Env.NAME}}",
-			Email: "{{.Env.MAIL}}",
-			Signing: config.CommitSigning{
-				Enabled: true,
-				Key:     "{{.Env.SIGNING_KEY}}",
-				Program: "{{.Env.GPG_PROGRAM}}",
-				Format:  "openpgp",
-			},
-		})
+		}),
+
+			config.CommitAuthor{
+				Name:  "{{.Env.NAME}}",
+				Email: "{{.Env.MAIL}}",
+				Signing: config.CommitSigning{
+					Enabled: true,
+					Key:     "{{.Env.SIGNING_KEY}}",
+					Program: "{{.Env.GPG_PROGRAM}}",
+					Format:  "openpgp",
+				},
+			})
 		require.NoError(t, err)
 		require.Equal(t, config.CommitAuthor{
 			Name:  "foo",
@@ -51,7 +55,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("invalid name tmpl", func(t *testing.T) {
 		_, err := Get(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			config.CommitAuthor{
 				Name:  "{{.Env.NOPE}}",
 				Email: "a",
@@ -61,7 +65,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("invalid email tmpl", func(t *testing.T) {
 		_, err := Get(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			config.CommitAuthor{
 				Name:  "a",
 				Email: "{{.Env.NOPE}}",
@@ -71,7 +75,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("invalid signing key tmpl", func(t *testing.T) {
 		_, err := Get(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			config.CommitAuthor{
 				Name:  "a",
 				Email: "b",
@@ -85,7 +89,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("invalid signing program tmpl", func(t *testing.T) {
 		_, err := Get(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			config.CommitAuthor{
 				Name:  "a",
 				Email: "b",
@@ -98,7 +102,7 @@ func TestGet(t *testing.T) {
 	})
 
 	t.Run("use github app token", func(t *testing.T) {
-		author, err := Get(testctx.New(), config.CommitAuthor{
+		author, err := Get(testctx.Wrap(t.Context()), config.CommitAuthor{
 			UseGitHubAppToken: true,
 		})
 		require.NoError(t, err)

--- a/internal/deprecate/deprecate_test.go
+++ b/internal/deprecate/deprecate_test.go
@@ -16,7 +16,7 @@ func TestNotice(t *testing.T) {
 	log.Log = log.New(&w)
 
 	log.Info("first")
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	Notice(ctx, "foo.bar_whatever: foobar")
 	Notice(ctx, "foo.bar_whatever: foobar")
 	Notice(ctx, "foo.bar_whatever: foobar")
@@ -32,7 +32,7 @@ func TestNoticeCustom(t *testing.T) {
 	log.Log = log.New(&w)
 
 	log.Info("first")
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	NoticeCustom(ctx, "something-else", "some custom template with a url {{ .URL }}")
 	NoticeCustom(ctx, "something-else", "ignored")
 	NoticeCustom(ctx, "something-else", "ignored")

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestExecute(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "blah",
 		Env: []string{
 			"TEST_A_SECRET=x",

--- a/internal/extrafiles/extra_files_test.go
+++ b/internal/extrafiles/extra_files_test.go
@@ -14,9 +14,10 @@ func TestTemplate(t *testing.T) {
 		{Glob: "./testdata/file{{ .Env.ONE }}.golden"},
 	}
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Env: []string{"ONE=1"},
 	})
+
 	files, err := Find(ctx, globs)
 	require.NoError(t, err)
 	require.Len(t, files, 1)
@@ -28,7 +29,7 @@ func TestBadTemplate(t *testing.T) {
 		{Glob: "./testdata/file{{ .Env.NOPE }}.golden"},
 	}
 
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	files, err := Find(ctx, globs)
 	require.Empty(t, files)
 	testlib.RequireTemplateError(t, err)
@@ -41,7 +42,7 @@ func TestShouldGetSpecificFile(t *testing.T) {
 		{Glob: "./testdata/file1.golden"},
 	}
 
-	files, err := Find(testctx.New(), globs)
+	files, err := Find(testctx.Wrap(t.Context()), globs)
 	require.NoError(t, err)
 	require.Len(t, files, 1)
 
@@ -53,7 +54,7 @@ func TestFailToGetSpecificFile(t *testing.T) {
 		{Glob: "./testdata/file453.golden"},
 	}
 
-	files, err := Find(testctx.New(), globs)
+	files, err := Find(testctx.Wrap(t.Context()), globs)
 	require.EqualError(t, err, "globbing failed for pattern ./testdata/file453.golden: matching \"./testdata/file453.golden\": file does not exist")
 	require.Empty(t, files)
 }
@@ -63,7 +64,7 @@ func TestShouldGetFilesWithSuperStar(t *testing.T) {
 		{Glob: "./**/file?.golden"},
 	}
 
-	files, err := Find(testctx.New(), globs)
+	files, err := Find(testctx.Wrap(t.Context()), globs)
 	require.NoError(t, err)
 	require.Len(t, files, 3)
 	require.Equal(t, "testdata/file2.golden", files["file2.golden"])
@@ -76,7 +77,7 @@ func TestShouldGetAllFilesWithGoldenExtension(t *testing.T) {
 		{Glob: "./testdata/*.golden"},
 	}
 
-	files, err := Find(testctx.New(), globs)
+	files, err := Find(testctx.Wrap(t.Context()), globs)
 	require.NoError(t, err)
 	require.Len(t, files, 2)
 	require.Equal(t, "testdata/file1.golden", files["file1.golden"])
@@ -88,7 +89,7 @@ func TestShouldGetAllFilesInsideTestdata(t *testing.T) {
 		{Glob: "./testdata/*"},
 	}
 
-	files, err := Find(testctx.New(), globs)
+	files, err := Find(testctx.Wrap(t.Context()), globs)
 	require.NoError(t, err)
 	require.Len(t, files, 4)
 	require.Equal(t, "testdata/sub3/file1.golden", files["file1.golden"])
@@ -105,7 +106,7 @@ func TestTargetName(t *testing.T) {
 		},
 	}
 
-	ctx := testctx.New(testctx.WithCurrentTag("v1.0.0"))
+	ctx := testctx.Wrap(t.Context(), testctx.WithCurrentTag("v1.0.0"))
 	files, err := Find(ctx, globs)
 	require.NoError(t, err)
 	require.Len(t, files, 1)
@@ -121,7 +122,7 @@ func TestTargetInvalidNameTemplate(t *testing.T) {
 		},
 	}
 
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	files, err := Find(ctx, globs)
 	require.Empty(t, files)
 	testlib.RequireTemplateError(t, err)
@@ -135,7 +136,7 @@ func TestTargetNameMatchesMultipleFiles(t *testing.T) {
 		},
 	}
 
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	files, err := Find(ctx, globs)
 	require.Empty(t, files)
 	require.EqualError(t, err, `failed to add extra_file: "./testdata/*" -> "file1.golden": glob matches multiple files`)
@@ -149,7 +150,7 @@ func TestTargetNameNoMatches(t *testing.T) {
 		},
 	}
 
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	files, err := Find(ctx, globs)
 	require.Empty(t, files)
 	require.EqualError(t, err, `globbing failed for pattern ./testdata/file1.silver: matching "./testdata/file1.silver": file does not exist`)
@@ -160,7 +161,7 @@ func TestGlobEvalsToEmpty(t *testing.T) {
 		{Glob: `{{ printf "" }}`},
 	}
 
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	files, err := Find(ctx, globs)
 	require.Empty(t, files)
 	require.NoError(t, err)
@@ -171,7 +172,7 @@ func TestTargetNameNoGlob(t *testing.T) {
 		{NameTemplate: "file1.golden"},
 	}
 
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	files, err := Find(ctx, globs)
 	require.Empty(t, files)
 	require.NoError(t, err)

--- a/internal/http/http_test.go
+++ b/internal/http/http_test.go
@@ -84,10 +84,11 @@ func TestDefaults(t *testing.T) {
 }
 
 func TestCheckConfig(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "blah",
 		Env:         []string{"TEST_A_SECRET=x"},
 	})
+
 	type args struct {
 		ctx    *context.Context
 		upload *config.Upload
@@ -232,13 +233,14 @@ func TestUpload(t *testing.T) {
 		}
 		return fmt.Errorf("unexpected http status code: %v", r.StatusCode)
 	}
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "blah",
 		Env: []string{
 			"TEST_A_SECRET=x",
 			"TEST_A_USERNAME=u2",
 		},
 	}, testctx.WithVersion("2.1.0"))
+
 	folder := t.TempDir()
 	for _, a := range []struct {
 		ext, format string
@@ -727,7 +729,7 @@ func TestManyUploads(t *testing.T) {
 		}, nil
 	}
 	defer assetOpenReset()
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "blah",
 		Env:         []string{"FOO=1"},
 		Uploads: []config.Upload{
@@ -747,6 +749,7 @@ func TestManyUploads(t *testing.T) {
 			},
 		},
 	}, testctx.WithVersion("2.1.0"))
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name: "checksums.txt",
 		Path: "doesnt-matter",

--- a/internal/pipe/announce/announce_test.go
+++ b/internal/pipe/announce/announce_test.go
@@ -15,7 +15,7 @@ func TestDescription(t *testing.T) {
 }
 
 func TestAnnounce(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Announce: config.Announce{
 			Twitter: config.Twitter{
 				Enabled: "true",
@@ -26,6 +26,7 @@ func TestAnnounce(t *testing.T) {
 			},
 		},
 	})
+
 	err := Pipe{}.Run(ctx)
 	require.Error(t, err)
 	merr := &multierror.Error{}
@@ -34,51 +35,54 @@ func TestAnnounce(t *testing.T) {
 }
 
 func TestAnnounceAllDisabled(t *testing.T) {
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	require.NoError(t, Pipe{}.Run(ctx))
 }
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		ctx := testctx.New(testctx.Skip(skips.Announce))
+		ctx := testctx.Wrap(t.Context(), testctx.Skip(skips.Announce))
 		b, err := Pipe{}.Skip(ctx)
 		require.NoError(t, err)
 		require.True(t, b)
 	})
 
 	t.Run("skip on patches", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Announce: config.Announce{
 				Skip: "{{gt .Patch 0}}",
 			},
 		}, testctx.WithSemver(0, 0, 1, ""))
+
 		b, err := Pipe{}.Skip(ctx)
 		require.NoError(t, err)
 		require.True(t, b)
 	})
 
 	t.Run("invalid template", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Announce: config.Announce{
 				Skip: "{{if eq .Patch 123}",
 			},
 		}, testctx.WithSemver(0, 0, 1, ""))
+
 		_, err := Pipe{}.Skip(ctx)
 		require.Error(t, err)
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		b, err := Pipe{}.Skip(testctx.New())
+		b, err := Pipe{}.Skip(testctx.Wrap(t.Context()))
 		require.NoError(t, err)
 		require.False(t, b)
 	})
 
 	t.Run("dont skip based on template", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Announce: config.Announce{
 				Skip: "{{gt .Patch 0}}",
 			},
 		})
+
 		b, err := Pipe{}.Skip(ctx)
 		require.NoError(t, err)
 		require.False(t, b)

--- a/internal/pipe/archive/archive_meta_test.go
+++ b/internal/pipe/archive/archive_meta_test.go
@@ -13,7 +13,7 @@ import (
 func TestMeta(t *testing.T) {
 	t.Run("good", func(t *testing.T) {
 		dist := t.TempDir()
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: dist,
 			Archives: []config.Archive{
 				{
@@ -37,7 +37,7 @@ func TestMeta(t *testing.T) {
 
 	t.Run("bad tmpl", func(t *testing.T) {
 		dist := t.TempDir()
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: dist,
 			Archives: []config.Archive{
 				{
@@ -56,7 +56,7 @@ func TestMeta(t *testing.T) {
 
 	t.Run("no files", func(t *testing.T) {
 		dist := t.TempDir()
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: dist,
 			Archives: []config.Archive{
 				{

--- a/internal/pipe/archive/archive_test.go
+++ b/internal/pipe/archive/archive_test.go
@@ -70,7 +70,7 @@ func TestRunPipe(t *testing.T) {
 			f, err := os.Create(filepath.Join(folder, "foo", "bar", "foobar", "blah.txt"))
 			require.NoError(t, err)
 			require.NoError(t, f.Close())
-			ctx := testctx.NewWithCfg(
+			ctx := testctx.WrapWithCfg(t.Context(),
 				config.Project{
 					Dist:        dist,
 					ProjectName: "foobar",
@@ -101,8 +101,8 @@ func TestRunPipe(t *testing.T) {
 							},
 						},
 					},
-				},
-			)
+				})
+
 			darwinUniversalBinary := &artifact.Artifact{
 				Goos:   "darwin",
 				Goarch: "all",
@@ -289,7 +289,7 @@ func TestRunPipeDifferentBinaryCount(t *testing.T) {
 		createFakeBinary(t, dist, arch, "bin/mybin")
 	}
 	createFakeBinary(t, dist, "darwinamd64", "bin/foobar")
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        dist,
 		ProjectName: "foobar",
 		Archives: []config.Archive{
@@ -301,6 +301,7 @@ func TestRunPipeDifferentBinaryCount(t *testing.T) {
 			},
 		},
 	})
+
 	darwinBuild := &artifact.Artifact{
 		Goos:   "darwin",
 		Goarch: "amd64",
@@ -356,13 +357,14 @@ func TestRunPipeNoBinaries(t *testing.T) {
 	folder := testlib.Mktmp(t)
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        dist,
 		ProjectName: "foobar",
 		Archives: []config.Archive{{
 			Builds: []string{"not-default"},
 		}},
 	}, testctx.WithVersion("0.0.1"), testctx.WithCurrentTag("v1.0.0"))
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Goos:   "linux",
 		Goarch: "amd64",
@@ -435,7 +437,7 @@ func TestRunPipeBinary(t *testing.T) {
 	f, err = os.Create(filepath.Join(folder, "README.md"))
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist: dist,
 			Archives: []config.Archive{
@@ -447,8 +449,8 @@ func TestRunPipeBinary(t *testing.T) {
 			},
 		},
 		testctx.WithVersion("0.0.1"),
-		testctx.WithCurrentTag("v0.0.1"),
-	)
+		testctx.WithCurrentTag("v0.0.1"))
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Goos:   "darwin",
 		Goarch: "amd64",
@@ -525,7 +527,7 @@ func TestRunPipeBinary(t *testing.T) {
 }
 
 func TestRunPipeDistRemoved(t *testing.T) {
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist: "/tmp/path/to/nope",
 			Archives: []config.Archive{
@@ -536,8 +538,8 @@ func TestRunPipeDistRemoved(t *testing.T) {
 				},
 			},
 		},
-		testctx.WithCurrentTag("v0.0.1"),
-	)
+		testctx.WithCurrentTag("v0.0.1"))
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Goos:   "windows",
 		Goarch: "amd64",
@@ -562,7 +564,7 @@ func TestRunPipeInvalidGlob(t *testing.T) {
 	f, err := os.Create(filepath.Join(dist, "darwinamd64", "mybin"))
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist: dist,
 			Archives: []config.Archive{
@@ -576,8 +578,8 @@ func TestRunPipeInvalidGlob(t *testing.T) {
 				},
 			},
 		},
-		testctx.WithCurrentTag("v0.0.1"),
-	)
+		testctx.WithCurrentTag("v0.0.1"))
+
 	ctx.Git.CurrentTag = "v0.0.1"
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Goos:   "darwin",
@@ -601,7 +603,7 @@ func TestRunPipeNameTemplateWithSpace(t *testing.T) {
 	f, err := os.Create(filepath.Join(dist, "darwinamd64", "mybin"))
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist: dist,
 			Archives: []config.Archive{
@@ -617,8 +619,8 @@ func TestRunPipeNameTemplateWithSpace(t *testing.T) {
 				},
 			},
 		},
-		testctx.WithCurrentTag("v0.0.1"),
-	)
+		testctx.WithCurrentTag("v0.0.1"))
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Goos:   "darwin",
 		Goarch: "amd64",
@@ -647,7 +649,7 @@ func TestRunPipeInvalidNameTemplate(t *testing.T) {
 	f, err := os.Create(filepath.Join(dist, "darwinamd64", "mybin"))
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist: dist,
 			Archives: []config.Archive{
@@ -658,8 +660,8 @@ func TestRunPipeInvalidNameTemplate(t *testing.T) {
 				},
 			},
 		},
-		testctx.WithCurrentTag("v0.0.1"),
-	)
+		testctx.WithCurrentTag("v0.0.1"))
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Goos:   "darwin",
 		Goarch: "amd64",
@@ -682,7 +684,7 @@ func TestRunPipeInvalidFilesNameTemplate(t *testing.T) {
 	f, err := os.Create(filepath.Join(dist, "darwinamd64", "mybin"))
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist: dist,
 			Archives: []config.Archive{
@@ -696,8 +698,8 @@ func TestRunPipeInvalidFilesNameTemplate(t *testing.T) {
 				},
 			},
 		},
-		testctx.WithCurrentTag("v0.0.1"),
-	)
+		testctx.WithCurrentTag("v0.0.1"))
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Goos:   "darwin",
 		Goarch: "amd64",
@@ -720,7 +722,7 @@ func TestRunPipeInvalidWrapInDirectoryTemplate(t *testing.T) {
 	f, err := os.Create(filepath.Join(dist, "darwinamd64", "mybin"))
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist: dist,
 			Archives: []config.Archive{
@@ -732,8 +734,8 @@ func TestRunPipeInvalidWrapInDirectoryTemplate(t *testing.T) {
 				},
 			},
 		},
-		testctx.WithCurrentTag("v0.0.1"),
-	)
+		testctx.WithCurrentTag("v0.0.1"))
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Goos:   "darwin",
 		Goarch: "amd64",
@@ -759,7 +761,7 @@ func TestRunPipeWrap(t *testing.T) {
 	f, err = os.Create(filepath.Join(folder, "README.md"))
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist: dist,
 			Archives: []config.Archive{
@@ -774,8 +776,8 @@ func TestRunPipeWrap(t *testing.T) {
 				},
 			},
 		},
-		testctx.WithCurrentTag("v0.0.1"),
-	)
+		testctx.WithCurrentTag("v0.0.1"))
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Goos:   "darwin",
 		Goarch: "amd64",
@@ -801,9 +803,10 @@ func TestRunPipeWrap(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Archives: []config.Archive{},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.NotEmpty(t, ctx.Config.Archives[0].NameTemplate)
 	require.Equal(t, "tar.gz", ctx.Config.Archives[0].Formats[0])
@@ -812,7 +815,7 @@ func TestDefault(t *testing.T) {
 }
 
 func TestDefaultSet(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Archives: []config.Archive{
 			{
 				Builds:       []string{"default"},
@@ -824,6 +827,7 @@ func TestDefaultSet(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "foo", ctx.Config.Archives[0].NameTemplate)
 	require.Equal(t, "zip", ctx.Config.Archives[0].Formats[0])
@@ -831,43 +835,46 @@ func TestDefaultSet(t *testing.T) {
 }
 
 func TestDefaultMixFormats(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Archives: []config.Archive{
 			{
 				Formats: []string{"tar.gz", "binary"},
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, defaultBinaryNameTemplate, ctx.Config.Archives[0].NameTemplate)
 }
 
 func TestDefaultNoFiles(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Archives: []config.Archive{
 			{
 				Formats: []string{"tar.gz"},
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, defaultNameTemplate, ctx.Config.Archives[0].NameTemplate)
 }
 
 func TestDefaultFormatBinary(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Archives: []config.Archive{
 			{
 				Formats: []string{"binary"},
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, defaultBinaryNameTemplate, ctx.Config.Archives[0].NameTemplate)
 }
 
 func TestFormatFor(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Archives: []config.Archive{
 			{
 				Builds:  []string{"default"},
@@ -885,6 +892,7 @@ func TestFormatFor(t *testing.T) {
 			},
 		},
 	})
+
 	require.Equal(t, []string{"zip", "7z"}, packageFormats(ctx.Config.Archives[0], "windows"))
 	require.Equal(t, []string{"tar.gz", "tar.xz"}, packageFormats(ctx.Config.Archives[0], "linux"))
 	require.Equal(t, []string{"none"}, packageFormats(ctx.Config.Archives[0], "darwin"))
@@ -905,7 +913,7 @@ func TestBinaryOverride(t *testing.T) {
 	f, err = os.Create(filepath.Join(folder, "README.md"))
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist:        dist,
 			ProjectName: "foobar",
@@ -926,8 +934,8 @@ func TestBinaryOverride(t *testing.T) {
 				},
 			},
 		},
-		testctx.WithCurrentTag("v0.0.1"),
-	)
+		testctx.WithCurrentTag("v0.0.1"))
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Goos:   "darwin",
 		Goarch: "amd64",
@@ -984,7 +992,7 @@ func TestRunPipeSameArchiveFilename(t *testing.T) {
 	f, err = os.Create(filepath.Join(dist, "windowsamd64", "mybin.exe"))
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist:        dist,
 			ProjectName: "foobar",
@@ -999,8 +1007,8 @@ func TestRunPipeSameArchiveFilename(t *testing.T) {
 					Formats: []string{"tar.gz"},
 				},
 			},
-		},
-	)
+		})
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Goos:   "darwin",
 		Goarch: "amd64",
@@ -1077,7 +1085,7 @@ func TestWrapInDirectory(t *testing.T) {
 }
 
 func TestSeveralArchivesWithTheSameID(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Archives: []config.Archive{
 			{
 				ID: "a",
@@ -1087,6 +1095,7 @@ func TestSeveralArchivesWithTheSameID(t *testing.T) {
 			},
 		},
 	})
+
 	require.EqualError(t, Pipe{}.Default(ctx), "found 2 archives with the ID 'a', please fix your config")
 }
 
@@ -1097,7 +1106,7 @@ func TestArchive_globbing(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, bin.Close()) })
 		dist := t.TempDir()
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: dist,
 			Archives: []config.Archive{
 				{
@@ -1175,7 +1184,7 @@ func TestArchive_globbing(t *testing.T) {
 }
 
 func TestInvalidFormat(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist: t.TempDir(),
 		Archives: []config.Archive{
 			{
@@ -1186,11 +1195,12 @@ func TestInvalidFormat(t *testing.T) {
 			},
 		},
 	})
+
 	require.EqualError(t, Pipe{}.Run(ctx), "invalid archive format: 7z")
 }
 
 func TestIssue3803(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist: t.TempDir(),
 		Archives: []config.Archive{
 			{
@@ -1213,13 +1223,14 @@ func TestIssue3803(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Run(ctx))
 	archives := ctx.Artifacts.List()
 	require.Len(t, archives, 2)
 }
 
 func TestExtraFormatWhenOverride(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist: t.TempDir(),
 		Archives: []config.Archive{
 			{
@@ -1236,6 +1247,7 @@ func TestExtraFormatWhenOverride(t *testing.T) {
 			},
 		},
 	})
+
 	windowsBuild := &artifact.Artifact{
 		Goos:    "windows",
 		Goarch:  "amd64",
@@ -1261,11 +1273,11 @@ func TestExtraFormatWhenOverride(t *testing.T) {
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		ctx := testctx.New(testctx.Skip(skips.Archive))
+		ctx := testctx.Wrap(t.Context(), testctx.Skip(skips.Archive))
 		require.True(t, Pipe{}.Skip(ctx))
 	})
 	t.Run("dont skip", func(t *testing.T) {
-		require.False(t, Pipe{}.Skip(testctx.New()))
+		require.False(t, Pipe{}.Skip(testctx.Wrap(t.Context())))
 	})
 }
 
@@ -1275,7 +1287,7 @@ func TestFormatOverrideWithNoFormatOrNoGoos(t *testing.T) {
 	require.NoError(t, os.Mkdir(dist, 0o755))
 	createFakeBinary(t, dist, "windowsamd64", "mybin.exe")
 
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist:        dist,
 			ProjectName: "foobar",
@@ -1291,8 +1303,7 @@ func TestFormatOverrideWithNoFormatOrNoGoos(t *testing.T) {
 			},
 		},
 		testctx.WithVersion("0.0.1"),
-		testctx.WithCurrentTag("v0.0.1"),
-	)
+		testctx.WithCurrentTag("v0.0.1"))
 
 	windowsBuild := &artifact.Artifact{
 		Goos:    "windows",
@@ -1325,7 +1336,7 @@ func TestFormatOverrideWithNoFormatOrNoGoos(t *testing.T) {
 }
 
 func TestDefaultDeprecatd(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Archives: []config.Archive{
 			{
 				Format: "tar.gz",
@@ -1337,6 +1348,7 @@ func TestDefaultDeprecatd(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.True(t, ctx.Deprecated)
 	require.Equal(t, "tar.gz", ctx.Config.Archives[0].Formats[0])

--- a/internal/pipe/artifactory/artifactory_test.go
+++ b/internal/pipe/artifactory/artifactory_test.go
@@ -167,7 +167,7 @@ func TestRunPipe_ModeBinary(t *testing.T) {
 		  }`)
 	})
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		Artifactories: []config.Upload{
@@ -190,6 +190,7 @@ func TestRunPipe_ModeBinary(t *testing.T) {
 			"ARTIFACTORY_PRODUCTION-EU_SECRET=productionuser-apikey",
 		},
 	})
+
 	for _, goos := range []string{"linux", "darwin"} {
 		ctx.Artifacts.Add(&artifact.Artifact{
 			Name:   "mybin",
@@ -216,7 +217,7 @@ func TestRunPipe_ModeArchive(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, debfile.Close())
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "goreleaser",
 		Dist:        folder,
 		Artifactories: []config.Upload{
@@ -230,6 +231,7 @@ func TestRunPipe_ModeArchive(t *testing.T) {
 		Archives: []config.Archive{{}},
 		Env:      []string{"ARTIFACTORY_PRODUCTION_SECRET=deployuser-secret"},
 	}, testctx.WithVersion("1.0.0"))
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Type: artifact.UploadableArchive,
 		Name: "bin.tar.gz",
@@ -311,7 +313,7 @@ func TestRunPipe_ArtifactoryDown(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, tarfile.Close())
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "goreleaser",
 		Dist:        folder,
 		Artifactories: []config.Upload{
@@ -324,6 +326,7 @@ func TestRunPipe_ArtifactoryDown(t *testing.T) {
 		},
 		Env: []string{"ARTIFACTORY_PRODUCTION_SECRET=deployuser-secret"},
 	}, testctx.WithVersion("2.0.0"))
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Type: artifact.UploadableArchive,
 		Name: "bin.tar.gz",
@@ -343,14 +346,14 @@ func TestRunPipe_TargetTemplateError(t *testing.T) {
 	dist := filepath.Join(folder, "dist")
 	binPath := filepath.Join(dist, "mybin", "mybin")
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		Artifactories: []config.Upload{
 			{
 				Name: "production",
 				Mode: "binary",
-				// This template is not correct and should fail
+
 				Target:   "http://storage.company.com/example-repo-local/{{.Name}",
 				Username: "deployuser",
 			},
@@ -358,6 +361,7 @@ func TestRunPipe_TargetTemplateError(t *testing.T) {
 		Archives: []config.Archive{{}},
 		Env:      []string{"ARTIFACTORY_PRODUCTION_SECRET=deployuser-secret"},
 	})
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "mybin",
 		Path:   binPath,
@@ -398,7 +402,7 @@ func TestRunPipe_BadCredentials(t *testing.T) {
 		  }`)
 	})
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		Artifactories: []config.Upload{
@@ -412,6 +416,7 @@ func TestRunPipe_BadCredentials(t *testing.T) {
 		Archives: []config.Archive{{}},
 		Env:      []string{"ARTIFACTORY_PRODUCTION_SECRET=deployuser-secret"},
 	})
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "mybin",
 		Path:   binPath,
@@ -448,7 +453,7 @@ func TestRunPipe_UnparsableErrorResponse(t *testing.T) {
 		fmt.Fprint(w, `<body><h1>error</h1></body>`)
 	})
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		Artifactories: []config.Upload{
@@ -462,6 +467,7 @@ func TestRunPipe_UnparsableErrorResponse(t *testing.T) {
 		Env:      []string{"ARTIFACTORY_PRODUCTION_SECRET=deployuser-secret"},
 		Archives: []config.Archive{{}},
 	})
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "mybin",
 		Path:   binPath,
@@ -475,7 +481,7 @@ func TestRunPipe_UnparsableErrorResponse(t *testing.T) {
 }
 
 func TestRunPipe_FileNotFound(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        "archivetest/dist",
 		Artifactories: []config.Upload{
@@ -489,6 +495,7 @@ func TestRunPipe_FileNotFound(t *testing.T) {
 		Env:      []string{"ARTIFACTORY_PRODUCTION_SECRET=deployuser-secret"},
 		Archives: []config.Archive{{}},
 	})
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "mybin",
 		Path:   "archivetest/dist/mybin/mybin",
@@ -510,7 +517,7 @@ func TestRunPipe_UnparsableTarget(t *testing.T) {
 	d1 := []byte("hello\ngo\n")
 	require.NoError(t, os.WriteFile(binPath, d1, 0o666))
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		Artifactories: []config.Upload{
@@ -524,6 +531,7 @@ func TestRunPipe_UnparsableTarget(t *testing.T) {
 		Archives: []config.Archive{{}},
 		Env:      []string{"ARTIFACTORY_PRODUCTION_SECRET=deployuser-secret"},
 	})
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "mybin",
 		Path:   binPath,
@@ -543,7 +551,7 @@ func TestRunPipe_DirUpload(t *testing.T) {
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0o755))
 	binPath := filepath.Join(dist, "mybin")
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		Artifactories: []config.Upload{
@@ -557,6 +565,7 @@ func TestRunPipe_DirUpload(t *testing.T) {
 		Archives: []config.Archive{{}},
 		Env:      []string{"ARTIFACTORY_PRODUCTION_SECRET=deployuser-secret"},
 	})
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "mybin",
 		Path:   filepath.Dir(binPath),
@@ -574,7 +583,7 @@ func TestDescription(t *testing.T) {
 }
 
 func TestArtifactoriesWithoutTarget(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Artifactories: []config.Upload{
 			{
 				Name:     "production",
@@ -583,12 +592,13 @@ func TestArtifactoriesWithoutTarget(t *testing.T) {
 		},
 		Env: []string{"ARTIFACTORY_PRODUCTION_SECRET=deployuser-secret"},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	testlib.AssertSkipped(t, Pipe{}.Publish(ctx))
 }
 
 func TestArtifactoriesWithoutUsername(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Artifactories: []config.Upload{
 			{
 				Name:   "production",
@@ -597,12 +607,13 @@ func TestArtifactoriesWithoutUsername(t *testing.T) {
 		},
 		Env: []string{"ARTIFACTORY_PRODUCTION_SECRET=deployuser-secret"},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	testlib.AssertSkipped(t, Pipe{}.Publish(ctx))
 }
 
 func TestArtifactoriesWithoutName(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Artifactories: []config.Upload{
 			{
 				Username: "deployuser",
@@ -610,12 +621,13 @@ func TestArtifactoriesWithoutName(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	testlib.AssertSkipped(t, Pipe{}.Publish(ctx))
 }
 
 func TestArtifactoriesWithoutSecret(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Artifactories: []config.Upload{
 			{
 				Name:     "production",
@@ -624,12 +636,13 @@ func TestArtifactoriesWithoutSecret(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	testlib.AssertSkipped(t, Pipe{}.Publish(ctx))
 }
 
 func TestArtifactoriesWithInvalidMode(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Artifactories: []config.Upload{
 			{
 				Name:     "production",
@@ -640,12 +653,13 @@ func TestArtifactoriesWithInvalidMode(t *testing.T) {
 		},
 		Env: []string{"ARTIFACTORY_PRODUCTION_SECRET=deployuser-secret"},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Error(t, Pipe{}.Publish(ctx))
 }
 
 func TestDefault(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Artifactories: []config.Upload{
 			{
 				Name:     "production",
@@ -662,15 +676,16 @@ func TestDefault(t *testing.T) {
 }
 
 func TestDefaultNoArtifactories(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Artifactories: []config.Upload{},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Empty(t, ctx.Config.Artifactories)
 }
 
 func TestDefaultSet(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Artifactories: []config.Upload{
 			{
 				Mode:           "custom",
@@ -678,6 +693,7 @@ func TestDefaultSet(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Len(t, ctx.Config.Artifactories, 1)
 	artifactory := ctx.Config.Artifactories[0]
@@ -687,13 +703,14 @@ func TestDefaultSet(t *testing.T) {
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		require.True(t, Pipe{}.Skip(testctx.New()))
+		require.True(t, Pipe{}.Skip(testctx.Wrap(t.Context())))
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Artifactories: []config.Upload{{}},
 		})
+
 		require.False(t, Pipe{}.Skip(ctx))
 	})
 }

--- a/internal/pipe/before/before_test.go
+++ b/internal/pipe/before/before_test.go
@@ -33,25 +33,25 @@ func TestRunPipe(t *testing.T) {
 		table = append(table, []string{`bash -c "go version; echo \"lala spaces and such\""`})
 	}
 	for _, tc := range table {
-		ctx := testctx.NewWithCfg(
+		ctx := testctx.WrapWithCfg(t.Context(),
 			config.Project{
 				Before: config.Before{
 					Hooks: tc,
 				},
-			},
-		)
+			})
+
 		require.NoError(t, Pipe{}.Run(ctx))
 	}
 }
 
 func TestRunPipeInvalidCommand(t *testing.T) {
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Before: config.Before{
 				Hooks: []string{`bash -c "echo \"unterminated command\"`},
 			},
-		},
-	)
+		})
+
 	require.EqualError(t, Pipe{}.Run(ctx), "invalid command line string")
 }
 
@@ -60,13 +60,13 @@ func TestRunPipeFail(t *testing.T) {
 		"go tool foobar",
 		"sh ./testdata/foo.sh",
 	} {
-		ctx := testctx.NewWithCfg(
+		ctx := testctx.WrapWithCfg(t.Context(),
 			config.Project{
 				Before: config.Before{
 					Hooks: []string{tc},
 				},
-			},
-		)
+			})
+
 		err := Pipe{}.Run(ctx)
 		require.ErrorContains(t, err, "hook failed")
 	}
@@ -74,7 +74,7 @@ func TestRunPipeFail(t *testing.T) {
 
 func TestRunWithEnv(t *testing.T) {
 	f := filepath.Join(t.TempDir(), "testfile")
-	require.NoError(t, Pipe{}.Run(testctx.NewWithCfg(
+	require.NoError(t, Pipe{}.Run(testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Env: []string{
 				"TEST_FILE=" + f,
@@ -82,41 +82,41 @@ func TestRunWithEnv(t *testing.T) {
 			Before: config.Before{
 				Hooks: []string{testlib.Touch("{{ .Env.TEST_FILE }}")},
 			},
-		},
-	)))
+		})))
 	require.FileExists(t, f)
 }
 
 func TestInvalidTemplate(t *testing.T) {
-	testlib.RequireTemplateError(t, Pipe{}.Run(testctx.NewWithCfg(
+	testlib.RequireTemplateError(t, Pipe{}.Run(testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Before: config.Before{
 				Hooks: []string{"doesnt-matter {{ .fasdsd }"},
 			},
-		},
-	)))
+		})))
 }
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		require.True(t, Pipe{}.Skip(testctx.New()))
+		require.True(t, Pipe{}.Skip(testctx.Wrap(t.Context())))
 	})
 
 	t.Run("skip before", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Before: config.Before{
 				Hooks: []string{""},
 			},
 		}, testctx.Skip(skips.Before))
+
 		require.True(t, Pipe{}.Skip(ctx))
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Before: config.Before{
 				Hooks: []string{""},
 			},
 		})
+
 		require.False(t, Pipe{}.Skip(ctx))
 	})
 }

--- a/internal/pipe/blob/blob_minio_test.go
+++ b/internal/pipe/blob/blob_minio_test.go
@@ -95,7 +95,7 @@ func TestMinioUpload(t *testing.T) {
 	require.NoError(t, os.WriteFile(debpath, []byte("fake\ndeb"), 0o744))
 	require.NoError(t, os.WriteFile(sigpath, []byte("fake\nsig"), 0o744))
 	require.NoError(t, os.WriteFile(certpath, []byte("fake\ncert"), 0o744))
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        directory,
 		ProjectName: "testupload",
 		Blobs: []config.Blob{
@@ -116,6 +116,7 @@ func TestMinioUpload(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v1.0.0"))
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Type: artifact.Metadata,
 		Name: "metadata.json",
@@ -194,7 +195,7 @@ func TestMinioUploadCustomBucketID(t *testing.T) {
 	require.NoError(t, os.WriteFile(debpath, []byte("fake\ndeb"), 0o744))
 	// Set custom BUCKET_ID env variable.
 	t.Setenv("BUCKET_ID", name)
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        directory,
 		ProjectName: "testupload",
 		Blobs: []config.Blob{
@@ -205,6 +206,7 @@ func TestMinioUploadCustomBucketID(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v1.0.0"))
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Type: artifact.UploadableArchive,
 		Name: "bin.tar.gz",
@@ -230,7 +232,7 @@ func TestMinioUploadExtraFilesOnly(t *testing.T) {
 	debpath := filepath.Join(directory, "bin.deb")
 	require.NoError(t, os.WriteFile(tgzpath, []byte("fake\ntargz"), 0o744))
 	require.NoError(t, os.WriteFile(debpath, []byte("fake\ndeb"), 0o744))
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        directory,
 		ProjectName: "testupload",
 		Blobs: []config.Blob{
@@ -248,6 +250,7 @@ func TestMinioUploadExtraFilesOnly(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v1.0.0"))
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Type: artifact.UploadableArchive,
 		Name: "bin.tar.gz",
@@ -277,7 +280,7 @@ func TestMinioUploadRootDirectory(t *testing.T) {
 	debpath := filepath.Join(directory, "bin.deb")
 	require.NoError(t, os.WriteFile(tgzpath, []byte("fake\ntargz"), 0o744))
 	require.NoError(t, os.WriteFile(debpath, []byte("fake\ndeb"), 0o744))
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        directory,
 		ProjectName: "testupload",
 		Blobs: []config.Blob{
@@ -289,6 +292,7 @@ func TestMinioUploadRootDirectory(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v1.0.0"))
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Type: artifact.UploadableArchive,
 		Name: "bin.tar.gz",
@@ -313,7 +317,7 @@ func TestMinioUploadInvalidCustomBucketID(t *testing.T) {
 	debpath := filepath.Join(directory, "bin.deb")
 	require.NoError(t, os.WriteFile(tgzpath, []byte("fake\ntargz"), 0o744))
 	require.NoError(t, os.WriteFile(debpath, []byte("fake\ndeb"), 0o744))
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        directory,
 		ProjectName: "testupload",
 		Blobs: []config.Blob{
@@ -324,6 +328,7 @@ func TestMinioUploadInvalidCustomBucketID(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v1.1.0"))
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Type: artifact.UploadableArchive,
 		Name: "bin.tar.gz",
@@ -350,7 +355,7 @@ func TestMinioUploadSkip(t *testing.T) {
 	require.NoError(t, os.WriteFile(debpath, []byte("fake\ndeb"), 0o744))
 
 	buildCtx := func(uploadID string) *context.Context {
-		ctx := testctx.NewWithCfg(
+		ctx := testctx.WrapWithCfg(t.Context(),
 			config.Project{
 				Dist:        directory,
 				ProjectName: "testupload",
@@ -376,8 +381,8 @@ func TestMinioUploadSkip(t *testing.T) {
 			testctx.WithCurrentTag("v1.0.0"),
 			testctx.WithEnv(map[string]string{
 				"UPLOAD_ID": uploadID,
-			}),
-		)
+			}))
+
 		ctx.Artifacts.Add(&artifact.Artifact{
 			Type: artifact.UploadableArchive,
 			Name: "bin.tar.gz",

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -116,9 +116,11 @@ func TestFullFormulae(t *testing.T) {
 	data.PostInstall = []string{`touch "/tmp/foo"`, `system "echo", "done"`}
 	data.CustomBlock = []string{"devel do", `  url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_x86_64.tar.gz"`, `  sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c68"`, "end"}
 	data.Tests = []string{`system "#{bin}/{{.ProjectName}}", "-version"`}
-	formulae, err := doBuildFormula(testctx.NewWithCfg(config.Project{
+	formulae, err := doBuildFormula(testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "foo",
-	}), data)
+	}),
+
+		data)
 	require.NoError(t, err)
 
 	golden.RequireEqualRb(t, []byte(formulae))
@@ -127,9 +129,11 @@ func TestFullFormulae(t *testing.T) {
 func TestFullFormulaeLinuxOnly(t *testing.T) {
 	data := defaultTemplateData
 	data.MacOSPackages = []releasePackage{}
-	formulae, err := doBuildFormula(testctx.NewWithCfg(config.Project{
+	formulae, err := doBuildFormula(testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "foo",
-	}), data)
+	}),
+
+		data)
 	require.NoError(t, err)
 
 	golden.RequireEqualRb(t, []byte(formulae))
@@ -138,16 +142,18 @@ func TestFullFormulaeLinuxOnly(t *testing.T) {
 func TestFullFormulaeMacOSOnly(t *testing.T) {
 	data := defaultTemplateData
 	data.LinuxPackages = []releasePackage{}
-	formulae, err := doBuildFormula(testctx.NewWithCfg(config.Project{
+	formulae, err := doBuildFormula(testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "foo",
-	}), data)
+	}),
+
+		data)
 	require.NoError(t, err)
 
 	golden.RequireEqualRb(t, []byte(formulae))
 }
 
 func TestFormulaeSimple(t *testing.T) {
-	formulae, err := doBuildFormula(testctx.NewWithCfg(config.Project{}), defaultTemplateData)
+	formulae, err := doBuildFormula(testctx.WrapWithCfg(t.Context(), config.Project{}), defaultTemplateData)
 	require.NoError(t, err)
 	assertDefaultTemplateData(t, formulae)
 	require.NotContains(t, formulae, "def caveats")
@@ -320,7 +326,7 @@ func TestFullPipe(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			folder := t.TempDir()
-			ctx := testctx.NewWithCfg(
+			ctx := testctx.WrapWithCfg(t.Context(),
 				config.Project{
 					Dist:        folder,
 					ProjectName: name,
@@ -350,8 +356,8 @@ func TestFullPipe(t *testing.T) {
 					Env: []string{"FOO=foo_is_bar"},
 				},
 				testctx.WithVersion("1.0.1"),
-				testctx.WithCurrentTag("v1.0.1"),
-			)
+				testctx.WithCurrentTag("v1.0.1"))
+
 			tt.prepare(ctx)
 			ctx.Artifacts.Add(&artifact.Artifact{
 				Name:    "bin.tgz",
@@ -459,7 +465,7 @@ func TestFullPipe(t *testing.T) {
 
 func TestRunPipeNameTemplate(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist:        folder,
 			ProjectName: "foo",
@@ -482,8 +488,8 @@ func TestRunPipeNameTemplate(t *testing.T) {
 			Env: []string{"FOO_BAR=is_bar"},
 		},
 		testctx.WithVersion("1.0.1"),
-		testctx.WithCurrentTag("v1.0.1"),
-	)
+		testctx.WithCurrentTag("v1.0.1"))
+
 	path := filepath.Join(folder, "bin.tar.gz")
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:    "bin.tar.gz",
@@ -516,7 +522,7 @@ func TestRunPipeNameTemplate(t *testing.T) {
 
 func TestRunPipeMultipleBrewsWithSkip(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist:        folder,
 			ProjectName: "foo",
@@ -575,8 +581,8 @@ func TestRunPipeMultipleBrewsWithSkip(t *testing.T) {
 			},
 		},
 		testctx.WithVersion("1.0.1"),
-		testctx.WithCurrentTag("v1.0.1"),
-	)
+		testctx.WithCurrentTag("v1.0.1"))
+
 	path := filepath.Join(folder, "bin.tar.gz")
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:    "bin.tar.gz",
@@ -625,7 +631,7 @@ func TestRunPipeForMultipleAmd64Versions(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			folder := t.TempDir()
-			ctx := testctx.NewWithCfg(
+			ctx := testctx.WrapWithCfg(t.Context(),
 				config.Project{
 					Dist:        folder,
 					ProjectName: name,
@@ -655,8 +661,8 @@ func TestRunPipeForMultipleAmd64Versions(t *testing.T) {
 				},
 				testctx.GitHubTokenType,
 				testctx.WithVersion("1.0.1"),
-				testctx.WithCurrentTag("v1.0.1"),
-			)
+				testctx.WithCurrentTag("v1.0.1"))
+
 			fn(ctx)
 			for _, a := range []struct {
 				name    string
@@ -747,7 +753,7 @@ func TestRunPipeForMultipleArmVersions(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			folder := t.TempDir()
-			ctx := testctx.NewWithCfg(
+			ctx := testctx.WrapWithCfg(t.Context(),
 				config.Project{
 					Dist:        folder,
 					ProjectName: name,
@@ -783,8 +789,8 @@ func TestRunPipeForMultipleArmVersions(t *testing.T) {
 				},
 				testctx.GitHubTokenType,
 				testctx.WithVersion("1.0.1"),
-				testctx.WithCurrentTag("v1.0.1"),
-			)
+				testctx.WithCurrentTag("v1.0.1"))
+
 			fn(ctx)
 			for _, a := range []struct {
 				name   string
@@ -856,7 +862,7 @@ func TestRunPipeForMultipleArmVersions(t *testing.T) {
 }
 
 func TestRunPipeNoBuilds(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Brews: []config.Homebrew{
 			{
 				Repository: config.RepoRef{
@@ -867,6 +873,7 @@ func TestRunPipeNoBuilds(t *testing.T) {
 			},
 		},
 	}, testctx.GitHubTokenType)
+
 	client := client.NewMock()
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.EqualError(t, runAll(ctx, client), ErrNoArchivesFound{
@@ -878,7 +885,7 @@ func TestRunPipeNoBuilds(t *testing.T) {
 }
 
 func TestRunPipeMultipleArchivesSameOsBuild(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Brews: []config.Homebrew{
 			{
 				Repository: config.RepoRef{
@@ -1024,7 +1031,7 @@ func TestRunPipeMultipleArchivesSameOsBuild(t *testing.T) {
 
 func TestRunPipeBinaryRelease(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist:        folder,
 			ProjectName: "foo",
@@ -1042,8 +1049,8 @@ func TestRunPipeBinaryRelease(t *testing.T) {
 			},
 		},
 		testctx.WithVersion("1.2.1"),
-		testctx.WithCurrentTag("v1.2.1"),
-	)
+		testctx.WithCurrentTag("v1.2.1"))
+
 	path := filepath.Join(folder, "dist/foo_darwin_all/foo")
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "foo_macos",
@@ -1072,7 +1079,7 @@ func TestRunPipeBinaryRelease(t *testing.T) {
 
 func TestRunPipePullRequest(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist:        folder,
 			ProjectName: "foo",
@@ -1094,8 +1101,8 @@ func TestRunPipePullRequest(t *testing.T) {
 			},
 		},
 		testctx.WithVersion("1.2.1"),
-		testctx.WithCurrentTag("v1.2.1"),
-	)
+		testctx.WithCurrentTag("v1.2.1"))
+
 	path := filepath.Join(folder, "dist/foo_darwin_all/foo")
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "foo_macos",
@@ -1126,7 +1133,7 @@ func TestRunPipePullRequest(t *testing.T) {
 
 func TestRunPipeNoUpload(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        folder,
 		ProjectName: "foo",
 		Release:     config.Release{},
@@ -1141,6 +1148,7 @@ func TestRunPipeNoUpload(t *testing.T) {
 		},
 		Env: []string{"SKIP_UPLOAD=true"},
 	}, testctx.WithCurrentTag("v1.0.1"), testctx.GitHubTokenType)
+
 	path := filepath.Join(folder, "whatever.tar.gz")
 	f, err := os.Create(path)
 	require.NoError(t, err)
@@ -1185,7 +1193,7 @@ func TestRunPipeNoUpload(t *testing.T) {
 
 func TestRunEmptyTokenType(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        folder,
 		ProjectName: "foo",
 		Release:     config.Release{},
@@ -1199,6 +1207,7 @@ func TestRunEmptyTokenType(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v1.0.0"))
+
 	path := filepath.Join(folder, "whatever.tar.gz")
 	f, err := os.Create(path)
 	require.NoError(t, err)
@@ -1242,7 +1251,7 @@ func TestDefault(t *testing.T) {
 			Draft: true,
 		},
 	}
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "myproject",
 		Brews: []config.Homebrew{
 			{
@@ -1250,6 +1259,7 @@ func TestDefault(t *testing.T) {
 			},
 		},
 	}, testctx.GitHubTokenType)
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, ctx.Config.ProjectName, ctx.Config.Brews[0].Name)
 	require.NotEmpty(t, ctx.Config.Brews[0].CommitAuthor.Name)
@@ -1269,28 +1279,30 @@ func TestGHFolder(t *testing.T) {
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		require.True(t, Pipe{}.Skip(testctx.New()))
+		require.True(t, Pipe{}.Skip(testctx.Wrap(t.Context())))
 	})
 	t.Run("skip flag", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Brews: []config.Homebrew{
 				{},
 			},
 		}, testctx.Skip(skips.Homebrew))
+
 		require.True(t, Pipe{}.Skip(ctx))
 	})
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Brews: []config.Homebrew{
 				{},
 			},
 		})
+
 		require.False(t, Pipe{}.Skip(ctx))
 	})
 }
 
 func TestRunSkipNoName(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Brews: []config.Homebrew{{}},
 	})
 
@@ -1301,7 +1313,7 @@ func TestRunSkipNoName(t *testing.T) {
 func TestInstalls(t *testing.T) {
 	t.Run("provided", func(t *testing.T) {
 		install, err := installs(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			config.Homebrew{Install: "bin.install \"foo\"\nbin.install \"bar\""},
 			&artifact.Artifact{},
 		)
@@ -1314,7 +1326,7 @@ func TestInstalls(t *testing.T) {
 
 	t.Run("from archives", func(t *testing.T) {
 		install, err := installs(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			config.Homebrew{},
 			&artifact.Artifact{
 				Type: artifact.UploadableArchive,
@@ -1332,7 +1344,7 @@ func TestInstalls(t *testing.T) {
 
 	t.Run("from binary", func(t *testing.T) {
 		install, err := installs(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			config.Homebrew{},
 			&artifact.Artifact{
 				Name: "foo_macos",
@@ -1350,7 +1362,7 @@ func TestInstalls(t *testing.T) {
 
 	t.Run("from template", func(t *testing.T) {
 		install, err := installs(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			config.Homebrew{
 				Install: `bin.install "foo_{{.Os}}" => "foo"`,
 			},
@@ -1369,7 +1381,7 @@ func TestInstalls(t *testing.T) {
 
 func TestRunPipeUniversalBinary(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist:        folder,
 			ProjectName: "unibin",
@@ -1390,8 +1402,8 @@ func TestRunPipeUniversalBinary(t *testing.T) {
 			},
 		},
 		testctx.WithCurrentTag("v1.0.1"),
-		testctx.WithVersion("1.0.1"),
-	)
+		testctx.WithVersion("1.0.1"))
+
 	path := filepath.Join(folder, "bin.tar.gz")
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "bin.tar.gz",
@@ -1424,7 +1436,7 @@ func TestRunPipeUniversalBinary(t *testing.T) {
 
 func TestRunPipeUniversalBinaryNotReplacing(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist:        folder,
 			ProjectName: "unibin",
@@ -1447,8 +1459,8 @@ func TestRunPipeUniversalBinaryNotReplacing(t *testing.T) {
 		},
 
 		testctx.WithCurrentTag("v1.0.1"),
-		testctx.WithVersion("1.0.1"),
-	)
+		testctx.WithVersion("1.0.1"))
+
 	path := filepath.Join(folder, "bin.tar.gz")
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:    "bin_amd64.tar.gz",

--- a/internal/pipe/build/filter_test.go
+++ b/internal/pipe/build/filter_test.go
@@ -21,7 +21,7 @@ var filterTestTargets = []string{
 
 func TestFilter(t *testing.T) {
 	t.Run("none", func(t *testing.T) {
-		ctx := testctx.New()
+		ctx := testctx.Wrap(t.Context())
 		require.Equal(t, filterTestTargets, filter(ctx, config.Build{
 			Builder: "go",
 			Targets: filterTestTargets,
@@ -29,10 +29,11 @@ func TestFilter(t *testing.T) {
 	})
 
 	t.Run("target", func(t *testing.T) {
-		ctx := testctx.New(func(ctx *context.Context) {
+		ctx := testctx.Wrap(t.Context(), func(ctx *context.Context) {
 			ctx.Partial = true
 			ctx.PartialTarget = "darwin_amd64_v1"
 		})
+
 		require.Equal(t, []string{
 			"darwin_amd64_v1",
 		}, filter(ctx, config.Build{
@@ -42,10 +43,11 @@ func TestFilter(t *testing.T) {
 	})
 
 	t.Run("incomplete target", func(t *testing.T) {
-		ctx := testctx.New(func(ctx *context.Context) {
+		ctx := testctx.Wrap(t.Context(), func(ctx *context.Context) {
 			ctx.Partial = true
 			ctx.PartialTarget = "darwin_amd64"
 		})
+
 		require.Equal(t, []string{
 			"darwin_amd64_v1",
 		}, filter(ctx, config.Build{
@@ -55,10 +57,11 @@ func TestFilter(t *testing.T) {
 	})
 
 	t.Run("target no match", func(t *testing.T) {
-		ctx := testctx.New(func(ctx *context.Context) {
+		ctx := testctx.Wrap(t.Context(), func(ctx *context.Context) {
 			ctx.Partial = true
 			ctx.PartialTarget = "linux_amd64_v1"
 		})
+
 		require.Empty(t, filter(ctx, config.Build{
 			Builder: "go",
 			Targets: []string{"darwin_amd64_v1"},

--- a/internal/pipe/cask/cask_test.go
+++ b/internal/pipe/cask/cask_test.go
@@ -150,9 +150,11 @@ module Utils
   end
 end
 `
-	cask, err := doBuildCask(testctx.NewWithCfg(config.Project{
+	cask, err := doBuildCask(testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "foo",
-	}), data)
+	}),
+
+		data)
 	require.NoError(t, err)
 
 	golden.RequireEqualRb(t, []byte(cask))
@@ -161,9 +163,11 @@ end
 func TestFullCaskLinuxOnly(t *testing.T) {
 	data := defaultTemplateData
 	data.MacOSPackages = []releasePackage{}
-	cask, err := doBuildCask(testctx.NewWithCfg(config.Project{
+	cask, err := doBuildCask(testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "foo",
-	}), data)
+	}),
+
+		data)
 	require.NoError(t, err)
 
 	golden.RequireEqualRb(t, []byte(cask))
@@ -172,16 +176,18 @@ func TestFullCaskLinuxOnly(t *testing.T) {
 func TestFullCaskMacOSOnly(t *testing.T) {
 	data := defaultTemplateData
 	data.LinuxPackages = []releasePackage{}
-	cask, err := doBuildCask(testctx.NewWithCfg(config.Project{
+	cask, err := doBuildCask(testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "foo",
-	}), data)
+	}),
+
+		data)
 	require.NoError(t, err)
 
 	golden.RequireEqualRb(t, []byte(cask))
 }
 
 func TestCaskSimple(t *testing.T) {
-	cask, err := doBuildCask(testctx.NewWithCfg(config.Project{}), defaultTemplateData)
+	cask, err := doBuildCask(testctx.WrapWithCfg(t.Context(), config.Project{}), defaultTemplateData)
 	require.NoError(t, err)
 	assertDefaultTemplateData(t, cask)
 	require.NotContains(t, cask, "def caveats")
@@ -428,7 +434,7 @@ func TestFullPipe(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			folder := t.TempDir()
-			ctx := testctx.NewWithCfg(
+			ctx := testctx.WrapWithCfg(t.Context(),
 				config.Project{
 					Dist:        folder,
 					ProjectName: name,
@@ -463,8 +469,8 @@ func TestFullPipe(t *testing.T) {
 					Env: []string{"FOO=foo_is_bar"},
 				},
 				testctx.WithVersion("1.0.1"),
-				testctx.WithCurrentTag("v1.0.1"),
-			)
+				testctx.WithCurrentTag("v1.0.1"))
+
 			tt.prepare(ctx)
 			ctx.Artifacts.Add(&artifact.Artifact{
 				Name:    "bin.tgz",
@@ -572,7 +578,7 @@ func TestFullPipe(t *testing.T) {
 
 func TestRunPipeNameTemplate(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist:        folder,
 			ProjectName: "foo",
@@ -594,8 +600,8 @@ func TestRunPipeNameTemplate(t *testing.T) {
 			Env: []string{"FOO_BAR=is_bar"},
 		},
 		testctx.WithVersion("1.0.1"),
-		testctx.WithCurrentTag("v1.0.1"),
-	)
+		testctx.WithCurrentTag("v1.0.1"))
+
 	path := filepath.Join(folder, "bin.tar.gz")
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:    "bin.tar.gz",
@@ -628,7 +634,7 @@ func TestRunPipeNameTemplate(t *testing.T) {
 
 func TestRunPipeMultipleBrewsWithSkip(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist:        folder,
 			ProjectName: "foo",
@@ -683,8 +689,8 @@ func TestRunPipeMultipleBrewsWithSkip(t *testing.T) {
 			},
 		},
 		testctx.WithVersion("1.0.1"),
-		testctx.WithCurrentTag("v1.0.1"),
-	)
+		testctx.WithCurrentTag("v1.0.1"))
+
 	path := filepath.Join(folder, "bin.tar.gz")
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:    "bin.tar.gz",
@@ -717,7 +723,7 @@ func TestRunPipeMultipleBrewsWithSkip(t *testing.T) {
 }
 
 func TestRunPipeNoBuilds(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Casks: []config.HomebrewCask{
 			{
 				Repository: config.RepoRef{
@@ -728,6 +734,7 @@ func TestRunPipeNoBuilds(t *testing.T) {
 			},
 		},
 	}, testctx.GitHubTokenType)
+
 	client := client.NewMock()
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.EqualError(t, runAll(ctx, client), ErrNoArchivesFound{
@@ -737,7 +744,7 @@ func TestRunPipeNoBuilds(t *testing.T) {
 }
 
 func TestRunPipeMultipleArchivesSameOsBuild(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Casks: []config.HomebrewCask{
 			{
 				Repository: config.RepoRef{
@@ -836,7 +843,7 @@ func TestRunPipeMultipleArchivesSameOsBuild(t *testing.T) {
 
 func TestRunPipeBinaryRelease(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist:        folder,
 			ProjectName: "foo",
@@ -855,8 +862,8 @@ func TestRunPipeBinaryRelease(t *testing.T) {
 			},
 		},
 		testctx.WithVersion("1.2.1"),
-		testctx.WithCurrentTag("v1.2.1"),
-	)
+		testctx.WithCurrentTag("v1.2.1"))
+
 	path := filepath.Join(folder, "dist/foo_darwin_all/foo")
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "foo_macos",
@@ -885,7 +892,7 @@ func TestRunPipeBinaryRelease(t *testing.T) {
 
 func TestRunPipePullRequest(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist:        folder,
 			ProjectName: "foo",
@@ -907,8 +914,8 @@ func TestRunPipePullRequest(t *testing.T) {
 			},
 		},
 		testctx.WithVersion("1.2.1"),
-		testctx.WithCurrentTag("v1.2.1"),
-	)
+		testctx.WithCurrentTag("v1.2.1"))
+
 	path := filepath.Join(folder, "dist/foo_darwin_all/foo")
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "foo_macos",
@@ -939,7 +946,7 @@ func TestRunPipePullRequest(t *testing.T) {
 
 func TestRunPipeNoUpload(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        folder,
 		ProjectName: "foo",
 		Release:     config.Release{},
@@ -953,6 +960,7 @@ func TestRunPipeNoUpload(t *testing.T) {
 		},
 		Env: []string{"SKIP_UPLOAD=true"},
 	}, testctx.WithCurrentTag("v1.0.1"), testctx.GitHubTokenType)
+
 	path := filepath.Join(folder, "whatever.tar.gz")
 	f, err := os.Create(path)
 	require.NoError(t, err)
@@ -997,7 +1005,7 @@ func TestRunPipeNoUpload(t *testing.T) {
 
 func TestRunEmptyTokenType(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        folder,
 		ProjectName: "foo",
 		Release:     config.Release{},
@@ -1010,6 +1018,7 @@ func TestRunEmptyTokenType(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v1.0.0"))
+
 	path := filepath.Join(folder, "whatever.tar.gz")
 	f, err := os.Create(path)
 	require.NoError(t, err)
@@ -1053,7 +1062,7 @@ func TestDefault(t *testing.T) {
 			Draft: true,
 		},
 	}
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "myproject",
 		Casks: []config.HomebrewCask{
 			{
@@ -1061,6 +1070,7 @@ func TestDefault(t *testing.T) {
 			},
 		},
 	}, testctx.GitHubTokenType)
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.False(t, ctx.Deprecated)
 	require.Equal(t, ctx.Config.ProjectName, ctx.Config.Casks[0].Name)
@@ -1072,7 +1082,7 @@ func TestDefault(t *testing.T) {
 }
 
 func TestDefaultDeprecated(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "myproject",
 		Casks: []config.HomebrewCask{
 			{
@@ -1081,6 +1091,7 @@ func TestDefaultDeprecated(t *testing.T) {
 			},
 		},
 	}, testctx.GitHubTokenType)
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.True(t, ctx.Deprecated)
 	require.Equal(t, []string{"bin"}, ctx.Config.Casks[0].Binaries)
@@ -1094,28 +1105,30 @@ func TestGHFolder(t *testing.T) {
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		require.True(t, Pipe{}.Skip(testctx.New()))
+		require.True(t, Pipe{}.Skip(testctx.Wrap(t.Context())))
 	})
 	t.Run("skip flag", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Casks: []config.HomebrewCask{
 				{},
 			},
 		}, testctx.Skip(skips.Homebrew))
+
 		require.True(t, Pipe{}.Skip(ctx))
 	})
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Casks: []config.HomebrewCask{
 				{},
 			},
 		})
+
 		require.False(t, Pipe{}.Skip(ctx))
 	})
 }
 
 func TestRunSkipNoName(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Casks: []config.HomebrewCask{{}},
 	})
 
@@ -1125,7 +1138,7 @@ func TestRunSkipNoName(t *testing.T) {
 
 func TestRunPipeUniversalBinary(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist:        folder,
 			ProjectName: "unibin",
@@ -1146,8 +1159,8 @@ func TestRunPipeUniversalBinary(t *testing.T) {
 			},
 		},
 		testctx.WithCurrentTag("v1.0.1"),
-		testctx.WithVersion("1.0.1"),
-	)
+		testctx.WithVersion("1.0.1"))
+
 	path := filepath.Join(folder, "bin.tar.gz")
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "bin.tar.gz",
@@ -1180,7 +1193,7 @@ func TestRunPipeUniversalBinary(t *testing.T) {
 
 func TestRunPipeUniversalBinaryNotReplacing(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist:        folder,
 			ProjectName: "unibin",
@@ -1201,8 +1214,8 @@ func TestRunPipeUniversalBinaryNotReplacing(t *testing.T) {
 			},
 		},
 		testctx.WithCurrentTag("v1.0.1"),
-		testctx.WithVersion("1.0.1"),
-	)
+		testctx.WithVersion("1.0.1"))
+
 	path := filepath.Join(folder, "bin.tar.gz")
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:    "bin_amd64.tar.gz",

--- a/internal/pipe/chocolatey/chocolatey_test.go
+++ b/internal/pipe/chocolatey/chocolatey_test.go
@@ -27,23 +27,25 @@ func TestDescription(t *testing.T) {
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		require.True(t, Pipe{}.Skip(testctx.New()))
+		require.True(t, Pipe{}.Skip(testctx.Wrap(t.Context())))
 	})
 	t.Run("skip flag", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Chocolateys: []config.Chocolatey{
 				{},
 			},
 		}, testctx.Skip(skips.Chocolatey))
+
 		require.True(t, Pipe{}.Skip(ctx))
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Chocolateys: []config.Chocolatey{
 				{},
 			},
 		})
+
 		require.False(t, Pipe{}.Skip(ctx))
 	})
 }
@@ -51,7 +53,7 @@ func TestSkip(t *testing.T) {
 func TestDefault(t *testing.T) {
 	testlib.Mktmp(t)
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "myproject",
 		Chocolateys: []config.Chocolatey{
 			{},
@@ -129,14 +131,13 @@ func Test_doRun(t *testing.T) {
 				cmd = stdCmd{}
 			})
 
-			ctx := testctx.NewWithCfg(
+			ctx := testctx.WrapWithCfg(t.Context(),
 				config.Project{
 					Dist:        folder,
 					ProjectName: "run-all",
 				},
 				testctx.WithCurrentTag("v1.0.1"),
-				testctx.WithVersion("1.0.1"),
-			)
+				testctx.WithVersion("1.0.1"))
 
 			ctx.Artifacts.Add(&artifact.Artifact{
 				Name:    "app_1.0.1_windows_amd64.zip",
@@ -169,7 +170,7 @@ func Test_doRun(t *testing.T) {
 }
 
 func Test_buildNuspec(t *testing.T) {
-	ctx := testctx.New(testctx.WithVersion("1.12.3"))
+	ctx := testctx.Wrap(t.Context(), testctx.WithVersion("1.12.3"))
 	choco := config.Chocolatey{
 		Name:        "goreleaser",
 		IDs:         []string{},
@@ -194,7 +195,7 @@ func Test_buildTemplate(t *testing.T) {
 	folder := t.TempDir()
 	file := filepath.Join(folder, "archive")
 	require.NoError(t, os.WriteFile(file, []byte("lorem ipsum"), 0o644))
-	ctx := testctx.New(testctx.WithVersion("1.0.0"), testctx.WithCurrentTag("v1.0.0"))
+	ctx := testctx.Wrap(t.Context(), testctx.WithVersion("1.0.0"), testctx.WithCurrentTag("v1.0.0"))
 	artifacts := []*artifact.Artifact{
 		{
 			Name:    "app_1.0.0_windows_386.zip",
@@ -309,7 +310,7 @@ func TestPublish(t *testing.T) {
 				cmd = stdCmd{}
 			})
 
-			ctx := testctx.New()
+			ctx := testctx.Wrap(t.Context())
 			for _, artifact := range tt.artifacts {
 				ctx.Artifacts.Add(&artifact)
 			}

--- a/internal/pipe/custompublishers/custompublishers_test.go
+++ b/internal/pipe/custompublishers/custompublishers_test.go
@@ -14,21 +14,22 @@ func TestDescription(t *testing.T) {
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		require.True(t, Pipe{}.Skip(testctx.New()))
+		require.True(t, Pipe{}.Skip(testctx.Wrap(t.Context())))
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Publishers: []config.Publisher{
 				{},
 			},
 		})
+
 		require.False(t, Pipe{}.Skip(ctx))
 	})
 }
 
 func TestPublish(t *testing.T) {
-	require.NoError(t, Pipe{}.Publish(testctx.NewWithCfg(config.Project{
+	require.NoError(t, Pipe{}.Publish(testctx.WrapWithCfg(t.Context(), config.Project{
 		Publishers: []config.Publisher{
 			{
 				Cmd: "echo",

--- a/internal/pipe/defaults/defaults_test.go
+++ b/internal/pipe/defaults/defaults_test.go
@@ -17,7 +17,7 @@ func TestFillBasicData(t *testing.T) {
 	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:goreleaser/goreleaser.git")
-	ctx := testctx.New(testctx.GitHubTokenType)
+	ctx := testctx.Wrap(t.Context(), testctx.GitHubTokenType)
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Owner)
 	require.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Name)
@@ -41,7 +41,7 @@ func TestFillPartial(t *testing.T) {
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:goreleaser/goreleaser.git")
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		GitHubURLs: config.GitHubURLs{
 			Download: "https://github.company.com",
 		},
@@ -84,6 +84,7 @@ func TestFillPartial(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Len(t, ctx.Config.Archives[0].Files, 1)
 	require.NotEmpty(t, ctx.Config.Dockers[0].Goos)
@@ -94,7 +95,7 @@ func TestFillPartial(t *testing.T) {
 	require.Equal(t, "disttt", ctx.Config.Dist)
 	require.NotEqual(t, "https://github.com", ctx.Config.GitHubURLs.Download)
 
-	ctx = testctx.NewWithCfg(config.Project{
+	ctx = testctx.WrapWithCfg(t.Context(), config.Project{
 		GiteaURLs: config.GiteaURLs{
 			API: "https://gitea.com/api/v1/",
 		},
@@ -131,7 +132,7 @@ func TestGiteaTemplateDownloadURL(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Env: []string{"GORELEASER_TEST_GITEA_URLS_API=https://gitea.com/api/v1"},
 			GiteaURLs: config.GiteaURLs{
 				API: tt.apiURL,

--- a/internal/pipe/dist/dist_test.go
+++ b/internal/pipe/dist/dist_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestDefault(t *testing.T) {
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "dist", ctx.Config.Dist)
 }
@@ -20,7 +20,7 @@ func TestDefault(t *testing.T) {
 func TestDistDoesNotExist(t *testing.T) {
 	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
-	require.NoError(t, Pipe{}.Run(testctx.NewWithCfg(config.Project{Dist: dist})))
+	require.NoError(t, Pipe{}.Run(testctx.WrapWithCfg(t.Context(), config.Project{Dist: dist})))
 }
 
 func TestPopulatedDistExists(t *testing.T) {
@@ -30,7 +30,7 @@ func TestPopulatedDistExists(t *testing.T) {
 	f, err := os.Create(filepath.Join(dist, "mybin"))
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
-	ctx := testctx.NewWithCfg(config.Project{Dist: dist})
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{Dist: dist})
 	require.Error(t, Pipe{}.Run(ctx))
 	require.NoError(t, CleanPipe{}.Run(ctx))
 	require.NoError(t, Pipe{}.Run(ctx))
@@ -42,7 +42,7 @@ func TestEmptyDistExists(t *testing.T) {
 	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
-	ctx := testctx.NewWithCfg(config.Project{Dist: dist})
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{Dist: dist})
 	require.NoError(t, Pipe{}.Run(ctx))
 	_, err := os.Stat(dist)
 	require.False(t, os.IsNotExist(err))
@@ -55,17 +55,17 @@ func TestString(t *testing.T) {
 
 func TestCleanSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		require.True(t, CleanPipe{}.Skip(testctx.New()))
+		require.True(t, CleanPipe{}.Skip(testctx.Wrap(t.Context())))
 	})
 	t.Run("don't skip", func(t *testing.T) {
-		require.False(t, CleanPipe{}.Skip(testctx.New(func(ctx *context.Context) {
+		require.False(t, CleanPipe{}.Skip(testctx.Wrap(t.Context(), func(ctx *context.Context) {
 			ctx.Clean = true
 		})))
 	})
 }
 
 func TestCleanSetDist(t *testing.T) {
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	require.NoError(t, CleanPipe{}.Run(ctx))
 	require.Equal(t, "dist", ctx.Config.Dist)
 }

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -986,7 +986,7 @@ func TestRunPipe(t *testing.T) {
 					require.NoError(t, f.Close())
 				}
 
-				ctx := testctx.NewWithCfg(
+				ctx := testctx.WrapWithCfg(t.Context(),
 					config.Project{
 						ProjectName:     "mybin",
 						Dist:            dist,
@@ -997,8 +997,8 @@ func TestRunPipe(t *testing.T) {
 					testctx.WithVersion("1.0.0"),
 					testctx.WithCurrentTag("v1.0.0"),
 					testctx.WithCommit("a1b2c3d4"),
-					testctx.WithSemver(1, 0, 0, ""),
-				)
+					testctx.WithSemver(1, 0, 0, ""))
+
 				for _, os := range []string{"linux", "darwin"} {
 					for _, arch := range []string{"amd64", "386", "arm64"} {
 						for _, bin := range []string{"mybin", "anotherbin", "subdir/subbin"} {
@@ -1133,7 +1133,7 @@ func TestDescription(t *testing.T) {
 }
 
 func TestNoDockerWithoutImageName(t *testing.T) {
-	testlib.AssertSkipped(t, Pipe{}.Run(testctx.NewWithCfg(config.Project{
+	testlib.AssertSkipped(t, Pipe{}.Run(testctx.WrapWithCfg(t.Context(), config.Project{
 		Dockers: []config.Docker{
 			{
 				Goos: "linux",
@@ -1143,7 +1143,7 @@ func TestNoDockerWithoutImageName(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dockers: []config.Docker{
 			{
 				IDs: []string{"aa"},
@@ -1159,6 +1159,7 @@ func TestDefault(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Len(t, ctx.Config.Dockers, 2)
 	docker := ctx.Config.Dockers[0]
@@ -1186,26 +1187,27 @@ func TestDefault(t *testing.T) {
 }
 
 func TestDefaultDuplicateID(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dockers: []config.Docker{
 			{ID: "foo"},
-			{ /* empty */ },
+			{},
 			{ID: "bar"},
 			{ID: "foo"},
 		},
 		DockerManifests: []config.DockerManifest{
 			{ID: "bar"},
-			{ /* empty */ },
+			{},
 			{ID: "bar"},
 			{ID: "foo"},
 		},
 	})
+
 	require.EqualError(t, Pipe{}.Default(ctx), "found 2 dockers with the ID 'foo', please fix your config")
 	require.EqualError(t, ManifestPipe{}.Default(ctx), "found 2 docker_manifests with the ID 'bar', please fix your config")
 }
 
 func TestDefaultInvalidUse(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dockers: []config.Docker{
 			{
 				Use: "something",
@@ -1217,6 +1219,7 @@ func TestDefaultInvalidUse(t *testing.T) {
 			},
 		},
 	})
+
 	err := Pipe{}.Default(ctx)
 	require.Error(t, err)
 	require.True(t, strings.HasPrefix(err.Error(), `docker: invalid use: something, valid options are`))
@@ -1227,7 +1230,7 @@ func TestDefaultInvalidUse(t *testing.T) {
 }
 
 func TestDefaultDockerfile(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds: []config.Build{
 			{},
 		},
@@ -1236,6 +1239,7 @@ func TestDefaultDockerfile(t *testing.T) {
 			{},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Len(t, ctx.Config.Dockers, 2)
 	require.Equal(t, "Dockerfile", ctx.Config.Dockers[0].Dockerfile)
@@ -1243,7 +1247,7 @@ func TestDefaultDockerfile(t *testing.T) {
 }
 
 func TestDraftRelease(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Release: config.Release{
 			Draft: true,
 		},
@@ -1253,15 +1257,16 @@ func TestDraftRelease(t *testing.T) {
 }
 
 func TestDefaultNoDockers(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dockers: []config.Docker{},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Empty(t, ctx.Config.Dockers)
 }
 
 func TestDefaultFilesDot(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist: "/tmp/distt",
 		Dockers: []config.Docker{
 			{
@@ -1269,11 +1274,12 @@ func TestDefaultFilesDot(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 }
 
 func TestDefaultFilesDis(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist: "/tmp/dist",
 		Dockers: []config.Docker{
 			{
@@ -1281,11 +1287,12 @@ func TestDefaultFilesDis(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 }
 
 func TestDefaultSet(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dockers: []config.Docker{
 			{
 				IDs:        []string{"foo"},
@@ -1295,6 +1302,7 @@ func TestDefaultSet(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Len(t, ctx.Config.Dockers, 1)
 	docker := ctx.Config.Dockers[0]
@@ -1305,7 +1313,7 @@ func TestDefaultSet(t *testing.T) {
 }
 
 func Test_processImageTemplates(t *testing.T) {
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Builds: []config.Build{
 				{
@@ -1328,8 +1336,7 @@ func Test_processImageTemplates(t *testing.T) {
 		testctx.WithVersion("1.0.0"),
 		testctx.WithCurrentTag("v1.0.0"),
 		testctx.WithCommit("a1b2c3d4"),
-		testctx.WithSemver(1, 0, 0, ""),
-	)
+		testctx.WithSemver(1, 0, 0, ""))
 
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Len(t, ctx.Config.Dockers, 1)
@@ -1349,40 +1356,44 @@ func Test_processImageTemplates(t *testing.T) {
 func TestSkip(t *testing.T) {
 	t.Run("image", func(t *testing.T) {
 		t.Run("skip", func(t *testing.T) {
-			require.True(t, Pipe{}.Skip(testctx.New()))
+			require.True(t, Pipe{}.Skip(testctx.Wrap(t.Context())))
 		})
 
 		t.Run("skip docker", func(t *testing.T) {
-			ctx := testctx.NewWithCfg(config.Project{
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 				Dockers: []config.Docker{{}},
 			}, testctx.Skip(skips.Docker))
+
 			require.True(t, Pipe{}.Skip(ctx))
 		})
 
 		t.Run("dont skip", func(t *testing.T) {
-			ctx := testctx.NewWithCfg(config.Project{
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 				Dockers: []config.Docker{{}},
 			})
+
 			require.False(t, Pipe{}.Skip(ctx))
 		})
 	})
 
 	t.Run("manifest", func(t *testing.T) {
 		t.Run("skip", func(t *testing.T) {
-			require.True(t, ManifestPipe{}.Skip(testctx.New()))
+			require.True(t, ManifestPipe{}.Skip(testctx.Wrap(t.Context())))
 		})
 
 		t.Run("skip docker", func(t *testing.T) {
-			ctx := testctx.NewWithCfg(config.Project{
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 				DockerManifests: []config.DockerManifest{{}},
 			}, testctx.Skip(skips.Docker))
+
 			require.True(t, ManifestPipe{}.Skip(ctx))
 		})
 
 		t.Run("dont skip", func(t *testing.T) {
-			ctx := testctx.NewWithCfg(config.Project{
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 				DockerManifests: []config.DockerManifest{{}},
 			})
+
 			require.False(t, ManifestPipe{}.Skip(ctx))
 		})
 	})
@@ -1427,7 +1438,7 @@ func TestWithDigest(t *testing.T) {
 }
 
 func TestDependencies(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dockers: []config.Docker{
 			{Use: useBuildx},
 			{Use: useDocker},
@@ -1439,6 +1450,7 @@ func TestDependencies(t *testing.T) {
 			{Use: "nope"},
 		},
 	})
+
 	require.Equal(t, []string{"docker", "docker"}, Pipe{}.Dependencies(ctx))
 	require.Equal(t, []string{"docker", "docker"}, ManifestPipe{}.Dependencies(ctx))
 }

--- a/internal/pipe/dockerdigest/digest_test.go
+++ b/internal/pipe/dockerdigest/digest_test.go
@@ -17,20 +17,20 @@ func TestString(t *testing.T) {
 
 func TestSkip(t *testing.T) {
 	t.Run("disabled", func(t *testing.T) {
-		ctx := testctx.New()
+		ctx := testctx.Wrap(t.Context())
 		ctx.Config.DockerDigest.Disable = "true"
 		skip, err := Pipe{}.Skip(ctx)
 		require.NoError(t, err)
 		require.True(t, skip)
 	})
 	t.Run("skip", func(t *testing.T) {
-		ctx := testctx.New(testctx.Skip(skips.Docker))
+		ctx := testctx.Wrap(t.Context(), testctx.Skip(skips.Docker))
 		skip, err := Pipe{}.Skip(ctx)
 		require.NoError(t, err)
 		require.True(t, skip)
 	})
 	t.Run("normal", func(t *testing.T) {
-		ctx := testctx.New()
+		ctx := testctx.Wrap(t.Context())
 		skip, err := Pipe{}.Skip(ctx)
 		require.NoError(t, err)
 		require.False(t, skip)
@@ -38,13 +38,13 @@ func TestSkip(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.NotEmpty(t, ctx.Config.DockerDigest.NameTemplate)
 }
 
 func TestRun(t *testing.T) {
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	ctx.Config.Dist = t.TempDir()
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:  "img1",
@@ -77,7 +77,7 @@ digest3  img3
 }
 
 func TestRunInvalidNameTemplate(t *testing.T) {
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	ctx.Config.DockerDigest.NameTemplate = "{{.Nope}}"
 	testlib.RequireTemplateError(t, Pipe{}.Publish(ctx))
 }

--- a/internal/pipe/effectiveconfig/config_test.go
+++ b/internal/pipe/effectiveconfig/config_test.go
@@ -19,9 +19,10 @@ func TestRun(t *testing.T) {
 	folder := testlib.Mktmp(t)
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist: dist,
 	})
+
 	require.NoError(t, Pipe{}.Run(ctx))
 	bts, err := os.ReadFile(filepath.Join(dist, "config.yaml"))
 	require.NoError(t, err)

--- a/internal/pipe/gomod/gomod_proxy_test.go
+++ b/internal/pipe/gomod/gomod_proxy_test.go
@@ -25,7 +25,7 @@ func TestCheckGoMod(t *testing.T) {
 	t.Run("replace on snapshot", func(t *testing.T) {
 		dir := testlib.Mktmp(t)
 		dist := filepath.Join(dir, "dist")
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: dist,
 			GoMod: config.GoMod{
 				Proxy:    true,
@@ -49,7 +49,7 @@ func TestCheckGoMod(t *testing.T) {
 	t.Run("no go mod", func(t *testing.T) {
 		dir := testlib.Mktmp(t)
 		dist := filepath.Join(dir, "dist")
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: dist,
 			GoMod: config.GoMod{
 				Proxy:    true,
@@ -71,7 +71,7 @@ func TestCheckGoMod(t *testing.T) {
 	t.Run("replace", func(t *testing.T) {
 		dir := testlib.Mktmp(t)
 		dist := filepath.Join(dir, "dist")
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: dist,
 			GoMod: config.GoMod{
 				Proxy:    true,
@@ -98,7 +98,7 @@ func TestGoModProxy(t *testing.T) {
 	t.Run("testmod", func(t *testing.T) {
 		dir := testlib.Mktmp(t)
 		dist := filepath.Join(dir, "dist")
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: dist,
 			GoMod: config.GoMod{
 				Proxy:    true,
@@ -115,6 +115,7 @@ func TestGoModProxy(t *testing.T) {
 		}, testctx.WithCurrentTag("v0.1.1"), func(ctx *context.Context) {
 			ctx.ModulePath = "github.com/goreleaser/test-mod"
 		})
+
 		fakeGoModAndSum(t, ctx.ModulePath)
 		require.NoError(t, ProxyPipe{}.Run(ctx))
 		requireGoMod(t)
@@ -126,7 +127,7 @@ func TestGoModProxy(t *testing.T) {
 	t.Run("no go.sum", func(t *testing.T) {
 		dir := testlib.Mktmp(t)
 		dist := filepath.Join(dir, "dist")
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: dist,
 			GoMod: config.GoMod{
 				Proxy:    true,
@@ -142,6 +143,7 @@ func TestGoModProxy(t *testing.T) {
 		}, testctx.WithCurrentTag("v0.0.1"), func(ctx *context.Context) {
 			ctx.ModulePath = "github.com/goreleaser/example-mod-proxy"
 		})
+
 		fakeGoMod(t, ctx.ModulePath)
 		require.NoError(t, ProxyPipe{}.Run(ctx))
 		requireGoMod(t)
@@ -152,7 +154,7 @@ func TestGoModProxy(t *testing.T) {
 	t.Run("goreleaser with main.go", func(t *testing.T) {
 		dir := testlib.Mktmp(t)
 		dist := filepath.Join(dir, "dist")
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: dist,
 			GoMod: config.GoMod{
 				Proxy:    true,
@@ -182,37 +184,40 @@ func TestProxyDescription(t *testing.T) {
 
 func TestSkipProxy(t *testing.T) {
 	t.Run("skip false gomod.proxy", func(t *testing.T) {
-		ctx := testctx.New()
+		ctx := testctx.Wrap(t.Context())
 		require.True(t, ProxyPipe{}.Skip(ctx))
 		require.True(t, CheckGoModPipe{}.Skip(ctx))
 	})
 
 	t.Run("skip snapshot", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			GoMod: config.GoMod{
 				Proxy: true,
 			},
 		}, withTestModulePath, testctx.Snapshot)
+
 		require.True(t, ProxyPipe{}.Skip(ctx))
 		require.False(t, CheckGoModPipe{}.Skip(ctx))
 	})
 
 	t.Run("skip not a go module", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			GoMod: config.GoMod{
 				Proxy: true,
 			},
 		}, func(ctx *context.Context) { ctx.ModulePath = "" })
+
 		require.True(t, ProxyPipe{}.Skip(ctx))
 		require.True(t, CheckGoModPipe{}.Skip(ctx))
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			GoMod: config.GoMod{
 				Proxy: true,
 			},
 		}, withTestModulePath)
+
 		require.False(t, ProxyPipe{}.Skip(ctx))
 		require.False(t, CheckGoModPipe{}.Skip(ctx))
 	})

--- a/internal/pipe/krew/krew_test.go
+++ b/internal/pipe/krew/krew_test.go
@@ -237,7 +237,7 @@ func TestFullPipe(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			folder := t.TempDir()
 
-			ctx := testctx.NewWithCfg(
+			ctx := testctx.WrapWithCfg(t.Context(),
 				config.Project{
 					Dist:        folder,
 					ProjectName: name,
@@ -252,8 +252,8 @@ func TestFullPipe(t *testing.T) {
 					Env: []string{"FOO=foo_is_bar", "BAR=honk"},
 				},
 				testctx.WithCurrentTag("v1.0.1"),
-				testctx.WithVersion("1.0.1"),
-			)
+				testctx.WithVersion("1.0.1"))
+
 			tt.prepare(ctx)
 			ctx.Artifacts.Add(&artifact.Artifact{
 				Name:    "bar_bin.tar.gz",
@@ -347,7 +347,7 @@ func TestFullPipe(t *testing.T) {
 
 func TestRunPipePullRequest(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist:        folder,
 			ProjectName: "foo",
@@ -373,8 +373,8 @@ func TestRunPipePullRequest(t *testing.T) {
 			},
 		},
 		testctx.WithVersion("1.2.1"),
-		testctx.WithCurrentTag("v1.2.1"),
-	)
+		testctx.WithCurrentTag("v1.2.1"))
+
 	path := filepath.Join(folder, "dist/foo_darwin_all/foo")
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "foo_macos.tar.gz",
@@ -406,7 +406,7 @@ func TestRunPipePullRequest(t *testing.T) {
 func TestRunPipeUniversalBinary(t *testing.T) {
 	folder := t.TempDir()
 
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist:        folder,
 			ProjectName: "unibin",
@@ -426,8 +426,7 @@ func TestRunPipeUniversalBinary(t *testing.T) {
 			},
 		},
 		testctx.WithCurrentTag("v1.0.1"),
-		testctx.WithVersion("1.0.1"),
-	)
+		testctx.WithVersion("1.0.1"))
 
 	path := filepath.Join(folder, "bin.tar.gz")
 	ctx.Artifacts.Add(&artifact.Artifact{
@@ -461,7 +460,7 @@ func TestRunPipeUniversalBinary(t *testing.T) {
 
 func TestRunPipeUniversalBinaryNotReplacing(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist:        folder,
 			ProjectName: "unibin",
@@ -481,8 +480,8 @@ func TestRunPipeUniversalBinaryNotReplacing(t *testing.T) {
 			},
 		},
 		testctx.WithCurrentTag("v1.0.1"),
-		testctx.WithVersion("1.0.1"),
-	)
+		testctx.WithVersion("1.0.1"))
+
 	path := filepath.Join(folder, "bin.tar.gz")
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:    "unibin_amd64.tar.gz",
@@ -542,7 +541,7 @@ func TestRunPipeUniversalBinaryNotReplacing(t *testing.T) {
 
 func TestRunPipeNameTemplate(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist:        folder,
 			ProjectName: "foo",
@@ -563,8 +562,8 @@ func TestRunPipeNameTemplate(t *testing.T) {
 			Env: []string{"FOO_BAR=" + t.Name()},
 		},
 		testctx.WithCurrentTag("v1.0.1"),
-		testctx.WithVersion("1.0.1"),
-	)
+		testctx.WithVersion("1.0.1"))
+
 	path := filepath.Join(folder, "bin.tar.gz")
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:    "bin.tar.gz",
@@ -598,7 +597,7 @@ func TestRunPipeNameTemplate(t *testing.T) {
 
 func TestRunPipeMultipleKrewWithSkip(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist:        folder,
 			ProjectName: "foo",
@@ -645,8 +644,8 @@ func TestRunPipeMultipleKrewWithSkip(t *testing.T) {
 			Env: []string{"FOO_BAR=is_bar"},
 		},
 		testctx.WithCurrentTag("v1.0.1"),
-		testctx.WithVersion("1.0.1"),
-	)
+		testctx.WithVersion("1.0.1"))
+
 	path := filepath.Join(folder, "bin.tar.gz")
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:    "bin.tar.gz",
@@ -693,7 +692,7 @@ func TestRunPipeForMultipleArmVersions(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			folder := t.TempDir()
-			ctx := testctx.NewWithCfg(
+			ctx := testctx.WrapWithCfg(t.Context(),
 				config.Project{
 					Dist:        folder,
 					ProjectName: name,
@@ -722,8 +721,8 @@ func TestRunPipeForMultipleArmVersions(t *testing.T) {
 				},
 				testctx.GitHubTokenType,
 				testctx.WithVersion("1.0.1"),
-				testctx.WithCurrentTag("v1.0.1"),
-			)
+				testctx.WithCurrentTag("v1.0.1"))
+
 			fn(ctx)
 			for _, a := range []struct {
 				name   string
@@ -797,7 +796,7 @@ func TestRunPipeForMultipleArmVersions(t *testing.T) {
 }
 
 func TestRunPipeNoBuilds(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Krews: []config.Krew{
 			{
 				Name:             manifestName(t),
@@ -810,6 +809,7 @@ func TestRunPipeNoBuilds(t *testing.T) {
 			},
 		},
 	}, testctx.GitHubTokenType)
+
 	client := client.NewMock()
 	require.Equal(t, ErrNoArchivesFound, runAll(ctx, client))
 	require.False(t, client.CreatedFile)
@@ -817,7 +817,7 @@ func TestRunPipeNoBuilds(t *testing.T) {
 
 func TestRunPipeNoUpload(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        folder,
 		ProjectName: "foo",
 		Release:     config.Release{},
@@ -833,6 +833,7 @@ func TestRunPipeNoUpload(t *testing.T) {
 			},
 		},
 	}, testctx.GitHubTokenType, testctx.WithCurrentTag("v1.0.1"))
+
 	path := filepath.Join(folder, "whatever.tar.gz")
 	f, err := os.Create(path)
 	require.NoError(t, err)
@@ -873,7 +874,7 @@ func TestRunPipeNoUpload(t *testing.T) {
 
 func TestRunEmptyTokenType(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        folder,
 		ProjectName: "foo",
 		Release:     config.Release{},
@@ -889,6 +890,7 @@ func TestRunEmptyTokenType(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v1.0.1"))
+
 	path := filepath.Join(folder, "whatever.tar.gz")
 	f, err := os.Create(path)
 	require.NoError(t, err)
@@ -913,7 +915,7 @@ func TestRunEmptyTokenType(t *testing.T) {
 
 func TestRunMultipleBinaries(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        folder,
 		ProjectName: "foo",
 		Release:     config.Release{},
@@ -929,6 +931,7 @@ func TestRunMultipleBinaries(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v1.0.1"))
+
 	path := filepath.Join(folder, "whatever.tar.gz")
 	f, err := os.Create(path)
 	require.NoError(t, err)
@@ -954,7 +957,7 @@ func TestRunMultipleBinaries(t *testing.T) {
 func TestDefault(t *testing.T) {
 	testlib.Mktmp(t)
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "myproject",
 		Krews: []config.Krew{
 			{
@@ -966,6 +969,7 @@ func TestDefault(t *testing.T) {
 			},
 		},
 	}, testctx.GitHubTokenType)
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, ctx.Config.ProjectName, ctx.Config.Krews[0].Name)
 	require.NotEmpty(t, ctx.Config.Krews[0].CommitAuthor.Name)
@@ -981,21 +985,22 @@ func TestGHFolder(t *testing.T) {
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		require.True(t, Pipe{}.Skip(testctx.New()))
+		require.True(t, Pipe{}.Skip(testctx.Wrap(t.Context())))
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Krews: []config.Krew{
 				{},
 			},
 		})
+
 		require.False(t, Pipe{}.Skip(ctx))
 	})
 }
 
 func TestRunSkipNoName(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Krews: []config.Krew{{}},
 	})
 

--- a/internal/pipe/linkedin/client_test.go
+++ b/internal/pipe/linkedin/client_test.go
@@ -20,7 +20,7 @@ func TestCreateLinkedInClient(t *testing.T) {
 		{
 			"non-empty context and access token",
 			oauthClientConfig{
-				Context:     testctx.New(),
+				Context:     testctx.Wrap(t.Context()),
 				AccessToken: "foo",
 			},
 			nil,
@@ -36,7 +36,7 @@ func TestCreateLinkedInClient(t *testing.T) {
 		{
 			"empty access token",
 			oauthClientConfig{
-				Context:     testctx.New(),
+				Context:     testctx.Wrap(t.Context()),
 				AccessToken: "",
 			},
 			fmt.Errorf("empty access token"),
@@ -66,7 +66,7 @@ func TestClient_Share(t *testing.T) {
 	defer server.Close()
 
 	c, err := createLinkedInClient(oauthClientConfig{
-		Context:     testctx.New(),
+		Context:     testctx.Wrap(t.Context()),
 		AccessToken: "foo",
 	})
 	if err != nil {
@@ -101,7 +101,7 @@ func TestClientLegacyProfile_Share(t *testing.T) {
 	defer server.Close()
 
 	c, err := createLinkedInClient(oauthClientConfig{
-		Context:     testctx.New(),
+		Context:     testctx.Wrap(t.Context()),
 		AccessToken: "foo",
 	})
 	if err != nil {

--- a/internal/pipe/linkedin/linkedin_test.go
+++ b/internal/pipe/linkedin/linkedin_test.go
@@ -14,19 +14,19 @@ func TestStringer(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, defaultMessageTemplate, ctx.Config.Announce.LinkedIn.MessageTemplate)
 }
 
 func TestAnnounceDisabled(t *testing.T) {
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.EqualError(t, Pipe{}.Announce(ctx), `linkedin: env: environment variable "LINKEDIN_ACCESS_TOKEN" should not be empty`)
 }
 
 func TestAnnounceInvalidTemplate(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Announce: config.Announce{
 			LinkedIn: config.LinkedIn{
 				Enabled:         "true",
@@ -34,36 +34,39 @@ func TestAnnounceInvalidTemplate(t *testing.T) {
 			},
 		},
 	})
+
 	testlib.RequireTemplateError(t, Pipe{}.Announce(ctx))
 }
 
 func TestAnnounceMissingEnv(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Announce: config.Announce{
 			LinkedIn: config.LinkedIn{
 				Enabled: "true",
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.EqualError(t, Pipe{}.Announce(ctx), `linkedin: env: environment variable "LINKEDIN_ACCESS_TOKEN" should not be empty`)
 }
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		skip, err := Pipe{}.Skip(testctx.New())
+		skip, err := Pipe{}.Skip(testctx.Wrap(t.Context()))
 		require.NoError(t, err)
 		require.True(t, skip)
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Announce: config.Announce{
 				LinkedIn: config.LinkedIn{
 					Enabled: "true",
 				},
 			},
 		})
+
 		skip, err := Pipe{}.Skip(ctx)
 		require.NoError(t, err)
 		require.False(t, skip)

--- a/internal/pipe/makeself/makeself_test.go
+++ b/internal/pipe/makeself/makeself_test.go
@@ -24,25 +24,26 @@ func TestDescription(t *testing.T) {
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		ctx := testctx.New(testctx.Skip(skips.Makeself))
+		ctx := testctx.Wrap(t.Context(), testctx.Skip(skips.Makeself))
 		require.True(t, Pipe{}.Skip(ctx))
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Makeselfs: []config.Makeself{{}},
 		})
+
 		require.False(t, Pipe{}.Skip(ctx))
 	})
 
 	t.Run("skip no makeselfs", func(t *testing.T) {
-		ctx := testctx.New()
+		ctx := testctx.Wrap(t.Context())
 		require.True(t, Pipe{}.Skip(ctx))
 	})
 }
 
 func TestDefault(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Makeselfs: []config.Makeself{
 			{},
 			{
@@ -72,10 +73,11 @@ func TestDefault(t *testing.T) {
 
 func makeContext(tb testing.TB) *context.Context {
 	tb.Helper()
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(tb.Context(), config.Project{
 		ProjectName: "myproj",
 		Dist:        tb.TempDir(),
 	}, testctx.WithVersion("1.2.3"))
+
 	tmp := tb.TempDir()
 	require.NoError(tb, os.WriteFile(
 		filepath.Join(tmp, "mybin"),

--- a/internal/pipe/mastodon/mastodon_test.go
+++ b/internal/pipe/mastodon/mastodon_test.go
@@ -14,45 +14,47 @@ func TestStringer(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, defaultMessageTemplate, ctx.Config.Announce.Mastodon.MessageTemplate)
 }
 
 func TestAnnounceInvalidTemplate(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Announce: config.Announce{
 			Mastodon: config.Mastodon{
 				MessageTemplate: "{{ .Foo }",
 			},
 		},
 	})
+
 	testlib.RequireTemplateError(t, Pipe{}.Announce(ctx))
 }
 
 func TestAnnounceMissingEnv(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Announce: config.Announce{
 			Mastodon: config.Mastodon{},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.EqualError(t, Pipe{}.Announce(ctx), `mastodon: env: environment variable "MASTODON_CLIENT_ID" should not be empty; environment variable "MASTODON_CLIENT_SECRET" should not be empty; environment variable "MASTODON_ACCESS_TOKEN" should not be empty`)
 }
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		skip, err := Pipe{}.Skip(testctx.New())
+		skip, err := Pipe{}.Skip(testctx.Wrap(t.Context()))
 		require.NoError(t, err)
 		require.True(t, skip)
 	})
 
 	t.Run("skip empty server", func(t *testing.T) {
-		skip, err := Pipe{}.Skip(testctx.NewWithCfg(config.Project{
+		skip, err := Pipe{}.Skip(testctx.WrapWithCfg(t.Context(), config.Project{
 			Announce: config.Announce{
 				Mastodon: config.Mastodon{
 					Enabled: "true",
-					Server:  "", // empty
+					Server:  "",
 				},
 			},
 		}))
@@ -61,7 +63,7 @@ func TestSkip(t *testing.T) {
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		skip, err := Pipe{}.Skip(testctx.NewWithCfg(config.Project{
+		skip, err := Pipe{}.Skip(testctx.WrapWithCfg(t.Context(), config.Project{
 			Announce: config.Announce{
 				Mastodon: config.Mastodon{
 					Enabled: "true",

--- a/internal/pipe/mattermost/mattermost_test.go
+++ b/internal/pipe/mattermost/mattermost_test.go
@@ -20,47 +20,50 @@ func TestStringer(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, defaultMessageTemplate, ctx.Config.Announce.Mattermost.MessageTemplate)
 }
 
 func TestAnnounceInvalidTemplate(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Announce: config.Announce{
 			Mattermost: config.Mattermost{
 				MessageTemplate: "{{ .Foo }",
 			},
 		},
 	})
+
 	testlib.RequireTemplateError(t, Pipe{}.Announce(ctx))
 }
 
 func TestAnnounceMissingEnv(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Announce: config.Announce{
 			Mattermost: config.Mattermost{},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.EqualError(t, Pipe{}.Announce(ctx), `mattermost: env: environment variable "MATTERMOST_WEBHOOK" should not be empty`)
 }
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		skip, err := Pipe{}.Skip(testctx.New())
+		skip, err := Pipe{}.Skip(testctx.Wrap(t.Context()))
 		require.NoError(t, err)
 		require.True(t, skip)
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Announce: config.Announce{
 				Mattermost: config.Mattermost{
 					Enabled: "true",
 				},
 			},
 		})
+
 		skip, err := Pipe{}.Skip(ctx)
 		require.NoError(t, err)
 		require.False(t, skip)
@@ -84,7 +87,7 @@ func TestPostWebhook(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "Honk",
 		Announce: config.Announce{
 			Mattermost: config.Mattermost{

--- a/internal/pipe/metadata/metadata_test.go
+++ b/internal/pipe/metadata/metadata_test.go
@@ -18,10 +18,11 @@ import (
 )
 
 func TestRunWithError(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        "testadata/nope",
 		ProjectName: "foo",
 	})
+
 	require.ErrorIs(t, MetaPipe{}.Run(ctx), os.ErrNotExist)
 	require.ErrorIs(t, ArtifactsPipe{}.Run(ctx), os.ErrNotExist)
 }
@@ -30,7 +31,8 @@ func TestRun(t *testing.T) {
 	modTime := time.Now().AddDate(-1, 0, 0).Round(time.Second).UTC()
 
 	getCtx := func(tmp string) *context.Context {
-		ctx := testctx.NewWithCfg(
+		ctx := testctx.WrapWithCfg(
+			t.Context(),
 			config.Project{
 				Dist:        tmp,
 				ProjectName: "name",

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -23,21 +23,21 @@ func TestDescription(t *testing.T) {
 }
 
 func TestRunPipeNoFormats(t *testing.T) {
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			NFPMs: []config.NFPM{
 				{},
 			},
 		},
 		testctx.WithCurrentTag("v1.0.1"),
-		testctx.WithVersion("1.0.1"),
-	)
+		testctx.WithVersion("1.0.1"))
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
 }
 
 func TestRunPipeError(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist: t.TempDir(),
 		NFPMs: []config.NFPM{
 			{
@@ -48,6 +48,7 @@ func TestRunPipeError(t *testing.T) {
 			},
 		},
 	})
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "mybin",
 		Path:   "testdata/testfile.txt",
@@ -63,7 +64,7 @@ func TestRunPipeError(t *testing.T) {
 }
 
 func TestRunPipeInvalidFormat(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "nope",
 		NFPMs: []config.NFPM{
 			{
@@ -77,6 +78,7 @@ func TestRunPipeInvalidFormat(t *testing.T) {
 			},
 		},
 	}, testctx.WithVersion("1.2.3"), testctx.WithCurrentTag("v1.2.3"))
+
 	for _, goos := range []string{"linux", "darwin"} {
 		for _, goarch := range []string{"amd64", "386"} {
 			ctx.Artifacts.Add(&artifact.Artifact{
@@ -115,7 +117,7 @@ func TestRunPipe(t *testing.T) {
 	fileInfo := config.FileInfo{
 		MTime: "{{.CommitDate}}",
 	}
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		Env: []string{
@@ -212,6 +214,7 @@ func TestRunPipe(t *testing.T) {
 	}, testctx.WithVersion("1.0.0"), testctx.WithCurrentTag("v1.0.0"), func(ctx *context.Context) {
 		ctx.Git.CommitDate = now
 	})
+
 	for _, goos := range []string{"linux", "darwin", "ios", "android", "aix"} {
 		for _, goarch := range []string{"amd64", "386", "arm64", "arm", "mips", "ppc64"} {
 			if goos == "ios" && goarch != "arm64" {
@@ -520,7 +523,7 @@ func TestSkipOne(t *testing.T) {
 	require.NoError(t, os.Mkdir(dist, 0o755))
 	binPath := filepath.ToSlash(filepath.Join(dist, "mybin"))
 	require.NoError(t, os.WriteFile(binPath, nil, 0o755))
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		NFPMs: []config.NFPM{
@@ -532,6 +535,7 @@ func TestSkipOne(t *testing.T) {
 			},
 		},
 	}, testctx.WithVersion("1.0.0"))
+
 	for _, goos := range []string{"linux", "darwin"} {
 		for _, goarch := range []string{"amd64", "arm64"} {
 			ctx.Artifacts.Add(&artifact.Artifact{
@@ -573,7 +577,7 @@ func doTestRunPipeConventionalNameTemplate(t *testing.T, snapshot bool) {
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0o755))
 	binPath := filepath.ToSlash(filepath.Join(dist, "mybin", "mybin"))
 	require.NoError(t, os.WriteFile(binPath, []byte("nope"), 0o755))
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		NFPMs: []config.NFPM{
@@ -601,6 +605,7 @@ func doTestRunPipeConventionalNameTemplate(t *testing.T, snapshot bool) {
 			},
 		},
 	}, testctx.WithVersion("1.0.0"), testctx.WithCurrentTag("v1.0.0"))
+
 	if snapshot {
 		ctx.Snapshot = true
 	}
@@ -796,7 +801,7 @@ func doTestRunPipeConventionalNameTemplate(t *testing.T, snapshot bool) {
 
 func TestInvalidTemplate(t *testing.T) {
 	makeCtx := func() *context.Context {
-		ctx := testctx.NewWithCfg(
+		ctx := testctx.WrapWithCfg(t.Context(),
 			config.Project{
 				ProjectName: "test",
 				NFPMs: []config.NFPM{
@@ -806,8 +811,8 @@ func TestInvalidTemplate(t *testing.T) {
 					},
 				},
 			},
-			testctx.WithVersion("1.2.3"),
-		)
+			testctx.WithVersion("1.2.3"))
+
 		ctx.Artifacts.Add(&artifact.Artifact{
 			Name:   "mybin",
 			Goos:   "linux",
@@ -906,7 +911,7 @@ func TestInvalidTemplate(t *testing.T) {
 }
 
 func TestRunPipeInvalidContentsSourceTemplate(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		NFPMs: []config.NFPM{
 			{
 				NFPMOverridables: config.NFPMOverridables{
@@ -923,6 +928,7 @@ func TestRunPipeInvalidContentsSourceTemplate(t *testing.T) {
 			},
 		},
 	})
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "mybin",
 		Goos:   "linux",
@@ -936,7 +942,7 @@ func TestRunPipeInvalidContentsSourceTemplate(t *testing.T) {
 }
 
 func TestNoBuildsFound(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		NFPMs: []config.NFPM{
 			{
 				Formats: []string{"deb"},
@@ -944,6 +950,7 @@ func TestNoBuildsFound(t *testing.T) {
 			},
 		},
 	})
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "mybin",
 		Goos:   "linux",
@@ -961,7 +968,7 @@ func TestCreateFileDoesntExist(t *testing.T) {
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0o755))
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        dist,
 		ProjectName: "asd",
 		NFPMs: []config.NFPM{
@@ -980,6 +987,7 @@ func TestCreateFileDoesntExist(t *testing.T) {
 			},
 		},
 	}, testctx.WithVersion("1.2.3"), testctx.WithCurrentTag("v1.2.3"))
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "mybin",
 		Path:   filepath.Join(dist, "mybin", "mybin"),
@@ -998,7 +1006,7 @@ func TestInvalidConfig(t *testing.T) {
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0o755))
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist: dist,
 		NFPMs: []config.NFPM{
 			{
@@ -1007,6 +1015,7 @@ func TestInvalidConfig(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v1.2.3"), testctx.WithVersion("1.2.3"))
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "mybin",
 		Path:   filepath.Join(dist, "mybin", "mybin"),
@@ -1021,12 +1030,13 @@ func TestInvalidConfig(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "foobar",
 		NFPMs: []config.NFPM{
 			{},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "/usr/bin", ctx.Config.NFPMs[0].Bindir)
 	require.Empty(t, ctx.Config.NFPMs[0].Builds)
@@ -1035,7 +1045,7 @@ func TestDefault(t *testing.T) {
 }
 
 func TestDefaultSet(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		NFPMs: []config.NFPM{
 			{
 				Builds: []string{"foo"},
@@ -1046,6 +1056,7 @@ func TestDefaultSet(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "/bin", ctx.Config.NFPMs[0].Bindir)
 	require.Equal(t, "foo", ctx.Config.NFPMs[0].FileNameTemplate)
@@ -1054,7 +1065,7 @@ func TestDefaultSet(t *testing.T) {
 }
 
 func TestOverrides(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		NFPMs: []config.NFPM{
 			{
 				Bindir: "/bin",
@@ -1069,6 +1080,7 @@ func TestOverrides(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	merged, err := mergeOverrides(ctx.Config.NFPMs[0], "deb")
 	require.NoError(t, err)
@@ -1089,7 +1101,7 @@ func TestDebSpecificConfig(t *testing.T) {
 		f, err := os.Create(binPath)
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			ProjectName: "mybin",
 			Dist:        dist,
 			NFPMs: []config.NFPM{
@@ -1115,6 +1127,7 @@ func TestDebSpecificConfig(t *testing.T) {
 				},
 			},
 		}, testctx.WithVersion("1.0.0"), testctx.WithCurrentTag("v1.0.0"))
+
 		for _, goos := range []string{"linux", "darwin", "android"} {
 			for _, goarch := range []string{"amd64", "386"} {
 				ctx.Artifacts.Add(&artifact.Artifact{
@@ -1222,7 +1235,7 @@ func TestRPMSpecificConfig(t *testing.T) {
 	f, err := os.Create(binPath)
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		NFPMs: []config.NFPM{
@@ -1247,6 +1260,7 @@ func TestRPMSpecificConfig(t *testing.T) {
 			},
 		},
 	}, testctx.WithVersion("1.0.0"), testctx.WithCurrentTag("v1.0.0"))
+
 	for _, goos := range []string{"linux", "darwin"} {
 		for _, goarch := range []string{"amd64", "386"} {
 			ctx.Artifacts.Add(&artifact.Artifact{
@@ -1294,7 +1308,7 @@ func TestRPMSpecificScriptsConfig(t *testing.T) {
 	f, err := os.Create(binPath)
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		NFPMs: []config.NFPM{
@@ -1314,6 +1328,7 @@ func TestRPMSpecificScriptsConfig(t *testing.T) {
 			},
 		},
 	}, testctx.WithVersion("1.0.0"), testctx.WithCurrentTag("v1.0.0"))
+
 	for _, goos := range []string{"linux", "darwin"} {
 		for _, goarch := range []string{"amd64", "386"} {
 			ctx.Artifacts.Add(&artifact.Artifact{
@@ -1355,7 +1370,7 @@ func TestAPKSpecificConfig(t *testing.T) {
 	f, err := os.Create(binPath)
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		NFPMs: []config.NFPM{
@@ -1381,6 +1396,7 @@ func TestAPKSpecificConfig(t *testing.T) {
 			},
 		},
 	}, testctx.WithVersion("1.0.0"), testctx.WithCurrentTag("v1.0.0"))
+
 	for _, goos := range []string{"linux", "darwin"} {
 		for _, goarch := range []string{"amd64", "386"} {
 			ctx.Artifacts.Add(&artifact.Artifact{
@@ -1432,7 +1448,7 @@ func TestAPKSpecificScriptsConfig(t *testing.T) {
 		PreUpgrade:  "/does/not/exist_preupgrade.sh",
 		PostUpgrade: "/does/not/exist_postupgrade.sh",
 	}
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		NFPMs: []config.NFPM{
@@ -1456,6 +1472,7 @@ func TestAPKSpecificScriptsConfig(t *testing.T) {
 			},
 		},
 	}, testctx.WithVersion("1.0.0"), testctx.WithCurrentTag("v1.0.0"))
+
 	for _, goos := range []string{"linux", "darwin"} {
 		for _, goarch := range []string{"amd64", "386"} {
 			ctx.Artifacts.Add(&artifact.Artifact{
@@ -1501,7 +1518,7 @@ func TestIPKSpecificConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		NFPMs: []config.NFPM{
@@ -1539,6 +1556,7 @@ func TestIPKSpecificConfig(t *testing.T) {
 			},
 		},
 	}, testctx.WithVersion("1.0.0"), testctx.WithCurrentTag("v1.0.0"))
+
 	for _, goos := range []string{"linux", "darwin"} {
 		for _, goarch := range []string{"amd64", "386"} {
 			ctx.Artifacts.Add(&artifact.Artifact{
@@ -1564,7 +1582,7 @@ func TestIPKSpecificConfig(t *testing.T) {
 }
 
 func TestSeveralNFPMsWithTheSameID(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		NFPMs: []config.NFPM{
 			{
 				ID: "a",
@@ -1574,6 +1592,7 @@ func TestSeveralNFPMsWithTheSameID(t *testing.T) {
 			},
 		},
 	})
+
 	require.EqualError(t, Pipe{}.Default(ctx), "found 2 nfpms with the ID 'a', please fix your config")
 }
 
@@ -1586,7 +1605,7 @@ func TestMeta(t *testing.T) {
 	f, err := os.Create(binPath)
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		NFPMs: []config.NFPM{
@@ -1638,6 +1657,7 @@ func TestMeta(t *testing.T) {
 			},
 		},
 	}, testctx.WithVersion("1.0.0"), testctx.WithCurrentTag("v1.0.0"))
+
 	for _, goos := range []string{"linux", "darwin"} {
 		for _, goarch := range []string{"amd64", "386"} {
 			ctx.Artifacts.Add(&artifact.Artifact{
@@ -1679,7 +1699,7 @@ func TestSkipSign(t *testing.T) {
 	binPath := filepath.Join(dist, "mybin", "mybin")
 	_, err := os.Create(binPath)
 	require.NoError(t, err)
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		NFPMs: []config.NFPM{
@@ -1715,6 +1735,7 @@ func TestSkipSign(t *testing.T) {
 			},
 		},
 	}, testctx.WithVersion("1.0.0"), testctx.WithCurrentTag("v1.0.0"))
+
 	for _, goos := range []string{"linux", "darwin"} {
 		for _, goarch := range []string{"amd64", "386"} {
 			ctx.Artifacts.Add(&artifact.Artifact{
@@ -1751,7 +1772,7 @@ func TestBinDirTemplating(t *testing.T) {
 	f, err := os.Create(binPath)
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		Env: []string{
@@ -1762,7 +1783,7 @@ func TestBinDirTemplating(t *testing.T) {
 		NFPMs: []config.NFPM{
 			{
 				ID: "someid",
-				// Bindir should pass through the template engine
+
 				Bindir:      "/usr/lib/{{ .Env.PRO }}/nagios/plugins",
 				Builds:      []string{"default"},
 				Formats:     []string{"rpm"},
@@ -1779,6 +1800,7 @@ func TestBinDirTemplating(t *testing.T) {
 			},
 		},
 	}, testctx.WithVersion("1.0.0"), testctx.WithCurrentTag("v1.0.0"))
+
 	for _, goos := range []string{"linux"} {
 		for _, goarch := range []string{"amd64", "386"} {
 			ctx.Artifacts.Add(&artifact.Artifact{
@@ -1808,29 +1830,31 @@ func TestBinDirTemplating(t *testing.T) {
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		require.True(t, Pipe{}.Skip(testctx.New()))
+		require.True(t, Pipe{}.Skip(testctx.Wrap(t.Context())))
 	})
 	t.Run("skip flag", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			NFPMs: []config.NFPM{
 				{},
 			},
 		}, testctx.Skip(skips.NFPM))
+
 		require.True(t, Pipe{}.Skip(ctx))
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			NFPMs: []config.NFPM{
 				{},
 			},
 		})
+
 		require.False(t, Pipe{}.Skip(ctx))
 	})
 }
 
 func TestTemplateExt(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist: t.TempDir(),
 		NFPMs: []config.NFPM{
 			{
@@ -1845,6 +1869,7 @@ func TestTemplateExt(t *testing.T) {
 			},
 		},
 	})
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "mybin",
 		Goos:   "android",

--- a/internal/pipe/nix/nix_test.go
+++ b/internal/pipe/nix/nix_test.go
@@ -31,17 +31,17 @@ func TestString(t *testing.T) {
 
 func TestSkip(t *testing.T) {
 	t.Run("no-nix", func(t *testing.T) {
-		require.True(t, Pipe{}.Skip(testctx.New()))
+		require.True(t, Pipe{}.Skip(testctx.Wrap(t.Context())))
 	})
 	t.Run("skip flag", func(t *testing.T) {
-		require.True(t, New().Skip(testctx.NewWithCfg(config.Project{
+		require.True(t, New().Skip(testctx.WrapWithCfg(t.Context(), config.Project{
 			Nix: []config.Nix{{}},
 		}, testctx.Skip(skips.Nix))))
 	})
 	t.Run("nix-all-good", func(t *testing.T) {
 		testlib.CheckPath(t, "nix-hash")
 		testlib.SkipIfWindows(t, "nix doesn't work on windows")
-		require.False(t, New().Skip(testctx.NewWithCfg(config.Project{
+		require.False(t, New().Skip(testctx.WrapWithCfg(t.Context(), config.Project{
 			Nix: []config.Nix{{}},
 		})))
 	})
@@ -423,7 +423,7 @@ func TestRunPipe(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			folder := t.TempDir()
-			ctx := testctx.NewWithCfg(
+			ctx := testctx.WrapWithCfg(t.Context(),
 				config.Project{
 					Dist:        folder,
 					ProjectName: "foo",
@@ -431,8 +431,8 @@ func TestRunPipe(t *testing.T) {
 				},
 				testctx.WithVersion("1.2.1"),
 				testctx.WithCurrentTag("v1.2.1"),
-				testctx.WithSemver(1, 2, 1, "rc1"),
-			)
+				testctx.WithSemver(1, 2, 1, "rc1"))
+
 			createFakeArtifact := func(id, goos, goarch, goamd64, goarm, format string, extra map[string]any) {
 				if goarch != "arm" {
 					goarm = ""

--- a/internal/pipe/notary/macos_test.go
+++ b/internal/pipe/notary/macos_test.go
@@ -20,7 +20,7 @@ func TestMacOSSkip(t *testing.T) {
 	p := MacOS{}
 	t.Run("skip notarize", func(t *testing.T) {
 		require.True(t,
-			p.Skip(testctx.NewWithCfg(config.Project{
+			p.Skip(testctx.WrapWithCfg(t.Context(), config.Project{
 				Notarize: config.Notarize{
 					MacOS: []config.MacOSSignNotarize{
 						{},
@@ -30,11 +30,11 @@ func TestMacOSSkip(t *testing.T) {
 	})
 	t.Run("skip no configs", func(t *testing.T) {
 		require.True(t,
-			p.Skip(testctx.NewWithCfg(config.Project{})))
+			p.Skip(testctx.WrapWithCfg(t.Context(), config.Project{})))
 	})
 	t.Run("dont skip", func(t *testing.T) {
 		require.False(t,
-			p.Skip(testctx.NewWithCfg(config.Project{
+			p.Skip(testctx.WrapWithCfg(t.Context(), config.Project{
 				Notarize: config.Notarize{
 					MacOS: []config.MacOSSignNotarize{
 						{},
@@ -45,7 +45,7 @@ func TestMacOSSkip(t *testing.T) {
 }
 
 func TestMacOSDefault(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "foo",
 		Notarize: config.Notarize{
 			MacOS: []config.MacOSSignNotarize{
@@ -61,6 +61,7 @@ func TestMacOSDefault(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, MacOS{}.Default(ctx))
 	require.Equal(t, []config.MacOSSignNotarize{
 		{
@@ -142,20 +143,21 @@ func TestMacOSRun(t *testing.T) {
 			},
 		} {
 			t.Run(name, func(t *testing.T) {
-				ctx := testctx.NewWithCfg(config.Project{
+				ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 					Notarize: config.Notarize{
 						MacOS: []config.MacOSSignNotarize{
 							{},
 						},
 					},
 				})
+
 				fn(ctx)
 				testlib.RequireTemplateError(t, MacOS{}.Run(ctx))
 			})
 		}
 	})
 	t.Run("skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Notarize: config.Notarize{
 				MacOS: []config.MacOSSignNotarize{
 					{},
@@ -165,6 +167,7 @@ func TestMacOSRun(t *testing.T) {
 				},
 			},
 		}, testctx.WithEnv(map[string]string{"SKIP": "false"}))
+
 		testlib.AssertSkipped(t, MacOS{}.Run(ctx))
 	})
 }

--- a/internal/pipe/opencollective/opencollective_test.go
+++ b/internal/pipe/opencollective/opencollective_test.go
@@ -14,46 +14,48 @@ func TestStringer(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, defaultTitleTemplate, ctx.Config.Announce.OpenCollective.TitleTemplate)
 	require.Equal(t, defaultMessageTemplate, ctx.Config.Announce.OpenCollective.MessageTemplate)
 }
 
 func TestAnnounceInvalidTemplate(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Announce: config.Announce{
 			OpenCollective: config.OpenCollective{
 				MessageTemplate: "{{ .Foo }",
 			},
 		},
 	})
+
 	testlib.RequireTemplateError(t, Pipe{}.Announce(ctx))
 }
 
 func TestAnnounceMissingEnv(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Announce: config.Announce{
 			OpenCollective: config.OpenCollective{},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.EqualError(t, Pipe{}.Announce(ctx), `opencollective: env: environment variable "OPENCOLLECTIVE_TOKEN" should not be empty`)
 }
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		skip, err := Pipe{}.Skip(testctx.New())
+		skip, err := Pipe{}.Skip(testctx.Wrap(t.Context()))
 		require.NoError(t, err)
 		require.True(t, skip)
 	})
 
 	t.Run("skip empty slug", func(t *testing.T) {
-		skip, err := Pipe{}.Skip(testctx.NewWithCfg(config.Project{
+		skip, err := Pipe{}.Skip(testctx.WrapWithCfg(t.Context(), config.Project{
 			Announce: config.Announce{
 				OpenCollective: config.OpenCollective{
 					Enabled: "true",
-					Slug:    "", // empty
+					Slug:    "",
 				},
 			},
 		}))
@@ -62,7 +64,7 @@ func TestSkip(t *testing.T) {
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		skip, err := Pipe{}.Skip(testctx.NewWithCfg(config.Project{
+		skip, err := Pipe{}.Skip(testctx.WrapWithCfg(t.Context(), config.Project{
 			Announce: config.Announce{
 				OpenCollective: config.OpenCollective{
 					Enabled: "true",

--- a/internal/pipe/partial/partial_test.go
+++ b/internal/pipe/partial/partial_test.go
@@ -18,45 +18,49 @@ func TestString(t *testing.T) {
 
 func TestSkip(t *testing.T) {
 	t.Run("partial", func(t *testing.T) {
-		ctx := testctx.New(testctx.Partial)
+		ctx := testctx.Wrap(t.Context(), testctx.Partial)
 		require.False(t, pipe.Skip(ctx))
 	})
 
 	t.Run("full", func(t *testing.T) {
-		require.True(t, pipe.Skip(testctx.New()))
+		require.True(t, pipe.Skip(testctx.Wrap(t.Context())))
 	})
 }
 
 func TestRun(t *testing.T) {
 	t.Run("target", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: "dist",
 		}, testctx.Partial)
+
 		t.Setenv("TARGET", "windows_arm64")
 		require.NoError(t, pipe.Run(ctx))
 		require.Equal(t, "windows_arm64", ctx.PartialTarget)
 	})
 	t.Run("no target", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: "dist",
 		}, testctx.Partial)
+
 		require.Error(t, pipe.Run(ctx))
 	})
 	t.Run("using GGOOS and GGOARCH", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist:   "dist",
 			Builds: []config.Build{{Builder: "go"}},
 		}, testctx.Partial)
+
 		t.Setenv("GGOOS", "windows")
 		t.Setenv("GGOARCH", "arm64")
 		require.NoError(t, pipe.Run(ctx))
 		require.Equal(t, "windows_arm64", ctx.PartialTarget)
 	})
 	t.Run("custom GGOARM", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist:   "dist",
 			Builds: []config.Build{{Builder: "go"}},
 		}, testctx.Partial)
+
 		t.Setenv("GGOOS", "linux")
 		t.Setenv("GGOARCH", "arm")
 		t.Run("default", func(t *testing.T) {
@@ -70,10 +74,11 @@ func TestRun(t *testing.T) {
 		})
 	})
 	t.Run("custom GGOARM64", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist:   "dist",
 			Builds: []config.Build{{Builder: "go"}},
 		}, testctx.Partial)
+
 		t.Setenv("GGOOS", "linux")
 		t.Setenv("GGOARCH", "arm64")
 		t.Run("default", func(t *testing.T) {
@@ -87,10 +92,11 @@ func TestRun(t *testing.T) {
 		})
 	})
 	t.Run("custom GGOAMD64", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist:   "dist",
 			Builds: []config.Build{{Builder: "go"}},
 		}, testctx.Partial)
+
 		t.Setenv("GGOOS", "linux")
 		t.Setenv("GGOARCH", "amd64")
 		t.Run("default", func(t *testing.T) {
@@ -104,10 +110,11 @@ func TestRun(t *testing.T) {
 		})
 	})
 	t.Run("custom GGOMIPS", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist:   "dist",
 			Builds: []config.Build{{Builder: "go"}},
 		}, testctx.Partial)
+
 		t.Setenv("GGOOS", "linux")
 		for _, mips := range []string{"mips", "mips64", "mipsle", "mips64le"} {
 			t.Run(mips, func(t *testing.T) {
@@ -125,10 +132,11 @@ func TestRun(t *testing.T) {
 		}
 	})
 	t.Run("custom GGO386", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist:   "dist",
 			Builds: []config.Build{{Builder: "go"}},
 		}, testctx.Partial)
+
 		t.Setenv("GGOOS", "linux")
 		t.Setenv("GGOARCH", "386")
 		t.Run("default", func(t *testing.T) {
@@ -142,10 +150,11 @@ func TestRun(t *testing.T) {
 		})
 	})
 	t.Run("custom GGOPPC64", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist:   "dist",
 			Builds: []config.Build{{Builder: "go"}},
 		}, testctx.Partial)
+
 		t.Setenv("GGOOS", "linux")
 		t.Setenv("GGOARCH", "ppc64")
 		t.Run("default", func(t *testing.T) {
@@ -159,10 +168,11 @@ func TestRun(t *testing.T) {
 		})
 	})
 	t.Run("custom GGORISCV64", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist:   "dist",
 			Builds: []config.Build{{Builder: "go"}},
 		}, testctx.Partial)
+
 		t.Setenv("GGOOS", "linux")
 		t.Setenv("GGOARCH", "riscv64")
 		t.Run("default", func(t *testing.T) {
@@ -176,10 +186,11 @@ func TestRun(t *testing.T) {
 		})
 	})
 	t.Run("using runtime", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist:   "dist",
 			Builds: []config.Build{{Builder: "go"}},
 		}, testctx.Partial)
+
 		require.NoError(t, pipe.Run(ctx))
 		target := fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH)
 		require.Equal(t, target, ctx.PartialTarget)
@@ -188,7 +199,7 @@ func TestRun(t *testing.T) {
 	t.Run("using runtime with other languages", func(t *testing.T) {
 		t.Setenv("GGOOS", "darwin")
 		t.Setenv("GGOARCH", "amd64")
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: "dist",
 			Builds: []config.Build{{
 				Builder: "rust",
@@ -201,6 +212,7 @@ func TestRun(t *testing.T) {
 				},
 			}},
 		}, testctx.Partial)
+
 		require.NoError(t, pipe.Run(ctx))
 		require.Equal(t, "x86_64-apple-darwin", ctx.PartialTarget)
 	})
@@ -208,7 +220,7 @@ func TestRun(t *testing.T) {
 	t.Run("using runtime with other languages no match", func(t *testing.T) {
 		t.Setenv("GGOOS", "darwin")
 		t.Setenv("GGOARCH", "amd64")
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Dist: "dist",
 			Builds: []config.Build{{
 				Builder: "rust",
@@ -218,6 +230,7 @@ func TestRun(t *testing.T) {
 				},
 			}},
 		}, testctx.Partial)
+
 		require.Error(t, pipe.Run(ctx))
 		require.Empty(t, ctx.PartialTarget)
 	})

--- a/internal/pipe/project/project_test.go
+++ b/internal/pipe/project/project_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestCustomProjectName(t *testing.T) {
 	_ = testlib.Mktmp(t)
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "foo",
 		Release: config.Release{
 			GitHub: config.Repo{
@@ -23,13 +23,14 @@ func TestCustomProjectName(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "foo", ctx.Config.ProjectName)
 }
 
 func TestEmptyProjectName_DefaultsToGitHubRelease(t *testing.T) {
 	_ = testlib.Mktmp(t)
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Release: config.Release{
 			GitHub: config.Repo{
 				Owner: "bar",
@@ -37,13 +38,14 @@ func TestEmptyProjectName_DefaultsToGitHubRelease(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "bar", ctx.Config.ProjectName)
 }
 
 func TestEmptyProjectName_DefaultsToGitLabRelease(t *testing.T) {
 	_ = testlib.Mktmp(t)
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Release: config.Release{
 			GitLab: config.Repo{
 				Owner: "bar",
@@ -51,13 +53,14 @@ func TestEmptyProjectName_DefaultsToGitLabRelease(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "bar", ctx.Config.ProjectName)
 }
 
 func TestEmptyProjectName_DefaultsToGiteaRelease(t *testing.T) {
 	_ = testlib.Mktmp(t)
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Release: config.Release{
 			Gitea: config.Repo{
 				Owner: "bar",
@@ -65,13 +68,14 @@ func TestEmptyProjectName_DefaultsToGiteaRelease(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "bar", ctx.Config.ProjectName)
 }
 
 func TestEmptyProjectName_DefaultsToGoModPath(t *testing.T) {
 	_ = testlib.Mktmp(t)
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	require.NoError(t, exec.CommandContext(t.Context(), "go", "mod", "init", "github.com/foo/bar").Run())
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "bar", ctx.Config.ProjectName)
@@ -79,7 +83,7 @@ func TestEmptyProjectName_DefaultsToGoModPath(t *testing.T) {
 
 func TestEmptyProjectName_DefaultsToCargo(t *testing.T) {
 	_ = testlib.Mktmp(t)
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	require.NoError(t, os.WriteFile("Cargo.toml", []byte("[package]\nname = \"bar\""), 0o644))
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "bar", ctx.Config.ProjectName)
@@ -87,7 +91,7 @@ func TestEmptyProjectName_DefaultsToCargo(t *testing.T) {
 
 func TestEmptyProjectName_DefaultsToGitURL(t *testing.T) {
 	_ = testlib.Mktmp(t)
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
 	require.NoError(t, Pipe{}.Default(ctx))
@@ -96,7 +100,7 @@ func TestEmptyProjectName_DefaultsToGitURL(t *testing.T) {
 
 func TestEmptyProjectName_DefaultsToNonSCMGitURL(t *testing.T) {
 	_ = testlib.Mktmp(t)
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@myhost.local:bar.git")
 	require.EqualError(t, Pipe{}.Default(ctx), "couldn't guess project_name, please add it to your config")
@@ -104,10 +108,11 @@ func TestEmptyProjectName_DefaultsToNonSCMGitURL(t *testing.T) {
 
 func TestEmptyProjectNameAndRelease(t *testing.T) {
 	_ = testlib.Mktmp(t)
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Release: config.Release{
 			GitHub: config.Repo{},
 		},
 	})
+
 	require.EqualError(t, Pipe{}.Default(ctx), "couldn't guess project_name, please add it to your config")
 }

--- a/internal/pipe/publish/publish_test.go
+++ b/internal/pipe/publish/publish_test.go
@@ -18,15 +18,16 @@ func TestDescription(t *testing.T) {
 }
 
 func TestPublish(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Release:      config.Release{Disable: "true"},
 		DockerDigest: config.DockerDigest{Disable: "true"},
 	}, testctx.GitHubTokenType)
+
 	require.NoError(t, New().Run(ctx))
 }
 
 func TestPublishSuccess(t *testing.T) {
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	lastStep := &testPublisher{}
 	err := Pipe{
 		pipeline: []Publisher{
@@ -50,7 +51,7 @@ func TestPublishSuccess(t *testing.T) {
 }
 
 func TestPublishError(t *testing.T) {
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	lastStep := &testPublisher{}
 	err := Pipe{
 		pipeline: []Publisher{
@@ -74,12 +75,12 @@ func TestPublishError(t *testing.T) {
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		ctx := testctx.New(testctx.Skip(skips.Publish))
+		ctx := testctx.Wrap(t.Context(), testctx.Skip(skips.Publish))
 		require.True(t, Pipe{}.Skip(ctx))
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		require.False(t, Pipe{}.Skip(testctx.New()))
+		require.False(t, Pipe{}.Skip(testctx.Wrap(t.Context())))
 	})
 }
 

--- a/internal/pipe/reddit/reddit_test.go
+++ b/internal/pipe/reddit/reddit_test.go
@@ -14,58 +14,62 @@ func TestStringer(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, defaultTitleTemplate, ctx.Config.Announce.Reddit.TitleTemplate)
 }
 
 func TestAnnounceInvalidURLTemplate(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Announce: config.Announce{
 			Reddit: config.Reddit{
 				URLTemplate: "{{ .Foo }",
 			},
 		},
 	})
+
 	testlib.RequireTemplateError(t, Pipe{}.Announce(ctx))
 }
 
 func TestAnnounceInvalidTitleTemplate(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Announce: config.Announce{
 			Reddit: config.Reddit{
 				TitleTemplate: "{{ .Foo }",
 			},
 		},
 	})
+
 	testlib.RequireTemplateError(t, Pipe{}.Announce(ctx))
 }
 
 func TestAnnounceMissingEnv(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Announce: config.Announce{
 			Reddit: config.Reddit{},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.EqualError(t, Pipe{}.Announce(ctx), `reddit: env: environment variable "REDDIT_SECRET" should not be empty; environment variable "REDDIT_PASSWORD" should not be empty`)
 }
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		skip, err := Pipe{}.Skip(testctx.New())
+		skip, err := Pipe{}.Skip(testctx.Wrap(t.Context()))
 		require.NoError(t, err)
 		require.True(t, skip)
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Announce: config.Announce{
 				Reddit: config.Reddit{
 					Enabled: "true",
 				},
 			},
 		})
+
 		skip, err := Pipe{}.Skip(ctx)
 		require.NoError(t, err)
 		require.False(t, skip)

--- a/internal/pipe/release/body_test.go
+++ b/internal/pipe/release/body_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestDescribeBody(t *testing.T) {
 	changelog := "feature1: description\nfeature2: other description"
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	ctx.ReleaseNotes = changelog
 	out, err := describeBody(ctx)
 	require.NoError(t, err)
@@ -26,7 +26,7 @@ func TestDescribeBody(t *testing.T) {
 
 func TestDontEscapeHTML(t *testing.T) {
 	changelog := "<h1>test</h1>"
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	ctx.ReleaseNotes = changelog
 
 	out, err := describeBody(ctx)
@@ -35,7 +35,7 @@ func TestDontEscapeHTML(t *testing.T) {
 }
 
 func TestDescribeBodyMultipleChecksums(t *testing.T) {
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Release: config.Release{
 				Header: "## Yada yada yada\nsomething\n",
@@ -48,8 +48,7 @@ func TestDescribeBodyMultipleChecksums(t *testing.T) {
 			},
 		},
 		testctx.WithCurrentTag("v1.0"),
-		func(ctx *context.Context) { ctx.ReleaseNotes = "nothing" },
-	)
+		func(ctx *context.Context) { ctx.ReleaseNotes = "nothing" })
 
 	checksums := map[string]string{
 		"bar.zip": "f674623cf1edd0f753e620688cedee4e7c0e837ac1e53c0cbbce132ffe35fd52",
@@ -80,7 +79,7 @@ func TestDescribeBodyMultipleChecksums(t *testing.T) {
 
 func TestDescribeBodyWithHeaderAndFooter(t *testing.T) {
 	changelog := "feature1: description\nfeature2: other description"
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Release: config.Release{
 				Header: "## Yada yada yada\nsomething\n",
@@ -102,8 +101,7 @@ Get GoReleaser Pro at https://goreleaser.com/pro
 			},
 		},
 		testctx.WithCurrentTag("v1.0"),
-		func(ctx *context.Context) { ctx.ReleaseNotes = changelog },
-	)
+		func(ctx *context.Context) { ctx.ReleaseNotes = changelog })
 
 	checksumPath := filepath.Join(t.TempDir(), "checksums.txt")
 	checksumContent := "f674623cf1edd0f753e620688cedee4e7c0e837ac1e53c0cbbce132ffe35fd52  foo.zip"
@@ -127,21 +125,23 @@ Get GoReleaser Pro at https://goreleaser.com/pro
 }
 
 func TestDescribeBodyWithInvalidHeaderTemplate(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Release: config.Release{
 			Header: "## {{ .Nop }\n",
 		},
 	})
+
 	_, err := describeBody(ctx)
 	testlib.RequireTemplateError(t, err)
 }
 
 func TestDescribeBodyWithInvalidFooterTemplate(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Release: config.Release{
 			Footer: "{{ .Nops }",
 		},
 	})
+
 	_, err := describeBody(ctx)
 	testlib.RequireTemplateError(t, err)
 }

--- a/internal/pipe/release/release_test.go
+++ b/internal/pipe/release/release_test.go
@@ -49,7 +49,7 @@ func TestRunPipeWithoutIDsThenDoesNotFilter(t *testing.T) {
 			IncludeMeta: true,
 		},
 	}
-	ctx := testctx.NewWithCfg(config, testctx.WithCurrentTag("v1.0.0"))
+	ctx := testctx.WrapWithCfg(t.Context(), config, testctx.WithCurrentTag("v1.0.0"))
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Type: artifact.UploadableArchive,
 		Name: "bin.tar.gz",
@@ -168,7 +168,7 @@ func TestRunPipeWithIDsThenFilters(t *testing.T) {
 			},
 		},
 	}
-	ctx := testctx.NewWithCfg(config, testctx.WithCurrentTag("v1.0.0"))
+	ctx := testctx.WrapWithCfg(t.Context(), config, testctx.WithCurrentTag("v1.0.0"))
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Type: artifact.UploadableArchive,
 		Name: "bin.tar.gz",
@@ -222,7 +222,7 @@ func TestRunPipeReleaseCreationFailed(t *testing.T) {
 			},
 		},
 	}
-	ctx := testctx.NewWithCfg(config, testctx.WithCurrentTag("v1.0.0"))
+	ctx := testctx.WrapWithCfg(t.Context(), config, testctx.WithCurrentTag("v1.0.0"))
 	client := &client.Mock{
 		FailToCreateRelease: true,
 	}
@@ -241,7 +241,7 @@ func TestRunPipeWithFileThatDontExist(t *testing.T) {
 			},
 		},
 	}
-	ctx := testctx.NewWithCfg(config, testctx.WithCurrentTag("v1.0.0"))
+	ctx := testctx.WrapWithCfg(t.Context(), config, testctx.WithCurrentTag("v1.0.0"))
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Type: artifact.UploadableArchive,
 		Name: "bin.tar.gz",
@@ -266,7 +266,7 @@ func TestRunPipeUploadFailure(t *testing.T) {
 			},
 		},
 	}
-	ctx := testctx.NewWithCfg(config, testctx.WithCurrentTag("v1.0.0"))
+	ctx := testctx.WrapWithCfg(t.Context(), config, testctx.WithCurrentTag("v1.0.0"))
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Type: artifact.UploadableArchive,
 		Name: "bin.tar.gz",
@@ -294,7 +294,7 @@ func TestRunPipeExtraFileNotFound(t *testing.T) {
 			},
 		},
 	}
-	ctx := testctx.NewWithCfg(config, testctx.WithCurrentTag("v1.0.0"))
+	ctx := testctx.WrapWithCfg(t.Context(), config, testctx.WithCurrentTag("v1.0.0"))
 	client := &client.Mock{}
 	require.EqualError(t, doPublish(ctx, client), "globbing failed for pattern ./nope: matching \"./nope\": file does not exist")
 	require.True(t, client.CreatedRelease)
@@ -314,7 +314,7 @@ func TestRunPipeExtraOverride(t *testing.T) {
 			},
 		},
 	}
-	ctx := testctx.NewWithCfg(config, testctx.WithCurrentTag("v1.0.0"))
+	ctx := testctx.WrapWithCfg(t.Context(), config, testctx.WithCurrentTag("v1.0.0"))
 	client := &client.Mock{}
 	require.NoError(t, doPublish(ctx, client))
 	require.True(t, client.CreatedRelease)
@@ -336,7 +336,7 @@ func TestRunPipeUploadRetry(t *testing.T) {
 			},
 		},
 	}
-	ctx := testctx.NewWithCfg(config, testctx.WithCurrentTag("v1.0.0"))
+	ctx := testctx.WrapWithCfg(t.Context(), config, testctx.WithCurrentTag("v1.0.0"))
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Type: artifact.UploadableArchive,
 		Name: "bin.tar.gz",
@@ -356,15 +356,15 @@ func TestDefault(t *testing.T) {
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:goreleaser/goreleaser.git")
 
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			GitHubURLs: config.GitHubURLs{
 				Download: "https://github.com",
 			},
 		},
 		testctx.GitHubTokenType,
-		testctx.WithCurrentTag("v1.0.0"),
-	)
+		testctx.WithCurrentTag("v1.0.0"))
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Name)
 	require.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Owner)
@@ -375,15 +375,15 @@ func TestDefaultInvalidURL(t *testing.T) {
 	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:goreleaser.git")
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			GitHubURLs: config.GitHubURLs{
 				Download: "https://github.com",
 			},
 		},
 		testctx.GitHubTokenType,
-		testctx.WithCurrentTag("v1.0.0"),
-	)
+		testctx.WithCurrentTag("v1.0.0"))
+
 	require.Error(t, Pipe{}.Default(ctx))
 }
 
@@ -392,15 +392,15 @@ func TestDefaultWithGitlab(t *testing.T) {
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@gitlab.com:gitlabowner/gitlabrepo.git")
 
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			GitLabURLs: config.GitLabURLs{
 				Download: "https://gitlab.com",
 			},
 		},
 		testctx.GitLabTokenType,
-		testctx.WithCurrentTag("v1.0.0"),
-	)
+		testctx.WithCurrentTag("v1.0.0"))
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "gitlabrepo", ctx.Config.Release.GitLab.Name)
 	require.Equal(t, "gitlabowner", ctx.Config.Release.GitLab.Owner)
@@ -411,15 +411,15 @@ func TestDefaultWithGitlabInvalidURL(t *testing.T) {
 	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@gitlab.com:gitlabrepo.git")
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			GitLabURLs: config.GitLabURLs{
 				Download: "https://gitlab.com",
 			},
 		},
 		testctx.GiteaTokenType,
-		testctx.WithCurrentTag("v1.0.0"),
-	)
+		testctx.WithCurrentTag("v1.0.0"))
+
 	require.Error(t, Pipe{}.Default(ctx))
 }
 
@@ -428,15 +428,15 @@ func TestDefaultWithGitea(t *testing.T) {
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@gitea.example.com:giteaowner/gitearepo.git")
 
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			GiteaURLs: config.GiteaURLs{
 				Download: "https://git.honk.com",
 			},
 		},
 		testctx.GiteaTokenType,
-		testctx.WithCurrentTag("v1.0.0"),
-	)
+		testctx.WithCurrentTag("v1.0.0"))
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "gitearepo", ctx.Config.Release.Gitea.Name)
 	require.Equal(t, "giteaowner", ctx.Config.Release.Gitea.Owner)
@@ -447,15 +447,15 @@ func TestDefaultWithGiteaInvalidURL(t *testing.T) {
 	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@gitea.example.com:gitearepo.git")
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			GiteaURLs: config.GiteaURLs{
 				Download: "https://git.honk.com",
 			},
 		},
 		testctx.GiteaTokenType,
-		testctx.WithCurrentTag("v1.0.0"),
-	)
+		testctx.WithCurrentTag("v1.0.0"))
+
 	require.Error(t, Pipe{}.Default(ctx))
 }
 
@@ -465,11 +465,12 @@ func TestDefaultPreRelease(t *testing.T) {
 	testlib.GitRemoteAdd(t, "git@github.com:goreleaser/goreleaser.git")
 
 	t.Run("prerelease", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Release: config.Release{
 				Prerelease: "true",
 			},
 		})
+
 		ctx.TokenType = context.TokenTypeGitHub
 		ctx.Semver = context.Semver{
 			Major: 1,
@@ -481,9 +482,10 @@ func TestDefaultPreRelease(t *testing.T) {
 	})
 
 	t.Run("release", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Release: config.Release{},
 		})
+
 		ctx.TokenType = context.TokenTypeGitHub
 		ctx.Semver = context.Semver{
 			Major:      1,
@@ -496,35 +498,35 @@ func TestDefaultPreRelease(t *testing.T) {
 	})
 
 	t.Run("auto-release", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(
+		ctx := testctx.WrapWithCfg(t.Context(),
 			config.Project{
 				Release: config.Release{
 					Prerelease: "auto",
 				},
 			},
 			testctx.GitHubTokenType,
-			testctx.WithSemver(1, 0, 0, ""),
-		)
+			testctx.WithSemver(1, 0, 0, ""))
+
 		require.NoError(t, Pipe{}.Default(ctx))
 		require.False(t, ctx.PreRelease)
 	})
 
 	t.Run("auto-rc", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(
+		ctx := testctx.WrapWithCfg(t.Context(),
 			config.Project{
 				Release: config.Release{
 					Prerelease: "auto",
 				},
 			},
 			testctx.GitHubTokenType,
-			testctx.WithSemver(1, 0, 0, "rc1"),
-		)
+			testctx.WithSemver(1, 0, 0, "rc1"))
+
 		require.NoError(t, Pipe{}.Default(ctx))
 		require.True(t, ctx.PreRelease)
 	})
 
 	t.Run("auto-rc-github-setup", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(
+		ctx := testctx.WrapWithCfg(t.Context(),
 			config.Project{
 				Release: config.Release{
 					GitHub: config.Repo{
@@ -535,8 +537,8 @@ func TestDefaultPreRelease(t *testing.T) {
 				},
 			},
 			testctx.GitHubTokenType,
-			testctx.WithSemver(1, 0, 0, "rc1"),
-		)
+			testctx.WithSemver(1, 0, 0, "rc1"))
+
 		require.NoError(t, Pipe{}.Default(ctx))
 		require.True(t, ctx.PreRelease)
 	})
@@ -547,11 +549,12 @@ func TestDefaultPipeDisabled(t *testing.T) {
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:goreleaser/goreleaser.git")
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Release: config.Release{
 			Disable: "true",
 		},
 	})
+
 	ctx.TokenType = context.TokenTypeGitHub
 	testlib.AssertSkipped(t, Pipe{}.Default(ctx))
 	require.Empty(t, ctx.Config.Release.GitHub.Name)
@@ -563,7 +566,7 @@ func TestDefaultFilled(t *testing.T) {
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:goreleaser/goreleaser.git")
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Release: config.Release{
 			GitHub: config.Repo{
 				Name:  "foo",
@@ -571,6 +574,7 @@ func TestDefaultFilled(t *testing.T) {
 			},
 		},
 	})
+
 	ctx.TokenType = context.TokenTypeGitHub
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "foo", ctx.Config.Release.GitHub.Name)
@@ -579,14 +583,14 @@ func TestDefaultFilled(t *testing.T) {
 
 func TestDefaultNotAGitRepo(t *testing.T) {
 	testlib.Mktmp(t)
-	ctx := testctx.New(testctx.GitHubTokenType)
+	ctx := testctx.Wrap(t.Context(), testctx.GitHubTokenType)
 	require.EqualError(t, Pipe{}.Default(ctx), "current folder is not a git repository")
 	require.Empty(t, ctx.Config.Release.GitHub.String())
 }
 
 func TestDefaultGitRepoWithoutOrigin(t *testing.T) {
 	testlib.Mktmp(t)
-	ctx := testctx.New(testctx.GitHubTokenType)
+	ctx := testctx.Wrap(t.Context(), testctx.GitHubTokenType)
 	testlib.GitInit(t)
 	require.EqualError(t, Pipe{}.Default(ctx), "no remote configured to list refs from")
 	require.Empty(t, ctx.Config.Release.GitHub.String())
@@ -594,20 +598,20 @@ func TestDefaultGitRepoWithoutOrigin(t *testing.T) {
 
 func TestDefaultNotAGitRepoSnapshot(t *testing.T) {
 	testlib.Mktmp(t)
-	ctx := testctx.New(testctx.GitHubTokenType, testctx.Snapshot)
+	ctx := testctx.Wrap(t.Context(), testctx.GitHubTokenType, testctx.Snapshot)
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Empty(t, ctx.Config.Release.GitHub.String())
 }
 
 func TestDefaultGitRepoWithoutRemote(t *testing.T) {
 	testlib.Mktmp(t)
-	ctx := testctx.New(testctx.GitHubTokenType)
+	ctx := testctx.Wrap(t.Context(), testctx.GitHubTokenType)
 	require.Error(t, Pipe{}.Default(ctx))
 	require.Empty(t, ctx.Config.Release.GitHub.String())
 }
 
 func TestDefaultMultipleReleasesDefined(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Release: config.Release{
 			GitHub: config.Repo{
 				Owner: "githubName",
@@ -623,50 +627,55 @@ func TestDefaultMultipleReleasesDefined(t *testing.T) {
 			},
 		},
 	})
+
 	require.EqualError(t, Pipe{}.Default(ctx), ErrMultipleReleases.Error())
 }
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Release: config.Release{
 				Disable: "true",
 			},
 		})
+
 		b, err := Pipe{}.Skip(ctx)
 		require.NoError(t, err)
 		require.True(t, b)
 	})
 
 	t.Run("skip tmpl", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Env: []string{"FOO=true"},
 			Release: config.Release{
 				Disable: "{{ .Env.FOO }}",
 			},
 		})
+
 		b, err := Pipe{}.Skip(ctx)
 		require.NoError(t, err)
 		require.True(t, b)
 	})
 
 	t.Run("tmpl err", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Release: config.Release{
 				Disable: "{{ .Env.FOO }}",
 			},
 		})
+
 		_, err := Pipe{}.Skip(ctx)
 		require.Error(t, err)
 	})
 
 	t.Run("skip upload", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Env: []string{"FOO=true"},
 			Release: config.Release{
 				SkipUpload: "{{ .Env.FOO }}",
 			},
 		})
+
 		ctx.Artifacts.Add(&artifact.Artifact{
 			Name: "a",
 			Path: "./doc.go",
@@ -680,11 +689,12 @@ func TestSkip(t *testing.T) {
 	})
 
 	t.Run("skip upload tmpl", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Release: config.Release{
 				SkipUpload: "true",
 			},
 		})
+
 		ctx.Artifacts.Add(&artifact.Artifact{
 			Name: "a",
 			Path: "./doc.go",
@@ -698,7 +708,7 @@ func TestSkip(t *testing.T) {
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.New()
+		ctx := testctx.Wrap(t.Context())
 		ctx.Artifacts.Add(&artifact.Artifact{
 			Name: "a",
 			Path: "./doc.go",

--- a/internal/pipe/release/scm_test.go
+++ b/internal/pipe/release/scm_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestSetupGitLab(t *testing.T) {
 	t.Run("no repo", func(t *testing.T) {
-		ctx := testctx.New()
+		ctx := testctx.Wrap(t.Context())
 		require.NoError(t, setupGitLab(ctx))
 		repo, err := git.ExtractRepoFromConfig(ctx)
 		require.NoError(t, err)
@@ -20,7 +20,7 @@ func TestSetupGitLab(t *testing.T) {
 	})
 
 	t.Run("with templates", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Env: []string{"NAME=foo", "OWNER=bar"},
 			GitLabURLs: config.GitLabURLs{
 				Download: "https://{{ .Env.OWNER }}/download",
@@ -41,7 +41,7 @@ func TestSetupGitLab(t *testing.T) {
 
 	t.Run("with invalid templates", func(t *testing.T) {
 		t.Run("owner", func(t *testing.T) {
-			ctx := testctx.NewWithCfg(config.Project{
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 				Release: config.Release{
 					GitLab: config.Repo{
 						Name:  "foo",
@@ -54,7 +54,7 @@ func TestSetupGitLab(t *testing.T) {
 		})
 
 		t.Run("name", func(t *testing.T) {
-			ctx := testctx.NewWithCfg(config.Project{
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 				Release: config.Release{
 					GitLab: config.Repo{
 						Name: "{{.Env.NOPE}}",
@@ -69,13 +69,13 @@ func TestSetupGitLab(t *testing.T) {
 
 func TestSetupGitea(t *testing.T) {
 	t.Run("no repo", func(t *testing.T) {
-		ctx := testctx.New()
+		ctx := testctx.Wrap(t.Context())
 		require.NoError(t, setupGitea(ctx))
 		require.Equal(t, "goreleaser", ctx.Config.Release.Gitea.Name)
 	})
 
 	t.Run("with templates", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Env: []string{"NAME=foo", "OWNER=bar"},
 			GiteaURLs: config.GiteaURLs{
 				Download: "https://{{ .Env.OWNER }}/download",
@@ -96,7 +96,7 @@ func TestSetupGitea(t *testing.T) {
 
 	t.Run("with invalid templates", func(t *testing.T) {
 		t.Run("owner", func(t *testing.T) {
-			ctx := testctx.NewWithCfg(config.Project{
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 				Release: config.Release{
 					Gitea: config.Repo{
 						Name:  "foo",
@@ -109,7 +109,7 @@ func TestSetupGitea(t *testing.T) {
 		})
 
 		t.Run("name", func(t *testing.T) {
-			ctx := testctx.NewWithCfg(config.Project{
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 				Release: config.Release{
 					Gitea: config.Repo{
 						Name: "{{.Env.NOPE}}",
@@ -124,13 +124,13 @@ func TestSetupGitea(t *testing.T) {
 
 func TestSetupGitHub(t *testing.T) {
 	t.Run("no repo", func(t *testing.T) {
-		ctx := testctx.New()
+		ctx := testctx.Wrap(t.Context())
 		require.NoError(t, setupGitHub(ctx))
 		require.Equal(t, "goreleaser", ctx.Config.Release.GitHub.Name)
 	})
 
 	t.Run("with templates", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Env: []string{"NAME=foo", "OWNER=bar"},
 			GitHubURLs: config.GitHubURLs{
 				Download: "https://{{ .Env.OWNER }}/download",
@@ -151,7 +151,7 @@ func TestSetupGitHub(t *testing.T) {
 
 	t.Run("with invalid templates", func(t *testing.T) {
 		t.Run("owner", func(t *testing.T) {
-			ctx := testctx.NewWithCfg(config.Project{
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 				Release: config.Release{
 					GitHub: config.Repo{
 						Name:  "foo",
@@ -164,7 +164,7 @@ func TestSetupGitHub(t *testing.T) {
 		})
 
 		t.Run("name", func(t *testing.T) {
-			ctx := testctx.NewWithCfg(config.Project{
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 				Release: config.Release{
 					GitHub: config.Repo{
 						Name: "{{.Env.NOPE}}",

--- a/internal/pipe/reportsizes/reportsizes_test.go
+++ b/internal/pipe/reportsizes/reportsizes_test.go
@@ -17,17 +17,17 @@ func TestString(t *testing.T) {
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		require.True(t, Pipe{}.Skip(testctx.New()))
+		require.True(t, Pipe{}.Skip(testctx.Wrap(t.Context())))
 	})
 	t.Run("dont skip", func(t *testing.T) {
-		require.False(t, Pipe{}.Skip(testctx.NewWithCfg(config.Project{
+		require.False(t, Pipe{}.Skip(testctx.WrapWithCfg(t.Context(), config.Project{
 			ReportSizes: true,
 		})))
 	})
 }
 
 func TestRun(t *testing.T) {
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	for i, tp := range []artifact.Type{
 		artifact.Binary,
 		artifact.UniversalBinary,

--- a/internal/pipe/scoop/scoop_test.go
+++ b/internal/pipe/scoop/scoop_test.go
@@ -27,7 +27,7 @@ func TestDescription(t *testing.T) {
 func TestDefault(t *testing.T) {
 	testlib.Mktmp(t)
 
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			ProjectName: "barr",
 			Scoops: []config.Scoop{
@@ -38,8 +38,8 @@ func TestDefault(t *testing.T) {
 				},
 			},
 		},
-		testctx.GitHubTokenType,
-	)
+		testctx.GitHubTokenType)
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Len(t, ctx.Config.Scoops, 1)
 	require.Equal(t, ctx.Config.ProjectName, ctx.Config.Scoops[0].Name)
@@ -86,7 +86,7 @@ func Test_doRun(t *testing.T) {
 		{
 			"multiple_artifacts",
 			args{
-				testctx.NewWithCfg(
+				testctx.WrapWithCfg(t.Context(),
 					config.Project{
 						Dist:        t.TempDir(),
 						ProjectName: "multi-arts",
@@ -102,8 +102,8 @@ func Test_doRun(t *testing.T) {
 					},
 					testctx.GitHubTokenType,
 					testctx.WithCurrentTag("v1.0.1"),
-					testctx.WithVersion("1.0.1"),
-				),
+					testctx.WithVersion("1.0.1")),
+
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
@@ -128,7 +128,7 @@ func Test_doRun(t *testing.T) {
 		{
 			"multiple_binaries",
 			args{
-				testctx.NewWithCfg(
+				testctx.WrapWithCfg(t.Context(),
 					config.Project{
 						Dist:        t.TempDir(),
 						ProjectName: "multi-bins",
@@ -145,8 +145,8 @@ func Test_doRun(t *testing.T) {
 					},
 					testctx.GitHubTokenType,
 					testctx.WithCurrentTag("v1.0.1"),
-					testctx.WithVersion("1.0.1"),
-				),
+					testctx.WithVersion("1.0.1")),
+
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
@@ -184,7 +184,7 @@ func Test_doRun(t *testing.T) {
 		{
 			"valid public github",
 			args{
-				testctx.NewWithCfg(
+				testctx.WrapWithCfg(t.Context(),
 					config.Project{
 						Dist:        t.TempDir(),
 						ProjectName: "run-pipe",
@@ -202,8 +202,8 @@ func Test_doRun(t *testing.T) {
 					},
 					testctx.GitHubTokenType,
 					testctx.WithCurrentTag("v1.0.1"),
-					testctx.WithVersion("1.0.1"),
-				),
+					testctx.WithVersion("1.0.1")),
+
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
@@ -238,7 +238,7 @@ func Test_doRun(t *testing.T) {
 		{
 			"git_remote",
 			args{
-				testctx.NewWithCfg(
+				testctx.WrapWithCfg(t.Context(),
 					config.Project{
 						ProjectName: "git-run-pipe",
 						Dist:        t.TempDir(),
@@ -260,8 +260,8 @@ func Test_doRun(t *testing.T) {
 					},
 					testctx.GitHubTokenType,
 					testctx.WithCurrentTag("v1.0.1"),
-					testctx.WithVersion("1.0.1"),
-				),
+					testctx.WithVersion("1.0.1")),
+
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
@@ -301,7 +301,7 @@ func Test_doRun(t *testing.T) {
 		{
 			"wrap in directory",
 			args{
-				testctx.NewWithCfg(
+				testctx.WrapWithCfg(t.Context(),
 					config.Project{
 						ProjectName: "run-pipe",
 						Scoops: []config.Scoop{
@@ -317,8 +317,8 @@ func Test_doRun(t *testing.T) {
 					},
 					testctx.GitHubTokenType,
 					testctx.WithCurrentTag("v1.0.1"),
-					testctx.WithVersion("1.0.1"),
-				),
+					testctx.WithVersion("1.0.1")),
+
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
@@ -351,7 +351,7 @@ func Test_doRun(t *testing.T) {
 		{
 			"valid enterprise github",
 			args{
-				testctx.NewWithCfg(
+				testctx.WrapWithCfg(t.Context(),
 					config.Project{
 						GitHubURLs:  config.GitHubURLs{Download: "https://api.custom.github.enterprise.com"},
 						ProjectName: "run-pipe",
@@ -368,8 +368,8 @@ func Test_doRun(t *testing.T) {
 					},
 					testctx.GitHubTokenType,
 					testctx.WithCurrentTag("v1.0.1"),
-					testctx.WithVersion("1.0.1"),
-				),
+					testctx.WithVersion("1.0.1")),
+
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
@@ -403,7 +403,7 @@ func Test_doRun(t *testing.T) {
 		{
 			"valid public gitlab",
 			args{
-				testctx.NewWithCfg(
+				testctx.WrapWithCfg(t.Context(),
 					config.Project{
 						ProjectName: "run-pipe",
 						Scoops: []config.Scoop{
@@ -419,8 +419,8 @@ func Test_doRun(t *testing.T) {
 					},
 					testctx.GitHubTokenType,
 					testctx.WithCurrentTag("v1.0.1"),
-					testctx.WithVersion("1.0.1"),
-				),
+					testctx.WithVersion("1.0.1")),
+
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
@@ -451,7 +451,7 @@ func Test_doRun(t *testing.T) {
 		{
 			"valid enterprise gitlab",
 			args{
-				testctx.NewWithCfg(
+				testctx.WrapWithCfg(t.Context(),
 					config.Project{
 						GitHubURLs:  config.GitHubURLs{Download: "https://api.custom.gitlab.enterprise.com"},
 						ProjectName: "run-pipe",
@@ -468,8 +468,8 @@ func Test_doRun(t *testing.T) {
 					},
 					testctx.GitHubTokenType,
 					testctx.WithCurrentTag("v1.0.1"),
-					testctx.WithVersion("1.0.1"),
-				),
+					testctx.WithVersion("1.0.1")),
+
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
@@ -500,7 +500,7 @@ func Test_doRun(t *testing.T) {
 		{
 			"no windows build",
 			args{
-				testctx.NewWithCfg(
+				testctx.WrapWithCfg(t.Context(),
 					config.Project{
 						ProjectName: "run-pipe",
 						Scoops: []config.Scoop{
@@ -516,8 +516,8 @@ func Test_doRun(t *testing.T) {
 					},
 					testctx.GitHubTokenType,
 					testctx.WithCurrentTag("v1.0.1"),
-					testctx.WithVersion("1.0.1"),
-				),
+					testctx.WithVersion("1.0.1")),
+
 				client.NewMock(),
 			},
 			[]artifact.Artifact{},
@@ -528,7 +528,7 @@ func Test_doRun(t *testing.T) {
 		{
 			"is prerelease and skip upload set to auto",
 			args{
-				testctx.NewWithCfg(
+				testctx.WrapWithCfg(t.Context(),
 					config.Project{
 						ProjectName: "run-pipe",
 						Scoops: []config.Scoop{
@@ -546,8 +546,8 @@ func Test_doRun(t *testing.T) {
 					testctx.GitHubTokenType,
 					testctx.WithCurrentTag("v1.0.1-pre.1"),
 					testctx.WithVersion("1.0.1-pre.1"),
-					testctx.WithSemver(1, 0, 0, "pre.1"),
-				),
+					testctx.WithSemver(1, 0, 0, "pre.1")),
+
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
@@ -578,7 +578,7 @@ func Test_doRun(t *testing.T) {
 		{
 			"skip upload set to true",
 			args{
-				testctx.NewWithCfg(
+				testctx.WrapWithCfg(t.Context(),
 					config.Project{
 						ProjectName: "run-pipe",
 						Scoops: []config.Scoop{
@@ -595,8 +595,8 @@ func Test_doRun(t *testing.T) {
 					},
 					testctx.GitHubTokenType,
 					testctx.WithCurrentTag("v1.0.1"),
-					testctx.WithVersion("1.0.1"),
-				),
+					testctx.WithVersion("1.0.1")),
+
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
@@ -627,7 +627,7 @@ func Test_doRun(t *testing.T) {
 		{
 			"no archive",
 			args{
-				testctx.NewWithCfg(
+				testctx.WrapWithCfg(t.Context(),
 					config.Project{
 						ProjectName: "run-pipe",
 						Scoops: []config.Scoop{
@@ -643,8 +643,8 @@ func Test_doRun(t *testing.T) {
 					},
 					testctx.GitHubTokenType,
 					testctx.WithCurrentTag("v1.0.1"),
-					testctx.WithVersion("1.0.1"),
-				),
+					testctx.WithVersion("1.0.1")),
+
 				client.NewMock(),
 			},
 			[]artifact.Artifact{},
@@ -655,7 +655,7 @@ func Test_doRun(t *testing.T) {
 		{
 			"invalid name tmpl",
 			args{
-				testctx.NewWithCfg(
+				testctx.WrapWithCfg(t.Context(),
 					config.Project{
 						ProjectName: "run-pipe",
 						Scoops: []config.Scoop{
@@ -670,8 +670,8 @@ func Test_doRun(t *testing.T) {
 					},
 					testctx.GitHubTokenType,
 					testctx.WithCurrentTag("v1.0.1"),
-					testctx.WithVersion("1.0.1"),
-				),
+					testctx.WithVersion("1.0.1")),
+
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
@@ -684,7 +684,7 @@ func Test_doRun(t *testing.T) {
 		{
 			"invalid description tmpl",
 			args{
-				testctx.NewWithCfg(
+				testctx.WrapWithCfg(t.Context(),
 					config.Project{
 						ProjectName: "run-pipe",
 						Scoops: []config.Scoop{
@@ -699,8 +699,8 @@ func Test_doRun(t *testing.T) {
 					},
 					testctx.GitHubTokenType,
 					testctx.WithCurrentTag("v1.0.1"),
-					testctx.WithVersion("1.0.1"),
-				),
+					testctx.WithVersion("1.0.1")),
+
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
@@ -713,7 +713,7 @@ func Test_doRun(t *testing.T) {
 		{
 			"invalid homepage tmpl",
 			args{
-				testctx.NewWithCfg(
+				testctx.WrapWithCfg(t.Context(),
 					config.Project{
 						ProjectName: "run-pipe",
 						Scoops: []config.Scoop{
@@ -728,8 +728,8 @@ func Test_doRun(t *testing.T) {
 					},
 					testctx.GitHubTokenType,
 					testctx.WithCurrentTag("v1.0.1"),
-					testctx.WithVersion("1.0.1"),
-				),
+					testctx.WithVersion("1.0.1")),
+
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
@@ -742,7 +742,7 @@ func Test_doRun(t *testing.T) {
 		{
 			"invalid skip upload tmpl",
 			args{
-				testctx.NewWithCfg(
+				testctx.WrapWithCfg(t.Context(),
 					config.Project{
 						ProjectName: "run-pipe",
 						Scoops: []config.Scoop{
@@ -757,8 +757,8 @@ func Test_doRun(t *testing.T) {
 					},
 					testctx.GitHubTokenType,
 					testctx.WithCurrentTag("v1.0.1"),
-					testctx.WithVersion("1.0.1"),
-				),
+					testctx.WithVersion("1.0.1")),
+
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
@@ -771,7 +771,7 @@ func Test_doRun(t *testing.T) {
 		{
 			"invalid ref tmpl",
 			args{
-				testctx.NewWithCfg(
+				testctx.WrapWithCfg(t.Context(),
 					config.Project{
 						ProjectName: "run-pipe",
 						Scoops: []config.Scoop{
@@ -788,8 +788,8 @@ func Test_doRun(t *testing.T) {
 					},
 					testctx.GitHubTokenType,
 					testctx.WithCurrentTag("v1.0.1"),
-					testctx.WithVersion("1.0.1"),
-				),
+					testctx.WithVersion("1.0.1")),
+
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
@@ -811,7 +811,7 @@ func Test_doRun(t *testing.T) {
 		{
 			"ref templ",
 			args{
-				testctx.NewWithCfg(
+				testctx.WrapWithCfg(t.Context(),
 					config.Project{
 						Env:         []string{"FOO=test", "BRANCH=main"},
 						ProjectName: "run-pipe",
@@ -828,8 +828,8 @@ func Test_doRun(t *testing.T) {
 					},
 					testctx.GitHubTokenType,
 					testctx.WithCurrentTag("v1.0.1"),
-					testctx.WithVersion("1.0.1"),
-				),
+					testctx.WithVersion("1.0.1")),
+
 				client.NewMock(),
 			},
 			[]artifact.Artifact{
@@ -872,7 +872,7 @@ func Test_doRun(t *testing.T) {
 
 func TestRunPipePullRequest(t *testing.T) {
 	directory := t.TempDir()
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist:        directory,
 			ProjectName: "foo",
@@ -892,8 +892,8 @@ func TestRunPipePullRequest(t *testing.T) {
 		},
 		testctx.WithVersion("1.2.1"),
 		testctx.WithCurrentTag("v1.2.1"),
-		testctx.WithEnv(map[string]string{"FOO": "foobar"}),
-	)
+		testctx.WithEnv(map[string]string{"FOO": "foobar"}))
+
 	path := filepath.Join(directory, "dist/foo_windows_amd64/foo.exe")
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "foo_windows_amd64.tar.gz",
@@ -933,7 +933,7 @@ func Test_buildManifest(t *testing.T) {
 	}{
 		{
 			"common",
-			testctx.NewWithCfg(
+			testctx.WrapWithCfg(t.Context(),
 				config.Project{
 					GitHubURLs: config.GitHubURLs{
 						Download: "https://github.com",
@@ -959,12 +959,11 @@ func Test_buildManifest(t *testing.T) {
 				},
 				testctx.GitHubTokenType,
 				testctx.WithCurrentTag("v1.0.1"),
-				testctx.WithVersion("1.0.1"),
-			),
+				testctx.WithVersion("1.0.1")),
 		},
 		{
 			"pre-post-install",
-			testctx.NewWithCfg(
+			testctx.WrapWithCfg(t.Context(),
 				config.Project{
 					GitHubURLs: config.GitHubURLs{
 						Download: "https://github.com",
@@ -992,12 +991,11 @@ func Test_buildManifest(t *testing.T) {
 				},
 				testctx.GitHubTokenType,
 				testctx.WithCurrentTag("v1.0.1"),
-				testctx.WithVersion("1.0.1"),
-			),
+				testctx.WithVersion("1.0.1")),
 		},
 		{
 			"url template",
-			testctx.NewWithCfg(
+			testctx.WrapWithCfg(t.Context(),
 				config.Project{
 					GitHubURLs: config.GitHubURLs{
 						Download: "https://github.com",
@@ -1019,12 +1017,11 @@ func Test_buildManifest(t *testing.T) {
 				},
 				testctx.WithCurrentTag("v1.0.1"),
 				testctx.GitHubTokenType,
-				testctx.WithVersion("1.0.1"),
-			),
+				testctx.WithVersion("1.0.1")),
 		},
 		{
 			"gitlab url template",
-			testctx.NewWithCfg(
+			testctx.WrapWithCfg(t.Context(),
 				config.Project{
 					GitLabURLs: config.GitLabURLs{
 						Download: "https://gitlab.com",
@@ -1046,8 +1043,7 @@ func Test_buildManifest(t *testing.T) {
 				},
 				testctx.GitHubTokenType,
 				testctx.WithCurrentTag("v1.0.1"),
-				testctx.WithVersion("1.0.1"),
-			),
+				testctx.WithVersion("1.0.1")),
 		},
 	}
 
@@ -1122,8 +1118,9 @@ func Test_buildManifest(t *testing.T) {
 	}
 }
 
-func getScoopPipeSkipCtx(directory string) (*context.Context, string) {
-	ctx := testctx.NewWithCfg(
+func getScoopPipeSkipCtx(tb testing.TB, directory string) (*context.Context, string) {
+	tb.Helper()
+	ctx := testctx.WrapWithCfg(tb.Context(),
 		config.Project{
 			Dist:        directory,
 			ProjectName: "run-pipe",
@@ -1140,8 +1137,7 @@ func getScoopPipeSkipCtx(directory string) (*context.Context, string) {
 			},
 		},
 		testctx.WithCurrentTag("v1.0.1"),
-		testctx.WithVersion("1.0.1"),
-	)
+		testctx.WithVersion("1.0.1"))
 
 	path := filepath.Join(directory, "bin.tar.gz")
 
@@ -1177,7 +1173,7 @@ func getScoopPipeSkipCtx(directory string) (*context.Context, string) {
 
 func TestRunPipeScoopWithSkipUpload(t *testing.T) {
 	directory := t.TempDir()
-	ctx, path := getScoopPipeSkipCtx(directory)
+	ctx, path := getScoopPipeSkipCtx(t, directory)
 	ctx.Config.Scoops[0].SkipUpload = "true"
 
 	f, err := os.Create(path)
@@ -1199,7 +1195,7 @@ func TestWrapInDirectory(t *testing.T) {
 	file := filepath.Join(directory, "archive")
 	require.NoError(t, os.WriteFile(file, []byte("lorem ipsum"), 0o644))
 
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			GitLabURLs: config.GitLabURLs{
 				Download: "https://gitlab.com",
@@ -1219,8 +1215,7 @@ func TestWrapInDirectory(t *testing.T) {
 		},
 		testctx.GitHubTokenType,
 		testctx.WithCurrentTag("v1.0.1"),
-		testctx.WithVersion("1.0.1"),
-	)
+		testctx.WithVersion("1.0.1"))
 
 	require.NoError(t, Pipe{}.Default(ctx))
 	cl, err := client.New(ctx)
@@ -1250,10 +1245,10 @@ func TestWrapInDirectory(t *testing.T) {
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		require.True(t, Pipe{}.Skip(testctx.New()))
+		require.True(t, Pipe{}.Skip(testctx.Wrap(t.Context())))
 	})
 	t.Run("skip flag", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Scoops: []config.Scoop{
 				{
 					Repository: config.RepoRef{
@@ -1262,10 +1257,11 @@ func TestSkip(t *testing.T) {
 				},
 			},
 		}, testctx.Skip(skips.Scoop))
+
 		require.True(t, Pipe{}.Skip(ctx))
 	})
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Scoops: []config.Scoop{
 				{
 					Repository: config.RepoRef{
@@ -1274,6 +1270,7 @@ func TestSkip(t *testing.T) {
 				},
 			},
 		})
+
 		require.False(t, Pipe{}.Skip(ctx))
 	})
 }

--- a/internal/pipe/semver/semver_test.go
+++ b/internal/pipe/semver/semver_test.go
@@ -15,7 +15,7 @@ func TestDescription(t *testing.T) {
 }
 
 func TestValidSemver(t *testing.T) {
-	ctx := testctx.New(testctx.WithCurrentTag("v1.5.2-rc1"))
+	ctx := testctx.Wrap(t.Context(), testctx.WithCurrentTag("v1.5.2-rc1"))
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Equal(t, context.Semver{
 		Major:      1,
@@ -26,16 +26,16 @@ func TestValidSemver(t *testing.T) {
 }
 
 func TestInvalidSemver(t *testing.T) {
-	ctx := testctx.New(testctx.WithCurrentTag("aaaav1.5.2-rc1"))
+	ctx := testctx.Wrap(t.Context(), testctx.WithCurrentTag("aaaav1.5.2-rc1"))
 	err := Pipe{}.Run(ctx)
 	require.ErrorContains(t, err, "failed to parse tag 'aaaav1.5.2-rc1' as semver")
 }
 
 func TestInvalidSemverSkipValidate(t *testing.T) {
-	ctx := testctx.New(
+	ctx := testctx.Wrap(t.Context(),
 		testctx.WithCurrentTag("aaaav1.5.2-rc1"),
-		testctx.Skip(skips.Validate),
-	)
+		testctx.Skip(skips.Validate))
+
 	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
 	require.Equal(t, context.Semver{
 		Major:      0,

--- a/internal/pipe/sign/sign_binary_test.go
+++ b/internal/pipe/sign/sign_binary_test.go
@@ -18,9 +18,10 @@ func TestBinarySignDescription(t *testing.T) {
 }
 
 func TestBinarySignDefault(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		BinarySigns: []config.BinarySign{{}},
 	})
+
 	err := BinaryPipe{}.Default(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "gpg", ctx.Config.BinarySigns[0].Cmd)
@@ -30,52 +31,56 @@ func TestBinarySignDefault(t *testing.T) {
 }
 
 func TestBinarySignDisabled(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		BinarySigns: []config.BinarySign{
 			{Artifacts: "none"},
 		},
 	})
+
 	err := BinaryPipe{}.Run(ctx)
 	require.EqualError(t, err, "artifact signing is disabled")
 }
 
 func TestBinarySignInvalidOption(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		BinarySigns: []config.BinarySign{
 			{Artifacts: "archive"},
 		},
 	})
+
 	err := BinaryPipe{}.Run(ctx)
 	require.EqualError(t, err, "invalid list of artifacts to sign: archive")
 }
 
 func TestBinarySkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		require.True(t, BinaryPipe{}.Skip(testctx.New()))
+		require.True(t, BinaryPipe{}.Skip(testctx.Wrap(t.Context())))
 	})
 
 	t.Run("skip sign", func(t *testing.T) {
-		ctx := testctx.New(testctx.Skip(skips.Sign))
+		ctx := testctx.Wrap(t.Context(), testctx.Skip(skips.Sign))
 		require.True(t, BinaryPipe{}.Skip(ctx))
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			BinarySigns: []config.BinarySign{
 				{},
 			},
 		})
+
 		require.False(t, BinaryPipe{}.Skip(ctx))
 	})
 }
 
 func TestBinaryDependencies(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		BinarySigns: []config.BinarySign{
 			{Cmd: "cosign"},
 			{Cmd: "gpg2"},
 		},
 	})
+
 	require.Equal(t, []string{"cosign", "gpg2"}, BinaryPipe{}.Dependencies(ctx))
 }
 
@@ -86,7 +91,7 @@ func TestBinarySign(t *testing.T) {
 		tb.Helper()
 		tmpdir := tb.TempDir()
 
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			BinarySigns: []config.BinarySign{sign},
 		})
 

--- a/internal/pipe/sign/sign_docker_test.go
+++ b/internal/pipe/sign/sign_docker_test.go
@@ -20,9 +20,10 @@ func TestDockerSignDescription(t *testing.T) {
 }
 
 func TestDockerSignDefault(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		DockerSigns: []config.Sign{{}},
 	})
+
 	err := DockerPipe{}.Default(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "cosign", ctx.Config.DockerSigns[0].Cmd)
@@ -31,21 +32,23 @@ func TestDockerSignDefault(t *testing.T) {
 }
 
 func TestDockerSignDisabled(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		DockerSigns: []config.Sign{
 			{Artifacts: "none"},
 		},
 	})
+
 	err := DockerPipe{}.Publish(ctx)
 	require.EqualError(t, err, "artifact signing is disabled")
 }
 
 func TestDockerSignInvalidArtifacts(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		DockerSigns: []config.Sign{
 			{Artifacts: "foo"},
 		},
 	})
+
 	err := DockerPipe{}.Publish(ctx)
 	require.EqualError(t, err, "invalid list of artifacts to sign: foo")
 }
@@ -222,9 +225,10 @@ func TestDockerSignArtifacts(t *testing.T) {
 
 	testWithArtifacts := func(tb testing.TB, cfg testcase, arts []artifact.Artifact) {
 		tb.Helper()
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			DockerSigns: cfg.Signs,
 		})
+
 		wd, err := os.Getwd()
 		require.NoError(tb, err)
 		tmp := testlib.Mktmp(tb)
@@ -304,30 +308,32 @@ func TestDockerSignArtifacts(t *testing.T) {
 
 func TestDockerSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		require.True(t, DockerPipe{}.Skip(testctx.New()))
+		require.True(t, DockerPipe{}.Skip(testctx.Wrap(t.Context())))
 	})
 
 	t.Run("skip sign", func(t *testing.T) {
-		ctx := testctx.New(testctx.Skip(skips.Sign))
+		ctx := testctx.Wrap(t.Context(), testctx.Skip(skips.Sign))
 		require.True(t, DockerPipe{}.Skip(ctx))
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			DockerSigns: []config.Sign{
 				{},
 			},
 		})
+
 		require.False(t, DockerPipe{}.Skip(ctx))
 	})
 }
 
 func TestDockerDependencies(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		DockerSigns: []config.Sign{
 			{Cmd: "cosign"},
 			{Cmd: "gpg2"},
 		},
 	})
+
 	require.Equal(t, []string{"cosign", "gpg2"}, DockerPipe{}.Dependencies(ctx))
 }

--- a/internal/pipe/sign/sign_test.go
+++ b/internal/pipe/sign/sign_test.go
@@ -56,9 +56,10 @@ func TestSignDefault(t *testing.T) {
 	_ = testlib.Mktmp(t)
 	testlib.GitInit(t)
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Signs: []config.Sign{{}},
 	})
+
 	setGpg(t, ctx, "") // force empty gpg.program
 
 	require.NoError(t, Pipe{}.Default(ctx))
@@ -72,9 +73,10 @@ func TestDefaultGpgFromGitConfig(t *testing.T) {
 	_ = testlib.Mktmp(t)
 	testlib.GitInit(t)
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Signs: []config.Sign{{}},
 	})
+
 	setGpg(t, ctx, "not-really-gpg")
 
 	require.NoError(t, Pipe{}.Default(ctx))
@@ -82,13 +84,13 @@ func TestDefaultGpgFromGitConfig(t *testing.T) {
 }
 
 func TestSignDisabled(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{Signs: []config.Sign{{Artifacts: "none"}}})
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{Signs: []config.Sign{{Artifacts: "none"}}})
 	err := Pipe{}.Run(ctx)
 	require.EqualError(t, err, "artifact signing is disabled")
 }
 
 func TestSignInvalidArtifacts(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{Signs: []config.Sign{{Artifacts: "foo"}}})
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{Signs: []config.Sign{{Artifacts: "foo"}}})
 	err := Pipe{}.Run(ctx)
 	require.EqualError(t, err, "invalid list of artifacts to sign: foo")
 }
@@ -111,7 +113,7 @@ func TestSignArtifacts(t *testing.T) {
 		{
 			desc:          "sign cmd not found",
 			expectedErrIs: exec.ErrNotFound,
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts: "all",
@@ -123,7 +125,7 @@ func TestSignArtifacts(t *testing.T) {
 		{
 			desc:           "sign errors",
 			expectedErrMsg: "sign: exit failed",
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts: "all",
@@ -136,7 +138,7 @@ func TestSignArtifacts(t *testing.T) {
 		{
 			desc:          "invalid certificate template",
 			expectedErrAs: &tmpl.Error{},
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts:   "all",
@@ -149,7 +151,7 @@ func TestSignArtifacts(t *testing.T) {
 		{
 			desc:          "invalid signature template",
 			expectedErrAs: &tmpl.Error{},
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts: "all",
@@ -162,7 +164,7 @@ func TestSignArtifacts(t *testing.T) {
 		{
 			desc:          "invalid args template",
 			expectedErrAs: &tmpl.Error{},
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts: "all",
@@ -178,7 +180,7 @@ func TestSignArtifacts(t *testing.T) {
 		{
 			desc:          "invalid env template",
 			expectedErrAs: &tmpl.Error{},
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts: "all",
@@ -190,55 +192,59 @@ func TestSignArtifacts(t *testing.T) {
 		},
 		{
 			desc: "sign all artifacts",
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts: "all",
 					},
 				},
 			}),
+
 			signaturePaths: []string{"artifact1.sig", "artifact2.sig", "artifact3.sig", "checksum.sig", "checksum2.sig", "linux_amd64/artifact4.sig", "artifact5.tar.gz.sig", "artifact5.tar.gz.sbom.sig", "package1.deb.sig"},
 			signatureNames: []string{"artifact1.sig", "artifact2.sig", "artifact3_1.0.0_linux_amd64.sig", "checksum.sig", "checksum2.sig", "artifact4_1.0.0_linux_amd64.sig", "artifact5.tar.gz.sig", "artifact5.tar.gz.sbom.sig", "package1.deb.sig"},
 		},
 		{
 			desc: "sign archives",
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts: "archive",
 					},
 				},
 			}),
+
 			signaturePaths: []string{"artifact1.sig", "artifact2.sig"},
 			signatureNames: []string{"artifact1.sig", "artifact2.sig"},
 		},
 		{
 			desc: "sign packages",
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts: "package",
 					},
 				},
 			}),
+
 			signaturePaths: []string{"package1.deb.sig"},
 			signatureNames: []string{"package1.deb.sig"},
 		},
 		{
 			desc: "sign binaries",
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts: "binary",
 					},
 				},
 			}),
+
 			signaturePaths: []string{"artifact3.sig", "linux_amd64/artifact4.sig"},
 			signatureNames: []string{"artifact3_1.0.0_linux_amd64.sig", "artifact4_1.0.0_linux_amd64.sig"},
 		},
 		{
 			desc: "multiple sign configs",
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Env: []string{
 					"GPG_KEY_ID=" + fakeGPGKeyID,
 				},
@@ -254,6 +260,7 @@ func TestSignArtifacts(t *testing.T) {
 					},
 				},
 			}),
+
 			signaturePaths: []string{
 				"artifact1." + fakeGPGKeyID + ".sig",
 				"artifact2." + fakeGPGKeyID + ".sig",
@@ -269,7 +276,7 @@ func TestSignArtifacts(t *testing.T) {
 		},
 		{
 			desc: "sign filtered artifacts",
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts: "all",
@@ -277,24 +284,26 @@ func TestSignArtifacts(t *testing.T) {
 					},
 				},
 			}),
+
 			signaturePaths: []string{"artifact1.sig", "artifact3.sig", "checksum.sig", "checksum2.sig", "artifact5.tar.gz.sig", "package1.deb.sig"},
 			signatureNames: []string{"artifact1.sig", "artifact3_1.0.0_linux_amd64.sig", "checksum.sig", "checksum2.sig", "artifact5.tar.gz.sig", "package1.deb.sig"},
 		},
 		{
 			desc: "sign only checksums",
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts: "checksum",
 					},
 				},
 			}),
+
 			signaturePaths: []string{"checksum.sig", "checksum2.sig"},
 			signatureNames: []string{"checksum.sig", "checksum2.sig"},
 		},
 		{
 			desc: "sign only filtered checksums",
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts: "checksum",
@@ -302,24 +311,26 @@ func TestSignArtifacts(t *testing.T) {
 					},
 				},
 			}),
+
 			signaturePaths: []string{"checksum.sig", "checksum2.sig"},
 			signatureNames: []string{"checksum.sig", "checksum2.sig"},
 		},
 		{
 			desc: "sign only source",
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts: "source",
 					},
 				},
 			}),
+
 			signaturePaths: []string{"artifact5.tar.gz.sig"},
 			signatureNames: []string{"artifact5.tar.gz.sig"},
 		},
 		{
 			desc: "sign only source filter by id",
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts: "source",
@@ -327,24 +338,26 @@ func TestSignArtifacts(t *testing.T) {
 					},
 				},
 			}),
+
 			signaturePaths: []string{"artifact5.tar.gz.sig"},
 			signatureNames: []string{"artifact5.tar.gz.sig"},
 		},
 		{
 			desc: "sign only sbom",
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts: "sbom",
 					},
 				},
 			}),
+
 			signaturePaths: []string{"artifact5.tar.gz.sbom.sig"},
 			signatureNames: []string{"artifact5.tar.gz.sbom.sig"},
 		},
 		{
 			desc: "sign all artifacts with env",
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts: "all",
@@ -362,12 +375,13 @@ func TestSignArtifacts(t *testing.T) {
 					fmt.Sprintf("TEST_USER=%s", user),
 				},
 			}),
+
 			signaturePaths: []string{"artifact1.sig", "artifact2.sig", "artifact3.sig", "checksum.sig", "checksum2.sig", "linux_amd64/artifact4.sig", "artifact5.tar.gz.sig", "artifact5.tar.gz.sbom.sig", "package1.deb.sig"},
 			signatureNames: []string{"artifact1.sig", "artifact2.sig", "artifact3_1.0.0_linux_amd64.sig", "checksum.sig", "checksum2.sig", "artifact4_1.0.0_linux_amd64.sig", "artifact5.tar.gz.sig", "artifact5.tar.gz.sbom.sig", "package1.deb.sig"},
 		},
 		{
 			desc: "sign all artifacts with template",
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts: "all",
@@ -385,12 +399,13 @@ func TestSignArtifacts(t *testing.T) {
 					fmt.Sprintf("SOME_TEST_USER=%s", user),
 				},
 			}),
+
 			signaturePaths: []string{"artifact1.sig", "artifact2.sig", "artifact3.sig", "checksum.sig", "checksum2.sig", "linux_amd64/artifact4.sig", "artifact5.tar.gz.sig", "artifact5.tar.gz.sbom.sig", "package1.deb.sig"},
 			signatureNames: []string{"artifact1.sig", "artifact2.sig", "artifact3_1.0.0_linux_amd64.sig", "checksum.sig", "checksum2.sig", "artifact4_1.0.0_linux_amd64.sig", "artifact5.tar.gz.sig", "artifact5.tar.gz.sbom.sig", "package1.deb.sig"},
 		},
 		{
 			desc: "sign single with password from stdin",
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts: "all",
@@ -411,13 +426,14 @@ func TestSignArtifacts(t *testing.T) {
 					},
 				},
 			}),
+
 			signaturePaths: []string{"artifact1.sig", "artifact2.sig", "artifact3.sig", "checksum.sig", "checksum2.sig", "linux_amd64/artifact4.sig", "artifact5.tar.gz.sig", "artifact5.tar.gz.sbom.sig", "package1.deb.sig"},
 			signatureNames: []string{"artifact1.sig", "artifact2.sig", "artifact3_1.0.0_linux_amd64.sig", "checksum.sig", "checksum2.sig", "artifact4_1.0.0_linux_amd64.sig", "artifact5.tar.gz.sig", "artifact5.tar.gz.sbom.sig", "package1.deb.sig"},
 			user:           passwordUser,
 		},
 		{
 			desc: "sign single with password from templated stdin",
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Env: []string{"GPG_PASSWORD=" + stdin},
 				Signs: []config.Sign{
 					{
@@ -439,13 +455,14 @@ func TestSignArtifacts(t *testing.T) {
 					},
 				},
 			}),
+
 			signaturePaths: []string{"artifact1.sig", "artifact2.sig", "artifact3.sig", "checksum.sig", "checksum2.sig", "linux_amd64/artifact4.sig", "artifact5.tar.gz.sig", "artifact5.tar.gz.sbom.sig", "package1.deb.sig"},
 			signatureNames: []string{"artifact1.sig", "artifact2.sig", "artifact3_1.0.0_linux_amd64.sig", "checksum.sig", "checksum2.sig", "artifact4_1.0.0_linux_amd64.sig", "artifact5.tar.gz.sig", "artifact5.tar.gz.sbom.sig", "package1.deb.sig"},
 			user:           passwordUser,
 		},
 		{
 			desc: "sign single with password from stdin_file",
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts: "all",
@@ -466,13 +483,14 @@ func TestSignArtifacts(t *testing.T) {
 					},
 				},
 			}),
+
 			signaturePaths: []string{"artifact1.sig", "artifact2.sig", "artifact3.sig", "checksum.sig", "checksum2.sig", "linux_amd64/artifact4.sig", "artifact5.tar.gz.sig", "artifact5.tar.gz.sbom.sig", "package1.deb.sig"},
 			signatureNames: []string{"artifact1.sig", "artifact2.sig", "artifact3_1.0.0_linux_amd64.sig", "checksum.sig", "checksum2.sig", "artifact4_1.0.0_linux_amd64.sig", "artifact5.tar.gz.sig", "artifact5.tar.gz.sbom.sig", "package1.deb.sig"},
 			user:           passwordUser,
 		},
 		{
 			desc: "missing stdin_file",
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts: "all",
@@ -487,11 +505,12 @@ func TestSignArtifacts(t *testing.T) {
 					},
 				},
 			}),
+
 			expectedErrIs: os.ErrNotExist,
 		},
 		{
 			desc: "sign creating certificate",
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Certificate: "${artifact}.pem",
@@ -499,13 +518,14 @@ func TestSignArtifacts(t *testing.T) {
 					},
 				},
 			}),
+
 			signaturePaths:   []string{"checksum.sig", "checksum2.sig"},
 			signatureNames:   []string{"checksum.sig", "checksum2.sig"},
 			certificateNames: []string{"checksum.pem", "checksum2.pem"},
 		},
 		{
 			desc: "sign all artifacts with env and certificate",
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Env:         []string{"NOT_HONK=honk", "HONK={{ .Env.NOT_HONK }}"},
@@ -514,13 +534,14 @@ func TestSignArtifacts(t *testing.T) {
 					},
 				},
 			}),
+
 			signaturePaths:   []string{"artifact1.sig", "artifact2.sig", "artifact3.sig", "checksum.sig", "checksum2.sig", "linux_amd64/artifact4.sig", "artifact5.tar.gz.sig", "artifact5.tar.gz.sbom.sig", "package1.deb.sig"},
 			signatureNames:   []string{"artifact1.sig", "artifact2.sig", "artifact3_1.0.0_linux_amd64.sig", "checksum.sig", "checksum2.sig", "artifact4_1.0.0_linux_amd64.sig", "artifact5.tar.gz.sig", "artifact5.tar.gz.sbom.sig", "package1.deb.sig"},
 			certificateNames: []string{"artifact1_honk.pem", "artifact2_honk.pem", "artifact3_1.0.0_linux_amd64_honk.pem", "checksum_honk.pem", "checksum2_honk.pem", "artifact4_1.0.0_linux_amd64_honk.pem", "artifact5_honk.pem", "artifact5.tar.gz.sbom_honk.pem", "package1_honk.pem"},
 		},
 		{
 			desc: "sign with templated output true",
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts: "all",
@@ -528,12 +549,13 @@ func TestSignArtifacts(t *testing.T) {
 					},
 				},
 			}),
+
 			signaturePaths: []string{"artifact1.sig", "artifact2.sig", "artifact3.sig", "checksum.sig", "checksum2.sig", "linux_amd64/artifact4.sig", "artifact5.tar.gz.sig", "artifact5.tar.gz.sbom.sig", "package1.deb.sig"},
 			signatureNames: []string{"artifact1.sig", "artifact2.sig", "artifact3_1.0.0_linux_amd64.sig", "checksum.sig", "checksum2.sig", "artifact4_1.0.0_linux_amd64.sig", "artifact5.tar.gz.sig", "artifact5.tar.gz.sbom.sig", "package1.deb.sig"},
 		},
 		{
 			desc: "sign with templated output false",
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts: "all",
@@ -541,13 +563,14 @@ func TestSignArtifacts(t *testing.T) {
 					},
 				},
 			}),
+
 			signaturePaths: []string{"artifact1.sig", "artifact2.sig", "artifact3.sig", "checksum.sig", "checksum2.sig", "linux_amd64/artifact4.sig", "artifact5.tar.gz.sig", "artifact5.tar.gz.sbom.sig", "package1.deb.sig"},
 			signatureNames: []string{"artifact1.sig", "artifact2.sig", "artifact3_1.0.0_linux_amd64.sig", "checksum.sig", "checksum2.sig", "artifact4_1.0.0_linux_amd64.sig", "artifact5.tar.gz.sig", "artifact5.tar.gz.sbom.sig", "package1.deb.sig"},
 		},
 		{
 			desc:          "sign with invalid output template",
 			expectedErrAs: &tmpl.Error{},
-			ctx: testctx.NewWithCfg(config.Project{
+			ctx: testctx.WrapWithCfg(t.Context(), config.Project{
 				Signs: []config.Sign{
 					{
 						Artifacts: "all",
@@ -778,7 +801,7 @@ func verifySignature(tb testing.TB, ctx *context.Context, sig string, user strin
 }
 
 func TestSeveralSignsWithTheSameID(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Signs: []config.Sign{
 			{
 				ID: "a",
@@ -788,36 +811,39 @@ func TestSeveralSignsWithTheSameID(t *testing.T) {
 			},
 		},
 	})
+
 	require.EqualError(t, Pipe{}.Default(ctx), "found 2 signs with the ID 'a', please fix your config")
 }
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		require.True(t, Pipe{}.Skip(testctx.New()))
+		require.True(t, Pipe{}.Skip(testctx.Wrap(t.Context())))
 	})
 
 	t.Run("skip sign", func(t *testing.T) {
-		ctx := testctx.New(testctx.Skip(skips.Sign))
+		ctx := testctx.Wrap(t.Context(), testctx.Skip(skips.Sign))
 		require.True(t, Pipe{}.Skip(ctx))
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Signs: []config.Sign{
 				{},
 			},
 		})
+
 		require.False(t, Pipe{}.Skip(ctx))
 	})
 }
 
 func TestDependencies(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Signs: []config.Sign{
 			{Cmd: "cosign"},
 			{Cmd: "gpg2"},
 		},
 	})
+
 	require.Equal(t, []string{"cosign", "gpg2"}, Pipe{}.Dependencies(ctx))
 }
 

--- a/internal/pipe/smtp/smtp_test.go
+++ b/internal/pipe/smtp/smtp_test.go
@@ -15,19 +15,20 @@ func TestStringer(t *testing.T) {
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		skip, err := Pipe{}.Skip(testctx.New())
+		skip, err := Pipe{}.Skip(testctx.Wrap(t.Context()))
 		require.NoError(t, err)
 		require.True(t, skip)
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Announce: config.Announce{
 				SMTP: config.SMTP{
 					Enabled: "true",
 				},
 			},
 		})
+
 		skip, err := Pipe{}.Skip(ctx)
 		require.NoError(t, err)
 		require.False(t, skip)
@@ -35,13 +36,14 @@ func TestSkip(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Announce: config.Announce{
 			SMTP: config.SMTP{
 				Enabled: "true",
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, defaultBodyTemplate, ctx.Config.Announce.SMTP.BodyTemplate)
 	require.Equal(t, defaultSubjectTemplate, ctx.Config.Announce.SMTP.SubjectTemplate)

--- a/internal/pipe/snapcraft/snapcraft_test.go
+++ b/internal/pipe/snapcraft/snapcraft_test.go
@@ -37,11 +37,12 @@ func TestRunPipeMissingInfo(t *testing.T) {
 		pipe.Skip("no summary nor description were provided"): {},
 	} {
 		t.Run(fmt.Sprintf("testing if %v happens", eerr), func(t *testing.T) {
-			ctx := testctx.NewWithCfg(config.Project{
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 				Snapcrafts: []config.Snapcraft{
 					snap,
 				},
 			})
+
 			require.Equal(t, eerr, Pipe{}.Run(ctx))
 		})
 	}
@@ -53,7 +54,7 @@ func TestRunPipe(t *testing.T) {
 	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		Snapcrafts: []config.Snapcraft{
@@ -92,6 +93,7 @@ func TestRunPipe(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v1.2.3"), testctx.WithVersion("1.2.3"), testctx.WithEnv(map[string]string{"SKIP": "true"}))
+
 	addBinaries(t, ctx, "foo", filepath.Join(dist, "foo"))
 	addBinaries(t, ctx, "bar", filepath.Join(dist, "bar"))
 	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
@@ -105,7 +107,7 @@ func TestBadTemplate(t *testing.T) {
 	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		Snapcrafts: []config.Snapcraft{
@@ -117,6 +119,7 @@ func TestBadTemplate(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v1.2.3"), testctx.WithVersion("1.2.3"))
+
 	addBinaries(t, ctx, "foo", filepath.Join(dist, "foo"))
 
 	t.Run("description", func(t *testing.T) {
@@ -138,7 +141,7 @@ func TestRunPipeInvalidNameTemplate(t *testing.T) {
 	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "foo",
 		Dist:        dist,
 		Snapcrafts: []config.Snapcraft{
@@ -151,6 +154,7 @@ func TestRunPipeInvalidNameTemplate(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v1.2.3"), testctx.WithVersion("1.2.3"))
+
 	addBinaries(t, ctx, "foo", dist)
 	testlib.RequireTemplateError(t, Pipe{}.Run(ctx))
 }
@@ -161,7 +165,7 @@ func TestRunPipeWithName(t *testing.T) {
 	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "testprojectname",
 		Dist:        dist,
 		Snapcrafts: []config.Snapcraft{
@@ -177,6 +181,7 @@ func TestRunPipeWithName(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v1.2.3"), testctx.WithVersion("1.2.3"))
+
 	addBinaries(t, ctx, "foo", dist)
 	require.NoError(t, Pipe{}.Run(ctx))
 	yamlFile, err := os.ReadFile(filepath.Join(dist, "foo_amd64", "prime", "meta", "snap.yaml"))
@@ -196,7 +201,7 @@ func TestRunPipeMetadata(t *testing.T) {
 	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "testprojectname",
 		Dist:        dist,
 		Snapcrafts: []config.Snapcraft{
@@ -227,7 +232,7 @@ func TestRunPipeMetadata(t *testing.T) {
 						BusName:      "foo_busname",
 						CommandChain: []string{"foo_cmd_chain"},
 						CommonID:     "foo_common_id",
-						Completer:    "", // Separately tested in TestCompleter
+						Completer:    "",
 						Daemon:       "simple",
 						Desktop:      "foo_desktop",
 						Environment: map[string]any{
@@ -270,6 +275,7 @@ func TestRunPipeMetadata(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v1.2.3"), testctx.WithVersion("1.2.3"))
+
 	addBinaries(t, ctx, "foo", dist)
 	require.NoError(t, Pipe{}.Run(ctx))
 	yamlFile, err := os.ReadFile(filepath.Join(dist, "foo_amd64", "prime", "meta", "snap.yaml"))
@@ -335,7 +341,7 @@ func TestRunPipeMetadata(t *testing.T) {
 
 func TestNoSnapcraftInPath(t *testing.T) {
 	t.Setenv("PATH", "")
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Snapcrafts: []config.Snapcraft{
 			{
 				Summary:     "dummy",
@@ -343,6 +349,7 @@ func TestNoSnapcraftInPath(t *testing.T) {
 			},
 		},
 	})
+
 	require.EqualError(t, Pipe{}.Run(ctx), ErrNoSnapcraft.Error())
 }
 
@@ -352,7 +359,7 @@ func TestRunNoArguments(t *testing.T) {
 	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "testprojectname",
 		Dist:        dist,
 		Snapcrafts: []config.Snapcraft{
@@ -371,6 +378,7 @@ func TestRunNoArguments(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v1.2.3"), testctx.WithVersion("1.2.3"))
+
 	addBinaries(t, ctx, "foo", dist)
 	require.NoError(t, Pipe{}.Run(ctx))
 	yamlFile, err := os.ReadFile(filepath.Join(dist, "foo_amd64", "prime", "meta", "snap.yaml"))
@@ -387,7 +395,7 @@ func TestCompleter(t *testing.T) {
 	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "testprojectname",
 		Dist:        dist,
 		Snapcrafts: []config.Snapcraft{
@@ -407,6 +415,7 @@ func TestCompleter(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v1.2.3"), testctx.WithVersion("1.2.3"))
+
 	addBinaries(t, ctx, "foo", dist)
 	addBinaries(t, ctx, "bar", dist)
 	require.NoError(t, Pipe{}.Run(ctx))
@@ -425,7 +434,7 @@ func TestCommand(t *testing.T) {
 	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "testprojectname",
 		Dist:        dist,
 		Snapcrafts: []config.Snapcraft{
@@ -445,6 +454,7 @@ func TestCommand(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v1.2.3"), testctx.WithVersion("1.2.3"))
+
 	addBinaries(t, ctx, "foo", dist)
 	require.NoError(t, Pipe{}.Run(ctx))
 	yamlFile, err := os.ReadFile(filepath.Join(dist, "foo_amd64", "prime", "meta", "snap.yaml"))
@@ -461,7 +471,7 @@ func TestExtraFile(t *testing.T) {
 	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "testprojectname",
 		Dist:        dist,
 		Snapcrafts: []config.Snapcraft{
@@ -484,6 +494,7 @@ func TestExtraFile(t *testing.T) {
 			},
 		},
 	}, testctx.WithCurrentTag("v1.2.3"), testctx.WithVersion("1.2.3"))
+
 	addBinaries(t, ctx, "foo", dist)
 	require.NoError(t, Pipe{}.Run(ctx))
 
@@ -494,13 +505,14 @@ func TestExtraFile(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Snapcrafts: []config.Snapcraft{{
 			Description: "hi",
 			Summary:     "hi",
 			Builds:      []string{"a"},
 		}},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, defaultNameTemplate, ctx.Config.Snapcrafts[0].NameTemplate)
 	require.Equal(t, []string{"edge", "beta", "candidate", "stable"}, ctx.Config.Snapcrafts[0].ChannelTemplates)
@@ -511,27 +523,29 @@ func TestDefault(t *testing.T) {
 }
 
 func TestDefaultNoDescription(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds: []config.Build{{ID: "foo"}},
 		Snapcrafts: []config.Snapcraft{{
 			Summary: "hi",
 		}},
 	})
+
 	require.Error(t, Pipe{}.Default(ctx))
 }
 
 func TestDefaultNoSummary(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds: []config.Build{{ID: "foo"}},
 		Snapcrafts: []config.Snapcraft{{
 			Description: "hi",
 		}},
 	})
+
 	require.Error(t, Pipe{}.Default(ctx))
 }
 
 func TestDefaultGradeTmpl(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Env: []string{"Grade=devel"},
 		Snapcrafts: []config.Snapcraft{
 			{
@@ -541,6 +555,7 @@ func TestDefaultGradeTmpl(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, defaultNameTemplate, ctx.Config.Snapcrafts[0].NameTemplate)
 	require.Equal(t, []string{"edge", "beta"}, ctx.Config.Snapcrafts[0].ChannelTemplates)
@@ -548,15 +563,16 @@ func TestDefaultGradeTmpl(t *testing.T) {
 }
 
 func TestDefaultGradeTmplError(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds:     []config.Build{{ID: "foo"}},
 		Snapcrafts: []config.Snapcraft{{Grade: "{{.Env.Grade}}"}},
 	})
+
 	testlib.RequireTemplateError(t, Pipe{}.Default(ctx))
 }
 
 func TestPublish(t *testing.T) {
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "mybin",
 		Path:   "nope.snap",
@@ -572,7 +588,7 @@ func TestPublish(t *testing.T) {
 }
 
 func TestDefaultSet(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Snapcrafts: []config.Snapcraft{
 			{
 				ID:           "devel",
@@ -590,6 +606,7 @@ func TestDefaultSet(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "foo", ctx.Config.Snapcrafts[0].NameTemplate)
 	require.Equal(t, []string{"edge", "beta"}, ctx.Config.Snapcrafts[0].ChannelTemplates)
@@ -597,7 +614,7 @@ func TestDefaultSet(t *testing.T) {
 }
 
 func Test_processChannelsTemplates(t *testing.T) {
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Builds: []config.Build{
 				{
@@ -620,8 +637,7 @@ func Test_processChannelsTemplates(t *testing.T) {
 		testctx.WithCommit("a1b2c3d4"),
 		testctx.WithCurrentTag("v1.0.0"),
 		testctx.WithSemver(1, 0, 0, ""),
-		testctx.WithVersion("1.0.0"),
-	)
+		testctx.WithVersion("1.0.0"))
 
 	require.NoError(t, Pipe{}.Default(ctx))
 	snap := ctx.Config.Snapcrafts[0]
@@ -687,7 +703,7 @@ func addBinaries(t *testing.T, ctx *context.Context, name, dist string) {
 }
 
 func TestSeveralSnapssWithTheSameID(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Snapcrafts: []config.Snapcraft{
 			{
 				ID:          "a",
@@ -701,6 +717,7 @@ func TestSeveralSnapssWithTheSameID(t *testing.T) {
 			},
 		},
 	})
+
 	require.EqualError(t, Pipe{}.Default(ctx), "found 2 snapcrafts with the ID 'a', please fix your config")
 }
 
@@ -726,32 +743,35 @@ func Test_isValidArch(t *testing.T) {
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		require.True(t, Pipe{}.Skip(testctx.New()))
+		require.True(t, Pipe{}.Skip(testctx.Wrap(t.Context())))
 	})
 	t.Run("skip flag", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Snapcrafts: []config.Snapcraft{
 				{},
 			},
 		}, testctx.Skip(skips.Snapcraft))
+
 		require.True(t, Pipe{}.Skip(ctx))
 	})
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Snapcrafts: []config.Snapcraft{
 				{},
 			},
 		})
+
 		require.False(t, Pipe{}.Skip(ctx))
 	})
 }
 
 func TestDependencies(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Snapcrafts: []config.Snapcraft{
 			{},
 		},
 	})
+
 	require.Equal(t, []string{"snapcraft"}, Pipe{}.Dependencies(ctx))
 }
 

--- a/internal/pipe/snapshot/snapshot_test.go
+++ b/internal/pipe/snapshot/snapshot_test.go
@@ -14,68 +14,74 @@ func TestStringer(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Snapshot: config.Snapshot{},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "{{ .Version }}-SNAPSHOT-{{ .ShortCommit }}", ctx.Config.Snapshot.VersionTemplate)
 }
 
 func TestDefaultDeprecated(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Snapshot: config.Snapshot{
 			NameTemplate: "snap",
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "snap", ctx.Config.Snapshot.VersionTemplate)
 }
 
 func TestDefaultSet(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Snapshot: config.Snapshot{
 			VersionTemplate: "snap",
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "snap", ctx.Config.Snapshot.VersionTemplate)
 }
 
 func TestSnapshotInvalidVersionTemplate(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Snapshot: config.Snapshot{
 			VersionTemplate: "{{.ShortCommit}{{{sss}}}",
 		},
 	})
+
 	testlib.RequireTemplateError(t, Pipe{}.Run(ctx))
 }
 
 func TestSnapshotEmptyFinalName(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Snapshot: config.Snapshot{
 			VersionTemplate: "{{ .Commit }}",
 		},
 	}, testctx.WithCurrentTag("v1.2.3"))
+
 	require.EqualError(t, Pipe{}.Run(ctx), "empty snapshot name")
 }
 
 func TestSnapshot(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Snapshot: config.Snapshot{
 			VersionTemplate: "{{ incpatch .Version }}",
 		},
 	}, testctx.WithVersion("1.2.3"))
+
 	require.NoError(t, Pipe{}.Run(ctx))
 	require.Equal(t, "1.2.4", ctx.Version)
 }
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		require.True(t, Pipe{}.Skip(testctx.New()))
+		require.True(t, Pipe{}.Skip(testctx.Wrap(t.Context())))
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.New(testctx.Snapshot)
+		ctx := testctx.Wrap(t.Context(), testctx.Snapshot)
 		require.False(t, Pipe{}.Skip(ctx))
 	})
 }

--- a/internal/pipe/sourcearchive/source_test.go
+++ b/internal/pipe/sourcearchive/source_test.go
@@ -50,7 +50,7 @@ subfolder/
 			t.Run("with extra files", func(t *testing.T) {
 				doVerifyTestArchive(
 					t,
-					testctx.NewWithCfg(
+					testctx.WrapWithCfg(t.Context(),
 						config.Project{
 							ProjectName: "foo",
 							Dist:        "dist",
@@ -66,8 +66,8 @@ subfolder/
 						},
 						testctx.WithCommit("HEAD"),
 						testctx.WithVersion("1.0.0"),
-						testctx.WithCurrentTag("v1.0.0"),
-					),
+						testctx.WithCurrentTag("v1.0.0")),
+
 					tmp,
 					format,
 					[]string{
@@ -91,7 +91,7 @@ subfolder/
 			t.Run("simple", func(t *testing.T) {
 				doVerifyTestArchive(
 					t,
-					testctx.NewWithCfg(
+					testctx.WrapWithCfg(t.Context(),
 						config.Project{
 							ProjectName: "foo",
 							Dist:        "dist",
@@ -103,8 +103,8 @@ subfolder/
 						},
 						testctx.WithCommit("HEAD"),
 						testctx.WithVersion("1.0.0"),
-						testctx.WithCurrentTag("v1.0.0"),
-					),
+						testctx.WithCurrentTag("v1.0.0")),
+
 					tmp,
 					format,
 					[]string{
@@ -151,7 +151,7 @@ func doVerifyTestArchive(tb testing.TB, ctx *context.Context, tmp, format string
 }
 
 func TestInvalidFormat(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist:        t.TempDir(),
 		ProjectName: "foo",
 		Source: config.Source{
@@ -160,12 +160,13 @@ func TestInvalidFormat(t *testing.T) {
 			PrefixTemplate: "{{ .ProjectName }}-{{ .Version }}/",
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.EqualError(t, Pipe{}.Run(ctx), "invalid source archive format: 7z")
 }
 
 func TestDefault(t *testing.T) {
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, config.Source{
 		NameTemplate: "{{ .ProjectName }}-{{ .Version }}",
@@ -174,12 +175,13 @@ func TestDefault(t *testing.T) {
 }
 
 func TestInvalidNameTemplate(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Source: config.Source{
 			Enabled:      true,
 			NameTemplate: "{{ .foo }-asdda",
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	testlib.RequireTemplateError(t, Pipe{}.Run(ctx))
 }
@@ -193,7 +195,7 @@ func TestInvalidInvalidFileTemplate(t *testing.T) {
 	testlib.GitAdd(t)
 	testlib.GitCommit(t, "feat: first")
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "foo",
 		Dist:        "dist",
 		Source: config.Source{
@@ -204,6 +206,7 @@ func TestInvalidInvalidFileTemplate(t *testing.T) {
 			},
 		},
 	})
+
 	ctx.Git.FullCommit = "HEAD"
 	ctx.Version = "1.0.0"
 	require.NoError(t, Pipe{}.Default(ctx))
@@ -211,32 +214,34 @@ func TestInvalidInvalidFileTemplate(t *testing.T) {
 }
 
 func TestInvalidPrefixTemplate(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist: t.TempDir(),
 		Source: config.Source{
 			Enabled:        true,
 			PrefixTemplate: "{{ .ProjectName }/",
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	testlib.RequireTemplateError(t, Pipe{}.Run(ctx))
 }
 
 func TestDisabled(t *testing.T) {
-	require.True(t, Pipe{}.Skip(testctx.New()))
+	require.True(t, Pipe{}.Skip(testctx.Wrap(t.Context())))
 }
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		require.True(t, Pipe{}.Skip(testctx.New()))
+		require.True(t, Pipe{}.Skip(testctx.Wrap(t.Context())))
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Source: config.Source{
 				Enabled: true,
 			},
 		})
+
 		require.False(t, Pipe{}.Skip(ctx))
 	})
 }

--- a/internal/pipe/teams/teams_test.go
+++ b/internal/pipe/teams/teams_test.go
@@ -14,13 +14,13 @@ func TestStringer(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, defaultMessageTemplate, ctx.Config.Announce.Teams.MessageTemplate)
 }
 
 func TestAnnounceInvalidTemplate(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Announce: config.Announce{
 			Teams: config.Teams{
 				Enabled:         "true",
@@ -28,36 +28,39 @@ func TestAnnounceInvalidTemplate(t *testing.T) {
 			},
 		},
 	})
+
 	testlib.RequireTemplateError(t, Pipe{}.Announce(ctx))
 }
 
 func TestAnnounceMissingEnv(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Announce: config.Announce{
 			Teams: config.Teams{
 				Enabled: "true",
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.EqualError(t, Pipe{}.Announce(ctx), `teams: env: environment variable "TEAMS_WEBHOOK" should not be empty`)
 }
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		skip, err := Pipe{}.Skip(testctx.New())
+		skip, err := Pipe{}.Skip(testctx.Wrap(t.Context()))
 		require.NoError(t, err)
 		require.True(t, skip)
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Announce: config.Announce{
 				Teams: config.Teams{
 					Enabled: "true",
 				},
 			},
 		})
+
 		skip, err := Pipe{}.Skip(ctx)
 		require.NoError(t, err)
 		require.False(t, skip)

--- a/internal/pipe/telegram/telegram_test.go
+++ b/internal/pipe/telegram/telegram_test.go
@@ -15,19 +15,19 @@ func TestStringer(t *testing.T) {
 
 func TestDefault(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		ctx := testctx.New()
+		ctx := testctx.Wrap(t.Context())
 		require.NoError(t, Pipe{}.Default(ctx))
 		require.Equal(t, defaultMessageTemplate, ctx.Config.Announce.Telegram.MessageTemplate)
 		require.Equal(t, parseModeMarkdown, ctx.Config.Announce.Telegram.ParseMode)
 	})
 	t.Run("markdownv2 parsemode", func(t *testing.T) {
-		ctx := testctx.New()
+		ctx := testctx.Wrap(t.Context())
 		ctx.Config.Announce.Telegram.ParseMode = parseModeMarkdown
 		require.NoError(t, Pipe{}.Default(ctx))
 		require.Equal(t, parseModeMarkdown, ctx.Config.Announce.Telegram.ParseMode)
 	})
 	t.Run("html parsemode", func(t *testing.T) {
-		ctx := testctx.New()
+		ctx := testctx.Wrap(t.Context())
 		ctx.Config.Announce.Telegram.ParseMode = parseModeHTML
 		require.NoError(t, Pipe{}.Default(ctx))
 		require.Equal(t, parseModeHTML, ctx.Config.Announce.Telegram.ParseMode)
@@ -36,17 +36,18 @@ func TestDefault(t *testing.T) {
 
 func TestAnnounceInvalidTemplate(t *testing.T) {
 	t.Run("message", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Announce: config.Announce{
 				Telegram: config.Telegram{
 					MessageTemplate: "{{ .Foo }",
 				},
 			},
 		})
+
 		testlib.RequireTemplateError(t, Pipe{}.Announce(ctx))
 	})
 	t.Run("chatid", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Announce: config.Announce{
 				Telegram: config.Telegram{
 					MessageTemplate: "test",
@@ -54,10 +55,11 @@ func TestAnnounceInvalidTemplate(t *testing.T) {
 				},
 			},
 		})
+
 		testlib.RequireTemplateError(t, Pipe{}.Announce(ctx))
 	})
 	t.Run("chatid not int", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Env: []string{"CHAT_ID=test"},
 			Announce: config.Announce{
 				Telegram: config.Telegram{
@@ -66,12 +68,13 @@ func TestAnnounceInvalidTemplate(t *testing.T) {
 				},
 			},
 		})
+
 		require.EqualError(t, Pipe{}.Announce(ctx), "telegram: strconv.ParseInt: parsing \"test\": invalid syntax")
 	})
 }
 
 func TestAnnounceMissingEnv(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Env: []string{"CHAT_ID=10"},
 		Announce: config.Announce{
 			Telegram: config.Telegram{
@@ -79,25 +82,27 @@ func TestAnnounceMissingEnv(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.EqualError(t, Pipe{}.Announce(ctx), `telegram: env: environment variable "TELEGRAM_TOKEN" should not be empty`)
 }
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		skip, err := Pipe{}.Skip(testctx.New())
+		skip, err := Pipe{}.Skip(testctx.Wrap(t.Context()))
 		require.NoError(t, err)
 		require.True(t, skip)
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Announce: config.Announce{
 				Telegram: config.Telegram{
 					Enabled: "true",
 				},
 			},
 		})
+
 		skip, err := Pipe{}.Skip(ctx)
 		require.NoError(t, err)
 		require.False(t, skip)
@@ -106,7 +111,7 @@ func TestSkip(t *testing.T) {
 
 func TestGetMessageDetails(t *testing.T) {
 	t.Run("default message template", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(
+		ctx := testctx.WrapWithCfg(t.Context(),
 			config.Project{
 				ProjectName: "foo",
 				Announce: config.Announce{
@@ -115,8 +120,8 @@ func TestGetMessageDetails(t *testing.T) {
 					},
 				},
 			},
-			testctx.WithCurrentTag("v1.0.0"),
-		)
+			testctx.WithCurrentTag("v1.0.0"))
+
 		require.NoError(t, Pipe{}.Default(ctx))
 		msg, _, err := getMessageDetails(ctx)
 		require.NoError(t, err)

--- a/internal/pipe/twitter/twitter_test.go
+++ b/internal/pipe/twitter/twitter_test.go
@@ -14,47 +14,50 @@ func TestStringer(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, defaultMessageTemplate, ctx.Config.Announce.Twitter.MessageTemplate)
 }
 
 func TestAnnounceInvalidTemplate(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Announce: config.Announce{
 			Twitter: config.Twitter{
 				MessageTemplate: "{{ .Foo }",
 			},
 		},
 	})
+
 	testlib.RequireTemplateError(t, Pipe{}.Announce(ctx))
 }
 
 func TestAnnounceMissingEnv(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Announce: config.Announce{
 			Twitter: config.Twitter{},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.EqualError(t, Pipe{}.Announce(ctx), `twitter: env: environment variable "TWITTER_CONSUMER_KEY" should not be empty; environment variable "TWITTER_CONSUMER_SECRET" should not be empty; environment variable "TWITTER_ACCESS_TOKEN" should not be empty; environment variable "TWITTER_ACCESS_TOKEN_SECRET" should not be empty`)
 }
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		skip, err := Pipe{}.Skip(testctx.New())
+		skip, err := Pipe{}.Skip(testctx.Wrap(t.Context()))
 		require.NoError(t, err)
 		require.True(t, skip)
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Announce: config.Announce{
 				Twitter: config.Twitter{
 					Enabled: "true",
 				},
 			},
 		})
+
 		skip, err := Pipe{}.Skip(ctx)
 		require.NoError(t, err)
 		require.False(t, skip)

--- a/internal/pipe/universalbinary/universalbinary_test.go
+++ b/internal/pipe/universalbinary/universalbinary_test.go
@@ -25,12 +25,13 @@ func TestDescription(t *testing.T) {
 
 func TestDefault(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			ProjectName: "proj",
 			UniversalBinaries: []config.UniversalBinary{
 				{},
 			},
 		})
+
 		require.NoError(t, Pipe{}.Default(ctx))
 		require.Equal(t, config.UniversalBinary{
 			ID:           "proj",
@@ -40,12 +41,13 @@ func TestDefault(t *testing.T) {
 	})
 
 	t.Run("given ids", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			ProjectName: "proj",
 			UniversalBinaries: []config.UniversalBinary{
 				{IDs: []string{"foo"}},
 			},
 		})
+
 		require.NoError(t, Pipe{}.Default(ctx))
 		require.Equal(t, config.UniversalBinary{
 			ID:           "proj",
@@ -55,12 +57,13 @@ func TestDefault(t *testing.T) {
 	})
 
 	t.Run("given id", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			ProjectName: "proj",
 			UniversalBinaries: []config.UniversalBinary{
 				{ID: "foo"},
 			},
 		})
+
 		require.NoError(t, Pipe{}.Default(ctx))
 		require.Equal(t, config.UniversalBinary{
 			ID:           "foo",
@@ -70,12 +73,13 @@ func TestDefault(t *testing.T) {
 	})
 
 	t.Run("given name", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			ProjectName: "proj",
 			UniversalBinaries: []config.UniversalBinary{
 				{NameTemplate: "foo"},
 			},
 		})
+
 		require.NoError(t, Pipe{}.Default(ctx))
 		require.Equal(t, config.UniversalBinary{
 			ID:           "proj",
@@ -85,26 +89,28 @@ func TestDefault(t *testing.T) {
 	})
 
 	t.Run("duplicated ids", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			ProjectName: "proj",
 			UniversalBinaries: []config.UniversalBinary{
 				{ID: "foo"},
 				{ID: "foo"},
 			},
 		})
+
 		require.EqualError(t, Pipe{}.Default(ctx), `found 2 universal_binaries with the ID 'foo', please fix your config`)
 	})
 }
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		require.True(t, Pipe{}.Skip(testctx.New()))
+		require.True(t, Pipe{}.Skip(testctx.Wrap(t.Context())))
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			UniversalBinaries: []config.UniversalBinary{{}},
 		})
+
 		require.False(t, Pipe{}.Skip(ctx))
 	})
 }
@@ -131,9 +137,9 @@ func TestRun(t *testing.T) {
 			},
 		},
 	}
-	ctx1 := testctx.NewWithCfg(cfg)
+	ctx1 := testctx.WrapWithCfg(t.Context(), cfg)
 
-	ctx2 := testctx.NewWithCfg(config.Project{
+	ctx2 := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist: dist,
 		UniversalBinaries: []config.UniversalBinary{
 			{
@@ -144,7 +150,7 @@ func TestRun(t *testing.T) {
 		},
 	})
 
-	ctx3 := testctx.NewWithCfg(config.Project{
+	ctx3 := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist: dist,
 		UniversalBinaries: []config.UniversalBinary{
 			{
@@ -155,7 +161,7 @@ func TestRun(t *testing.T) {
 		},
 	})
 
-	ctx4 := testctx.NewWithCfg(config.Project{
+	ctx4 := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist: dist,
 		UniversalBinaries: []config.UniversalBinary{
 			{
@@ -166,7 +172,7 @@ func TestRun(t *testing.T) {
 		},
 	})
 
-	ctx5 := testctx.NewWithCfg(config.Project{
+	ctx5 := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist: dist,
 		UniversalBinaries: []config.UniversalBinary{
 			{
@@ -186,7 +192,7 @@ func TestRun(t *testing.T) {
 		},
 	})
 
-	ctx6 := testctx.NewWithCfg(config.Project{
+	ctx6 := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist: dist,
 		UniversalBinaries: []config.UniversalBinary{
 			{
@@ -198,7 +204,7 @@ func TestRun(t *testing.T) {
 	})
 
 	modTime := time.Now().AddDate(-1, 0, 0).Round(time.Second).UTC()
-	ctx7 := testctx.NewWithCfg(config.Project{
+	ctx7 := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist: dist,
 		UniversalBinaries: []config.UniversalBinary{
 			{
@@ -287,7 +293,7 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("bad template", func(t *testing.T) {
-		testlib.RequireTemplateError(t, Pipe{}.Run(testctx.NewWithCfg(config.Project{
+		testlib.RequireTemplateError(t, Pipe{}.Run(testctx.WrapWithCfg(t.Context(), config.Project{
 			UniversalBinaries: []config.UniversalBinary{
 				{
 					NameTemplate: "{{.Name}",

--- a/internal/pipe/upload/upload_test.go
+++ b/internal/pipe/upload/upload_test.go
@@ -100,7 +100,7 @@ func TestRunPipe_ModeBinary(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 	})
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		Uploads: []config.Upload{
@@ -125,6 +125,7 @@ func TestRunPipe_ModeBinary(t *testing.T) {
 			"UPLOAD_PRODUCTION-EU_SECRET=productionuser-apikey",
 		},
 	})
+
 	for _, goos := range []string{"linux", "darwin"} {
 		ctx.Artifacts.Add(&artifact.Artifact{
 			Name:   "mybin",
@@ -150,7 +151,7 @@ func TestRunPipe_ModeArchive(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, debfile.Close())
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "goreleaser",
 		Dist:        folder,
 		Uploads: []config.Upload{
@@ -165,6 +166,7 @@ func TestRunPipe_ModeArchive(t *testing.T) {
 		Archives: []config.Archive{{}},
 		Env:      []string{"UPLOAD_PRODUCTION_SECRET=deployuser-secret"},
 	}, testctx.WithVersion("1.0.0"))
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Type: artifact.UploadableArchive,
 		Name: "bin.tar.gz",
@@ -237,7 +239,7 @@ func TestRunPipe_ModeBinary_CustomArtifactName(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 	})
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		Uploads: []config.Upload{
@@ -253,6 +255,7 @@ func TestRunPipe_ModeBinary_CustomArtifactName(t *testing.T) {
 		Archives: []config.Archive{{}},
 		Env:      []string{"UPLOAD_PRODUCTION-US_SECRET=deployuser-secret"},
 	})
+
 	for _, goos := range []string{"linux", "darwin"} {
 		ctx.Artifacts.Add(&artifact.Artifact{
 			Name:   "mybin",
@@ -278,7 +281,7 @@ func TestRunPipe_ModeArchive_CustomArtifactName(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, debfile.Close())
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "goreleaser",
 		Dist:        folder,
 		Uploads: []config.Upload{
@@ -296,6 +299,7 @@ func TestRunPipe_ModeArchive_CustomArtifactName(t *testing.T) {
 			"UPLOAD_PRODUCTION_SECRET=deployuser-secret",
 		},
 	}, testctx.WithVersion("1.0.0"))
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Type: artifact.UploadableArchive,
 		Name: "bin.tar.gz",
@@ -342,7 +346,7 @@ func TestRunPipe_ServerDown(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, tarfile.Close())
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "goreleaser",
 		Dist:        folder,
 		Uploads: []config.Upload{
@@ -356,6 +360,7 @@ func TestRunPipe_ServerDown(t *testing.T) {
 		},
 		Env: []string{"UPLOAD_PRODUCTION_SECRET=deployuser-secret"},
 	}, testctx.WithVersion("2.0.0"))
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Type: artifact.UploadableArchive,
 		Name: "bin.tar.gz",
@@ -373,7 +378,7 @@ func TestRunPipe_TargetTemplateError(t *testing.T) {
 	dist := filepath.Join(folder, "dist")
 	binPath := filepath.Join(dist, "mybin", "mybin")
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		Uploads: []config.Upload{
@@ -381,7 +386,7 @@ func TestRunPipe_TargetTemplateError(t *testing.T) {
 				Method: http.MethodPut,
 				Name:   "production",
 				Mode:   "binary",
-				// This template is not correct and should fail
+
 				Target:   "http://storage.company.com/example-repo-local/{{ .ProjectName}",
 				Username: "deployuser",
 			},
@@ -389,6 +394,7 @@ func TestRunPipe_TargetTemplateError(t *testing.T) {
 		Archives: []config.Archive{{}},
 		Env:      []string{"UPLOAD_PRODUCTION_SECRET=deployuser-secret"},
 	})
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "mybin",
 		Path:   binPath,
@@ -421,7 +427,7 @@ func TestRunPipe_BadCredentials(t *testing.T) {
 		w.WriteHeader(http.StatusUnauthorized)
 	})
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		Uploads: []config.Upload{
@@ -436,6 +442,7 @@ func TestRunPipe_BadCredentials(t *testing.T) {
 		Archives: []config.Archive{{}},
 		Env:      []string{"UPLOAD_PRODUCTION_SECRET=deployuser-secret"},
 	})
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "mybin",
 		Path:   binPath,
@@ -484,7 +491,7 @@ func TestRunPipe_UnparsableTarget(t *testing.T) {
 	d1 := []byte("hello\ngo\n")
 	require.NoError(t, os.WriteFile(binPath, d1, 0o666))
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		Uploads: []config.Upload{
@@ -501,6 +508,7 @@ func TestRunPipe_UnparsableTarget(t *testing.T) {
 		},
 		Env: []string{"UPLOAD_PRODUCTION_SECRET=deployuser-secret"},
 	})
+
 	ctx.Env = map[string]string{
 		"UPLOAD_PRODUCTION_SECRET": "deployuser-secret",
 	}
@@ -522,7 +530,7 @@ func TestRunPipe_DirUpload(t *testing.T) {
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0o755))
 	binPath := filepath.Join(dist, "mybin")
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "mybin",
 		Dist:        dist,
 		Uploads: []config.Upload{
@@ -537,6 +545,7 @@ func TestRunPipe_DirUpload(t *testing.T) {
 		Archives: []config.Archive{{}},
 		Env:      []string{"UPLOAD_PRODUCTION_SECRET=deployuser-secret"},
 	})
+
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name:   "mybin",
 		Path:   filepath.Dir(binPath),
@@ -553,7 +562,7 @@ func TestDescription(t *testing.T) {
 }
 
 func TestPutsWithoutTarget(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Uploads: []config.Upload{
 			{
 				Method:   http.MethodPut,
@@ -568,7 +577,7 @@ func TestPutsWithoutTarget(t *testing.T) {
 }
 
 func TestPutsWithoutUsername(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Uploads: []config.Upload{
 			{
 				Method: http.MethodPut,
@@ -583,7 +592,7 @@ func TestPutsWithoutUsername(t *testing.T) {
 }
 
 func TestPutsWithoutName(t *testing.T) {
-	require.True(t, pipe.IsSkip(Pipe{}.Publish(testctx.NewWithCfg(config.Project{
+	require.True(t, pipe.IsSkip(Pipe{}.Publish(testctx.WrapWithCfg(t.Context(), config.Project{
 		Uploads: []config.Upload{
 			{
 				Method:   http.MethodPut,
@@ -595,7 +604,7 @@ func TestPutsWithoutName(t *testing.T) {
 }
 
 func TestPutsWithoutSecret(t *testing.T) {
-	require.True(t, pipe.IsSkip(Pipe{}.Publish(testctx.NewWithCfg(config.Project{
+	require.True(t, pipe.IsSkip(Pipe{}.Publish(testctx.WrapWithCfg(t.Context(), config.Project{
 		Uploads: []config.Upload{
 			{
 				Method:   http.MethodPut,
@@ -608,7 +617,7 @@ func TestPutsWithoutSecret(t *testing.T) {
 }
 
 func TestPutsWithInvalidMode(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Uploads: []config.Upload{
 			{
 				Method:   http.MethodPut,
@@ -620,11 +629,12 @@ func TestPutsWithInvalidMode(t *testing.T) {
 		},
 		Env: []string{"UPLOAD_PRODUCTION_SECRET=deployuser-secret"},
 	})
+
 	require.Error(t, Pipe{}.Publish(ctx))
 }
 
 func TestDefault(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Uploads: []config.Upload{
 			{
 				Name:     "production",
@@ -633,6 +643,7 @@ func TestDefault(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Len(t, ctx.Config.Uploads, 1)
 	upload := ctx.Config.Uploads[0]
@@ -641,15 +652,16 @@ func TestDefault(t *testing.T) {
 }
 
 func TestDefaultNoPuts(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Uploads: []config.Upload{},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Empty(t, ctx.Config.Uploads)
 }
 
 func TestDefaultSet(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Uploads: []config.Upload{
 			{
 				Method: http.MethodPost,
@@ -657,6 +669,7 @@ func TestDefaultSet(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Len(t, ctx.Config.Uploads, 1)
 	upload := ctx.Config.Uploads[0]
@@ -666,15 +679,16 @@ func TestDefaultSet(t *testing.T) {
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		require.True(t, Pipe{}.Skip(testctx.New()))
+		require.True(t, Pipe{}.Skip(testctx.Wrap(t.Context())))
 	})
 
 	t.Run("dont skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			Uploads: []config.Upload{
 				{},
 			},
 		})
+
 		require.False(t, Pipe{}.Skip(ctx))
 	})
 }

--- a/internal/pipe/upx/upx_test.go
+++ b/internal/pipe/upx/upx_test.go
@@ -20,11 +20,12 @@ func TestStringer(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		UPXs: []config.UPX{
 			{},
 		},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Len(t, ctx.Config.UPXs, 1)
 	require.Equal(t, "upx", ctx.Config.UPXs[0].Binary)
@@ -32,17 +33,19 @@ func TestDefault(t *testing.T) {
 
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			UPXs: []config.UPX{},
 		})
+
 		require.True(t, Pipe{}.Skip(ctx))
 	})
 	t.Run("do not skip", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			UPXs: []config.UPX{
 				{},
 			},
 		})
+
 		require.False(t, Pipe{}.Skip(ctx))
 	})
 }
@@ -55,7 +58,7 @@ func TestRun(t *testing.T) {
 	fakeupx, err := filepath.Abs(bin)
 	require.NoError(t, err)
 
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		UPXs: []config.UPX{
 			{
 				Enabled: "true",
@@ -140,37 +143,40 @@ func TestRun(t *testing.T) {
 
 func TestEnabled(t *testing.T) {
 	t.Run("no config", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			UPXs: []config.UPX{
 				{},
 			},
 		})
+
 		testlib.AssertSkipped(t, Pipe{}.Run(ctx))
 	})
 	t.Run("tmpl", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			UPXs: []config.UPX{
 				{
 					Enabled: `{{ printf "false" }}`,
 				},
 			},
 		})
+
 		testlib.AssertSkipped(t, Pipe{}.Run(ctx))
 	})
 	t.Run("invalid template", func(t *testing.T) {
-		ctx := testctx.NewWithCfg(config.Project{
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			UPXs: []config.UPX{
 				{
 					Enabled: `{{ .Foo }}`,
 				},
 			},
 		})
+
 		testlib.RequireTemplateError(t, Pipe{}.Run(ctx))
 	})
 }
 
 func TestUpxNotInstalled(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		UPXs: []config.UPX{
 			{
 				Enabled: "true",
@@ -178,11 +184,12 @@ func TestUpxNotInstalled(t *testing.T) {
 			},
 		},
 	})
+
 	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
 }
 
 func TestFindBinaries(t *testing.T) {
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	tmp := t.TempDir()
 	main := filepath.Join(tmp, "main.go")
 	require.NoError(t, os.WriteFile(main, []byte("package main\nfunc main(){ println(1) }"), 0o644))

--- a/internal/pipe/winget/winget_test.go
+++ b/internal/pipe/winget/winget_test.go
@@ -28,15 +28,15 @@ func TestString(t *testing.T) {
 
 func TestSkip(t *testing.T) {
 	t.Run("should", func(t *testing.T) {
-		require.True(t, Pipe{}.Skip(testctx.New()))
+		require.True(t, Pipe{}.Skip(testctx.Wrap(t.Context())))
 	})
 	t.Run("skip flag", func(t *testing.T) {
-		require.True(t, Pipe{}.Skip(testctx.NewWithCfg(config.Project{
+		require.True(t, Pipe{}.Skip(testctx.WrapWithCfg(t.Context(), config.Project{
 			Winget: []config.Winget{{}},
 		}, testctx.Skip(skips.Winget))))
 	})
 	t.Run("should not", func(t *testing.T) {
-		require.False(t, Pipe{}.Skip(testctx.NewWithCfg(config.Project{
+		require.False(t, Pipe{}.Skip(testctx.WrapWithCfg(t.Context(), config.Project{
 			Winget: []config.Winget{{}},
 		})))
 	})
@@ -661,7 +661,7 @@ func TestRunPipe(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			folder := t.TempDir()
-			ctx := testctx.NewWithCfg(
+			ctx := testctx.WrapWithCfg(t.Context(),
 				config.Project{
 					Dist:        folder,
 					ProjectName: "foo",
@@ -670,8 +670,8 @@ func TestRunPipe(t *testing.T) {
 				testctx.WithVersion("1.2.1"),
 				testctx.WithCurrentTag("v1.2.1"),
 				testctx.WithSemver(1, 2, 1, "rc1"),
-				testctx.WithDate(time.Date(2023, 6, 12, 20, 32, 10, 12, time.Local)),
-			)
+				testctx.WithDate(time.Date(2023, 6, 12, 20, 32, 10, 12, time.Local)))
+
 			ctx.ReleaseNotes = "the changelog for this release..."
 			createFakeArtifact := func(id, goos, goarch, goamd64, goarm string, extra map[string]any) {
 				path := filepath.Join(folder, "dist/foo_"+goos+goarch+goamd64+goarm+".zip")
@@ -806,10 +806,11 @@ func TestErrNoArchivesFound(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	ctx := testctx.NewWithCfg(config.Project{
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "foo",
 		Winget:      []config.Winget{{}},
 	})
+
 	require.NoError(t, Pipe{}.Default(ctx))
 	winget := ctx.Config.Winget[0]
 	require.Equal(t, "v1", winget.Goamd64)
@@ -819,7 +820,7 @@ func TestDefault(t *testing.T) {
 
 func TestFormatBinary(t *testing.T) {
 	folder := t.TempDir()
-	ctx := testctx.NewWithCfg(
+	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Dist:        folder,
 			ProjectName: "foo",
@@ -838,8 +839,8 @@ func TestFormatBinary(t *testing.T) {
 		testctx.WithVersion("1.2.1"),
 		testctx.WithCurrentTag("v1.2.1"),
 		testctx.WithSemver(1, 2, 1, "rc1"),
-		testctx.WithDate(time.Date(2023, 6, 12, 20, 32, 10, 12, time.Local)),
-	)
+		testctx.WithDate(time.Date(2023, 6, 12, 20, 32, 10, 12, time.Local)))
+
 	ctx.ReleaseNotes = "the changelog for this release..."
 	createFakeArtifact := func(id, goos, goarch, goamd64 string) {
 		path := filepath.Join(folder, "dist/foo_"+goos+goarch+goamd64+".exe")

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -15,7 +15,7 @@ import (
 func TestRunCommand(t *testing.T) {
 	t.Run("simple", func(t *testing.T) {
 		require.NoError(t, shell.Run(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			"",
 			strings.Fields(testlib.Echo("oi")),
 			[]string{},
@@ -25,7 +25,7 @@ func TestRunCommand(t *testing.T) {
 
 	t.Run("empty command", func(t *testing.T) {
 		require.NoError(t, shell.Run(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			"",
 			[]string{},
 			[]string{},
@@ -35,7 +35,7 @@ func TestRunCommand(t *testing.T) {
 
 	t.Run("cmd failed", func(t *testing.T) {
 		require.Error(t, shell.Run(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			"",
 			strings.Fields(testlib.Exit(1)),
 			[]string{},
@@ -46,7 +46,7 @@ func TestRunCommand(t *testing.T) {
 	t.Run("cmd with output", func(t *testing.T) {
 		testlib.SkipIfWindows(t, "what would be a similar behavior in windows?")
 		err := shell.Run(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			".",
 			[]string{"sh", "-c", `echo something; exit 1`},
 			[]string{},
@@ -64,7 +64,7 @@ func TestRunCommand(t *testing.T) {
 		touch, err := exec.LookPath("touch")
 		require.NoError(t, err)
 		err = shell.Run(
-			testctx.New(),
+			testctx.Wrap(t.Context()),
 			dir,
 			[]string{"sh", "-c", touch + " $FOO"},
 			[]string{"FOO=bar"},

--- a/internal/skips/skips_test.go
+++ b/internal/skips/skips_test.go
@@ -17,7 +17,7 @@ func TestString(t *testing.T) {
 		"before, ko, and sbom": {skips.SBOM, skips.Ko, skips.Before},
 	} {
 		t.Run(expect, func(t *testing.T) {
-			ctx := testctx.New(testctx.Skip(keys...))
+			ctx := testctx.Wrap(t.Context(), testctx.Skip(keys...))
 			require.Equal(t, expect, skips.String(ctx))
 		})
 	}
@@ -25,29 +25,29 @@ func TestString(t *testing.T) {
 
 func TestAny(t *testing.T) {
 	t.Run("false", func(t *testing.T) {
-		ctx := testctx.New()
+		ctx := testctx.Wrap(t.Context())
 		require.False(t, skips.Any(ctx, skips.Release...))
 	})
 	t.Run("true", func(t *testing.T) {
-		ctx := testctx.New(testctx.Skip(skips.Publish))
+		ctx := testctx.Wrap(t.Context(), testctx.Skip(skips.Publish))
 		require.True(t, skips.Any(ctx, skips.Release...))
 	})
 }
 
 func TestSet(t *testing.T) {
-	ctx := testctx.New()
+	ctx := testctx.Wrap(t.Context())
 	skips.Set(ctx, skips.Publish, skips.Announce)
 	require.ElementsMatch(t, []string{"publish", "announce"}, slices.Collect(maps.Keys(ctx.Skips)))
 }
 
 func TestSetAllowed(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		ctx := testctx.New()
+		ctx := testctx.Wrap(t.Context())
 		require.NoError(t, skips.SetBuild(ctx, "", "validate", ""))
 		require.ElementsMatch(t, []string{"validate"}, slices.Collect(maps.Keys(ctx.Skips)))
 	})
 	t.Run("error", func(t *testing.T) {
-		ctx := testctx.New()
+		ctx := testctx.Wrap(t.Context())
 		require.ErrorContains(t, skips.SetBuild(ctx, "validate", "", "publish", ""), "--skip=publish is not allowed.")
 		require.ElementsMatch(t, []string{"validate"}, slices.Collect(maps.Keys(ctx.Skips)))
 	})

--- a/internal/testctx/testctx.go
+++ b/internal/testctx/testctx.go
@@ -135,17 +135,3 @@ func WrapWithCfg(parent stdctx.Context, c config.Project, opts ...Opt) *context.
 func Wrap(parent stdctx.Context, opts ...Opt) *context.Context {
 	return WrapWithCfg(parent, config.Project{}, opts...)
 }
-
-// NewWithCfg creates a new context.
-//
-// Deprecated: use [WrapWithCfg] instead.
-func NewWithCfg(c config.Project, opts ...Opt) *context.Context {
-	return WrapWithCfg(stdctx.Background(), c, opts...)
-}
-
-// New creates a new context with default configuration.
-//
-// Deprecated: use [Wrap] instead.
-func New(opts ...Opt) *context.Context {
-	return NewWithCfg(config.Project{}, opts...)
-}

--- a/internal/tmpl/fuzz_test.go
+++ b/internal/tmpl/fuzz_test.go
@@ -12,7 +12,7 @@ import (
 
 func FuzzTemplateApplier(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data string) {
-		ctx := testctx.NewWithCfg(config.Project{ProjectName: "test"})
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{ProjectName: "test"})
 		tpl := New(ctx)
 		_, err := tpl.Apply(data)
 		if err == nil {
@@ -24,7 +24,7 @@ func FuzzTemplateApplier(f *testing.F) {
 
 func FuzzTemplateWithArtifact(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data string) {
-		ctx := testctx.NewWithCfg(config.Project{ProjectName: "test"})
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{ProjectName: "test"})
 		tpl := New(ctx).WithArtifact(&artifact.Artifact{
 			Name:   "test",
 			Path:   "fake-filename.bin",
@@ -43,7 +43,7 @@ func FuzzTemplateWithArtifact(f *testing.F) {
 
 func FuzzTemplateBool(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data string) {
-		ctx := testctx.New()
+		ctx := testctx.Wrap(t.Context())
 		tpl := New(ctx)
 		_, err := tpl.Apply(data)
 		if err == nil {
@@ -55,7 +55,7 @@ func FuzzTemplateBool(f *testing.F) {
 
 func FuzzTemplateSlice(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data string) {
-		ctx := testctx.New()
+		ctx := testctx.Wrap(t.Context())
 		tpl := New(ctx)
 		_, err := tpl.Slice([]string{data})
 		if err == nil {
@@ -67,7 +67,7 @@ func FuzzTemplateSlice(f *testing.F) {
 
 func FuzzTemplateWithBuildOptions(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data string) {
-		ctx := testctx.New()
+		ctx := testctx.Wrap(t.Context())
 		target := &buildTarget{
 			Target: "linux_amd64",
 			Goos:   "linux",

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -62,12 +62,11 @@ func TestRegisterAndGet(t *testing.T) {
 }
 
 func TestDependencies(t *testing.T) {
-	require.Equal(t, []string{"fake"}, Dependencies(testctx.NewWithCfg(
+	require.Equal(t, []string{"fake"}, Dependencies(testctx.WrapWithCfg(t.Context(),
 		config.Project{
 			Builds: []config.Build{
 				{Builder: "completedummy"},
 				{Builder: "dummy"},
 			},
-		},
-	)))
+		})))
 }


### PR DESCRIPTION
```sh
gofmt -w -r 'testctx.NewWithCfg(a) -> testctx.WrapWithCfg(t.Context(), a)' .
gofmt -w -r 'testctx.NewWithCfg(a, b) -> testctx.WrapWithCfg(t.Context(), a, b)' .
gofmt -w -r 'testctx.NewWithCfg(a, b, c) -> testctx.WrapWithCfg(t.Context(), a, b, c)' .
gofmt -w -r 'testctx.NewWithCfg(a, b, c, d) -> testctx.WrapWithCfg(t.Context(), a, b, c, d)' .
gofmt -w -r 'testctx.NewWithCfg(a, b, c, d, e) -> testctx.WrapWithCfg(t.Context(), a, b, c, d, e)' .
gofmt -w -r 'testctx.NewWithCfg(a, b, c, d, e, f) -> testctx.WrapWithCfg(t.Context(), a, b, c, d, e, f)' .
gofmt -w -r 'testctx.NewWithCfg(a, b, c, d, e, f, g) -> testctx.WrapWithCfg(t.Context(), a, b, c, d, e, f, g)' .
gofmt -w -r 'testctx.NewWithCfg(a, b, c, d, e, f, g, h) -> testctx.WrapWithCfg(t.Context(), a, b, c, d, e, f, g, h)' .
gofmt -w -r 'testctx.NewWithCfg(a, b, c, d, e, f, g, h, i) -> testctx.WrapWithCfg(t.Context(), a, b, c, d, e, f, g, h, i)' .
gofmt -w -r 'testctx.NewWithCfg(a, b, c, d, e, f, g, h, i, j) -> testctx.WrapWithCfg(t.Context(), a, b, c, d, e, f, g, h, i, j)' .
gofmt -w -r 'testctx.New() -> testctx.Wrap(t.Context())' .
gofmt -w -r 'testctx.New(a) -> testctx.Wrap(t.Context(), a)' .
gofmt -w -r 'testctx.New(a, b) -> testctx.Wrap(t.Context(), a, b)' .
gofmt -w -r 'testctx.New(a, b, c) -> testctx.Wrap(t.Context(), a, b, c)' .
gofmt -w -r 'testctx.New(a, b, c, d) -> testctx.Wrap(t.Context(), a, b, c, d)' .
gofmt -w -r 'testctx.New(a, b, c, d, e) -> testctx.Wrap(t.Context(), a, b, c, d, e)' .
gofmt -w -r 'testctx.New(a, b, c, d, e, f) -> testctx.Wrap(t.Context(), a, b, c, d, e, f)' .
gofmt -w -r 'testctx.New(a, b, c, d, e, f, g) -> testctx.Wrap(t.Context(), a, b, c, d, e, f, g)' .
gofmt -w -r 'testctx.New(a, b, c, d, e, f, g, h) -> testctx.Wrap(t.Context(), a, b, c, d, e, f, g, h)' .
gofmt -w -r 'testctx.New(a, b, c, d, e, f, g, h, i) -> testctx.Wrap(t.Context(), a, b, c, d, e, f, g, h, i)' .
gofmt -w -r 'testctx.New(a, b, c, d, e, f, g, h, i, j) -> testctx.Wrap(t.Context(), a, b, c, d, e, f, g, h, i, j)' .


```