### PR TITLE
docs: Fix typo In Deprecation Docs on Homebrew Formulas

### DIFF
--- a/www/docs/deprecations.md
+++ b/www/docs/deprecations.md
@@ -356,7 +356,7 @@ rm Formula/foo.rb
 ```
 
 With this, when the user tries to upgrade, it should automatically update to the
-Formula instead.
+Cask instead.
 
 ### archives.builds
 


### PR DESCRIPTION
Corrected a typo in the deprecations documentation.

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->


<!-- If applied, this commit will... -->

Correct documentation on the deprecation of formulas and recommendation on upgrading casks
...

<!-- Why is this change being made? -->

Small typo. 
...

<!-- # Provide links to any relevant tickets, URLs or other resources -->

...
