### PR TITLE
Correct nix build warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - run: nix profile install nixpkgs#nixfmt-rfc-style nixpkgs#alejandra
+      - run: nix profile add nixpkgs#pkgs.nixfmt nixpkgs#alejandra
         if: matrix.os == 'ubuntu-latest'
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:


### PR DESCRIPTION
correcting below warning in `build`

```
Run nix profile install nixpkgs#nixfmt-rfc-style nixpkgs#alejandra
warning: 'install' is a deprecated alias for 'add'
unpacking 'github:NixOS/nixpkgs/afce96367b2e37fc29afb5543573cd49db3357b7' into the Git cache...
evaluation warning: nixfmt-rfc-style is now the same as pkgs.nixfmt which should be used instead.
```
https://github.com/gliptak/goreleaser/actions/runs/21448902556/job/61772138110?pr=2