### PR TITLE
fix(docker): regression with newer docker buildx versions

### DIFF
--- a/internal/pipe/docker/api_docker.go
+++ b/internal/pipe/docker/api_docker.go
@@ -3,6 +3,8 @@ package docker
 import (
 	"fmt"
 	"regexp"
+	"slices"
+	"strings"
 
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
 )
@@ -78,6 +80,22 @@ func (i dockerImager) buildCommand(images, flags []string) []string {
 	for _, image := range images {
 		base = append(base, "-t", image)
 	}
-	base = append(base, flags...)
+	base = append(base, ensureProvenanceAndSBOM(flags)...)
 	return base
+}
+
+func ensureProvenanceAndSBOM(flags []string) []string {
+	if !containsFlag(flags, "--provenance") {
+		flags = append(flags, "--provenance=false")
+	}
+	if !containsFlag(flags, "--sbom") {
+		flags = append(flags, "--sbom=false")
+	}
+	return flags
+}
+
+func containsFlag(flags []string, flag string) bool {
+	return slices.ContainsFunc(flags, func(s string) bool {
+		return strings.Contains(s, flag)
+	})
 }

--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -19,6 +19,7 @@ import (
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/experimental"
+	"github.com/goreleaser/goreleaser/v2/internal/gerrors"
 	"github.com/goreleaser/goreleaser/v2/internal/gio"
 	"github.com/goreleaser/goreleaser/v2/internal/ids"
 	"github.com/goreleaser/goreleaser/v2/internal/logext"
@@ -251,16 +252,20 @@ func process(ctx *context.Context, docker config.Docker, artifacts []*artifact.A
 				files = append(files, info.Name())
 				return nil
 			})
-			return fmt.Errorf(`seems like you tried to copy a file that is not available in the build context.
+			return gerrors.Wrap(
+				err,
+				gerrors.WithMessage("could not build image"),
+				gerrors.WithDetails(
+					"use", docker.Use,
+					"image", images[0],
+					"info", fmt.Sprintf(`seems like you tried to copy a file that is not available in the build context.
 
 Here's more information about the build context:
 
 dir: %q
 files in that dir:
  %s
-
-Previous error:
-%w`, tmp, strings.Join(files, "\n "), err)
+`, tmp, strings.Join(files, "\n "))))
 		}
 		if isBuildxContextError(err.Error()) {
 			return errors.New("docker buildx is not set to default context - please switch with 'docker context use default'")


### PR DESCRIPTION
`docker buildx build` will now always create a manifest, we should use `--provenance=false` to force it not to.

should fix the broken CI since ~3 days ago