### PR TITLE
fix(upload): prevent sendFile race condition on Windows

### DIFF
--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -71,6 +71,7 @@ func assetOpenDefault(kind string, a *artifact.Artifact) (*asset, error) {
 		// using sendFile/TransmitFile on Windows, which has a known
 		// data race between the connection's readLoop and writeBody
 		// goroutines on the underlying TCP socket FD.
+		// See: https://github.com/golang/go/issues/78015
 		ReadCloser: struct {
 			io.Reader
 			io.Closer


### PR DESCRIPTION
## Problem

`TestRunPipe_ModeBinary_CustomArtifactName` in `internal/pipe/upload` fails on Windows CI with a data race:

```
WARNING: DATA RACE
Read at 0x00c0003eeb80 by goroutine 51:
  internal/poll.(*FD).execIO()
  ...
Previous write at 0x00c0003eeb80 by goroutine 53:
  internal/poll.(*FD).setOffset()
  ...
  internal/poll.SendFile()
  ...
  net/http.(*transferWriter).writeBody()
```

## Root Cause

When an `*os.File` is passed as the HTTP request body, Go's HTTP client on Windows uses `TransmitFile` (via `sendFile`) for zero-copy transfer. This causes a data race between the connection's `readLoop` and `writeBody` goroutines, both of which access the same TCP socket file descriptor's overlapped struct.

**Upstream Go issue:** https://github.com/golang/go/issues/78015
**Reproducer:** https://github.com/caarlos0-graveyard/go-windows-sendfile-race

## Fix

Wrap the opened file in a struct that only exposes `io.Reader` and `io.Closer` interfaces. This prevents Go's `net` package from detecting the body as an `*os.File` and using the `sendFile` optimization, avoiding the race entirely. The performance impact is negligible for upload workloads.