### PR TITLE
docs: fix static url

### DIFF
--- a/www/hugo.yaml
+++ b/www/hugo.yaml
@@ -5,6 +5,11 @@ title: "GoReleaser"
 module:
   imports:
     - path: github.com/imfing/hextra
+  mounts:
+    - source: static
+      target: static
+    - source: static
+      target: static/static
 
 enableRobotsTXT: true
 enableGitInfo: true

--- a/www/static/_redirects
+++ b/www/static/_redirects
@@ -288,8 +288,6 @@
 /cookbooks/cgo-and-crosscompiling   /resources/limitations/cgo/  301
 
 # Dynamic redirects (splats) — must appear after all static rules per Cloudflare Pages docs
-# static files
-/static/*  /:splat  301
 /announce/*  /customization/announce/:splat  301
 /limitations/*  /resources/limitations/:splat  301
 /errors/*  /resources/errors/:splat  301


### PR DESCRIPTION
the 301 should work but apparently the GitHub action isn't following it properly, so we  serve both the old and new for now.