### PR TITLE
feat: add UploadableTypes canonical var and use it across pipes

### DIFF
--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -112,10 +112,38 @@ const (
 	DockerImageV2
 	// Flatpak is a Flatpak bundle.
 	Flatpak
+
+	// XXX: if it is an uploadable kind of artifact, add it to UploadableTypes
+	// below.
+
 	// lastMarker is used in tests to denote the last valid type.
 	// always add new types before this one.
 	lastMarker
 )
+
+// ReleaseUploadableTypes returns the canonical list of artifact types that should be
+// uploaded, checksummed, signed, and otherwise distributed.
+// When adding a new artifact type that should be part of a release, add it
+// here and all pipes that use this func will automatically include it.
+//
+// GoReleaser Pro has more formats: MSI, DMG, etc.
+func ReleaseUploadableTypes() []Type {
+	return []Type{
+		UploadableArchive,
+		UploadableBinary,
+		UploadableFile,
+		UploadableSourceArchive,
+		Makeself,
+		LinuxPackage,
+		Flatpak,
+		SBOM,
+		PyWheel,
+		PySdist,
+		Checksum,
+		Signature,
+		Certificate,
+	}
+}
 
 func (t Type) isUploadable() bool {
 	switch t {

--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -1105,3 +1105,25 @@ func TestArtifactTypeIsUploadable(t *testing.T) {
 		})
 	}
 }
+
+func TestReleaseUploadableTypes(t *testing.T) {
+	expected := []Type{
+		UploadableArchive,
+		UploadableBinary,
+		UploadableFile,
+		UploadableSourceArchive,
+		Makeself,
+		LinuxPackage,
+		Flatpak,
+		SBOM,
+		PyWheel,
+		PySdist,
+		Checksum,
+		Signature,
+		Certificate,
+	}
+	require.Equal(t, expected, ReleaseUploadableTypes())
+	for _, tp := range ReleaseUploadableTypes() {
+		require.Truef(t, tp.isUploadable(), "type %s should be uploadable", tp)
+	}
+}

--- a/internal/pipe/blob/upload.go
+++ b/internal/pipe/blob/upload.go
@@ -159,20 +159,7 @@ func artifactList(ctx *context.Context, conf config.Blob) []*artifact.Artifact {
 	if conf.ExtraFilesOnly {
 		return nil
 	}
-	types := []artifact.Type{
-		artifact.UploadableArchive,
-		artifact.UploadableBinary,
-		artifact.UploadableSourceArchive,
-		artifact.Makeself,
-		artifact.Checksum,
-		artifact.Signature,
-		artifact.Certificate,
-		artifact.LinuxPackage,
-		artifact.Flatpak,
-		artifact.SBOM,
-		artifact.PySdist,
-		artifact.PyWheel,
-	}
+	types := artifact.ReleaseUploadableTypes()
 	if conf.IncludeMeta {
 		types = append(types, artifact.Metadata)
 	}

--- a/internal/pipe/checksums/checksums.go
+++ b/internal/pipe/checksums/checksums.go
@@ -178,17 +178,8 @@ func refreshAll(ctx *context.Context, filepath string) error {
 
 func buildArtifactList(ctx *context.Context) ([]*artifact.Artifact, error) {
 	filter := artifact.And(
-		artifact.ByTypes(
-			artifact.UploadableArchive,
-			artifact.UploadableBinary,
-			artifact.UploadableSourceArchive,
-			artifact.Makeself,
-			artifact.LinuxPackage,
-			artifact.Flatpak,
-			artifact.SBOM,
-			artifact.PyWheel,
-			artifact.PySdist,
-		),
+		artifact.ByTypes(artifact.ReleaseUploadableTypes()...),
+		artifact.Not(artifact.ByType(artifact.Checksum)),
 		artifact.ByIDs(ctx.Config.Checksum.IDs...),
 	)
 	artifactList := ctx.Artifacts.Filter(filter).List()

--- a/internal/pipe/release/release.go
+++ b/internal/pipe/release/release.go
@@ -157,21 +157,7 @@ func doPublish(ctx *context.Context, client client.Client) error {
 		})
 	}
 
-	types := []artifact.Type{
-		artifact.UploadableArchive,
-		artifact.UploadableBinary,
-		artifact.UploadableSourceArchive,
-		artifact.Makeself,
-		artifact.UploadableFile,
-		artifact.Checksum,
-		artifact.Signature,
-		artifact.Certificate,
-		artifact.LinuxPackage,
-		artifact.Flatpak,
-		artifact.SBOM,
-		artifact.PyWheel,
-		artifact.PySdist,
-	}
+	types := artifact.ReleaseUploadableTypes()
 	if ctx.Config.Release.IncludeMeta {
 		types = append(types, artifact.Metadata)
 	}

--- a/internal/pipe/reportsizes/reportsizes.go
+++ b/internal/pipe/reportsizes/reportsizes.go
@@ -17,16 +17,15 @@ func (Pipe) String() string                 { return "size reports" }
 
 func (Pipe) Run(ctx *context.Context) error {
 	return ctx.Artifacts.Filter(artifact.ByTypes(
-		artifact.Binary,
-		artifact.UniversalBinary,
-		artifact.UploadableArchive,
-		artifact.Makeself,
-		artifact.PublishableSnapcraft,
-		artifact.LinuxPackage,
-		artifact.Flatpak,
-		artifact.CArchive,
-		artifact.CShared,
-		artifact.Header,
+		append(
+			artifact.ReleaseUploadableTypes(),
+			artifact.Binary,
+			artifact.UniversalBinary,
+			artifact.PublishableSnapcraft,
+			artifact.CArchive,
+			artifact.CShared,
+			artifact.Header,
+		)...,
 	)).Visit(func(a *artifact.Artifact) error {
 		stat, err := os.Stat(a.Path)
 		if err != nil {

--- a/internal/pipe/sign/sign.go
+++ b/internal/pipe/sign/sign.go
@@ -101,18 +101,7 @@ func (Pipe) Run(ctx *context.Context) error {
 					log.Warn("when artifacts is `source`, `ids` has no effect. ignoring")
 				}
 			case "all":
-				filters = append(filters, artifact.ByTypes(
-					artifact.UploadableArchive,
-					artifact.UploadableBinary,
-					artifact.UploadableSourceArchive,
-					artifact.Makeself,
-					artifact.Checksum,
-					artifact.LinuxPackage,
-					artifact.Flatpak,
-					artifact.SBOM,
-					artifact.PySdist,
-					artifact.PyWheel,
-				))
+				filters = append(filters, artifact.ByTypes(artifact.ReleaseUploadableTypes()...))
 			case "archive":
 				filters = append(filters, artifact.ByType(artifact.UploadableArchive))
 			case "binary":


### PR DESCRIPTION
Adds artifact.UploadableTypes as the single source of truth for which artifact types should be uploaded, checksummed, signed, and reported. Pipes now reference this var instead of maintaining their own lists, so adding a new uploadable artifact type only requires updating one place.

Also fixes reportsizes and checksums missing several uploadable types (UploadableBinary, UploadableFile, UploadableSourceArchive, SBOM, PyWheel, PySdist in reportsizes; UploadableFile in checksums).

Closes #6481
