### PR TITLE
fix(snapcraft): correct channel template args in fmt.Errorf

### DIFF
--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -474,7 +474,7 @@ func processChannelsTemplates(ctx *context.Context, snap config.Snapcraft) ([]st
 	for _, channeltemplate := range snap.ChannelTemplates {
 		channel, err := tmpl.New(ctx).Apply(channeltemplate)
 		if err != nil {
-			return nil, fmt.Errorf("failed to execute channel template '%s': %w", err, err)
+			return nil, fmt.Errorf("failed to execute channel template '%s': %w", channeltemplate, err)
 		}
 		if channel == "" {
 			continue


### PR DESCRIPTION
## What

Fixes incorrect arguments to `fmt.Errorf` in `processChannelsTemplates`: the format string uses `%s` for the channel template and `%w` for the error, but `err` was passed twice, so the template string was never included in the message.

## Why

Improves error messages when channel template execution fails (shows which template failed).