### PR TITLE
fix(archive): use current binary for ExtraReplaces in skip

### DIFF
--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -324,7 +324,7 @@ func skip(ctx *context.Context, archive config.Archive, binaries []*artifact.Art
 				artifact.ExtraBinary: binary.Name,
 			},
 		}
-		if rep, ok := binaries[0].Extra[artifact.ExtraReplaces]; ok {
+		if rep, ok := binary.Extra[artifact.ExtraReplaces]; ok {
 			art.Extra[artifact.ExtraReplaces] = rep
 		}
 		if artifact.ExtraOr(*binary, artifact.ExtranDynLink, false) {


### PR DESCRIPTION
## What

In `skip()`, when emitting uploadable binary artifacts for skipped archives, `ExtraReplaces` was read from `binaries[0]` inside the loop over all binaries.

## Why

Each emitted artifact should reflect the **current** binary’s metadata so multiple binaries get the correct replaces data when they differ.