### PR TITLE
refactor: fix modernize lint issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,6 +10,7 @@ linters:
     - gocritic
     - godoclint
     - misspell
+    - modernize
     - noctx
     - nolintlint
     - perfsprint
@@ -39,6 +40,9 @@ linters:
     gocritic:
       disabled-checks:
         - appendAssign
+    modernize:
+      disable:
+        - omitzero
     perfsprint:
       int-conversion: false
       err-error: false

--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -121,7 +121,7 @@ func (c *githubClient) GenerateReleaseNotes(ctx *context.Context, repo Repo, pre
 	c.checkRateLimit(ctx, time.Sleep)
 	notes, _, err := c.client.Repositories.GenerateReleaseNotes(ctx, repo.Owner, repo.Name, &github.GenerateNotesOptions{
 		TagName:         current,
-		PreviousTagName: github.Ptr(prev),
+		PreviousTagName: &prev,
 	})
 	if err != nil {
 		return "", err
@@ -292,11 +292,11 @@ func (c *githubClient) OpenPullRequest(
 		base.Owner,
 		base.Name,
 		&github.NewPullRequest{
-			Title: github.Ptr(title),
-			Base:  github.Ptr(base.Branch),
-			Head:  github.Ptr(headString(base, head)),
-			Body:  github.Ptr(strings.Join([]string{tpl, prFooter}, "\n")),
-			Draft: github.Ptr(draft),
+			Title: &title,
+			Base:  &base.Branch,
+			Head:  new(headString(base, head)),
+			Body:  new(strings.Join([]string{tpl, prFooter}, "\n")),
+			Draft: &draft,
 		},
 	)
 	if err != nil {
@@ -324,7 +324,7 @@ func (c *githubClient) SyncFork(ctx *context.Context, head, base Repo) error {
 		head.Owner,
 		head.Name,
 		&github.RepoMergeUpstreamRequest{
-			Branch: github.Ptr(branch),
+			Branch: &branch,
 		},
 	)
 	if err != nil {
@@ -357,15 +357,15 @@ func (c *githubClient) CreateFile(
 
 	options := &github.RepositoryContentFileOptions{
 		Content: content,
-		Message: github.Ptr(message),
+		Message: &message,
 	}
 
 	// When using a GitHub App token, omit the committer to get automatic signed commits
 	// See: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#signature-verification-for-bots
 	if !commitAuthor.UseGitHubAppToken {
 		options.Committer = &github.CommitAuthor{
-			Name:  github.Ptr(commitAuthor.Name),
-			Email: github.Ptr(commitAuthor.Email),
+			Name:  &commitAuthor.Name,
+			Email: &commitAuthor.Email,
 		}
 	}
 
@@ -450,13 +450,13 @@ func (c *githubClient) CreateRelease(ctx *context.Context, body string) (string,
 	body = truncateReleaseBody(body)
 
 	data := &github.RepositoryRelease{
-		Name:    github.Ptr(title),
-		TagName: github.Ptr(ctx.Git.CurrentTag),
-		Body:    github.Ptr(body),
+		Name:    &title,
+		TagName: &ctx.Git.CurrentTag,
+		Body:    &body,
 		// Always start with a draft release while uploading artifacts.
 		// PublishRelease will undraft it.
-		Draft:      github.Ptr(true),
-		Prerelease: github.Ptr(ctx.PreRelease),
+		Draft:      new(true),
+		Prerelease: &ctx.PreRelease,
 	}
 
 	if target := ctx.Config.Release.TargetCommitish; target != "" {
@@ -465,7 +465,7 @@ func (c *githubClient) CreateRelease(ctx *context.Context, body string) (string,
 			return "", err
 		}
 		if target != "" {
-			data.TargetCommitish = github.Ptr(target)
+			data.TargetCommitish = &target
 		}
 	}
 
@@ -488,17 +488,17 @@ func (c *githubClient) PublishRelease(ctx *context.Context, releaseID string) er
 		return fmt.Errorf("non-numeric release ID %q: %w", releaseID, err)
 	}
 	data := &github.RepositoryRelease{
-		Draft: github.Ptr(draft),
+		Draft: &draft,
 	}
 	latest, err := tmpl.New(ctx).Apply(ctx.Config.Release.MakeLatest)
 	if err != nil {
 		return fmt.Errorf("templating GitHub make_latest: %w", err)
 	}
 	if latest != "" {
-		data.MakeLatest = github.Ptr(latest)
+		data.MakeLatest = &latest
 	}
 	if ctx.Config.Release.DiscussionCategoryName != "" {
-		data.DiscussionCategoryName = github.Ptr(ctx.Config.Release.DiscussionCategoryName)
+		data.DiscussionCategoryName = &ctx.Config.Release.DiscussionCategoryName
 	}
 	release, err := c.updateRelease(ctx, releaseIDInt, data)
 	if err != nil {
@@ -539,7 +539,7 @@ func (c *githubClient) createOrUpdateRelease(ctx *context.Context, data *github.
 	}
 
 	data.Draft = release.Draft
-	data.Body = github.Ptr(getReleaseNotes(release.GetBody(), body, ctx.Config.Release.ReleaseNotesMode))
+	data.Body = new(getReleaseNotes(release.GetBody(), body, ctx.Config.Release.ReleaseNotesMode))
 	return c.updateRelease(ctx, release.GetID(), data)
 }
 

--- a/internal/client/github_test.go
+++ b/internal/client/github_test.go
@@ -483,8 +483,8 @@ func TestGitHubOpenPullRequestCrossRepo(t *testing.T) {
 
 		if r.URL.Path == "/api/v3/repos/someone/something/contents/.github/PULL_REQUEST_TEMPLATE.md" {
 			content := github.RepositoryContent{
-				Encoding: github.Ptr("base64"),
-				Content:  github.Ptr(base64.StdEncoding.EncodeToString([]byte(testPRTemplate))),
+				Encoding: new("base64"),
+				Content:  new(base64.StdEncoding.EncodeToString([]byte(testPRTemplate))),
 			}
 			bts, _ := json.Marshal(content)
 			_, _ = w.Write(bts)
@@ -545,8 +545,8 @@ func TestGitHubOpenPullRequestHappyPath(t *testing.T) {
 
 		if r.URL.Path == "/api/v3/repos/someone/something/contents/.github/PULL_REQUEST_TEMPLATE.md" {
 			content := github.RepositoryContent{
-				Encoding: github.Ptr("base64"),
-				Content:  github.Ptr(base64.StdEncoding.EncodeToString([]byte(testPRTemplate))),
+				Encoding: new("base64"),
+				Content:  new(base64.StdEncoding.EncodeToString([]byte(testPRTemplate))),
 			}
 			bts, _ := json.Marshal(content)
 			_, _ = w.Write(bts)

--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -708,7 +708,7 @@ func (c *gitlabClient) OpenPullRequest(
 		SourceBranch: &head.Branch,
 		TargetBranch: &base.Branch,
 		Title:        &title,
-		Description:  gitlab.Ptr(prFooter),
+		Description:  new(prFooter),
 	}
 
 	if targetProjectID != 0 {

--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -369,14 +370,7 @@ func filterOut(tags []string, exclude []string) string {
 		return tags[0]
 	}
 	for _, tag := range tags {
-		excluded := false
-		for _, exl := range exclude {
-			if exl == tag {
-				excluded = true
-				break
-			}
-		}
-		if !excluded {
+		if !slices.Contains(exclude, tag) {
 			return tag
 		}
 	}


### PR DESCRIPTION
Fix [`modernize`](https://golangci-lint.run/docs/linters/configuration/#modernize) lint issues to simplify code.

Changes:

- Replace `github.Ptr` and `gitlab.Ptr` with `new` or `&`.
- Use `slices.Contains`.