### PR TITLE
test: require to use assert and require only

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -37,6 +37,9 @@ linters:
     forbidigo:
       forbid:
         - pattern: ioutil\.*
+        - pattern: ^testing\.T\.Errorf?$
+        - pattern: ^testing\.T\.Fatalf?$
+      analyze-types: true
     gocritic:
       disabled-checks:
         - appendAssign

--- a/internal/client/github_test.go
+++ b/internal/client/github_test.go
@@ -514,7 +514,7 @@ func TestGitHubOpenPullRequestCrossRepo(t *testing.T) {
 			return
 		}
 
-		t.Error("unhandled request: " + r.URL.Path)
+		assert.Fail(t, "unhandled request: "+r.URL.Path)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -569,7 +569,7 @@ func TestGitHubOpenPullRequestHappyPath(t *testing.T) {
 			return
 		}
 
-		t.Error("unhandled request: " + r.URL.Path)
+		assert.Fail(t, "unhandled request: "+r.URL.Path)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -629,7 +629,7 @@ func TestGitHubOpenPullRequestNoBaseBranchDraft(t *testing.T) {
 			return
 		}
 
-		t.Error("unhandled request: " + r.URL.Path)
+		assert.Fail(t, "unhandled request: "+r.URL.Path)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -677,7 +677,7 @@ func TestGitHubOpenPullRequestPRExists(t *testing.T) {
 			return
 		}
 
-		t.Error("unhandled request: " + r.URL.Path)
+		assert.Fail(t, "unhandled request: "+r.URL.Path)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -729,7 +729,7 @@ func TestGitHubOpenPullRequestBaseEmpty(t *testing.T) {
 			return
 		}
 
-		t.Error("unhandled request: " + r.URL.Path)
+		assert.Fail(t, "unhandled request: "+r.URL.Path)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -781,7 +781,7 @@ func TestGitHubOpenPullRequestHeadEmpty(t *testing.T) {
 			return
 		}
 
-		t.Error("unhandled request: " + r.URL.Path)
+		assert.Fail(t, "unhandled request: "+r.URL.Path)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -831,7 +831,7 @@ func TestGitHubCreateFileHappyPathCreate(t *testing.T) {
 			return
 		}
 
-		t.Error("unhandled request: " + r.URL.Path)
+		assert.Fail(t, "unhandled request: "+r.URL.Path)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -881,7 +881,7 @@ func TestGitHubCreateFileHappyPathUpdate(t *testing.T) {
 			return
 		}
 
-		t.Error("unhandled request: " + r.URL.Path)
+		assert.Fail(t, "unhandled request: "+r.URL.Path)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -943,7 +943,7 @@ func TestGitHubCreateFileFeatureBranchAlreadyExists(t *testing.T) {
 			return
 		}
 
-		t.Error("unhandled request: " + r.Method + " " + r.URL.Path)
+		assert.Fail(t, "unhandled request: "+r.Method+" "+r.URL.Path)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -1005,7 +1005,7 @@ func TestGitHubCreateFileFeatureBranchDoesNotExist(t *testing.T) {
 			return
 		}
 
-		t.Error("unhandled request: " + r.Method + " " + r.URL.Path)
+		assert.Fail(t, "unhandled request: "+r.Method+" "+r.URL.Path)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -1053,7 +1053,7 @@ func TestGitHubCreateFileFeatureBranchNilObject(t *testing.T) {
 			return
 		}
 
-		t.Error("unhandled request: " + r.Method + " " + r.URL.Path)
+		assert.Fail(t, "unhandled request: "+r.Method+" "+r.URL.Path)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -1097,7 +1097,7 @@ func TestGitHubCheckRateLimit(t *testing.T) {
 			first.Store(true)
 			return
 		}
-		t.Error("unhandled request: " + r.Method + " " + r.URL.Path)
+		assert.Fail(t, "unhandled request: "+r.Method+" "+r.URL.Path)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -1141,7 +1141,7 @@ func TestGitHubCreateRelease(t *testing.T) {
 			return
 		}
 
-		t.Error("unhandled request: " + r.Method + " " + r.URL.Path)
+		assert.Fail(t, "unhandled request: "+r.Method+" "+r.URL.Path)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -1210,7 +1210,7 @@ func TestGitHubCreateReleaseDeleteExistingDraft(t *testing.T) {
 			return
 		}
 
-		t.Error("unhandled request: " + r.Method + " " + r.URL.Path)
+		assert.Fail(t, "unhandled request: "+r.Method+" "+r.URL.Path)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -1269,7 +1269,7 @@ func TestGitHubCreateReleaseUpdateExisting(t *testing.T) {
 			return
 		}
 
-		t.Error("unhandled request: " + r.Method + " " + r.URL.Path)
+		assert.Fail(t, "unhandled request: "+r.Method+" "+r.URL.Path)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -1331,7 +1331,7 @@ func TestGitHubCreateReleaseUseExistingDraft(t *testing.T) {
 			return
 		}
 
-		t.Error("unhandled request: " + r.Method + " " + r.URL.Path)
+		assert.Fail(t, "unhandled request: "+r.Method+" "+r.URL.Path)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -1400,7 +1400,7 @@ func TestGitHubCreateFileWithGitHubAppToken(t *testing.T) {
 			return
 		}
 
-		t.Error("unhandled request: " + r.URL.Path)
+		assert.Fail(t, "unhandled request: "+r.URL.Path)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -1463,7 +1463,7 @@ func TestGitHubCreateFileWithoutGitHubAppToken(t *testing.T) {
 			return
 		}
 
-		t.Error("unhandled request: " + r.URL.Path)
+		assert.Fail(t, "unhandled request: "+r.URL.Path)
 	}))
 	t.Cleanup(srv.Close)
 

--- a/internal/client/gitlab_test.go
+++ b/internal/client/gitlab_test.go
@@ -346,7 +346,7 @@ func TestGitLabCreateReleaseReleaseNotExists(t *testing.T) {
 					return
 				}
 
-				t.Fatal("should not reach here")
+				assert.Fail(t, "should not reach here")
 			}))
 			defer srv.Close()
 
@@ -400,7 +400,7 @@ func TestGitLabCreateReleaseReleaseExists(t *testing.T) {
 			return
 		}
 
-		t.Fatal("should not reach here")
+		assert.Fail(t, "should not reach here")
 	}))
 	defer srv.Close()
 
@@ -482,7 +482,7 @@ func TestGitLabGetDefaultBranchEnv(t *testing.T) {
 		if strings.HasSuffix(r.URL.Path, "/version") {
 			return
 		}
-		t.Error("shouldn't have made any calls to the API")
+		assert.Fail(t, "shouldn't have made any calls to the API")
 	}))
 	t.Cleanup(srv.Close)
 
@@ -842,7 +842,7 @@ func TestGitLabOpenPullRequestCrossRepo(t *testing.T) {
 			return
 		}
 
-		t.Error("unhandled request: " + r.URL.Path)
+		assert.Fail(t, "unhandled request: "+r.URL.Path)
 	}))
 	defer srv.Close()
 
@@ -901,7 +901,7 @@ func TestGitLabOpenPullRequestBaseEmpty(t *testing.T) {
 			return
 		}
 
-		t.Error("unhandled request: " + r.URL.Path)
+		assert.Fail(t, "unhandled request: "+r.URL.Path)
 	}))
 	defer srv.Close()
 
@@ -956,7 +956,7 @@ func TestGitLabOpenPullRequestDraft(t *testing.T) {
 			return
 		}
 
-		t.Error("unhandled request: " + r.URL.Path)
+		assert.Fail(t, "unhandled request: "+r.URL.Path)
 	}))
 	defer srv.Close()
 
@@ -1005,7 +1005,7 @@ func TestGitLabOpenPullRequestBaseBranchGiven(t *testing.T) {
 			return
 		}
 
-		t.Error("unhandled request: " + r.URL.Path)
+		assert.Fail(t, "unhandled request: "+r.URL.Path)
 	}))
 	defer srv.Close()
 

--- a/internal/http/http_test.go
+++ b/internal/http/http_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/pkg/config"
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,31 +32,21 @@ func TestAssetOpenDefault(t *testing.T) {
 	a, err := assetOpenDefault("blah", &artifact.Artifact{
 		Path: tf,
 	})
-	if err != nil {
-		t.Fatalf("can not open asset: %v", err)
-	}
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, a.ReadCloser.Close())
 	})
 	bs, err := io.ReadAll(a.ReadCloser)
-	if err != nil {
-		t.Fatalf("can not read asset: %v", err)
-	}
-	if string(bs) != "a" {
-		t.Fatalf("unexpected read content")
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "a", string(bs))
 	_, err = assetOpenDefault("blah", &artifact.Artifact{
 		Path: "blah",
 	})
-	if err == nil {
-		t.Fatalf("should fail on missing file")
-	}
+	require.Error(t, err)
 	_, err = assetOpenDefault("blah", &artifact.Artifact{
 		Path: t.TempDir(),
 	})
-	if err == nil {
-		t.Fatalf("should fail on existing dir")
-	}
+	require.Error(t, err)
 }
 
 func TestDefaults(t *testing.T) {
@@ -65,20 +56,17 @@ func TestDefaults(t *testing.T) {
 	tests := []struct {
 		name     string
 		args     args
-		wantErr  bool
 		wantMode string
 	}{
-		{"set default", args{[]config.Upload{{Name: "a", Target: "http://"}}}, false, ModeArchive},
-		{"keep value", args{[]config.Upload{{Name: "a", Target: "http://...", Mode: ModeBinary}}}, false, ModeBinary},
+		{"set default", args{[]config.Upload{{Name: "a", Target: "http://"}}}, ModeArchive},
+		{"keep value", args{[]config.Upload{{Name: "a", Target: "http://...", Mode: ModeBinary}}}, ModeBinary},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := Defaults(tt.args.uploads); (err != nil) != tt.wantErr {
-				t.Errorf("Defaults() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if tt.wantMode != tt.args.uploads[0].Mode {
-				t.Errorf("Incorrect Defaults() mode %q , wanted %q", tt.args.uploads[0].Mode, tt.wantMode)
-			}
+			err := Defaults(tt.args.uploads)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantMode, tt.args.uploads[0].Mode)
 		})
 	}
 }
@@ -114,8 +102,12 @@ func TestCheckConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := CheckConfig(tt.args.ctx, tt.args.upload, tt.args.kind); (err != nil) != tt.wantErr {
-				t.Errorf("CheckConfig() error = %v, wantErr %v", err, tt.wantErr)
+			err := CheckConfig(tt.args.ctx, tt.args.upload, tt.args.kind)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}
@@ -132,8 +124,11 @@ func TestCheckConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := CheckConfig(tt.args.ctx, tt.args.upload, tt.args.kind); (err != nil) != tt.wantErr {
-				t.Errorf("CheckConfig() error = %v, wantErr %v", err, tt.wantErr)
+			err := CheckConfig(tt.args.ctx, tt.args.upload, tt.args.kind)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}
@@ -675,12 +670,16 @@ func TestUpload(t *testing.T) {
 		if srv.Certificate() != nil {
 			wantErr = wantErrTLS
 		}
-		if err := Upload(ctx, []config.Upload{upload}, "test", is2xx); (err != nil) != wantErr {
-			t.Errorf("Upload() error = %v, wantErr %v", err, wantErr)
+
+		err := Upload(ctx, []config.Upload{upload}, "test", is2xx)
+		if wantErr {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
 		}
-		if err := check(requests); err != nil {
-			t.Errorf("Upload() request invalid. Error: %v", err)
-		}
+
+		err = check(requests)
+		require.NoError(t, err)
 	}
 
 	for _, tt := range tests {

--- a/internal/pipe/archive/archive_test.go
+++ b/internal/pipe/archive/archive_test.go
@@ -397,7 +397,7 @@ func zipInfo(t *testing.T, path, name string) fs.FileInfo {
 			return next.FileInfo()
 		}
 	}
-	t.Fatalf("could not find %q in %q", name, path)
+	require.Failf(t, "unexpected", "could not find %q in %q", name, path)
 	return nil
 }
 
@@ -419,7 +419,7 @@ func tarInfo(t *testing.T, path, name string) *tar.Header {
 			return next
 		}
 	}
-	t.Fatalf("could not find %q in %q", name, path)
+	require.Failf(t, "unexpected", "could not find %q in %q", name, path)
 	return nil
 }
 

--- a/internal/pipe/chocolatey/chocolatey_test.go
+++ b/internal/pipe/chocolatey/chocolatey_test.go
@@ -155,12 +155,9 @@ func Test_doRun(t *testing.T) {
 			client := client.NewMock()
 			got := doRun(ctx, client, tt.choco)
 
-			var err string
-			if got != nil {
-				err = got.Error()
-			}
-			if tt.err != err {
-				t.Errorf("Unexpected error: %s (expected %s)", err, tt.err)
+			if tt.err != "" {
+				require.EqualError(t, got, tt.err)
+				return
 			}
 
 			list := ctx.Artifacts.Filter(artifact.ByType(artifact.PublishableChocolatey)).List()
@@ -220,9 +217,7 @@ func Test_buildTemplate(t *testing.T) {
 	client := client.NewMock()
 
 	data, err := dataFor(ctx, client, choco, artifacts)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	out, err := buildTemplate(choco.Name, scriptTemplate, data)
 	require.NoError(t, err)
@@ -317,12 +312,10 @@ func TestPublish(t *testing.T) {
 
 			got := Pipe{}.Publish(ctx)
 
-			var err string
-			if got != nil {
-				err = got.Error()
-			}
-			if tt.err != err {
-				t.Errorf("Unexpected error: %s (expected %s)", err, tt.err)
+			if tt.err != "" {
+				require.EqualError(t, got, tt.err)
+			} else {
+				require.NoError(t, got)
 			}
 		})
 	}

--- a/internal/pipe/docker/manifest_test.go
+++ b/internal/pipe/docker/manifest_test.go
@@ -1,13 +1,12 @@
 package docker
 
 import (
-	"slices"
-	"strings"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/pkg/config"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -136,15 +135,10 @@ func Test_manifestImages(t *testing.T) {
 			got, err := manifestImages(ctx, manifest)
 
 			if tt.wantErr {
-				require.Error(t, err)
-				if !strings.Contains(err.Error(), tt.errContains) {
-					t.Fatalf("expected error to contain %q, got: %v", tt.errContains, err)
-				}
+				require.ErrorContains(t, err, tt.errContains)
 			} else {
 				require.NoError(t, err)
-				if !slices.Equal(got, tt.want) {
-					t.Fatalf("unexpected output: want: %v, got: %v", tt.want, got)
-				}
+				assert.Equal(t, tt.want, got)
 			}
 		})
 	}

--- a/internal/pipe/docker/v2/docker_integration_test.go
+++ b/internal/pipe/docker/v2/docker_integration_test.go
@@ -97,7 +97,7 @@ func TestRun(t *testing.T) {
 	if !pipe.IsSkip(err) {
 		de, ok := errors.AsType[gerrors.ErrDetailed](err)
 		require.True(t, ok)
-		t.Fatalf("should have been a skip, got message: %s, details: %v, output: %s", de.Messages(), maps.Collect(de.Details()), de.Output())
+		require.Failf(t, "should have been a skip", "got message: %s, details: %v, output: %s", de.Messages(), maps.Collect(de.Details()), de.Output())
 	}
 
 	t.Run("main", func(t *testing.T) {
@@ -250,7 +250,7 @@ func TestPublish(t *testing.T) {
 	if err != nil {
 		de, ok := errors.AsType[gerrors.ErrDetailed](err)
 		require.True(t, ok)
-		t.Fatalf("should have been a skip, got message: %s, details: %v, output: %s", de.Messages(), maps.Collect(de.Details()), de.Output())
+		require.Failf(t, "should have been a skip", "got message: %s, details: %v, output: %s", de.Messages(), maps.Collect(de.Details()), de.Output())
 	}
 
 	t.Run("main", func(t *testing.T) {
@@ -359,7 +359,7 @@ func TestSnapshotNoDaemon(t *testing.T) {
 	if err != nil {
 		de, ok := errors.AsType[gerrors.ErrDetailed](err)
 		require.True(t, ok)
-		t.Fatalf("should have been a skip, got message: %s, details: %v, output: %s", de.Messages(), maps.Collect(de.Details()), de.Output())
+		require.Failf(t, "should have been a skip", "got message: %s, details: %v, output: %s", de.Messages(), maps.Collect(de.Details()), de.Output())
 	}
 
 	images := ctx.Artifacts.Filter(

--- a/internal/pipe/linkedin/client_test.go
+++ b/internal/pipe/linkedin/client_test.go
@@ -69,16 +69,12 @@ func TestClient_Share(t *testing.T) {
 		Context:     testctx.Wrap(t.Context()),
 		AccessToken: "foo",
 	})
-	if err != nil {
-		t.Fatalf("could not create client: %v", err)
-	}
+	require.NoError(t, err)
 
 	c.baseURL = server.URL
 
 	link, err := c.Share(t.Context(), "test")
-	if err != nil {
-		t.Fatalf("could not share: %v", err)
-	}
+	require.NoError(t, err)
 
 	wantLink := "https://www.linkedin.com/feed/update/123456789"
 	require.Equal(t, wantLink, link)
@@ -104,16 +100,12 @@ func TestClientLegacyProfile_Share(t *testing.T) {
 		Context:     testctx.Wrap(t.Context()),
 		AccessToken: "foo",
 	})
-	if err != nil {
-		t.Fatalf("could not create client: %v", err)
-	}
+	require.NoError(t, err)
 
 	c.baseURL = server.URL
 
 	link, err := c.Share(t.Context(), "test")
-	if err != nil {
-		t.Fatalf("could not share: %v", err)
-	}
+	require.NoError(t, err)
 
 	wantLink := "https://www.linkedin.com/feed/update/123456789"
 	require.Equal(t, wantLink, link)


### PR DESCRIPTION
Refactor tests to use `assert` or `require` instead of `t.Error` and `t.Fatal`.

Extend `forbidigo.forbid` patterns to prevent future regressions.