### PR TITLE
docs: Fix signature verification of checksum file

### DIFF
--- a/www/content/getting-started/install.md
+++ b/www/content/getting-started/install.md
@@ -447,8 +447,7 @@ All artifacts are checksummed, and the checksum file is signed with [cosign][].
 {{< tabs >}}
 {{< tab "OSS" >}}
 
-1. Download the files you want, and the `checksums.txt`, `checksum.txt.pem` and
-   `checksums.txt.sig` files from the
+1. Download the files you want, and the `checksums.txt`, `checksum.txt.sigstore.json` files from the
    [releases](https://github.com/goreleaser/goreleaser/releases) page:
 
 ```bash
@@ -475,8 +474,7 @@ sha256sum --ignore-missing -c checksums.txt
 {{< /tab >}}
 {{< tab "Pro" >}}
 
-1. Download the files you want, and the `checksums.txt`, `checksum.txt.pem` and
-   `checksums.txt.sig` files from the
+1. Download the files you want, and the `checksums.txt`, `checksum.txt.sigstore.json` files from the
    [releases](https://github.com/goreleaser/goreleaser-pro/releases) page:
 
 ```bash


### PR DESCRIPTION
The fix correctly mentions the necessary files for signature verification.

After the switch to the sigstore bundle, the commands for signature verification were updated but the text still mentioned the old signature and certificate files.