### PR TITLE
feat(archive): xz format

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -11,6 +11,7 @@ import (
 	"github.com/goreleaser/goreleaser/v2/pkg/archive/targz"
 	"github.com/goreleaser/goreleaser/v2/pkg/archive/tarxz"
 	"github.com/goreleaser/goreleaser/v2/pkg/archive/tarzst"
+	"github.com/goreleaser/goreleaser/v2/pkg/archive/xz"
 	"github.com/goreleaser/goreleaser/v2/pkg/archive/zip"
 	"github.com/goreleaser/goreleaser/v2/pkg/config"
 )
@@ -36,6 +37,8 @@ func New(w io.Writer, format string) (Archive, error) {
 		return tarzst.New(w), nil
 	case "zip":
 		return zip.New(w), nil
+	case "xz":
+		return xz.New(w), nil
 	}
 	return nil, fmt.Errorf("invalid archive format: %s", format)
 }

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -18,7 +18,7 @@ func TestArchive(t *testing.T) {
 	require.NoError(t, empty.Close())
 	require.NoError(t, os.Mkdir(folder+"/folder-inside", 0o755))
 
-	for _, format := range []string{"tar.gz", "zip", "gz", "tar.xz", "tar", "tgz", "txz", "tar.zst", "tzst"} {
+	for _, format := range []string{"tar.gz", "zip", "gz", "tar.xz", "tar", "tgz", "txz", "tar.zst", "tzst", "xz"} {
 		t.Run(format, func(t *testing.T) {
 			f1, err := os.Create(filepath.Join(t.TempDir(), "1.tar"))
 			require.NoError(t, err)
@@ -36,7 +36,7 @@ func TestArchive(t *testing.T) {
 			require.NoError(t, archive.Close())
 			require.NoError(t, f1.Close())
 
-			if format == "tar.xz" || format == "txz" || format == "gz" || format == "tar.zst" || format == "tzst" {
+			if format == "tar.xz" || format == "txz" || format == "gz" || format == "tar.zst" || format == "tzst" || format == "xz" {
 				_, err := Copy(f1, io.Discard, format)
 				require.Error(t, err)
 				return

--- a/pkg/archive/xz/xz.go
+++ b/pkg/archive/xz/xz.go
@@ -1,0 +1,59 @@
+// Package xz implements the Archive interface providing xz archiving
+// and compression.
+package xz
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/goreleaser/goreleaser/v2/pkg/config"
+	"github.com/ulikunitz/xz"
+)
+
+// Archive as xz.
+type Archive struct {
+	name    string
+	modTime time.Time
+	xzw     *xz.Writer
+}
+
+// New xz archive.
+func New(target io.Writer) *Archive {
+	xzw, _ := xz.WriterConfig{DictCap: 16 * 1024 * 1024}.NewWriter(target)
+	return &Archive{
+		xzw: xzw,
+	}
+}
+
+// Close all closeables.
+func (a *Archive) Close() error {
+	return a.xzw.Close()
+}
+
+// Add file to the archive.
+func (a *Archive) Add(f config.File) error {
+	if a.name != "" {
+		return fmt.Errorf("xz: failed to add %s, only one file can be archived in xz format", f.Destination)
+	}
+
+	file, err := os.Open(f.Source) // #nosec
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+
+	if info.IsDir() {
+		return nil
+	}
+
+	a.name = f.Destination
+	_, err = io.Copy(a.xzw, file)
+	return err
+}

--- a/pkg/archive/xz/xz_test.go
+++ b/pkg/archive/xz/xz_test.go
@@ -1,0 +1,50 @@
+package xz_test
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	xza "github.com/goreleaser/goreleaser/v2/pkg/archive/xz"
+	"github.com/goreleaser/goreleaser/v2/pkg/config"
+	"github.com/stretchr/testify/require"
+	"github.com/ulikunitz/xz"
+)
+
+func TestXzFile(t *testing.T) {
+	tmp := t.TempDir()
+
+	f, err := os.Create(filepath.Join(tmp, "test.xz"))
+	require.NoError(t, err)
+	defer f.Close()
+
+	archive := xza.New(f)
+	defer archive.Close()
+
+	require.NoError(t, archive.Add(config.File{
+		Destination: "sub1/sub2/subfoo.txt",
+		Source:      "../testdata/sub1/sub2/subfoo.txt",
+	}))
+	require.EqualError(t, archive.Add(config.File{
+		Destination: "foo.txt",
+		Source:      "../testdata/foo.txt",
+	}), "xz: failed to add foo.txt, only one file can be archived in xz format")
+	require.NoError(t, archive.Close())
+	require.NoError(t, f.Close())
+
+	f, err = os.Open(f.Name())
+	require.NoError(t, err)
+	defer f.Close()
+
+	info, err := f.Stat()
+	require.NoError(t, err)
+	require.Lessf(t, info.Size(), int64(500), "archived file should be smaller than %d", info.Size())
+
+	xzf, err := xz.NewReader(f)
+	require.NoError(t, err)
+
+	bts, err := io.ReadAll(xzf)
+	require.NoError(t, err)
+	require.Equal(t, "sub\n", string(bts))
+}

--- a/www/content/customization/package/archives.md
+++ b/www/content/customization/package/archives.md
@@ -38,6 +38,7 @@ archives:
     # - `tzst` {{< inline_version "v2.1" >}}
     # - `tar`
     # - `gz`
+    # - `xz`
     # - `zip`
     # - `binary`
     #
@@ -102,6 +103,7 @@ archives:
         # - `tzst` # {{< inline_version "v2.1" >}}
         # - `tar`
         # - `gz`
+        # - `xz`
         # - `zip`
         # - `binary` # be extra-cautious with the file name template in this case!
         # - `none`   # skips this archive
@@ -275,23 +277,24 @@ archive. Any glob that doesn't match any file should work.
 
 For more information, check [#602](https://github.com/goreleaser/goreleaser/issues/602)
 
-## A note about Gzip
+## A note about Gzip/XZ
 
-Gzip is a compression-only format, therefore, it couldn't have more than one
-file inside.
+Gzip and xz are a compression-only format, therefore, it couldn't have more than
+one file inside.
 
 Presumably, you'll want that file to be the binary, so, your archive section
 will probably look like this:
 
 ```yaml {filename=".goreleaser.yaml"}
 archives:
+  # Note: Replace gz with xz for xz.
   - format: gz
     files:
       - none*
 ```
 
 This should create `.gz` files with the binaries only, which should be
-extracted with something like `gzip -d file.gz`.
+extracted with something like `gzip -d file.gz` (`unxz file.xz` for xz).
 
 > [!WARNING]
 > You won't be able to package multiple builds in a single archive either.

--- a/www/content/customization/package/archives.md
+++ b/www/content/customization/package/archives.md
@@ -38,7 +38,7 @@ archives:
     # - `tzst` {{< inline_version "v2.1" >}}
     # - `tar`
     # - `gz`
-    # - `xz` {{< g_inline_version "v2.6-unreleased" >}}
+    # - `xz` {{< g_inline_version "v2.16-unreleased" >}}
     # - `zip`
     # - `binary`
     #
@@ -103,7 +103,7 @@ archives:
         # - `tzst` # {{< inline_version "v2.1" >}}
         # - `tar`
         # - `gz`
-        # - `xz` {{< g_inline_version "v2.6-unreleased" >}}
+        # - `xz` {{< g_inline_version "v2.16-unreleased" >}}
         # - `zip`
         # - `binary` # be extra-cautious with the file name template in this case!
         # - `none`   # skips this archive

--- a/www/content/customization/package/archives.md
+++ b/www/content/customization/package/archives.md
@@ -38,7 +38,7 @@ archives:
     # - `tzst` {{< inline_version "v2.1" >}}
     # - `tar`
     # - `gz`
-    # - `xz`
+    # - `xz` {{< g_inline_version "v2.6-unreleased" >}}
     # - `zip`
     # - `binary`
     #
@@ -103,7 +103,7 @@ archives:
         # - `tzst` # {{< inline_version "v2.1" >}}
         # - `tar`
         # - `gz`
-        # - `xz`
+        # - `xz` {{< g_inline_version "v2.6-unreleased" >}}
         # - `zip`
         # - `binary` # be extra-cautious with the file name template in this case!
         # - `none`   # skips this archive


### PR DESCRIPTION
Adds `xz` as a format. Note this format doesn't support ModTime, 
at least not in the way gzip apparently does (TIL!) so that will have 
no effect.

Added this primarily for my own desire to have better compression
ratio than gz, not horribly offended if this isn't merged for being
not that useful 😄 