### PR TITLE
fix(homebrew_cask): sha256 before url in per-arch blocks

### DIFF
--- a/internal/pipe/cask/templates/linux_packages.rb
+++ b/internal/pipe/cask/templates/linux_packages.rb
@@ -5,8 +5,8 @@
   {{- else if eq $element.Arch "arm64" }}
   on_arm do
   {{- end }}
-    url "{{ $element.URL.Download }}"{{- include "additional_url_params" $element.URL }}
     sha256 "{{ $element.SHA256 }}"
+    url "{{ $element.URL.Download }}"{{- include "additional_url_params" $element.URL }}
     {{- if .Binary }}
     binary "{{ .Name }}", target: "{{ .Binary }}"
     {{- end }}

--- a/internal/pipe/cask/templates/macos_packages.rb
+++ b/internal/pipe/cask/templates/macos_packages.rb
@@ -1,8 +1,8 @@
 {{- define "macos_packages" }}
 {{- range $element := .MacOSPackages }}
   {{- if eq $element.Arch "all" }}
-  url "{{ $element.URL.Download }}"{{- include "additional_url_params" $element.URL }}
   sha256 "{{ $element.SHA256 }}"
+  url "{{ $element.URL.Download }}"{{- include "additional_url_params" $element.URL }}
   {{- if .Binary }}
   binary "{{ .Name }}", target: "{{ .Binary }}"
   {{- end }}
@@ -14,8 +14,8 @@
   {{- if eq $element.Arch "arm64" }}
   on_arm do
   {{- end }}
-    url "{{ $element.URL.Download }}"{{- include "additional_url_params" $element.URL }}
     sha256 "{{ $element.SHA256 }}"
+    url "{{ $element.URL.Download }}"{{- include "additional_url_params" $element.URL }}
     {{- if .Binary }}
     binary "{{ .Name }}", target: "{{ .Binary }}"
     {{- end }}

--- a/internal/pipe/cask/testdata/TestFullCask.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullCask.rb.golden
@@ -13,23 +13,23 @@ cask "test" do
 
   on_macos do
     on_intel do
-      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_x86_64.tar.gz"
       sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c68"
+      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_x86_64.tar.gz"
     end
     on_arm do
-      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_arm64.tar.gz"
       sha256 "1df5fdc2bad4ed4c28fbdc77b6c542988c0dc0e2ae34e0dc912bbb1c66646c58"
+      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_arm64.tar.gz"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Linux_x86_64.tar.gz"
       sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67"
+      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Linux_x86_64.tar.gz"
     end
     on_arm do
-      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Arm64.tar.gz"
       sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67"
+      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Arm64.tar.gz"
     end
   end
 

--- a/internal/pipe/cask/testdata/TestFullCaskLinuxOnly.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullCaskLinuxOnly.rb.golden
@@ -4,12 +4,12 @@ cask "test" do
 
   on_linux do
     on_intel do
-      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Linux_x86_64.tar.gz"
       sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67"
+      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Linux_x86_64.tar.gz"
     end
     on_arm do
-      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Arm64.tar.gz"
       sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67"
+      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Arm64.tar.gz"
     end
   end
 

--- a/internal/pipe/cask/testdata/TestFullCaskMacOSOnly.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullCaskMacOSOnly.rb.golden
@@ -4,12 +4,12 @@ cask "test" do
 
   on_macos do
     on_intel do
-      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_x86_64.tar.gz"
       sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c68"
+      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_x86_64.tar.gz"
     end
     on_arm do
-      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_arm64.tar.gz"
       sha256 "1df5fdc2bad4ed4c28fbdc77b6c542988c0dc0e2ae34e0dc912bbb1c66646c58"
+      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_arm64.tar.gz"
     end
   end
 

--- a/internal/pipe/cask/testdata/TestFullPipe/custom_block.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/custom_block.rb.golden
@@ -6,19 +6,19 @@ cask "custom_block" do
 
   on_macos do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tgz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
     end
     on_arm do
-      url "https://dummyhost/download/v#{version}/bin.txz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.txz"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tar.zst"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tar.zst"
     end
   end
 

--- a/internal/pipe/cask/testdata/TestFullPipe/custom_block_url.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/custom_block_url.rb.golden
@@ -36,34 +36,34 @@ cask "custom_block_url" do
 
   on_macos do
     on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "#{GitHubHelper.release_asset_url("v#{version}", "bin.tgz")}",
         header: [
           "Accept: application/octet-stream",
           "Authorization: Bearer #{GitHubHelper.token}",
           "X-GitHub-Api-Version: 2022-11-28",
         ]
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     end
     on_arm do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "#{GitHubHelper.release_asset_url("v#{version}", "bin.txz")}",
         header: [
           "Accept: application/octet-stream",
           "Authorization: Bearer #{GitHubHelper.token}",
           "X-GitHub-Api-Version: 2022-11-28",
         ]
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     end
   end
 
   on_linux do
     on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "#{GitHubHelper.release_asset_url("v#{version}", "bin.tar.zst")}",
         header: [
           "Accept: application/octet-stream",
           "Authorization: Bearer #{GitHubHelper.token}",
           "X-GitHub-Api-Version: 2022-11-28",
         ]
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     end
   end
 

--- a/internal/pipe/cask/testdata/TestFullPipe/default.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/default.rb.golden
@@ -4,19 +4,19 @@ cask "default" do
 
   on_macos do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tgz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
     end
     on_arm do
-      url "https://dummyhost/download/v#{version}/bin.txz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.txz"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tar.zst"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tar.zst"
     end
   end
 

--- a/internal/pipe/cask/testdata/TestFullPipe/default_gitlab.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/default_gitlab.rb.golden
@@ -4,19 +4,19 @@ cask "default_gitlab" do
 
   on_macos do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tgz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
     end
     on_arm do
-      url "https://dummyhost/download/v#{version}/bin.txz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.txz"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tar.zst"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tar.zst"
     end
   end
 

--- a/internal/pipe/cask/testdata/TestFullPipe/generate_completions.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/generate_completions.rb.golden
@@ -4,19 +4,19 @@ cask "generate_completions" do
 
   on_macos do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tgz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
     end
     on_arm do
-      url "https://dummyhost/download/v#{version}/bin.txz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.txz"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tar.zst"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tar.zst"
     end
   end
 

--- a/internal/pipe/cask/testdata/TestFullPipe/generate_completions_default_executable.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/generate_completions_default_executable.rb.golden
@@ -4,19 +4,19 @@ cask "generate_completions_default_executable" do
 
   on_macos do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tgz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
     end
     on_arm do
-      url "https://dummyhost/download/v#{version}/bin.txz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.txz"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tar.zst"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tar.zst"
     end
   end
 

--- a/internal/pipe/cask/testdata/TestFullPipe/git_remote.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/git_remote.rb.golden
@@ -4,19 +4,19 @@ cask "git_remote" do
 
   on_macos do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tgz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
     end
     on_arm do
-      url "https://dummyhost/download/v#{version}/bin.txz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.txz"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tar.zst"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tar.zst"
     end
   end
 

--- a/internal/pipe/cask/testdata/TestFullPipe/hooks_templated.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/hooks_templated.rb.golden
@@ -4,19 +4,19 @@ cask "hooks_templated" do
 
   on_macos do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tgz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
     end
     on_arm do
-      url "https://dummyhost/download/v#{version}/bin.txz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.txz"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tar.zst"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tar.zst"
     end
   end
 

--- a/internal/pipe/cask/testdata/TestFullPipe/manpages_glob.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/manpages_glob.rb.golden
@@ -4,19 +4,19 @@ cask "manpages_glob" do
 
   on_macos do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tgz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
     end
     on_arm do
-      url "https://dummyhost/download/v#{version}/bin.txz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.txz"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tar.zst"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tar.zst"
     end
   end
 

--- a/internal/pipe/cask/testdata/TestFullPipe/many-dependencies-and-conflicts.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/many-dependencies-and-conflicts.rb.golden
@@ -4,19 +4,19 @@ cask "many-dependencies-and-conflicts" do
 
   on_macos do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tgz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
     end
     on_arm do
-      url "https://dummyhost/download/v#{version}/bin.txz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.txz"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tar.zst"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tar.zst"
     end
   end
 

--- a/internal/pipe/cask/testdata/TestFullPipe/open_pr.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/open_pr.rb.golden
@@ -4,19 +4,19 @@ cask "open_pr" do
 
   on_macos do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tgz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
     end
     on_arm do
-      url "https://dummyhost/download/v#{version}/bin.txz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.txz"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tar.zst"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tar.zst"
     end
   end
 

--- a/internal/pipe/cask/testdata/TestFullPipe/uninstall.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/uninstall.rb.golden
@@ -4,19 +4,19 @@ cask "uninstall" do
 
   on_macos do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tgz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
     end
     on_arm do
-      url "https://dummyhost/download/v#{version}/bin.txz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.txz"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tar.zst"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tar.zst"
     end
   end
 

--- a/internal/pipe/cask/testdata/TestFullPipe/url_parameters_curl.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/url_parameters_curl.rb.golden
@@ -4,6 +4,7 @@ cask "url_parameters_curl" do
 
   on_macos do
     on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.tgz",
         using: :homebrew_curl,
         cookies: {
@@ -14,9 +15,9 @@ cask "url_parameters_curl" do
           "Accept: application/octet-stream",
         ],
         user_agent: "GoReleaser"
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     end
     on_arm do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.txz",
         using: :homebrew_curl,
         cookies: {
@@ -27,12 +28,12 @@ cask "url_parameters_curl" do
           "Accept: application/octet-stream",
         ],
         user_agent: "GoReleaser"
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     end
   end
 
   on_linux do
     on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.tar.zst",
         using: :homebrew_curl,
         cookies: {
@@ -43,7 +44,6 @@ cask "url_parameters_curl" do
           "Accept: application/octet-stream",
         ],
         user_agent: "GoReleaser"
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     end
   end
 

--- a/internal/pipe/cask/testdata/TestFullPipe/url_parameters_post.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/url_parameters_post.rb.golden
@@ -4,6 +4,7 @@ cask "url_parameters_post" do
 
   on_macos do
     on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.tgz",
         verified: "https://dummyhost/download/",
         using: :post,
@@ -13,9 +14,9 @@ cask "url_parameters_post" do
         data: {
           "payload" => "hello_world",
         }
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     end
     on_arm do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.txz",
         verified: "https://dummyhost/download/",
         using: :post,
@@ -25,12 +26,12 @@ cask "url_parameters_post" do
         data: {
           "payload" => "hello_world",
         }
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     end
   end
 
   on_linux do
     on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.tar.zst",
         verified: "https://dummyhost/download/",
         using: :post,
@@ -40,7 +41,6 @@ cask "url_parameters_post" do
         data: {
           "payload" => "hello_world",
         }
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     end
   end
 

--- a/internal/pipe/cask/testdata/TestFullPipe/valid_repository_templates.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/valid_repository_templates.rb.golden
@@ -4,19 +4,19 @@ cask "valid_repository_templates" do
 
   on_macos do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tgz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
     end
     on_arm do
-      url "https://dummyhost/download/v#{version}/bin.txz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.txz"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tar.zst"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tar.zst"
     end
   end
 

--- a/internal/pipe/cask/testdata/TestFullPipe/zap.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/zap.rb.golden
@@ -4,19 +4,19 @@ cask "zap" do
 
   on_macos do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tgz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
     end
     on_arm do
-      url "https://dummyhost/download/v#{version}/bin.txz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.txz"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tar.zst"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tar.zst"
     end
   end
 

--- a/internal/pipe/cask/testdata/TestGenerateCompletionsFromExecutable.rb.golden
+++ b/internal/pipe/cask/testdata/TestGenerateCompletionsFromExecutable.rb.golden
@@ -4,23 +4,23 @@ cask "test" do
 
   on_macos do
     on_intel do
-      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_x86_64.tar.gz"
       sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c68"
+      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_x86_64.tar.gz"
     end
     on_arm do
-      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_arm64.tar.gz"
       sha256 "1df5fdc2bad4ed4c28fbdc77b6c542988c0dc0e2ae34e0dc912bbb1c66646c58"
+      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_arm64.tar.gz"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Linux_x86_64.tar.gz"
       sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67"
+      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Linux_x86_64.tar.gz"
     end
     on_arm do
-      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Arm64.tar.gz"
       sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67"
+      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Arm64.tar.gz"
     end
   end
 

--- a/internal/pipe/cask/testdata/TestGenerateCompletionsFromExecutableAllOptions.rb.golden
+++ b/internal/pipe/cask/testdata/TestGenerateCompletionsFromExecutableAllOptions.rb.golden
@@ -4,23 +4,23 @@ cask "test" do
 
   on_macos do
     on_intel do
-      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_x86_64.tar.gz"
       sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c68"
+      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_x86_64.tar.gz"
     end
     on_arm do
-      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_arm64.tar.gz"
       sha256 "1df5fdc2bad4ed4c28fbdc77b6c542988c0dc0e2ae34e0dc912bbb1c66646c58"
+      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_arm64.tar.gz"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Linux_x86_64.tar.gz"
       sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67"
+      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Linux_x86_64.tar.gz"
     end
     on_arm do
-      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Arm64.tar.gz"
       sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67"
+      url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Arm64.tar.gz"
     end
   end
 

--- a/internal/pipe/cask/testdata/TestRunPipeBinaryRelease.rb.golden
+++ b/internal/pipe/cask/testdata/TestRunPipeBinaryRelease.rb.golden
@@ -3,8 +3,8 @@ cask "foo" do
   version "1.2.1"
 
   on_macos do
-    url "https://dummyhost/download/v#{version}/foo_macos"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    url "https://dummyhost/download/v#{version}/foo_macos"
     binary "foo_macos", target: "foo"
   end
 

--- a/internal/pipe/cask/testdata/TestRunPipeNameTemplate.rb.golden
+++ b/internal/pipe/cask/testdata/TestRunPipeNameTemplate.rb.golden
@@ -4,8 +4,8 @@ cask "foo_is_bar" do
 
   on_macos do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tar.gz"
     end
     on_arm do
       def caveats

--- a/internal/pipe/cask/testdata/TestRunPipePullRequest.rb.golden
+++ b/internal/pipe/cask/testdata/TestRunPipePullRequest.rb.golden
@@ -3,8 +3,8 @@ cask "foo" do
   version "1.2.1"
 
   on_macos do
-    url "https://dummyhost/download/v#{version}/foo_macos"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    url "https://dummyhost/download/v#{version}/foo_macos"
     binary "foo_macos", target: "foo"
   end
 

--- a/internal/pipe/cask/testdata/TestRunPipeUniversalBinary.rb.golden
+++ b/internal/pipe/cask/testdata/TestRunPipeUniversalBinary.rb.golden
@@ -3,8 +3,8 @@ cask "unibin" do
   version "1.0.1"
 
   on_macos do
-    url "https://dummyhost/download/v#{version}/bin.tar.gz"
     sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    url "https://dummyhost/download/v#{version}/bin.tar.gz"
   end
 
   name "unibin"

--- a/internal/pipe/cask/testdata/TestRunPipeUniversalBinaryNotReplacing.rb.golden
+++ b/internal/pipe/cask/testdata/TestRunPipeUniversalBinaryNotReplacing.rb.golden
@@ -4,12 +4,12 @@ cask "unibin" do
 
   on_macos do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin_amd64.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin_amd64.tar.gz"
     end
     on_arm do
-      url "https://dummyhost/download/v#{version}/bin_arm64.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin_arm64.tar.gz"
     end
   end
 

--- a/internal/pipe/cask/testdata/TestRunPipeWrappedIn.rb.golden
+++ b/internal/pipe/cask/testdata/TestRunPipeWrappedIn.rb.golden
@@ -4,14 +4,14 @@ cask "wrappedin" do
 
   on_macos do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin_amd64.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin_amd64.tar.gz"
       rename "wrappedin_1.0.1_darwin_amd64/wrappedin", "wrappedin"
       rename "wrappedin_1.0.1_darwin_amd64/other", "other"
     end
     on_arm do
-      url "https://dummyhost/download/v#{version}/bin_arm64.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin_arm64.tar.gz"
       rename "wrappedin_1.0.1_darwin_arm64/wrappedin", "wrappedin"
       rename "wrappedin_1.0.1_darwin_arm64/other", "other"
     end
@@ -19,8 +19,8 @@ cask "wrappedin" do
 
   on_linux do
     on_intel do
-      url "https://dummyhost/download/v#{version}/bin_linux.tar.gz"
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin_linux.tar.gz"
       rename "wrappedin_1.0.1_linux_amd64/wrappedin", "wrappedin"
       rename "wrappedin_1.0.1_linux_amd64/other", "other"
     end


### PR DESCRIPTION
Follow-up to #6466, which only reordered the top-level stanzas in cask.rb. brew style's Cask/StanzaOrder also requires sha256 before url inside on_intel/on_arm blocks.

see https://docs.brew.sh/Cask-Cookbook#stanza-order