### PR TITLE
Allow custom glibc version in config file's targets

### DIFF
--- a/internal/builders/rust/build.go
+++ b/internal/builders/rust/build.go
@@ -53,6 +53,12 @@ func (b *Builder) AllowConcurrentBuilds() bool { return false }
 // Prepare implements build.PreparedBuilder.
 func (b *Builder) Prepare(ctx *context.Context, build config.Build) error {
 	for _, target := range build.Targets {
+		if strings.Contains(target, "-gnu.") {
+			prefix, _, ok := strings.Cut(target, ".")
+			if ok {
+				target = prefix
+			}
+		}
 		out, err := exec.CommandContext(ctx, "rustup", "target", "add", target).CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("could not add target %s: %w: %s", target, err, string(out))

--- a/www/content/customization/builds/builders/rust.md
+++ b/www/content/customization/builds/builders/rust.md
@@ -149,6 +149,16 @@ Projects that use Cargo workspaces might not work depending on usage.
 If you want to try it, add `-p=[name]` to the `flags` property.
 We might improve this in the future.
 
+### Custom glibc version
+
+By default, a `target` ending in `-gnu` will have Zig implicitly build for
+a default version of glibc that varies based on the release of Zig (v15
+releases default to glibc 2.31) (see
+[cargo-zigbuild](https://github.com/rust-cross/cargo-zigbuild#specify-glibc-version)).
+
+To override the default verison of glibc, you can append that version to the
+`target` in question, e.g. `x86_64-unknown-linux-gnu.2.38`.
+
 [^fail]:
     GoReleaser will error if you try to use them. Give it a try with
     `goreleaser r --snapshot --clean`.


### PR DESCRIPTION
<!-- If applied, this commit will... -->

This change will strip the custom glibc version target (as introduced in https://github.com/annihilatorrrr/goreleaser/commit/6f074fe80b75b2db5009eb8b3e6d92e8412b8f43) for the `rustup target add` command, as well as add documentation for specifying a custom glibc version.

<!-- Why is this change being made? -->

The custom glibc version target could not yet be used within the goreleaser config file's `targets` directive. With this change it is possible to specify the glibc version as part of the target in the config file.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

[Original Issue about custom glibc versions](https://github.com/goreleaser/goreleaser/issues/6482)
[Further context for this PR](https://github.com/goreleaser/goreleaser/issues/6482#issuecomment-4243044999)
