### PR TITLE
fix(rust): glibc version stripping for gnueabi/gnueabihf targets

### DIFF
--- a/internal/builders/rust/build.go
+++ b/internal/builders/rust/build.go
@@ -53,11 +53,8 @@ func (b *Builder) AllowConcurrentBuilds() bool { return false }
 // Prepare implements build.PreparedBuilder.
 func (b *Builder) Prepare(ctx *context.Context, build config.Build) error {
 	for _, target := range build.Targets {
-		if strings.Contains(target, "-gnu.") {
-			prefix, _, ok := strings.Cut(target, ".")
-			if ok {
-				target = prefix
-			}
+		if clean, ok := stripGlibcVersion(target); ok {
+			target = clean
 		}
 		out, err := exec.CommandContext(ctx, "rustup", "target", "add", target).CombinedOutput()
 		if err != nil {

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -61,9 +61,21 @@ func TestCustomGlibc(t *testing.T) {
 		})
 		require.NoError(t, err)
 	})
+	t.Run("valid-gnueabihf", func(t *testing.T) {
+		_, err := Default.WithDefaults(config.Build{
+			Targets: []string{"armv7-unknown-linux-gnueabihf.2.17"},
+		})
+		require.NoError(t, err)
+	})
 	t.Run("invalid", func(t *testing.T) {
 		_, err := Default.WithDefaults(config.Build{
 			Targets: []string{"aarch64-unknown-linux-musl.2.17"},
+		})
+		require.ErrorContains(t, err, "invalid target")
+	})
+	t.Run("invalid-gnullvm", func(t *testing.T) {
+		_, err := Default.WithDefaults(config.Build{
+			Targets: []string{"aarch64-pc-windows-gnullvm.2.17"},
 		})
 		require.ErrorContains(t, err, "invalid target")
 	})
@@ -220,6 +232,40 @@ func TestParse(t *testing.T) {
 			Libc:   "2.17",
 		}, target)
 	})
+	t.Run("glibc-version-gnueabihf", func(t *testing.T) {
+		target, err := Default.Parse("armv7-unknown-linux-gnueabihf.2.17")
+		require.NoError(t, err)
+		require.Equal(t, Target{
+			Target: "armv7-unknown-linux-gnueabihf.2.17",
+			Os:     "linux",
+			Arch:   "arm",
+			Vendor: "unknown",
+			Abi:    "gnueabihf",
+			Libc:   "2.17",
+		}, target)
+	})
+}
+
+func TestStripGlibcVersion(t *testing.T) {
+	for name, tt := range map[string]struct {
+		input string
+		want  string
+		ok    bool
+	}{
+		"gnu":       {"aarch64-unknown-linux-gnu.2.17", "aarch64-unknown-linux-gnu", true},
+		"gnueabihf": {"armv7-unknown-linux-gnueabihf.2.17", "armv7-unknown-linux-gnueabihf", true},
+		"gnueabi":   {"arm-unknown-linux-gnueabi.2.31", "arm-unknown-linux-gnueabi", true},
+		"no-suffix": {"aarch64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", false},
+		"musl":      {"aarch64-unknown-linux-musl.2.17", "aarch64-unknown-linux-musl.2.17", false},
+		"gnullvm":   {"aarch64-pc-windows-gnullvm.2.17", "aarch64-pc-windows-gnullvm.2.17", false},
+		"no-dashes": {"nodashes.2.17", "nodashes.2.17", false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, ok := stripGlibcVersion(tt.input)
+			require.Equal(t, tt.ok, ok)
+			require.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestIsSettingPackage(t *testing.T) {

--- a/internal/builders/rust/targets.go
+++ b/internal/builders/rust/targets.go
@@ -56,13 +56,30 @@ func (t Target) String() string {
 // clean returns the target without any gnu version suffix.
 // this is used by cargo-zigbuild internally.
 func (t Target) clean() string {
-	if strings.Contains(t.Target, "-gnu.") {
-		prefix, _, ok := strings.Cut(t.Target, ".")
-		if ok {
-			return prefix
-		}
+	if clean, ok := stripGlibcVersion(t.Target); ok {
+		return clean
 	}
 	return t.Target
+}
+
+// stripGlibcVersion removes a glibc version suffix (e.g., ".2.17") from
+// gnu-based targets.
+// Returns the base target and true if a suffix was stripped.
+func stripGlibcVersion(target string) (string, bool) {
+	prefix, _, ok := strings.Cut(target, ".")
+	if !ok {
+		return target, false
+	}
+	// only gnu-based ABIs use glibc (not gnullvm which is Windows/LLVM)
+	lastDash := strings.LastIndex(prefix, "-")
+	if lastDash == -1 {
+		return target, false
+	}
+	abi := prefix[lastDash+1:]
+	if strings.HasPrefix(abi, "gnu") && abi != "gnullvm" {
+		return prefix, true
+	}
+	return target, false
 }
 
 func convertToGoarch(s string) string {
@@ -91,11 +108,8 @@ func isValid(target string) bool {
 	targetsOnce.Do(func() {
 		allTargets = strings.Split(string(allTargetsBts), "\n")
 	})
-	if strings.Contains(target, "-gnu.") {
-		prefix, _, ok := strings.Cut(target, ".")
-		if ok {
-			return slices.Contains(allTargets, prefix)
-		}
+	if clean, ok := stripGlibcVersion(target); ok {
+		return slices.Contains(allTargets, clean)
 	}
 	return slices.Contains(allTargets, target)
 }


### PR DESCRIPTION
The glibc version suffix checks (e.g., ".2.17") only matched "-gnu." literally, which missed "-gnueabi." and "-gnueabihf." targets. This caused isValid() to reject them, Prepare() to pass the wrong target to rustup, and clean() to produce wrong output paths.

Extract stripGlibcVersion helper that checks if the ABI starts with "gnu" (excluding "gnullvm") to handle all gnu-based ABIs correctly.

refs #6482
refs #6492
refs #6557