### PR TITLE
fix(build): set per-binary artifact IDs for ./... builds

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -582,6 +582,10 @@ func checkBuildElipsis(
 		return nil, nil, err
 	}
 
+	if len(mains) > 1 && !build.InternalDefaults.ID {
+		return nil, nil, errors.New("'main' contains an ellipsis path (e.g. './...') and resolves to more than one main package, and 'id' is set: either set 'main' to a specific package, or unset 'id'")
+	}
+
 	var bins []string
 	var pkgs []string
 	t := options.Target.(Target)
@@ -596,7 +600,11 @@ func checkBuildElipsis(
 		}
 		bins = append(bins, name)
 		pkgs = append(pkgs, mains[bin])
-		binaries = append(binaries, getBinaryArtifact(t, build, name, path, options.Ext))
+		a := getBinaryArtifact(t, build, name, path, options.Ext)
+		if len(mains) > 1 && build.InternalDefaults.ID {
+			a.Extra[artifact.ExtraID] = bin
+		}
+		binaries = append(binaries, a)
 	}
 
 	logBuild(pkgs, bins, t.String())

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -646,12 +646,13 @@ func TestBuildVariadic(t *testing.T) {
 	writeMainWithoutMainFunc(t, filepath.Join(folder, "cmd/nope"))
 
 	build := config.Build{
-		ID:     "foo",
 		Main:   "./...",
 		Binary: "foo",
 		InternalDefaults: config.BuildInternalDefaults{
 			Binary: true,
+			ID:     true,
 		},
+		ID: "foo",
 		Targets: []string{
 			"linux_amd64",
 			"windows_amd64",
@@ -710,7 +711,7 @@ func TestBuildVariadic(t *testing.T) {
 			Target:  "linux_amd64_v1",
 			Type:    artifact.Binary,
 			Extra: map[string]any{
-				artifact.ExtraID:      "foo",
+				artifact.ExtraID:      "a",
 				artifact.ExtraExt:     "",
 				artifact.ExtraBinary:  "a",
 				artifact.ExtraBuilder: "go",
@@ -740,7 +741,7 @@ func TestBuildVariadic(t *testing.T) {
 			Target:  "windows_amd64_v1",
 			Type:    artifact.Binary,
 			Extra: map[string]any{
-				artifact.ExtraID:      "foo",
+				artifact.ExtraID:      "a",
 				artifact.ExtraExt:     ".exe",
 				artifact.ExtraBinary:  "a",
 				artifact.ExtraBuilder: "go",
@@ -769,7 +770,7 @@ func TestBuildVariadic(t *testing.T) {
 			Target: "js_wasm",
 			Type:   artifact.Binary,
 			Extra: map[string]any{
-				artifact.ExtraID:      "foo",
+				artifact.ExtraID:      "a",
 				artifact.ExtraExt:     ".wasm",
 				artifact.ExtraBinary:  "a",
 				artifact.ExtraBuilder: "go",
@@ -1488,6 +1489,9 @@ func TestCheckBuildElipsisWithProxiedSubpathMain(t *testing.T) {
 		UnproxiedMain: "./cmd/...",
 		UnproxiedDir:  folder,
 		Dir:           filepath.Join(folder, "dist", "proxy", "foo"),
+		InternalDefaults: config.BuildInternalDefaults{
+			ID: true,
+		},
 	}, options)
 	require.NoError(t, err)
 	require.Equal(t, map[string]string{
@@ -1499,6 +1503,54 @@ func TestCheckBuildElipsisWithProxiedSubpathMain(t *testing.T) {
 		require.NotContains(t, b.Path, "github.com/foo/bar")
 		require.Equal(t, filepath.Dir(options.Path), filepath.Dir(b.Path))
 	}
+}
+
+func TestCheckBuildElipsisWithExplicitIDError(t *testing.T) {
+	folder := testlib.Mktmp(t)
+	writeGoMod(t, folder, "github.com/foo/bar")
+	writeGoodMain(t, filepath.Join(folder, "cmd", "a"))
+	writeGoodMain(t, filepath.Join(folder, "cmd", "b"))
+
+	options := api.Options{
+		Target: mustParse(t, runtimeTarget),
+		Path:   filepath.Join(folder, "dist", runtimeTarget, "foo"),
+	}
+
+	_, _, err := checkBuild(config.Build{
+		ID:   "myid",
+		Main: "./cmd/...",
+		Dir:  folder,
+		InternalDefaults: config.BuildInternalDefaults{
+			Binary: true,
+		},
+	}, options)
+	require.EqualError(t, err, "'main' contains an ellipsis path (e.g. './...') and resolves to more than one main package, and 'id' is set: either set 'main' to a specific package, or unset 'id'")
+}
+
+func TestCheckBuildElipsisSingleMain(t *testing.T) {
+	folder := testlib.Mktmp(t)
+	writeGoMod(t, folder, "github.com/foo/bar")
+	writeGoodMain(t, filepath.Join(folder, "cmd", "a"))
+
+	options := api.Options{
+		Target: mustParse(t, runtimeTarget),
+		Path:   filepath.Join(folder, "dist", runtimeTarget, "foo"),
+	}
+
+	mains, binaries, err := checkBuild(config.Build{
+		ID:   "foo",
+		Main: "./cmd/...",
+		Dir:  folder,
+		InternalDefaults: config.BuildInternalDefaults{
+			Binary: true,
+			ID:     true,
+		},
+	}, options)
+	require.NoError(t, err)
+	require.Len(t, mains, 1)
+	require.Len(t, binaries, 1)
+	// single main with auto-set ID keeps the default ID
+	require.Equal(t, "foo", binaries[0].Extra[artifact.ExtraID])
 }
 
 func TestOverrides(t *testing.T) {

--- a/internal/pipe/build/build.go
+++ b/internal/pipe/build/build.go
@@ -120,6 +120,7 @@ func buildWithDefaults(ctx *context.Context, build config.Build) (config.Build, 
 	}
 	if build.ID == "" {
 		build.ID = ctx.Config.ProjectName
+		build.InternalDefaults.ID = true
 	}
 	for k, v := range build.Env {
 		build.Env[k] = os.ExpandEnv(v)

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -318,6 +318,7 @@ func TestDefaultEmptyBuild(t *testing.T) {
 	require.NoError(t, Pipe{}.Default(ctx))
 	build := ctx.Config.Builds[0]
 	require.Equal(t, ctx.Config.ProjectName, build.ID)
+	require.True(t, build.InternalDefaults.ID)
 	require.Equal(t, ctx.Config.ProjectName, build.Binary)
 	require.Equal(t, ".", build.Dir)
 	require.Equal(t, []string{"linux", "darwin", "windows"}, build.Goos)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -521,6 +521,10 @@ type BuildInternalDefaults struct {
 	// whether the pipe set the current binary.
 	// this is true when the user didn't set a binary name.
 	Binary bool
+
+	// whether the pipe set the current ID.
+	// this is true when the user didn't set an ID.
+	ID bool
 }
 
 type BuildDetailsOverride struct {


### PR DESCRIPTION
When main=./... resolves to multiple mains and no explicit ID is set, each artifact now gets the binary name as its ID instead of sharing the build-level default. Errors if user sets an explicit ID with a multi-main ellipsis path.

see: https://github.com/goreleaser/goreleaser/discussions/6559