### PR TITLE
fix(build): allow explicit binary with ellipsis when single main

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -571,15 +571,15 @@ func checkBuildElipsis(
 ) (map[string]string, []*artifact.Artifact, error) {
 	logFindingMains(build, main)
 
-	// we should try and find all `func main`'s:
-	if build.Binary != "" && !build.InternalDefaults.Binary {
-		return nil, nil, errors.New("'main' contains an ellipsis path (e.g. './...') and 'binary' is also set: either set 'main' to a specific package, or unset 'binary' to auto-detect all mains and binary names")
-	}
-
 	var binaries []*artifact.Artifact
 	mains, err := gomain.All(dir, main)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	// we should try and find all `func main`'s:
+	if len(mains) > 1 && build.Binary != "" && !build.InternalDefaults.Binary {
+		return nil, nil, errors.New("'main' contains an ellipsis path (e.g. './...') and 'binary' is also set: either set 'main' to a specific package, or unset 'binary' to auto-detect all mains and binary names")
 	}
 
 	if len(mains) > 1 && !build.InternalDefaults.ID {

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -1527,6 +1527,29 @@ func TestCheckBuildElipsisWithExplicitIDError(t *testing.T) {
 	require.EqualError(t, err, "'main' contains an ellipsis path (e.g. './...') and resolves to more than one main package, and 'id' is set: either set 'main' to a specific package, or unset 'id'")
 }
 
+func TestCheckBuildElipsisWithExplicitBinaryError(t *testing.T) {
+	folder := testlib.Mktmp(t)
+	writeGoMod(t, folder, "github.com/foo/bar")
+	writeGoodMain(t, filepath.Join(folder, "cmd", "a"))
+	writeGoodMain(t, filepath.Join(folder, "cmd", "b"))
+
+	options := api.Options{
+		Target: mustParse(t, runtimeTarget),
+		Path:   filepath.Join(folder, "dist", runtimeTarget, "foo"),
+	}
+
+	_, _, err := checkBuild(config.Build{
+		ID:     "default",
+		Main:   "./cmd/...",
+		Dir:    folder,
+		Binary: "mybin",
+		InternalDefaults: config.BuildInternalDefaults{
+			ID: true,
+		},
+	}, options)
+	require.EqualError(t, err, "'main' contains an ellipsis path (e.g. './...') and 'binary' is also set: either set 'main' to a specific package, or unset 'binary' to auto-detect all mains and binary names")
+}
+
 func TestCheckBuildElipsisSingleMain(t *testing.T) {
 	folder := testlib.Mktmp(t)
 	writeGoMod(t, folder, "github.com/foo/bar")
@@ -1551,6 +1574,27 @@ func TestCheckBuildElipsisSingleMain(t *testing.T) {
 	require.Len(t, binaries, 1)
 	// single main with auto-set ID keeps the default ID
 	require.Equal(t, "foo", binaries[0].Extra[artifact.ExtraID])
+}
+
+func TestCheckBuildElipsisSingleMainWithExplicitBinary(t *testing.T) {
+	folder := testlib.Mktmp(t)
+	writeGoMod(t, folder, "github.com/foo/bar")
+	writeGoodMain(t, filepath.Join(folder, "cmd", "a"))
+
+	options := api.Options{
+		Target: mustParse(t, runtimeTarget),
+		Path:   filepath.Join(folder, "dist", runtimeTarget, "mybin"),
+	}
+
+	mains, binaries, err := checkBuild(config.Build{
+		ID:     "foo",
+		Main:   "./cmd/...",
+		Dir:    folder,
+		Binary: "mybin",
+	}, options)
+	require.NoError(t, err)
+	require.Len(t, mains, 1)
+	require.Len(t, binaries, 1)
 }
 
 func TestOverrides(t *testing.T) {


### PR DESCRIPTION
The check rejected ./... + binary unconditionally, even when only one main package was found. Move check after resolution so single-main ellipsis paths work with explicit binary names.
