### PR TITLE
docs(templates): note git fields unavailable in top-level env block

### DIFF
--- a/www/content/customization/general/templates.md
+++ b/www/content/customization/general/templates.md
@@ -11,7 +11,19 @@ support templating.
 
 ## Common Fields
 
-In fields that support templates, these fields are always available:
+In fields that support templates, these fields are always available,
+**with one exception**: the top-level `env` block is resolved before the
+git state is collected, so `.FullCommit`, `.Commit`, `.ShortCommit`,
+`.CommitDate`, `.CommitTimestamp`, `.GitURL`, `.GitTreeState`,
+`.IsGitClean`, `.IsGitDirty`, `.Branch`, `.Tag`, `.PreviousTag`, `.Summary`,
+`.TagSubject`, `.TagContents`, and `.TagBody` all evaluate to their
+zero values there (empty strings, or `0001-01-01T00:00:00Z` /
+`-62135596800` for the date/timestamp fields). Use these fields in
+hooks, builds, archives, etc. instead. For reproducible-build use cases
+in particular, the common `SOURCE_DATE_EPOCH={{ .CommitTimestamp }}` trick
+will not work in the top-level `env:` block and should be set in a
+`before.hooks` step or exported from the CI system instead
+(see [goreleaser/goreleaser#6500](https://github.com/goreleaser/goreleaser/issues/6500)).
 
 | Key                | Description                                                                                                |
 | ------------------ | ---------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Fixes #6500.

## Problem

The templates reference says the common fields are "always available", but the top-level `env:` block is evaluated before goreleaser collects the repository git state. Fields that depend on git (`.FullCommit`, `.Commit`, `.ShortCommit`, `.CommitDate`, `.CommitTimestamp`, `.GitURL`, `.GitTreeState`, `.IsGitClean`, `.IsGitDirty`, `.Branch`, `.Tag`, `.PreviousTag`, `.Summary`, `.TagSubject`, `.TagContents`, `.TagBody`) therefore evaluate to empty strings, or to Go zero-time values like `0001-01-01T00:00:00Z` / `-62135596800` for the date/timestamp fields.

The reporter ran into this while setting up a reproducible-build `SOURCE_DATE_EPOCH` and ended up debugging a bogus `-62135596800` value for 30 minutes.

## Fix

Add an explicit note at the top of "Common Fields" documenting the carve-out, listing the affected fields, and pointing readers at `before.hooks` (or an exported CI env var) as the right way to produce something like `SOURCE_DATE_EPOCH` from the commit timestamp. No behaviour change.

This is the least-disruptive of the three options the reporter enumerated (error / reorder / doc warning). Reordering the env resolution relative to git state collection would work but affects other template paths; the doc note is a narrow, backport-safe fix that stops future users from hitting the same pit.

Signed off per DCO.
