### PR TITLE
Fix grouping of different arm version when creating archives of rust builds

### DIFF
--- a/internal/builders/rust/build.go
+++ b/internal/builders/rust/build.go
@@ -75,7 +75,7 @@ func (b *Builder) Parse(target string) (api.Target, error) {
 		Target: target,
 		Os:     parts[2],
 		Vendor: parts[1],
-		Arch:   convertToGoarch(parts[0]),
+		Arch:   parts[0],
 	}
 
 	if len(parts) > 3 {

--- a/internal/builders/rust/build.go
+++ b/internal/builders/rust/build.go
@@ -161,7 +161,7 @@ func (b *Builder) Build(ctx *context.Context, build config.Build, options api.Op
 		Path:   options.Path,
 		Name:   options.Name,
 		Goos:   t.Os,
-		Goarch: convertToGoarch(t.Arch),
+		Goarch: t.Arch,
 		Target: t.Target,
 		Extra: map[string]any{
 			artifact.ExtraBinary:  strings.TrimSuffix(filepath.Base(options.Path), options.Ext),

--- a/internal/builders/rust/build.go
+++ b/internal/builders/rust/build.go
@@ -162,6 +162,7 @@ func (b *Builder) Build(ctx *context.Context, build config.Build, options api.Op
 		Name:   options.Name,
 		Goos:   t.Os,
 		Goarch: t.Arch,
+		Goarm:  t.Arm,
 		Target: t.Target,
 		Extra: map[string]any{
 			artifact.ExtraBinary:  strings.TrimSuffix(filepath.Base(options.Path), options.Ext),
@@ -173,9 +174,6 @@ func (b *Builder) Build(ctx *context.Context, build config.Build, options api.Op
 	}
 	if t.Libc != "" {
 		a.Extra[keyLibc] = t.Libc
-	}
-	if t.Arm != "" {
-		a.Goarm = t.Arm
 	}
 
 	env := []string{}

--- a/internal/builders/rust/build.go
+++ b/internal/builders/rust/build.go
@@ -78,6 +78,10 @@ func (b *Builder) Parse(target string) (api.Target, error) {
 		Arch:   convertToGoarch(parts[0]),
 	}
 
+	if arm, ok := getArmVersion(parts[0]); ok {
+		t.Arm = arm
+	}
+
 	if len(parts) > 3 {
 		t.Abi = parts[3]
 		abi, libc, ok := strings.Cut(t.Abi, ".")
@@ -170,9 +174,8 @@ func (b *Builder) Build(ctx *context.Context, build config.Build, options api.Op
 	if t.Libc != "" {
 		a.Extra[keyLibc] = t.Libc
 	}
-
-	if arm, ok := getArmVersion(t.Arch); ok {
-		a.Goarm = arm
+	if t.Arm != "" {
+		a.Goarm = t.Arm
 	}
 
 	env := []string{}

--- a/internal/builders/rust/build.go
+++ b/internal/builders/rust/build.go
@@ -75,7 +75,7 @@ func (b *Builder) Parse(target string) (api.Target, error) {
 		Target: target,
 		Os:     parts[2],
 		Vendor: parts[1],
-		Arch:   parts[0],
+		Arch:   convertToGoarch(parts[0]),
 	}
 
 	if len(parts) > 3 {

--- a/internal/builders/rust/build.go
+++ b/internal/builders/rust/build.go
@@ -171,6 +171,10 @@ func (b *Builder) Build(ctx *context.Context, build config.Build, options api.Op
 		a.Extra[keyLibc] = t.Libc
 	}
 
+	if arm, ok := getArmVersion(t.Arch); ok {
+		a.Goarm = arm
+	}
+
 	env := []string{}
 	env = append(env, ctx.Env.Strings()...)
 

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -204,7 +204,7 @@ func TestParse(t *testing.T) {
 		require.Equal(t, Target{
 			Target: "aarch64-apple-darwin",
 			Os:     "darwin",
-			Arch:   "arm64",
+			Arch:   "aarch64",
 			Vendor: "apple",
 		}, target)
 	})
@@ -215,7 +215,7 @@ func TestParse(t *testing.T) {
 		require.Equal(t, Target{
 			Target: "aarch64-pc-windows-gnullvm",
 			Os:     "windows",
-			Arch:   "arm64",
+			Arch:   "aarch64",
 			Vendor: "pc",
 			Abi:    "gnullvm",
 		}, target)
@@ -226,7 +226,7 @@ func TestParse(t *testing.T) {
 		require.Equal(t, Target{
 			Target: "aarch64-unknown-linux-gnu.2.17",
 			Os:     "linux",
-			Arch:   "arm64",
+			Arch:   "aarch64",
 			Vendor: "unknown",
 			Abi:    "gnu",
 			Libc:   "2.17",
@@ -238,7 +238,7 @@ func TestParse(t *testing.T) {
 		require.Equal(t, Target{
 			Target: "armv7-unknown-linux-gnueabihf.2.17",
 			Os:     "linux",
-			Arch:   "arm",
+			Arch:   "armv7",
 			Vendor: "unknown",
 			Abi:    "gnueabihf",
 			Libc:   "2.17",

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -322,6 +322,7 @@ func TestParse(t *testing.T) {
 			Target: "armv7-unknown-linux-gnueabihf.2.17",
 			Os:     "linux",
 			Arch:   "arm",
+			Arm:    "7",
 			Vendor: "unknown",
 			Abi:    "gnueabihf",
 			Libc:   "2.17",

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -192,6 +192,89 @@ func TestBuild(t *testing.T) {
 	require.True(t, modTime.Equal(fi.ModTime()))
 }
 
+func TestBuildArm(t *testing.T) {
+	testlib.CheckPath(t, "cargo")
+	testlib.CheckPath(t, "cargo-zigbuild")
+
+	folder := testlib.Mktmp(t)
+	_, err := exec.CommandContext(t.Context(), "cargo", "init", "--bin", "--name=proj").CombinedOutput()
+	require.NoError(t, err)
+
+	f, err := os.OpenFile("Cargo.toml", os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString("\n[profile.release]\nopt-level = 0\n")
+	require.NoError(t, f.Close())
+	require.NoError(t, err)
+
+	modTime := time.Now().AddDate(-1, 0, 0).Round(time.Second).UTC()
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Dist:        "dist",
+		ProjectName: "proj",
+		Builds: []config.Build{
+			{
+				ID:           "default",
+				Dir:          ".",
+				ModTimestamp: fmt.Sprintf("%d", modTime.Unix()),
+				BuildDetails: config.BuildDetails{
+					Flags: []string{"--release"},
+				},
+			},
+		},
+	})
+
+	build, err := Default.WithDefaults(ctx.Config.Builds[0])
+	require.NoError(t, err)
+	require.NoError(t, Default.Prepare(ctx, build))
+
+	target := "armv7-unknown-linux-gnueabihf.2.17"
+	options := api.Options{
+		Name: "proj",
+		Path: filepath.Join("dist", "proj-"+target, "proj"),
+	}
+	options.Target, err = Default.Parse(target)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(options.Path), 0o755)) // this happens on internal/pipe/build/ when in prod
+
+	require.NoError(t, Default.Build(ctx, build, options))
+
+	list := ctx.Artifacts
+	require.NoError(t, list.Visit(func(a *artifact.Artifact) error {
+		s, err := filepath.Rel(folder, a.Path)
+		if err == nil {
+			a.Path = s
+		}
+		return nil
+	}))
+
+	bins := list.List()
+	require.Len(t, bins, 1)
+
+	bin := bins[0]
+	require.Equal(t, artifact.Artifact{
+		Name:   "proj",
+		Path:   filepath.ToSlash(options.Path),
+		Goos:   "linux",
+		Goarch: "arm",
+		Goarm:  "7",
+		Target: target,
+		Type:   artifact.Binary,
+		Extra: artifact.Extras{
+			artifact.ExtraBinary:   "proj",
+			artifact.ExtraBuilder:  "rust",
+			artifact.ExtraExt:      "",
+			artifact.ExtraID:       "default",
+			artifact.ExtranDynLink: true,
+			keyAbi:                 "gnueabihf",
+			keyLibc:                "2.17",
+		},
+	}, *bin)
+
+	require.FileExists(t, bin.Path)
+	fi, err := os.Stat(bin.Path)
+	require.NoError(t, err)
+	require.True(t, modTime.Equal(fi.ModTime()))
+}
+
 func TestParse(t *testing.T) {
 	t.Run("invalid", func(t *testing.T) {
 		_, err := Default.Parse("a-b")

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -287,7 +287,7 @@ func TestParse(t *testing.T) {
 		require.Equal(t, Target{
 			Target: "aarch64-apple-darwin",
 			Os:     "darwin",
-			Arch:   "aarch64",
+			Arch:   "arm64",
 			Vendor: "apple",
 		}, target)
 	})
@@ -298,7 +298,7 @@ func TestParse(t *testing.T) {
 		require.Equal(t, Target{
 			Target: "aarch64-pc-windows-gnullvm",
 			Os:     "windows",
-			Arch:   "aarch64",
+			Arch:   "arm64",
 			Vendor: "pc",
 			Abi:    "gnullvm",
 		}, target)
@@ -309,7 +309,7 @@ func TestParse(t *testing.T) {
 		require.Equal(t, Target{
 			Target: "aarch64-unknown-linux-gnu.2.17",
 			Os:     "linux",
-			Arch:   "aarch64",
+			Arch:   "arm64",
 			Vendor: "unknown",
 			Abi:    "gnu",
 			Libc:   "2.17",
@@ -321,7 +321,7 @@ func TestParse(t *testing.T) {
 		require.Equal(t, Target{
 			Target: "armv7-unknown-linux-gnueabihf.2.17",
 			Os:     "linux",
-			Arch:   "armv7",
+			Arch:   "arm",
 			Vendor: "unknown",
 			Abi:    "gnueabihf",
 			Libc:   "2.17",

--- a/internal/builders/rust/targets.go
+++ b/internal/builders/rust/targets.go
@@ -123,3 +123,17 @@ func defaultTargets() []string {
 		"aarch64-apple-darwin",
 	}
 }
+
+// Get ARM version for `(artifact.Artifact).Goarm`
+func getArmVersion(s string) (string, bool) {
+	// Values sourced from https://go.dev/wiki/GoArm in combination with
+	// https://doc.rust-lang.org/nightly/rustc/platform-support.html
+	ss, ok := map[string]string{
+		"arm":     "6",
+		"armv5te": "5",
+		"armv7":   "7",
+		"armv7a":  "7",
+		"armv7r":  "7",
+	}[s]
+	return ss, ok
+}

--- a/internal/builders/rust/targets.go
+++ b/internal/builders/rust/targets.go
@@ -32,6 +32,7 @@ type Target struct {
 	Target string
 	Os     string
 	Arch   string
+	Arm    string
 	Vendor string
 	Abi    string
 	Libc   string
@@ -42,6 +43,7 @@ func (t Target) Fields() map[string]string {
 	return map[string]string{
 		tmpl.KeyOS:   t.Os,
 		tmpl.KeyArch: t.Arch,
+		tmpl.KeyArm:  t.Arm,
 		keyAbi:       t.Abi,
 		keyVendor:    t.Vendor,
 		keyLibc:      t.Libc,


### PR DESCRIPTION
Archiving multiple rust arm builds would fail because armv7 and arm would be grouped into a single archive and fail with the following error:

```
  • archives
    • group linuxarm64musl has 1 binaries
    • group linuxarmgnueabihf has 2 binaries
...
  ⨯ release failed after 2s                          error=failed to add: 'dist/dnst-cross_armv7-unknown-linux-gnueabihf/dnst' -> 'dnst': add dnst: file already exists
```

This was because rust builds didn't store the arm version in the `Goarm` field. This PR fixes that.


The relevant config snippet was this:
```yml
builds:
  - builder: rust
    id: dnst-cross
    flags:
      - --release
      - --features=static-openssl
    targets:
      - aarch64-unknown-linux-musl
      - arm-unknown-linux-gnueabihf
      - armv7-unknown-linux-gnueabihf

archives:
  - formats: [tar.gz]
    format_overrides:
      - goos: windows
        formats: [zip]
    allow_different_binary_count: true # added to skip the error of having 2 binaries vs 1 binary in linuxarm64musl
```

With this fix, it successfully separates the binaries into different archives:

```
    • group linuxarmgnueabihf7 has 1 binaries
    • group linuxarm64musl has 1 binaries
    • group linuxarmgnueabihf6 has 1 binaries
```

For the test added in 978108fb037f51c8dd68038d0188ae6becc51767 I just copied the existing build test for aarch64 and changed the expected artifact values at the bottom.