### PR TITLE
fix: wrong goreleaser URL 

### DIFF
--- a/internal/pipe/docker/v2/docker.go
+++ b/internal/pipe/docker/v2/docker.go
@@ -553,7 +553,7 @@ func isFileNotFoundError(out string) bool {
 
 func warnExperimental() {
 	log.WithField("details", `Keep an eye on the release notes if you wish to rely on this for production builds.
-Please provide any feedback you might have at https://github.com/orgs/goreleaser/discussions/6005`).
+Please provide any feedback you might have at https://github.com/goreleaser/goreleaser/discussions/6005`).
 		Warn(logext.Warning("dockers_v2 is experimental and subject to change"))
 }
 

--- a/internal/pipe/mcp/mcp.go
+++ b/internal/pipe/mcp/mcp.go
@@ -202,6 +202,6 @@ func authProvider(registryURL, method, token string) (auth.Provider, error) {
 
 func warnExperimental() {
 	log.WithField("details", `Keep an eye on the release notes if you wish to rely on this for production builds.
-Please provide any feedback you might have at https://github.com/orgs/goreleaser/discussions/6251`).
+Please provide any feedback you might have at https://github.com/goreleaser/goreleaser/discussions/6251`).
 		Warn(logext.Warning("mcp is experimental and subject to change"))
 }

--- a/www/content/blog/github-secure-fund.md
+++ b/www/content/blog/github-secure-fund.md
@@ -71,7 +71,7 @@ the [GoReleaser Discord](https://discord.gg/RGEBtg8vQ6) - feel free to chime in 
 Our greatest thanks to both the fund and the fund's partners for making this
 possible.
 
-[discussions]: https://github.com/orgs/goreleaser/discussions/new?category=ideas-issue-triage-and-general-discussions
+[discussions]: https://github.com/goreleaser/goreleaser/discussions/new?category=ideas-issue-triage-and-general-discussions
 [ghosf]: https://github.com/open-source/github-secure-open-source-fund
 [example]: https://github.com/goreleaser/example-secure
 [govulncheck]: https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck

--- a/www/content/blog/goreleaser-v2.10.md
+++ b/www/content/blog/goreleaser-v2.10.md
@@ -126,7 +126,7 @@ and that's it.
 
 We're also very interested in other tools GoReleaser MCP can provide.
 Feel free to hop in our
-[discussion](https://github.com/orgs/goreleaser/discussions/5816) and give
+[discussion](https://github.com/goreleaser/goreleaser/discussions/5816) and give
 whatever feedback or ideas you have!
 
 ## Other smaller changes

--- a/www/content/blog/goreleaser-v2.5.md
+++ b/www/content/blog/goreleaser-v2.5.md
@@ -85,7 +85,7 @@ and the Rust and Zig community for being (seemingly) open to the idea!
 
 Probably more languages!
 Join our [Discord][] and help prioritize and shape how they'll work.
-I already created a [new discussion](https://github.com/orgs/goreleaser/discussions/5367)
+I already created a [new discussion](https://github.com/goreleaser/goreleaser/discussions/5367)
 on GitHub to help prioritize languages as well.
 You are absolutely invited to chime in!
 

--- a/www/content/blog/release-cadence.md
+++ b/www/content/blog/release-cadence.md
@@ -136,7 +136,7 @@ See you all soon!
 
 [v1]: /blog/goreleaser-v1/
 [deprecations]: /resources/deprecations/
-[dis]: https://github.com/orgs/goreleaser/discussions/4169
+[dis]: https://github.com/goreleaser/goreleaser/discussions/4169
 [gpro]: /pro/
 [gha]: https://github.com/goreleaser/goreleaser-action
 [Sponsors]: https://github.com/caarlos0

--- a/www/content/customization/package/dockers_v2.md
+++ b/www/content/customization/package/dockers_v2.md
@@ -5,7 +5,7 @@ weight: 130
 
 {{< g_version "v2.12" >}}
 
-{{< g_experimental "https://github.com/orgs/goreleaser/discussions/6005" >}}
+{{< g_experimental "https://github.com/goreleaser/goreleaser/discussions/6005" >}}
 
 This feature uses `docker buildx` to build multi-arch manifests,
 reusing the previously built binaries and/or packages.

--- a/www/content/customization/publish/mcp.md
+++ b/www/content/customization/publish/mcp.md
@@ -6,7 +6,7 @@ weight: 160
 
 {{< g_version "v2.13" >}}
 
-{{< g_experimental "https://github.com/orgs/goreleaser/discussions/6251" >}}
+{{< g_experimental "https://github.com/goreleaser/goreleaser/discussions/6251" >}}
 
 After building your binaries, GoReleaser can generate and publish a Model
 Context Protocol (MCP) server manifest file (`server.json`) to the

--- a/www/content/resources/deprecations.md
+++ b/www/content/resources/deprecations.md
@@ -360,7 +360,7 @@ tags, and will create Docker images instead of manifests, as manifests can't be
 created without pushing.
 
 Feel free to suggest improvements
-[here](https://github.com/orgs/goreleaser/discussions/6005).
+[here](https://github.com/goreleaser/goreleaser/discussions/6005).
 
 Regarding signing, you may also remove the `artifacts` option from you
 `docker_signs`:


### PR DESCRIPTION

<!-- If applied, this commit will... -->

This PR fixes invalid URL, ex: https://github.com/orgs/goreleaser/discussions/6005
<!-- Why is this change being made? -->

Those URLs lead to a 404.

Luckily, I think nobody can claim the name `orgs` :wink: 
