### PR TITLE
docs(actions): note immutable nightly resolution

### DIFF
--- a/www/content/blog/immutable-releases.md
+++ b/www/content/blog/immutable-releases.md
@@ -1,0 +1,50 @@
+---
+title: Moving to Immutable Releases
+date: 2026-04-26
+slug: immutable-releases
+tags:
+  - announcements
+  - security
+authors:
+  - caarlos0
+---
+
+GoReleaser is moving to immutable releases. From now on, no tag we publish
+can ever be overwritten — once a version is out, it stays exactly as it was
+published, forever.
+
+<!--more-->
+
+We should have enabled this a long time ago, but GitHub only allows to enable
+immutable releases for all releases, and we were using a moving `nightly` tag
+for the nightly releases.
+
+To fix that, we needed to [update our action][action], and tune our
+configuration a bit as well.
+
+Starting now, nightly builds will get their own tags in the
+`{next-minor}-{sha}-nightly` format.
+
+For example, instead of pulling `nightly`, you'll see tags like
+`v2.16.0-abc1234-nightly`. The previous moving `nightly` tag is still there, but
+it will never be updated again, and might be deleted in the future.
+
+## Why
+
+Mutable tags are a supply-chain hazard. If the bytes behind a tag can change,
+then a compromised release pipeline — ours or anyone else's — can silently swap
+a known-good artifact for a malicious one, and every consumer pinning that tag
+picks it up on the next pull. There is no way for a downstream user to detect
+it short of hashing every download.
+
+Immutable releases close that door. Once `vX.Y.Z` (or
+`vX.Y.Z-sha-nightly`) is published, the contents are frozen. A release can't
+be hijacked after the fact, and reproducing or auditing a specific build
+becomes a matter of pinning a single version string.
+
+This is also still a part of the [GitHub Open Source Secure Fund][ghossf]
+initiative, as well as a request from [several users][request].
+
+[action]: https://github.com/goreleaser/goreleaser-action/releases/tag/v7.2.0
+[ghossf]: /blog/github-secure-fund/
+[request]: https://github.com/goreleaser/goreleaser/discussions/6550

--- a/www/content/customization/ci/actions.md
+++ b/www/content/customization/ci/actions.md
@@ -78,6 +78,14 @@ jobs:
 > [!NOTE]
 > For detailed instructions please follow GitHub Actions [workflow syntax][syntax].
 
+### Nightly builds
+
+Setting `version: nightly` on `goreleaser-action` (≥ `v7.2.0`) installs the
+latest immutable nightly release (e.g. `v2.16.0-abc1234-nightly`) instead of a
+moving tag. The action resolves it through the GitHub Releases API, so make
+sure `GITHUB_TOKEN` is exported on the step (the example above already does)
+to avoid the unauthenticated rate limit.
+
 ### Signing
 
 If [signing is enabled][signing] in your GoReleaser configuration, you can use


### PR DESCRIPTION
Adds a small note to `customization/ci/actions.md` explaining that `version: nightly` on `goreleaser-action` ≥ v7.2.0 now resolves to the latest immutable `vX.Y.Z-<sha>-nightly` release via the GitHub Releases API, and recommends exporting `GITHUB_TOKEN` to avoid rate limits.

Companion to goreleaser/goreleaser-action#558.