### PR TITLE
fix(github): remove author lookup by email

### DIFF
--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -184,16 +184,16 @@ func (c *githubClient) Changelog(ctx *context.Context, repo Repo, prev, current 
 func (c *githubClient) authorsLookup(authors []Author) []Author {
 	for i := range authors {
 		author := &authors[i]
-		if before, ok := strings.CutSuffix(author.Email, "@users.noreply.github.com"); ok {
-			// GitHub noreply format: ID+USERNAME@users.noreply.github.com
-			if _, clean, ok := strings.Cut(before, "+"); ok {
-				author.Username = clean
-				continue
-			}
-			author.Username = before
+		before, ok := strings.CutSuffix(author.Email, "@users.noreply.github.com")
+		if !ok {
 			continue
 		}
-
+		// GitHub noreply format: ID+USERNAME@users.noreply.github.com
+		if _, clean, ok := strings.Cut(before, "+"); ok {
+			author.Username = clean
+			continue
+		}
+		author.Username = before
 	}
 	return authors
 }

--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -104,13 +104,6 @@ func (c *githubClient) checkRateLimit(ctx *context.Context) {
 	})
 }
 
-func (c *githubClient) checkSearchRateLimit(ctx *context.Context) {
-	// 5 should be safe enough (search limit is 30/min)
-	c.rateLimitChecker(ctx, 5, func(limits *github.RateLimits) *github.Rate {
-		return limits.Search
-	})
-}
-
 func (c *githubClient) rateLimitChecker(
 	ctx *context.Context,
 	target int,
@@ -154,7 +147,6 @@ func (c *githubClient) Changelog(ctx *context.Context, repo Repo, prev, current 
 	c.checkRateLimit(ctx)
 	var log []ChangelogItem
 	opts := &github.ListOptions{PerPage: 100}
-	cache := map[string]string{}
 
 	for {
 		result, resp, err := githubDo(ctx, func() (*github.CommitsComparison, *github.Response, error) {
@@ -173,7 +165,7 @@ func (c *githubClient) Changelog(ctx *context.Context, repo Repo, prev, current 
 				})
 			}
 			coauthors := changelog.ExtractCoAuthors(commit.Commit.GetMessage())
-			authors = append(authors, c.authorsLookup(ctx, coauthors, cache)...)
+			authors = append(authors, c.authorsLookup(coauthors)...)
 			log = append(log, fillDeprecated(ChangelogItem{
 				SHA:     commit.GetSHA(),
 				Message: strings.Split(commit.Commit.GetMessage(), "\n")[0],
@@ -189,7 +181,7 @@ func (c *githubClient) Changelog(ctx *context.Context, repo Repo, prev, current 
 	return log, nil
 }
 
-func (c *githubClient) authorsLookup(ctx *context.Context, authors []Author, cache map[string]string) []Author {
+func (c *githubClient) authorsLookup(authors []Author) []Author {
 	for i := range authors {
 		author := &authors[i]
 		if before, ok := strings.CutSuffix(author.Email, "@users.noreply.github.com"); ok {
@@ -201,19 +193,7 @@ func (c *githubClient) authorsLookup(ctx *context.Context, authors []Author, cac
 			author.Username = before
 			continue
 		}
-		if username, ok := cache[author.Email]; ok {
-			author.Username = username
-			continue
-		}
-		c.checkSearchRateLimit(ctx)
-		res, _, err := githubDo(ctx, func() (*github.UsersSearchResult, *github.Response, error) {
-			return c.client.Search.Users(ctx, author.Email, nil)
-		})
-		if err == nil && len(res.Users) == 1 {
-			author.Username = res.Users[0].GetLogin()
-			cache[author.Email] = author.Username
-			continue
-		}
+
 	}
 	return authors
 }

--- a/internal/client/github_test.go
+++ b/internal/client/github_test.go
@@ -1270,96 +1270,42 @@ func TestGitHubCreateFileWithoutGitHubAppToken(t *testing.T) {
 }
 
 func TestGitHubAuthorsLookup(t *testing.T) {
-	srv := githubTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-		defer r.Body.Close()
-
-		if r.URL.Path == "/api/v3/search/users" {
-			q := r.URL.Query().Get("q")
-			switch q {
-			case "single@example.com", "cached@example.com":
-				fmt.Fprint(w, `{"total_count": 1, "items": [{"login": "singleuser"}]}`)
-			case "multiple@example.com":
-				fmt.Fprint(w, `{"total_count": 2, "items": [{"login": "user1"}, {"login": "user2"}]}`)
-			case "error@example.com":
-				w.WriteHeader(http.StatusInternalServerError)
-			default:
-				fmt.Fprint(w, `{"total_count": 0, "items": []}`)
-			}
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	})
-
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
-		GitHubURLs: config.GitHubURLs{
-			API: srv.URL,
-		},
 		Retry: config.Retry{Attempts: 1},
 	})
 	client, err := newGitHub(ctx, "test-token")
 	require.NoError(t, err)
-	cache := map[string]string{}
 
 	t.Run("noreply email without numeric id", func(t *testing.T) {
-		result := client.authorsLookup(ctx, []Author{
+		result := client.authorsLookup([]Author{
 			{Name: "Foo Bar", Email: "foobar@users.noreply.github.com"},
-		}, cache)
+		})
 		require.Equal(t, "foobar", result[0].Username)
 	})
 
 	t.Run("noreply email with numeric id", func(t *testing.T) {
-		result := client.authorsLookup(ctx, []Author{
+		result := client.authorsLookup([]Author{
 			{Name: "Foo Bar", Email: "12345+foobar@users.noreply.github.com"},
-		}, cache)
+		})
 		require.Equal(t, "foobar", result[0].Username)
 	})
 
-	t.Run("api lookup single result", func(t *testing.T) {
-		result := client.authorsLookup(ctx, []Author{
-			{Name: "Single User", Email: "single@example.com"},
-		}, cache)
-		require.Equal(t, "singleuser", result[0].Username)
-	})
-
-	t.Run("api lookup cache", func(t *testing.T) {
-		result := client.authorsLookup(ctx, []Author{
-			{Name: "Cached User", Email: "cached@example.com"},
-			{Name: "Cached User 2", Email: "cached@example.com"},
-		}, cache)
-		require.Equal(t, "singleuser", result[0].Username)
-		require.Equal(t, "singleuser", result[1].Username)
-	})
-
-	t.Run("api lookup no results", func(t *testing.T) {
-		result := client.authorsLookup(ctx, []Author{
-			{Name: "Unknown User", Email: "unknown@example.com"},
-		}, cache)
-		require.Empty(t, result[0].Username)
-	})
-
-	t.Run("api lookup multiple results", func(t *testing.T) {
-		result := client.authorsLookup(ctx, []Author{
-			{Name: "Ambiguous User", Email: "multiple@example.com"},
-		}, cache)
-		require.Empty(t, result[0].Username)
-	})
-
-	t.Run("api lookup error", func(t *testing.T) {
-		result := client.authorsLookup(ctx, []Author{
-			{Name: "Error User", Email: "error@example.com"},
-		}, cache)
+	t.Run("non-noreply email is left alone", func(t *testing.T) {
+		result := client.authorsLookup([]Author{
+			{Name: "Some User", Email: "someone@example.com"},
+		})
 		require.Empty(t, result[0].Username)
 	})
 
 	t.Run("mixed authors", func(t *testing.T) {
-		result := client.authorsLookup(ctx, []Author{
+		result := client.authorsLookup([]Author{
 			{Name: "Noreply User", Email: "noreplyuser@users.noreply.github.com"},
 			{Name: "Noreply Plus", Email: "999+noreplyplus@users.noreply.github.com"},
-			{Name: "Single User", Email: "single@example.com"},
-		}, cache)
+			{Name: "Regular User", Email: "regular@example.com"},
+		})
 		require.Equal(t, "noreplyuser", result[0].Username)
 		require.Equal(t, "noreplyplus", result[1].Username)
-		require.Equal(t, "singleuser", result[2].Username)
+		require.Empty(t, result[2].Username)
 	})
 }
 


### PR DESCRIPTION
On a big release, this will likely lead to secondary rate limit hits.

On top of that, most users have their primary emails private anyway, so this doesn't help in those cases either.

This should also be faster.

closes #6599
