### PR TITLE
docs: fix invalid 'neq' template function in pkg example

### DIFF
--- a/www/content/customization/package/pkg.md
+++ b/www/content/customization/package/pkg.md
@@ -22,7 +22,7 @@ pkgs:
     #
     # Default: '{{.ProjectName}}_{{.Arch}}'.
     # Templates: allowed.
-    name: 'myproject{{ if neq .Arch "all" }}-{{.Arch}}{{ end }}'
+    name: 'myproject{{ if ne .Arch "all" }}-{{.Arch}}{{ end }}'
 
     # IDs of the builds to use.
     # Empty means all IDs.


### PR DESCRIPTION
<!-- If applied, this commit will... -->

Fix the `pkgs[].name` template example in the macOS Pkg docs so it actually parses.

<!-- Why is this change being made? -->

Go's `text/template` provides `ne` for not-equal; `neq` is not defined and `template.Parse` rejects it with `function "neq" not defined`. Anyone copy-pasting the snippet hits this immediately.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

Closes #6603.