### PR TITLE
fix: return error when go.mod is unreadable in CheckGoModPipe

### DIFF
--- a/internal/pipe/gomod/gomod_proxy.go
+++ b/internal/pipe/gomod/gomod_proxy.go
@@ -42,8 +42,10 @@ func (CheckGoModPipe) Run(ctx *context.Context) error {
 		path := filepath.Join(build.UnproxiedDir, "go.mod")
 		mod, err := os.ReadFile(path)
 		if err != nil {
-			log.Errorf("could not check %q", path)
-			return nil
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return fmt.Errorf("could not check %q: %w", path, err)
 		}
 		for line := range strings.SplitSeq(string(mod), "\n") {
 			if !replaceRe.MatchString(line) {

--- a/internal/pipe/gomod/gomod_proxy_test.go
+++ b/internal/pipe/gomod/gomod_proxy_test.go
@@ -68,6 +68,32 @@ func TestCheckGoMod(t *testing.T) {
 
 		require.NoError(t, CheckGoModPipe{}.Run(ctx))
 	})
+	t.Run("unreadable go mod", func(t *testing.T) {
+		dir := testlib.Mktmp(t)
+		dist := filepath.Join(dir, "dist")
+		// Create a directory named "go.mod" so ReadFile fails with a
+		// non-ErrNotExist error.
+		require.NoError(t, os.Mkdir(filepath.Join(dir, "go.mod"), 0o755))
+
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			Dist: dist,
+			GoMod: config.GoMod{
+				Proxy:    true,
+				GoBinary: "go",
+			},
+			Builds: []config.Build{
+				{
+					ID:     "foo",
+					Goos:   []string{runtime.GOOS},
+					Goarch: []string{runtime.GOARCH},
+					Main:   ".",
+					Dir:    ".",
+				},
+			},
+		}, withTestModulePath)
+
+		require.Error(t, CheckGoModPipe{}.Run(ctx))
+	})
 	t.Run("replace", func(t *testing.T) {
 		dir := testlib.Mktmp(t)
 		dist := filepath.Join(dir, "dist")


### PR DESCRIPTION
<!-- If applied, this commit will... -->

Return an error when `os.ReadFile` fails with a non-`ErrNotExist` error in `CheckGoModPipe.Run`, instead of silently swallowing the error.

<!-- Why is this change being made? -->

`CheckGoModPipe.Run` validates that `go.mod` does not contain `replace` directives when `gomod.proxy` is enabled. When `os.ReadFile` fails (e.g., permission denied, I/O error), the error is logged but `nil` is returned, silently skipping the validation. This means a user whose `go.mod` is unreadable proceeds to the proxy build step, which fails later with a confusing error instead of a clear early message.

The fix distinguishes between `os.ErrNotExist` (expected for non-Go builds, skip gracefully) and other errors (return to caller). This matches the pattern already used by `copyGoSum` in the same file.

**Bug origin:** Introduced in #4398 (2023-11-03).

<!-- # Provide links to any relevant tickets, URLs or other resources -->

- #4398 (original PR that introduced the behavior)

AI was used in authoring this PR (Grok, assisted by user).
