### PR TITLE
fix(gitlab): add direct asset URL compatibility option

### DIFF
--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -602,23 +602,7 @@ func (c *gitlabClient) Upload(
 			WithField("url", baseLinkURL).
 			Debug("uploaded file")
 
-		name := artifact.Name
-		filename := "/" + name
-		opt := &gitlab.CreateReleaseLinkOptions{
-			Name: &name,
-			URL:  &linkURL,
-		}
-		if c.isV17OrLater {
-			opt.DirectAssetPath = &filename
-		} else {
-			opt.FilePath = &filename
-		}
-
-		releaseLink, resp, err := c.client.ReleaseLinks.CreateReleaseLink(
-			projectID,
-			releaseID,
-			opt,
-		)
+		releaseLink, resp, err := c.createReleaseLink(ctx, projectID, releaseID, artifact.Name, linkURL)
 		if err != nil {
 			// this status means the asset already exists
 			if resp != nil && resp.StatusCode == http.StatusBadRequest && releaseLink != nil {
@@ -650,6 +634,71 @@ func (c *gitlabClient) Upload(
 
 		return nil
 	}, retryx.IsRetriable)
+}
+
+type createGitLabReleaseLinkOptions struct {
+	Name           *string               `json:"name,omitempty"`
+	URL            *string               `json:"url,omitempty"`
+	DirectAssetURL *string               `json:"direct_asset_url,omitempty"`
+	LinkType       *gitlab.LinkTypeValue `json:"link_type,omitempty"`
+}
+
+func (c *gitlabClient) createReleaseLink(
+	ctx *context.Context,
+	projectID,
+	releaseID,
+	name,
+	linkURL string,
+) (*gitlab.ReleaseLink, *gitlab.Response, error) {
+	if ctx.Config.GitLabURLs.UseDirectAssetURL {
+		return c.createReleaseLinkWithDirectAssetURL(projectID, releaseID, name, linkURL)
+	}
+
+	filename := "/" + name
+	opt := &gitlab.CreateReleaseLinkOptions{
+		Name: &name,
+		URL:  &linkURL,
+	}
+	if c.isV17OrLater {
+		opt.DirectAssetPath = &filename
+	} else {
+		opt.FilePath = &filename
+	}
+
+	return c.client.ReleaseLinks.CreateReleaseLink(projectID, releaseID, opt)
+}
+
+func (c *gitlabClient) createReleaseLinkWithDirectAssetURL(
+	projectID,
+	releaseID,
+	name,
+	linkURL string,
+) (*gitlab.ReleaseLink, *gitlab.Response, error) {
+	// Some GitLab CE versions, including 13.4.3, accept direct_asset_url in
+	// create release link requests. go-gitlab does not expose it in its create
+	// options, so this opt-in compatibility path builds the request directly.
+	u := fmt.Sprintf(
+		"projects/%s/releases/%s/assets/links",
+		gitlab.PathEscape(projectID),
+		gitlab.PathEscape(releaseID),
+	)
+	linkType := gitlab.OtherLinkType
+	req, err := c.client.NewRequest(http.MethodPost, u, &createGitLabReleaseLinkOptions{
+		Name:           &name,
+		URL:            &linkURL,
+		DirectAssetURL: &linkURL,
+		LinkType:       &linkType,
+	}, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	releaseLink := new(gitlab.ReleaseLink)
+	resp, err := c.client.Do(req, releaseLink)
+	if err != nil {
+		return nil, resp, err
+	}
+	return releaseLink, resp, err
 }
 
 // getMilestoneByTitle returns a milestone by title.

--- a/internal/client/gitlab_test.go
+++ b/internal/client/gitlab_test.go
@@ -285,6 +285,70 @@ func TestGitLabURLsDownloadTemplate(t *testing.T) {
 	}
 }
 
+func TestGitLabUploadUseDirectAssetURL(t *testing.T) {
+	t.Parallel()
+	for _, usePackageRegistry := range []bool{false, true} {
+		t.Run(strconv.FormatBool(usePackageRegistry), func(t *testing.T) {
+			t.Parallel()
+			bodyCh := make(chan map[string]string, 1)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer r.Body.Close()
+				switch {
+				case strings.HasPrefix(r.URL.Path, "/api/v4/version"):
+					fmt.Fprint(w, `{"version":"18.0.0"}`)
+				case strings.Contains(r.URL.Path, "packages/generic") && r.Method == http.MethodPut:
+					w.WriteHeader(http.StatusCreated)
+					fmt.Fprint(w, `{"message":"201 Created"}`)
+				case strings.Contains(r.URL.Path, "uploads") && r.Method == http.MethodPost:
+					fmt.Fprint(w, `{"alt":"test","url":"/uploads/abc/test.tar.gz","full_path":"someone/something/uploads/abc/test.tar.gz","markdown":"[test](/uploads/abc/test.tar.gz)"}`)
+				case strings.Contains(r.URL.Path, "assets/links") && r.Method == http.MethodPost:
+					b, err := io.ReadAll(r.Body)
+					if err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+						return
+					}
+					requestBody := map[string]string{}
+					if err := json.Unmarshal(b, &requestBody); err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+						return
+					}
+					bodyCh <- requestBody
+					w.WriteHeader(http.StatusCreated)
+					fmt.Fprint(w, `{"id":1,"name":"test.tar.gz","direct_asset_url":"http://example.com/test.tar.gz"}`)
+				default:
+					w.WriteHeader(http.StatusOK)
+					fmt.Fprint(w, "{}")
+				}
+			}))
+			t.Cleanup(srv.Close)
+
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+				ProjectName: "myproject",
+				GitLabURLs: config.GitLabURLs{
+					API:                srv.URL,
+					Download:           srv.URL,
+					UsePackageRegistry: usePackageRegistry,
+					UseDirectAssetURL:  true,
+				},
+				Release: config.Release{
+					GitLab: config.Repo{Owner: "someone", Name: "something"},
+				},
+			}, testctx.WithVersion("1.0.0"), testctx.WithCurrentTag("v1.0.0"))
+			client, err := newGitLab(ctx, "test-token")
+			require.NoError(t, err)
+
+			err = client.Upload(ctx, "v1.0.0", &artifact.Artifact{Name: "test.tar.gz", Path: "testdata/gitlab/milestone.json"})
+			require.NoError(t, err)
+			requestBody := <-bodyCh
+			require.Equal(t, "test.tar.gz", requestBody["name"])
+			require.Equal(t, requestBody["url"], requestBody["direct_asset_url"])
+			require.Equal(t, "other", requestBody["link_type"])
+			require.Empty(t, requestBody["filepath"])
+			require.Empty(t, requestBody["direct_asset_path"])
+		})
+	}
+}
+
 func TestGitLabCreateReleaseUnknownHost(t *testing.T) {
 	t.Parallel()
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,6 +36,7 @@ type GitLabURLs struct {
 	SkipTLSVerify      bool   `yaml:"skip_tls_verify,omitempty" json:"skip_tls_verify,omitempty"`
 	UsePackageRegistry bool   `yaml:"use_package_registry,omitempty" json:"use_package_registry,omitempty"`
 	UseJobToken        bool   `yaml:"use_job_token,omitempty" json:"use_job_token,omitempty"`
+	UseDirectAssetURL  bool   `yaml:"use_direct_asset_url,omitempty" json:"use_direct_asset_url,omitempty"`
 }
 
 // GiteaURLs holds the URLs to be used when using gitea.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -22,6 +22,17 @@ func TestEmptyRepoNameAndOwner(t *testing.T) {
 	require.Empty(t, Repo{}.String())
 }
 
+func TestGitLabURLsConfig(t *testing.T) {
+	conf := `
+gitlab_urls:
+    use_direct_asset_url: true
+`
+	prop, err := LoadReader(strings.NewReader(conf))
+
+	require.NoError(t, err)
+	require.True(t, prop.GitLabURLs.UseDirectAssetURL)
+}
+
 func TestLoadReader(t *testing.T) {
 	conf := `
 nfpms:

--- a/www/content/customization/publish/scm/gitlab.md
+++ b/www/content/customization/publish/scm/gitlab.md
@@ -83,6 +83,29 @@ gitlab_urls:
   use_package_registry: true
 ```
 
+## Direct asset URLs
+
+By default, GoReleaser asks GitLab to create a permanent direct asset link for
+each uploaded artifact.
+
+Some older GitLab instances may create broken direct asset URLs when GoReleaser
+sends an asset path for GitLab to derive the final URL. This has been observed
+on GitLab Community Edition 13.4.3 and is tracked in
+[goreleaser/goreleaser#3299](https://github.com/goreleaser/goreleaser/issues/3299).
+If your release links work, but the generated direct asset URLs return 404, set
+`use_direct_asset_url` to `true`:
+
+```yaml {filename=".goreleaser.yaml"}
+gitlab_urls:
+  use_direct_asset_url: true
+```
+
+With this option enabled, GoReleaser sends the uploaded artifact URL as the
+release link's direct asset URL instead of asking GitLab to derive it from an
+asset path. Keep the default value unless your GitLab version accepts
+`direct_asset_url` in release link create requests and you need this
+compatibility behavior.
+
 ## Example release
 
 You can check [this example repository](https://gitlab.com/goreleaser/example/-/releases) for a real world example.

--- a/www/static/schema.json
+++ b/www/static/schema.json
@@ -1622,6 +1622,9 @@
 					},
 					"use_job_token": {
 						"type": "boolean"
+					},
+					"use_direct_asset_url": {
+						"type": "boolean"
 					}
 				},
 				"additionalProperties": false,


### PR DESCRIPTION
## Summary

This adds an opt-in GitLab compatibility mode for release asset links through
`gitlab_urls.use_direct_asset_url`.

When enabled, GoReleaser sends the uploaded artifact URL as
`direct_asset_url` when creating GitLab release links, instead of asking GitLab
to derive the direct asset URL from `filepath` or `direct_asset_path`.

## Motivation

Some older GitLab Community Edition instances, including GitLab CE 13.4.3, may
accept release links successfully but generate broken direct asset URLs when the
direct URL is derived from an asset path. In that case, release links can appear
valid while the generated direct asset URLs return 404.

This addresses the compatibility case described in
#3299 while keeping the existing default behavior
unchanged.

## Changes

- Added `gitlab_urls.use_direct_asset_url` to the project configuration.
- Added a GitLab release-link creation path that sends `direct_asset_url`
  directly in the request body.
- Kept the existing `filepath` / `direct_asset_path` behavior as the default.
- Updated the JSON schema with the new option.
- Documented when and why to enable the compatibility option.
- Added tests for config loading and GitLab upload request behavior.

## Validation

```bash
go test ./internal/client ./pkg/config
```