### PR TITLE
fix(client): skip merge-upstream when target repo is not a fork

### DIFF
--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -371,10 +371,10 @@ func (c *githubClient) SyncFork(ctx *context.Context, head, base Repo) error {
 	case err != nil:
 		log.WithField("repo", head.String()).
 			WithError(err).
-			Debug("could not check if target is a fork; attempting sync anyway")
+			Warn("could not check if target is a fork; attempting sync anyway")
 	case !fork:
 		log.WithField("repo", head.String()).
-			Debug("target is not a fork; skipping merge-upstream")
+			Info("target is not a fork; skipping merge-upstream")
 		return nil
 	}
 

--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -226,6 +226,18 @@ func (c *githubClient) authorsLookup(authors []Author) []Author {
 	return authors
 }
 
+// isFork reports whether the given repository is a fork.
+func (c *githubClient) isFork(ctx *context.Context, repo Repo) (bool, error) {
+	c.checkRateLimit(ctx)
+	p, _, err := githubDo(ctx, func() (*github.Repository, *github.Response, error) {
+		return c.client.Repositories.Get(ctx, repo.Owner, repo.Name)
+	})
+	if err != nil {
+		return false, err
+	}
+	return p.GetFork(), nil
+}
+
 // getDefaultBranch returns the default branch of a github repo
 func (c *githubClient) getDefaultBranch(ctx *context.Context, repo Repo) (string, error) {
 	c.checkRateLimit(ctx)
@@ -353,6 +365,19 @@ func (c *githubClient) OpenPullRequest(
 }
 
 func (c *githubClient) SyncFork(ctx *context.Context, head, base Repo) error {
+	// merge-upstream returns 422 for non-forks; skip the call when we can tell.
+	fork, err := c.isFork(ctx, head)
+	switch {
+	case err != nil:
+		log.WithField("repo", head.String()).
+			WithError(err).
+			Debug("could not check if target is a fork; attempting sync anyway")
+	case !fork:
+		log.WithField("repo", head.String()).
+			Debug("target is not a fork; skipping merge-upstream")
+		return nil
+	}
+
 	branch := base.Branch
 	if branch == "" {
 		def, err := c.getDefaultBranch(ctx, base)

--- a/internal/client/github_test.go
+++ b/internal/client/github_test.go
@@ -1547,6 +1547,11 @@ func TestGitHubSyncFork(t *testing.T) {
 		t.Parallel()
 		srv := githubTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 			defer r.Body.Close()
+			if r.URL.Path == "/api/v3/repos/headowner/headname" && r.Method == http.MethodGet {
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, `{"fork":true}`)
+				return
+			}
 			if r.URL.Path == "/api/v3/repos/headowner/headname/merge-upstream" && r.Method == http.MethodPost {
 				w.WriteHeader(http.StatusOK)
 				fmt.Fprint(w, `{"merge_type":"fast-forward","base_branch":"main","message":"Successfully fetched"}`)
@@ -1571,6 +1576,11 @@ func TestGitHubSyncFork(t *testing.T) {
 		t.Parallel()
 		srv := githubTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 			defer r.Body.Close()
+			if r.URL.Path == "/api/v3/repos/headowner/headname" && r.Method == http.MethodGet {
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, `{"fork":true}`)
+				return
+			}
 			if r.URL.Path == "/api/v3/repos/headowner/headname/merge-upstream" && r.Method == http.MethodPost {
 				w.WriteHeader(http.StatusUnprocessableEntity)
 				fmt.Fprint(w, `{"message":"merge conflict"}`)
@@ -1595,6 +1605,11 @@ func TestGitHubSyncFork(t *testing.T) {
 		t.Parallel()
 		srv := githubTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 			defer r.Body.Close()
+			if r.URL.Path == "/api/v3/repos/headowner/headname" && r.Method == http.MethodGet {
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, `{"fork":true}`)
+				return
+			}
 			if r.URL.Path == "/api/v3/repos/baseowner/basename" && r.Method == http.MethodGet {
 				w.WriteHeader(http.StatusOK)
 				fmt.Fprint(w, `{"default_branch":"develop"}`)
@@ -1616,6 +1631,58 @@ func TestGitHubSyncFork(t *testing.T) {
 			ctx,
 			Repo{Owner: "headowner", Name: "headname"},
 			Repo{Owner: "baseowner", Name: "basename"},
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("skips merge-upstream when target is not a fork", func(t *testing.T) {
+		t.Parallel()
+		srv := githubTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			defer r.Body.Close()
+			if r.URL.Path == "/api/v3/repos/headowner/headname" && r.Method == http.MethodGet {
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, `{"fork":false}`)
+				return
+			}
+			t.Error("unhandled request: " + r.Method + " " + r.URL.Path)
+		})
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			GitHubURLs: config.GitHubURLs{API: srv.URL},
+		})
+		client, err := newGitHub(ctx, "test-token")
+		require.NoError(t, err)
+		err = client.SyncFork(
+			ctx,
+			Repo{Owner: "headowner", Name: "headname"},
+			Repo{Owner: "baseowner", Name: "basename", Branch: "main"},
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("falls through when fork precheck errors", func(t *testing.T) {
+		t.Parallel()
+		srv := githubTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			defer r.Body.Close()
+			if r.URL.Path == "/api/v3/repos/headowner/headname" && r.Method == http.MethodGet {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			if r.URL.Path == "/api/v3/repos/headowner/headname/merge-upstream" && r.Method == http.MethodPost {
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, `{"merge_type":"fast-forward","base_branch":"main","message":"Successfully fetched"}`)
+				return
+			}
+			t.Error("unhandled request: " + r.Method + " " + r.URL.Path)
+		})
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			GitHubURLs: config.GitHubURLs{API: srv.URL},
+		})
+		client, err := newGitHub(ctx, "test-token")
+		require.NoError(t, err)
+		err = client.SyncFork(
+			ctx,
+			Repo{Owner: "headowner", Name: "headname"},
+			Repo{Owner: "baseowner", Name: "basename", Branch: "main"},
 		)
 		require.NoError(t, err)
 	})
@@ -1896,6 +1963,11 @@ func TestGitHubSyncForkDefaultBranchError(t *testing.T) {
 	t.Parallel()
 	srv := githubTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
+		if r.URL.Path == "/api/v3/repos/headowner/headname" && r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"fork":true}`)
+			return
+		}
 		if r.URL.Path == "/api/v3/repos/baseowner/basename" && r.Method == http.MethodGet {
 			w.WriteHeader(http.StatusInternalServerError)
 			return


### PR DESCRIPTION
## Problem

When a publisher (brew, cask, nix, scoop, krew, winget) is configured with `repository.pull_request.enabled: true` and the target repository is **not a fork**, every release logs a misleading error:

```
homebrew formula
  • could not sync fork  error=POST /repos/<owner>/<repo>/merge-upstream: 422 Validation Failed
```

The release and the PR are still created successfully — the warning is cosmetic — but it's noisy, conditions readers to ignore "errors" from the publisher step, and obscures the genuine 422s that fork users actually need to act on (merge conflicts, branch protection, divergent history, etc.).

The root cause is that `SyncFork` calls GitHub's `merge-upstream` endpoint unconditionally. That endpoint is documented to only work on actual forks and returns 422 for everything else. The sync step was added in #4720 / #4721 for the winget flow, where contributors really do fork `microsoft/winget-pkgs`. It's correct for that case but fires for every `pull_request`-enabled publisher today — including same-owner Homebrew taps, which are the common Homebrew setup.

## Change

Before calling `merge-upstream`, query `Repositories.Get` on the target (head) repo and check `fork`:

- `fork == false` → log at debug and return early. No wasted API call, no scary warning.
- `fork == true` → proceed exactly as today.
- Precheck call itself errors → fall through and attempt the sync anyway. This preserves current behavior on transient API issues so the change can't regress fork users.

This is a single change in `SyncFork`; every pipe (`brew`, `cask`, `krew`, `nix`, `scoop`, `winget`) routes through it, so no per-publisher edits are needed.

### Why a precheck instead of swallowing the 422?

422 is GitHub's catch-all for `merge-upstream` and is also returned for genuine failures (merge conflicts surface here in some cases, branch protection rules, etc.). Silently dropping all 422s would hide real, actionable failures from fork users — exactly the people the sync step was added for. A precheck distinguishes "this call is structurally impossible" from "this call failed for a fixable reason", which is the actual semantic difference that matters.

### Why no config knob?

Behavior is detectable from the GitHub API. A `fork:` or `sync_fork:` field would add a config surface that users would have to set correctly to get the same result. Auto-detection is zero-config and correct by construction.

### Cost

One additional `GET /repos/:owner/:name` per release per publisher. Runs once per release, well inside rate limits. Not worth caching.

## Tests

`internal/client/github_test.go`:
- Existing `TestGitHubSyncFork` happy-path / error / no-base-branch tests updated to mock the new `GET /repos/headowner/headname` response.
- New `skips merge-upstream when target is not a fork` — asserts `merge-upstream` is never called when precheck reports `fork: false`.
- New `falls through when fork precheck errors` — asserts `merge-upstream` is still attempted when the precheck call returns 500, preserving current behavior on API hiccups.
- `TestGitHubSyncForkDefaultBranchError` updated for the new precheck.

All tests in `./internal/client/...` pass locally. `gofumpt -l` and `go vet` clean.

---

*Drafted with [Claude Code](https://claude.com/claude-code) assistance.*