### PR TITLE
fix(mcp): clean subfolder path

### DIFF
--- a/internal/pipe/mcp/mcp.go
+++ b/internal/pipe/mcp/mcp.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/internal/deprecate"
@@ -111,7 +112,7 @@ func (p Pipe) Publish(ctx *context.Context) error {
 			URL:       mcp.Repository.URL,
 			Source:    mcp.Repository.Source,
 			ID:        mcp.Repository.ID,
-			Subfolder: mcp.Repository.Subfolder,
+			Subfolder: cleanSubfolder(mcp.Repository.Subfolder),
 		}
 	}
 	server := apiv0.ServerJSON{
@@ -185,6 +186,16 @@ func (p Pipe) Publish(ctx *context.Context) error {
 
 		return nil
 	}, retryx.IsRetriable)
+}
+
+// cleanSubfolder normalizes the repository subfolder path so it passes the MCP
+// registry validation, which rejects paths with "./" prefixes, trailing
+// slashes, and similar non-clean forms.
+func cleanSubfolder(subfolder string) string {
+	if cleaned := path.Clean(subfolder); cleaned != "." {
+		return cleaned
+	}
+	return ""
 }
 
 func authProvider(registryURL, method, token string) (auth.Provider, error) {

--- a/internal/pipe/mcp/mcp_test.go
+++ b/internal/pipe/mcp/mcp_test.go
@@ -495,7 +495,7 @@ func TestPublishWithRepository(t *testing.T) {
 					URL:       "https://gitlab.com/group/project",
 					Source:    "gitlab",
 					ID:        "group/project",
-					Subfolder: "servers/mcp",
+					Subfolder: "./servers/mcp/",
 				},
 				Auth: config.MCPAuth{
 					Type: "none",
@@ -526,6 +526,25 @@ func TestPublishWithRepository(t *testing.T) {
 		Packages: nil,
 	}
 	require.Equal(t, expected, receivedRequest)
+}
+
+func TestCleanSubfolder(t *testing.T) {
+	for input, expected := range map[string]string{
+		"":                  "",
+		".":                 "",
+		"./":                "",
+		"servers/mcp":       "servers/mcp",
+		"./servers/mcp":     "servers/mcp",
+		"./servers/mcp/":    "servers/mcp",
+		"servers/mcp/":      "servers/mcp",
+		"servers//mcp":      "servers/mcp",
+		"./internal/ns/mcp": "internal/ns/mcp",
+		"servers/./mcp":     "servers/mcp",
+	} {
+		t.Run(input, func(t *testing.T) {
+			require.Equal(t, expected, cleanSubfolder(input))
+		})
+	}
 }
 
 func TestAuthProvider(t *testing.T) {


### PR DESCRIPTION
refs https://github.com/goreleaser/goreleaser/discussions/6251#discussioncomment-16976263
