### PR TITLE
docs: fix "lets" -> "let's" in quick-start guide

### DIFF
--- a/www/content/getting-started/quick-start.md
+++ b/www/content/getting-started/quick-start.md
@@ -106,7 +106,7 @@ Run the init command to create an example `.goreleaser.yaml` file:
 goreleaser init
 ```
 
-Now, lets run a "local-only" release to see if it works using the release command:
+Now, let's run a "local-only" release to see if it works using the release command:
 
 ```sh
 goreleaser release --snapshot --clean


### PR DESCRIPTION
Tiny grammar fix in the Quick Start guide: "Now, lets run a local-only release" should be "let's" (contraction of "let us"). It's the line right before the first command in the onboarding tutorial.
