### PR TITLE
ci: improve ci times

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,11 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
+        include:
+          # the race detector is OS-independent and coverage is only uploaded
+          # from ubuntu, so skip both on windows to speed up the slowest job.
+          - os: windows-latest
+            test-args: RACE=false COVER=false
     runs-on: ${{ matrix.os }}
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
@@ -116,7 +121,7 @@ jobs:
       - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       - run: task setup
       - run: task build
-      - run: task test
+      - run: task test ${{ matrix.test-args }}
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: matrix.os == 'ubuntu-latest'
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: crazy-max/ghaction-upx@c83f378efc804f828e988debb88ed6116feb2368 # v4.0.0
         with:
           install-only: true
-      - name: setup-makeself
+      - name: install-flatpak-makeself
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt update -q

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,13 +73,25 @@ jobs:
       - uses: crazy-max/ghaction-upx@c83f378efc804f828e988debb88ed6116feb2368 # v4.0.0
         with:
           install-only: true
-      - name: setup-makeself-flatpak
+      - name: setup-makeself
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt update -q
           sudo apt install -yq makeself flatpak flatpak-builder
-          sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-          sudo flatpak install -y --noninteractive flathub org.freedesktop.Platform/x86_64/24.08 org.freedesktop.Sdk/x86_64/24.08 org.freedesktop.Platform/aarch64/24.08 org.freedesktop.Sdk/aarch64/24.08
+      - name: cache-flatpak
+        id: cache-flatpak
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        with:
+          path: ~/.local/share/flatpak
+          key: flatpak-${{ runner.os }}-freedesktop-24.08
+      - name: setup-flatpak
+        # runtimes are installed --user so the cache (runner-owned) can restore
+        # them without sudo; only download on a cache miss.
+        if: matrix.os == 'ubuntu-latest' && steps.cache-flatpak.outputs.cache-hit != 'true'
+        run: |
+          flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+          flatpak install -y --user --noninteractive flathub org.freedesktop.Platform/x86_64/24.08 org.freedesktop.Sdk/x86_64/24.08 org.freedesktop.Platform/aarch64/24.08 org.freedesktop.Sdk/aarch64/24.08
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         if: matrix.os == 'ubuntu-latest'
         with:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -40,8 +40,10 @@ tasks:
       TEST_OPTIONS: '{{default "" .TEST_OPTIONS}}'
       SOURCE_FILES: '{{default "./..." .SOURCE_FILES}}'
       TEST_PATTERN: '{{default "." .TEST_PATTERN}}'
+      RACE: '{{if eq (default "true" .RACE) "true"}}-race{{end}}'
+      COVER: '{{if eq (default "true" .COVER) "true"}}-coverpkg=./... -covermode=atomic -coverprofile=coverage.txt{{end}}'
     cmds:
-      - go test {{.TEST_OPTIONS}} -failfast -race -coverpkg=./... -covermode=atomic -coverprofile=coverage.txt {{.SOURCE_FILES}} -run {{.TEST_PATTERN}} -timeout=15m
+      - go test {{.TEST_OPTIONS}} -failfast {{.RACE}} {{.COVER}} {{.SOURCE_FILES}} -run {{.TEST_PATTERN}} -timeout=15m
 
   fuzz:tmpl:
     cmds:


### PR DESCRIPTION
- race is os-independent, so we don't need to run it on windows too
- we don't publish coverage from windows, so we can disable it on windows as well
- caching the flatpak runtimes (need to test this one)
- node cleanup no longer necessary, already removed on main