### PR TITLE
fix(builders): reject empty target string

### DIFF
--- a/internal/builders/bun/build_test.go
+++ b/internal/builders/bun/build_test.go
@@ -109,6 +109,13 @@ func TestWithDefaults(t *testing.T) {
 		})
 		require.Error(t, err)
 	})
+
+	t.Run("empty target", func(t *testing.T) {
+		_, err := Default.WithDefaults(config.Build{
+			Targets: []string{""},
+		})
+		require.ErrorContains(t, err, "invalid target")
+	})
 }
 
 func TestBuild(t *testing.T) {

--- a/internal/builders/bun/targets.go
+++ b/internal/builders/bun/targets.go
@@ -84,7 +84,9 @@ func convertToGoarch(s string) string {
 
 func isValid(target string) bool {
 	targetsOnce.Do(func() {
-		allTargets = strings.Split(string(allTargetsBts), "\n")
+		allTargets = slices.DeleteFunc(strings.Split(string(allTargetsBts), "\n"), func(s string) bool {
+			return s == ""
+		})
 	})
 
 	return slices.Contains(allTargets, target) ||

--- a/internal/builders/deno/build_test.go
+++ b/internal/builders/deno/build_test.go
@@ -68,6 +68,13 @@ func TestWithDefaults(t *testing.T) {
 		})
 		require.Error(t, err)
 	})
+
+	t.Run("empty target", func(t *testing.T) {
+		_, err := Default.WithDefaults(config.Build{
+			Targets: []string{""},
+		})
+		require.ErrorContains(t, err, "invalid target")
+	})
 }
 
 func TestBuild(t *testing.T) {

--- a/internal/builders/deno/targets.go
+++ b/internal/builders/deno/targets.go
@@ -79,7 +79,9 @@ func convertToGoarch(s string) string {
 
 func isValid(target string) bool {
 	targetsOnce.Do(func() {
-		allTargets = strings.Split(string(allTargetsBts), "\n")
+		allTargets = slices.DeleteFunc(strings.Split(string(allTargetsBts), "\n"), func(s string) bool {
+			return s == ""
+		})
 	})
 
 	return slices.Contains(allTargets, target)

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -46,6 +46,13 @@ func TestWithDefaults(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("empty target", func(t *testing.T) {
+		_, err := Default.WithDefaults(config.Build{
+			Targets: []string{""},
+		})
+		require.ErrorContains(t, err, "invalid target")
+	})
+
 	t.Run("invalid config option", func(t *testing.T) {
 		_, err := Default.WithDefaults(config.Build{
 			Main: "something",

--- a/internal/builders/rust/targets.go
+++ b/internal/builders/rust/targets.go
@@ -108,7 +108,9 @@ func convertToGoarch(s string) string {
 
 func isValid(target string) bool {
 	targetsOnce.Do(func() {
-		allTargets = strings.Split(string(allTargetsBts), "\n")
+		allTargets = slices.DeleteFunc(strings.Split(string(allTargetsBts), "\n"), func(s string) bool {
+			return s == ""
+		})
 	})
 	if clean, ok := stripGlibcVersion(target); ok {
 		return slices.Contains(allTargets, clean)

--- a/internal/builders/zig/build_test.go
+++ b/internal/builders/zig/build_test.go
@@ -85,6 +85,13 @@ func TestWithDefaults(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("empty target", func(t *testing.T) {
+		_, err := Default.WithDefaults(config.Build{
+			Targets: []string{""},
+		})
+		require.ErrorContains(t, err, "invalid target")
+	})
+
 	t.Run("invalid config option", func(t *testing.T) {
 		_, err := Default.WithDefaults(config.Build{
 			Main: "something",

--- a/internal/builders/zig/targets.go
+++ b/internal/builders/zig/targets.go
@@ -85,8 +85,9 @@ func (t targetStatus) String() string {
 
 func checkTarget(target string) targetStatus {
 	targetsOnce.Do(func() {
-		allTargets = strings.Split(string(allTargetsBts), "\n")
-		errTargets = strings.Split(string(errTargetsBts), "\n")
+		isEmpty := func(s string) bool { return s == "" }
+		allTargets = slices.DeleteFunc(strings.Split(string(allTargetsBts), "\n"), isEmpty)
+		errTargets = slices.DeleteFunc(strings.Split(string(errTargetsBts), "\n"), isEmpty)
 	})
 
 	if slices.Contains(errTargets, target) {


### PR DESCRIPTION
The rust, zig, deno, and bun builders load their valid-target lists from embedded `.txt` files and parse them with `strings.Split(string(bts), "\n")`. Those files end with a trailing newline, so the split leaves an empty string at the end of `allTargets` (and zig's `errTargets`). That makes an empty target validate as if it were a real one: `isValid("")` returns true for rust/deno/bun, and zig's `checkTarget("")` returns `targetBroken` instead of `targetInvalid`.

As a result, an empty entry in a build's `targets` list (for example a stray empty item in the YAML list) is silently accepted instead of failing with the usual `invalid target` error.

This drops empty entries when building the lists, so an empty target is rejected like any other unknown one. I added an `empty target` case to each builder's `TestWithDefaults`; it fails before the change and passes after.

AI disclosure: I used AI assistance while writing this change, and I've reviewed and understand all of it.
