### PR TITLE
fix(winget): default head branch to a versioned template

### DIFF
--- a/internal/pipe/winget/winget.go
+++ b/internal/pipe/winget/winget.go
@@ -71,6 +71,12 @@ func (Pipe) Default(ctx *context.Context) error {
 		if winget.Goamd64 == "" {
 			winget.Goamd64 = "v1"
 		}
+		// winget-pkgs rejects PRs that touch more than a single package version,
+		// so the head branch must change per release. Default to a versioned
+		// template when the user did not set one and a PR is being opened.
+		if winget.Repository.Branch == "" && winget.Repository.PullRequest.Enabled {
+			winget.Repository.Branch = "update-{{ .ProjectName }}-{{ .Version }}"
+		}
 		winget.DefaultLocale = cmp.Or(winget.DefaultLocale, defaultLocale)
 		winget.PackageName = cmp.Or(winget.PackageName, winget.Name)
 	}

--- a/internal/pipe/winget/winget_test.go
+++ b/internal/pipe/winget/winget_test.go
@@ -851,6 +851,48 @@ func TestDefault(t *testing.T) {
 	require.Equal(t, "foo", winget.Name)
 }
 
+func TestDefaultBranch(t *testing.T) {
+	t.Run("pull request disabled keeps branch empty", func(t *testing.T) {
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			ProjectName: "foo",
+			Winget:      []config.Winget{{}},
+		})
+		require.NoError(t, Pipe{}.Default(ctx))
+		require.Empty(t, ctx.Config.Winget[0].Repository.Branch)
+	})
+
+	t.Run("pull request enabled defaults to a versioned branch", func(t *testing.T) {
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			ProjectName: "foo",
+			Winget: []config.Winget{{
+				Repository: config.RepoRef{
+					PullRequest: config.PullRequest{Enabled: true},
+				},
+			}},
+		})
+		require.NoError(t, Pipe{}.Default(ctx))
+		require.Equal(
+			t,
+			"update-{{ .ProjectName }}-{{ .Version }}",
+			ctx.Config.Winget[0].Repository.Branch,
+		)
+	})
+
+	t.Run("user-set branch is preserved", func(t *testing.T) {
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			ProjectName: "foo",
+			Winget: []config.Winget{{
+				Repository: config.RepoRef{
+					Branch:      "my-branch",
+					PullRequest: config.PullRequest{Enabled: true},
+				},
+			}},
+		})
+		require.NoError(t, Pipe{}.Default(ctx))
+		require.Equal(t, "my-branch", ctx.Config.Winget[0].Repository.Branch)
+	})
+}
+
 func TestFormatBinary(t *testing.T) {
 	folder := t.TempDir()
 	ctx := testctx.WrapWithCfg(t.Context(),


### PR DESCRIPTION
<!-- If applied, this commit will... -->

Default the winget head branch to `update-{{ .ProjectName }}-{{ .Version }}` when the user has not set one and pull requests are enabled, so each release opens its own PR instead of stacking onto a constant branch.

<!-- Why is this change being made? -->

Microsoft's [winget-pkgs](https://github.com/microsoft/winget-pkgs) automatically rejects pull requests that touch more than one package version, so reusing the same head branch across releases stacks updates and breaks the PR. Today, `winget.repository.branch` is unset by default and there is no winget-specific defaulting, so users either have to remember to template the version into the branch themselves or hit this failure on the second release.

This matches the maintainer suggestion on the issue: change the default so a fresh, versioned branch is used per release. `Default()` only sets the branch when both:

- `winget.repository.branch` is empty (user did not configure it), and
- `winget.repository.pull_request.enabled` is true (we are actually opening a PR; otherwise we are committing to the user's own repo and the existing behaviour is fine).

If the user already sets `branch:`, their value is preserved exactly as before.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

Fixes #6672

### Tests

Added `TestDefaultBranch` in `internal/pipe/winget/winget_test.go` covering three cases:

1. pull request disabled keeps `branch` empty (no behaviour change),
2. pull request enabled with empty `branch` defaults to `update-{{ .ProjectName }}-{{ .Version }}`,
3. a user-set `branch` is preserved.

`go test ./internal/pipe/winget/` passes locally.

### AI disclosure

This change was written with the assistance of Claude. I have reviewed the diff and the test and take responsibility for the code.
