### PR TITLE
feat(scm): allow a custom token on the release repository

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -147,9 +147,15 @@ func newWithToken(ctx *context.Context, token string) (Client, error) {
 	}
 }
 
+// NewIfToken returns a client that uses the given token (templated as an
+// environment variable) when it is set. Otherwise it returns cli, or a default
+// client built from the context when cli is nil.
 func NewIfToken(ctx *context.Context, cli Client, token string) (Client, error) {
 	if token == "" {
-		return cli, nil
+		if cli != nil {
+			return cli, nil
+		}
+		return New(ctx)
 	}
 	token, err := tmpl.New(ctx).ApplySingleEnvOnly(token)
 	if err != nil {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -171,6 +171,14 @@ func TestNewIfToken(t *testing.T) {
 		require.IsType(t, &gitlabClient{}, client)
 	})
 
+	t.Run("empty, nil fallback", func(t *testing.T) {
+		ctx := testctx.Wrap(t.Context(), testctx.GitLabTokenType)
+
+		client, err := NewIfToken(ctx, nil, "")
+		require.NoError(t, err)
+		require.IsType(t, &gitlabClient{}, client)
+	})
+
 	t.Run("invalid tmpl", func(t *testing.T) {
 		ctx := testctx.Wrap(t.Context(), testctx.GitLabTokenType)
 		_, err := NewIfToken(ctx, nil, "nope")

--- a/internal/pipe/release/release.go
+++ b/internal/pipe/release/release.go
@@ -98,7 +98,7 @@ func getRepository(ctx *context.Context) (config.Repo, error) {
 
 // Publish the release.
 func (Pipe) Publish(ctx *context.Context) error {
-	c, err := client.New(ctx)
+	c, err := releaseClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -110,6 +110,13 @@ func (Pipe) Publish(ctx *context.Context) error {
 			Info("release published")
 	}
 	return nil
+}
+
+// releaseClient creates the SCM client for the release, honoring a custom token
+// set on the release repository, if any.
+func releaseClient(ctx *context.Context) (client.Client, error) {
+	repo := releaseRepo(ctx)
+	return client.NewIfToken(ctx, nil, repo.Token)
 }
 
 func releaseRepo(ctx *context.Context) config.Repo {

--- a/internal/pipe/release/release_test.go
+++ b/internal/pipe/release/release_test.go
@@ -46,6 +46,49 @@ func TestReleaseRepo(t *testing.T) {
 	})
 }
 
+func TestReleaseClient(t *testing.T) {
+	t.Run("no custom token", func(t *testing.T) {
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			Release: config.Release{
+				GitHub: config.Repo{Owner: "foo", Name: "bar"},
+			},
+		}, testctx.GitHubTokenType)
+		c, err := releaseClient(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, c)
+	})
+
+	t.Run("custom token", func(t *testing.T) {
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			Env: []string{"TK=token"},
+			Release: config.Release{
+				GitHub: config.Repo{
+					Owner: "foo",
+					Name:  "bar",
+					Token: "{{ .Env.TK }}",
+				},
+			},
+		}, testctx.GitHubTokenType)
+		c, err := releaseClient(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, c)
+	})
+
+	t.Run("invalid custom token", func(t *testing.T) {
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			Release: config.Release{
+				GitHub: config.Repo{
+					Owner: "foo",
+					Name:  "bar",
+					Token: "plain-text-token",
+				},
+			},
+		}, testctx.GitHubTokenType)
+		_, err := releaseClient(ctx)
+		require.Error(t, err)
+	})
+}
+
 func createTmpFile(tb testing.TB, folder, path string) string {
 	tb.Helper()
 	f, err := os.Create(filepath.Join(folder, path))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,6 +51,10 @@ type Repo struct {
 	Owner  string `yaml:"owner,omitempty" json:"owner,omitempty"`
 	Name   string `yaml:"name,omitempty" json:"name,omitempty"`
 	RawURL string `yaml:"-" json:"-"`
+
+	// Override the default token for this specific repository, e.g. when
+	// releasing to a repository that needs a different token.
+	Token string `yaml:"token,omitempty" json:"token,omitempty"`
 }
 
 // String of the repo, e.g. owner/name.

--- a/www/content/customization/publish/scm/_index.md
+++ b/www/content/customization/publish/scm/_index.md
@@ -18,6 +18,16 @@ release:
     owner: user
     name: repo
 
+    # Token to use for this release, instead of the default one.
+    #
+    # Useful when the release repository requires a different token than the
+    # one used to build from - for instance, when publishing to a repository
+    # in another organization.
+    #
+    # {{< g_inline_version "v2.17-unreleased" >}}
+    # Templates: allowed (environment variables only).
+    token: "{{ .Env.RELEASE_GITHUB_TOKEN }}"
+
   # IDs of the archives to use.
   # Empty means all IDs.
   #

--- a/www/static/schema.json
+++ b/www/static/schema.json
@@ -4273,6 +4273,9 @@
 					},
 					"name": {
 						"type": "string"
+					},
+					"token": {
+						"type": "string"
 					}
 				},
 				"additionalProperties": false,


### PR DESCRIPTION
Useful when cross-releasing (e.g. code private, release public).

