### PR TITLE
ci: use nightly goreleaser in the release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/v') }} # only on tags
         with:
           distribution: goreleaser-pro
-          version: "~> 2"
+          version: nightly
           args: release --clean --timeout 60m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #6692.

Changes the `release` job's `goreleaser-action` step from `version: "~> 2"` to `version: nightly`, so the release binary is always new enough to parse config fields introduced in the same release being tagged (as described in the issue). `distribution: goreleaser-pro` is unchanged, and only the release job is affected.
