### PR TITLE
fix(builder/go): parse GORISCV64 and GOPPC64 for riscv64 and ppc64le targets

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -96,9 +96,9 @@ func (b *Builder) Parse(target string) (api.Target, error) {
 			t.Abi = abi
 		case "mips", "mipsle", "mips64", "mips64le":
 			t.Gomips = extra
-		case "ppc64":
+		case "ppc64", "ppc64le":
 			t.Goppc64 = extra
-		case "riscv":
+		case "riscv64":
 			t.Goriscv64 = extra
 		}
 	}

--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -98,7 +98,7 @@ func (b *Builder) Parse(target string) (api.Target, error) {
 			t.Gomips = extra
 		case "ppc64", "ppc64le":
 			t.Goppc64 = extra
-		case "riscv64":
+		case "riscv", "riscv64":
 			t.Goriscv64 = extra
 		}
 	}

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -148,6 +148,30 @@ func TestParse(t *testing.T) {
 			Goarch:  "arm64",
 			Goarm64: "v9.0",
 		},
+		"linux_ppc64": {
+			Target:  "linux_ppc64_power8",
+			Goos:    "linux",
+			Goarch:  "ppc64",
+			Goppc64: "power8",
+		},
+		"linux_ppc64le_power9": {
+			Target:  "linux_ppc64le_power9",
+			Goos:    "linux",
+			Goarch:  "ppc64le",
+			Goppc64: "power9",
+		},
+		"linux_riscv64": {
+			Target:    "linux_riscv64_rva20u64",
+			Goos:      "linux",
+			Goarch:    "riscv64",
+			Goriscv64: "rva20u64",
+		},
+		"linux_riscv64_rva22u64": {
+			Target:    "linux_riscv64_rva22u64",
+			Goos:      "linux",
+			Goarch:    "riscv64",
+			Goriscv64: "rva22u64",
+		},
 	} {
 		t.Run(target, func(t *testing.T) {
 			got, err := Default.Parse(target)


### PR DESCRIPTION
<!-- If applied, this commit will... -->

Correctly parse the microarchitecture level for `riscv64` and `ppc64le` build targets, so `GORISCV64` and `GOPPC64` are populated in the build environment.

<!-- Why is this change being made? -->

The Go builder's target parser matched on `riscv` and `ppc64`, but Go's actual GOARCH values are `riscv64` and `ppc64le` (the latter alongside `ppc64`). So for a target like `linux_riscv64_rva22u64` or `linux_ppc64le_power9` the microarch level (`extra`) was dropped and the build ran with an empty `GORISCV64`/`GOPPC64`. The `case "riscv"` branch was effectively dead code since no GOARCH is ever literally `riscv`.

This widens the `ppc64` case to also cover `ppc64le` and corrects `riscv` to `riscv64`.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

GOARCH-specific env var reference: https://go.dev/doc/install/source#environment (GORISCV64, GOPPC64).

<!-- Tests: -->

Added the missing rows to `TestParse` in `internal/builders/golang/build_test.go` covering `linux_ppc64_power8`, `linux_ppc64le_power9`, `linux_riscv64_rva20u64`, and `linux_riscv64_rva22u64`. Verified with `go test ./internal/builders/golang/...` and `gofmt`.
