### PR TITLE
feat: add iru custom apps publisher

### DIFF
--- a/internal/pipe/iru/doc.go
+++ b/internal/pipe/iru/doc.go
@@ -1,0 +1,3 @@
+// Package iru publishes artifacts as Custom Apps to iru.com (formerly
+// Kandji) endpoint management.
+package iru

--- a/internal/pipe/iru/iru.go
+++ b/internal/pipe/iru/iru.go
@@ -1,0 +1,329 @@
+package iru
+
+import (
+	"bytes"
+	"cmp"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/caarlos0/log"
+	"github.com/goreleaser/goreleaser/v2/internal/artifact"
+	"github.com/goreleaser/goreleaser/v2/internal/pipe"
+	"github.com/goreleaser/goreleaser/v2/internal/retryx"
+	"github.com/goreleaser/goreleaser/v2/internal/semerrgroup"
+	"github.com/goreleaser/goreleaser/v2/internal/skips"
+	"github.com/goreleaser/goreleaser/v2/internal/tmpl"
+	"github.com/goreleaser/goreleaser/v2/pkg/config"
+	"github.com/goreleaser/goreleaser/v2/pkg/context"
+)
+
+const (
+	defaultInstallType        = "package"
+	defaultInstallEnforcement = "install_once"
+	tokenEnvKey               = "IRU_API_TOKEN"
+)
+
+// Pipe for iru custom apps.
+type Pipe struct{}
+
+func (Pipe) String() string        { return "iru custom apps" }
+func (Pipe) ContinueOnError() bool { return true }
+func (Pipe) Skip(ctx *context.Context) bool {
+	return skips.Any(ctx, skips.Iru) || ctx.Config.Iru.URL == ""
+}
+
+func (Pipe) Default(ctx *context.Context) error {
+	iru := &ctx.Config.Iru
+	iru.Name = cmp.Or(iru.Name, ctx.Config.ProjectName)
+	iru.InstallType = cmp.Or(iru.InstallType, defaultInstallType)
+	iru.InstallEnforcement = cmp.Or(iru.InstallEnforcement, defaultInstallEnforcement)
+	return nil
+}
+
+func (p Pipe) Publish(ctx *context.Context) error {
+	cfg := ctx.Config.Iru
+
+	t := tmpl.New(ctx)
+	disabled, err := t.Bool(cfg.Disable)
+	if err != nil {
+		return fmt.Errorf("could not evaluate iru.disable: %w", err)
+	}
+	if disabled {
+		return pipe.Skip("iru.disable is set")
+	}
+
+	if err := t.ApplyAll(
+		&cfg.URL,
+		&cfg.APIToken,
+		&cfg.LibraryItemID,
+		&cfg.SelfServiceCategoryID,
+	); err != nil {
+		return fmt.Errorf("could not apply templates: %w", err)
+	}
+	cfg.URL = strings.TrimRight(cfg.URL, "/")
+	if cfg.URL == "" {
+		return errors.New("url templated to an empty string")
+	}
+	cfg.APIToken = cmp.Or(cfg.APIToken, ctx.Env[tokenEnvKey])
+	if cfg.APIToken == "" {
+		return fmt.Errorf("missing API token: set iru.api_token or the $%s environment variable", tokenEnvKey)
+	}
+	if err := validate(cfg); err != nil {
+		return err
+	}
+
+	artifacts := ctx.Artifacts.Filter(artifact.And(
+		artifact.ByTypes(
+			artifact.UploadableArchive,
+			artifact.UploadableBinary,
+			artifact.UploadableFile,
+		),
+		artifact.ByIDs(cfg.IDs...),
+	)).List()
+	if len(artifacts) == 0 {
+		return pipe.Skip("no artifacts found matching the given filters")
+	}
+	if cfg.LibraryItemID != "" && len(artifacts) > 1 {
+		return fmt.Errorf(
+			"library_item_id is set, but %d artifacts matched: use iru.ids to select a single artifact",
+			len(artifacts),
+		)
+	}
+
+	g := semerrgroup.New(ctx.Parallelism)
+	for _, art := range artifacts {
+		g.Go(func() error {
+			return p.publishArtifact(ctx, cfg, art)
+		})
+	}
+	return g.Wait()
+}
+
+// validate checks the conditionally required field combinations documented
+// by the Iru API, so misconfigurations fail before anything is uploaded.
+func validate(cfg config.Iru) error {
+	if cfg.InstallType == "zip" && cfg.UnzipLocation == "" {
+		return errors.New("install_type is zip, but unzip_location is not set")
+	}
+	if cfg.InstallEnforcement == "continuously_enforce" && cfg.AuditScript == "" {
+		return errors.New("install_enforcement is continuously_enforce, but audit_script is not set")
+	}
+	if cfg.ShowInSelfService != nil && *cfg.ShowInSelfService && cfg.SelfServiceCategoryID == "" {
+		return errors.New("show_in_self_service is enabled, but self_service_category_id is not set")
+	}
+	return nil
+}
+
+func (p Pipe) publishArtifact(ctx *context.Context, cfg config.Iru, art *artifact.Artifact) error {
+	name, err := tmpl.New(ctx).WithArtifact(art).Apply(cfg.Name)
+	if err != nil {
+		return fmt.Errorf("could not apply templates to iru.name: %w", err)
+	}
+
+	upload, err := p.initUpload(ctx, cfg, art.Name)
+	if err != nil {
+		return fmt.Errorf("could not initialize upload: %w", err)
+	}
+
+	log.WithField("file", art.Name).Info("uploading")
+	if err := p.uploadToS3(ctx, upload, art); err != nil {
+		return fmt.Errorf("could not upload file: %w", err)
+	}
+
+	item, err := p.createOrUpdate(ctx, cfg, name, upload.FileKey)
+	if err != nil {
+		return fmt.Errorf("could not save custom app: %w", err)
+	}
+
+	log.
+		WithField("name", item.Name).
+		WithField("id", item.ID).
+		Info("published custom app to iru")
+	return nil
+}
+
+type uploadDetails struct {
+	PostURL  string            `json:"post_url"`
+	PostData map[string]string `json:"post_data"`
+	FileKey  string            `json:"file_key"`
+}
+
+// initUpload asks the Iru API for pre-signed S3 upload details.
+func (p Pipe) initUpload(ctx *context.Context, cfg config.Iru, fileName string) (*uploadDetails, error) {
+	body, err := json.Marshal(map[string]string{"name": fileName})
+	if err != nil {
+		return nil, err
+	}
+
+	var details uploadDetails
+	if err := retryx.Do(ctx, ctx.Config.Retry, func() error {
+		return p.apiDo(ctx, cfg, http.MethodPost, cfg.URL+"/api/v1/library/custom-apps/upload", "application/json", body, &details)
+	}, retryx.IsRetriable); err != nil {
+		return nil, err
+	}
+	if details.PostURL == "" || details.FileKey == "" {
+		return nil, errors.New("invalid upload response: missing post_url or file_key")
+	}
+	return &details, nil
+}
+
+// uploadToS3 posts the file to the pre-signed S3 URL, sending all fields
+// from post_data followed by the file itself.
+func (Pipe) uploadToS3(ctx *context.Context, details *uploadDetails, art *artifact.Artifact) error {
+	info, err := os.Stat(art.Path)
+	if err != nil {
+		return err
+	}
+
+	return retryx.Do(ctx, ctx.Config.Retry, func() error {
+		file, err := os.Open(art.Path)
+		if err != nil {
+			return retryx.Unrecoverable(err)
+		}
+		defer file.Close()
+
+		var head bytes.Buffer
+		writer := multipart.NewWriter(&head)
+		for key, value := range details.PostData {
+			if err := writer.WriteField(key, value); err != nil {
+				return retryx.Unrecoverable(err)
+			}
+		}
+		// S3 requires the file to be the last field in the form. The part
+		// header lands in head, the content is streamed from the file, and
+		// the closing boundary follows as the tail.
+		if _, err := writer.CreateFormFile("file", art.Name); err != nil {
+			return retryx.Unrecoverable(err)
+		}
+		tail := "\r\n--" + writer.Boundary() + "--\r\n"
+
+		req, err := http.NewRequestWithContext(
+			ctx,
+			http.MethodPost,
+			details.PostURL,
+			io.MultiReader(bytes.NewReader(head.Bytes()), file, strings.NewReader(tail)),
+		)
+		if err != nil {
+			return retryx.Unrecoverable(err)
+		}
+		req.ContentLength = int64(head.Len()) + info.Size() + int64(len(tail))
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return retryx.HTTP(err, resp)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode < 200 || resp.StatusCode > 299 {
+			respBody, _ := io.ReadAll(resp.Body)
+			return retryx.HTTP(fmt.Errorf("got status code %d: %s", resp.StatusCode, string(respBody)), resp)
+		}
+		return nil
+	}, retryx.IsRetriable)
+}
+
+type customApp struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// createOrUpdate creates a new Custom App library item, or, if
+// library_item_id is set, updates the existing one to point at the newly
+// uploaded file. Optional fields are only sent when configured, so updates
+// do not reset settings managed in the Iru dashboard.
+func (p Pipe) createOrUpdate(ctx *context.Context, cfg config.Iru, name, fileKey string) (*customApp, error) {
+	form := url.Values{}
+	form.Set("name", name)
+	form.Set("file_key", fileKey)
+	form.Set("install_type", cfg.InstallType)
+	form.Set("install_enforcement", cfg.InstallEnforcement)
+	for key, value := range map[string]string{
+		"unzip_location":           cfg.UnzipLocation,
+		"audit_script":             cfg.AuditScript,
+		"preinstall_script":        cfg.PreinstallScript,
+		"postinstall_script":       cfg.PostinstallScript,
+		"self_service_category_id": cfg.SelfServiceCategoryID,
+	} {
+		if value != "" {
+			form.Set(key, value)
+		}
+	}
+	for key, value := range map[string]*bool{
+		"show_in_self_service":     cfg.ShowInSelfService,
+		"self_service_recommended": cfg.SelfServiceRecommended,
+		"restart":                  cfg.Restart,
+	} {
+		if value != nil {
+			form.Set(key, strconv.FormatBool(*value))
+		}
+	}
+	body := []byte(form.Encode())
+
+	var item customApp
+	if cfg.LibraryItemID != "" {
+		endpoint := cfg.URL + "/api/v1/library/custom-apps/" + url.PathEscape(cfg.LibraryItemID)
+		if err := retryx.Do(ctx, ctx.Config.Retry, func() error {
+			return p.apiDo(ctx, cfg, http.MethodPatch, endpoint, "application/x-www-form-urlencoded", body, &item)
+		}, retryx.IsRetriable); err != nil {
+			return nil, err
+		}
+		return &item, nil
+	}
+
+	// Creating is not idempotent: a retry whose previous attempt did reach
+	// the server would create a duplicate library item. Only clean
+	// rejections are retried: right after the S3 upload the API answers
+	// with a 503 ("The upload is still being processed") until the file
+	// has been ingested, and a 503/429 guarantees nothing was created.
+	if err := retryx.Do(ctx, ctx.Config.Retry, func() error {
+		return p.apiDo(ctx, cfg, http.MethodPost, cfg.URL+"/api/v1/library/custom-apps", "application/x-www-form-urlencoded", body, &item)
+	}, isCleanRejection); err != nil {
+		return nil, err
+	}
+	return &item, nil
+}
+
+// isCleanRejection returns true for errors where the server definitely did
+// not process the request, making a retry of a non-idempotent call safe.
+func isCleanRejection(err error) bool {
+	if he, ok := errors.AsType[retryx.HTTPError](err); ok {
+		return he.Status == http.StatusServiceUnavailable ||
+			he.Status == http.StatusTooManyRequests
+	}
+	return false
+}
+
+// apiDo performs an authenticated request against the Iru API and decodes
+// the JSON response into out.
+func (Pipe) apiDo(ctx *context.Context, cfg config.Iru, method, endpoint, contentType string, body []byte, out any) error {
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return retryx.Unrecoverable(err)
+	}
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("Authorization", "Bearer "+cfg.APIToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return retryx.HTTP(err, resp)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return retryx.HTTP(fmt.Errorf("got status code %d: %s", resp.StatusCode, string(respBody)), resp)
+	}
+	return json.Unmarshal(respBody, out)
+}

--- a/internal/pipe/iru/iru.go
+++ b/internal/pipe/iru/iru.go
@@ -40,14 +40,6 @@ func (Pipe) Skip(ctx *context.Context) bool {
 	return skips.Any(ctx, skips.Iru) || ctx.Config.Iru.URL == ""
 }
 
-func (Pipe) Default(ctx *context.Context) error {
-	iru := &ctx.Config.Iru
-	iru.Name = cmp.Or(iru.Name, ctx.Config.ProjectName)
-	iru.InstallType = cmp.Or(iru.InstallType, defaultInstallType)
-	iru.InstallEnforcement = cmp.Or(iru.InstallEnforcement, defaultInstallEnforcement)
-	return nil
-}
-
 func (p Pipe) Publish(ctx *context.Context) error {
 	cfg := ctx.Config.Iru
 
@@ -97,6 +89,11 @@ func (p Pipe) Publish(ctx *context.Context) error {
 			len(artifacts),
 		)
 	}
+	for _, art := range artifacts {
+		if err := validateArtifact(cfg, art); err != nil {
+			return err
+		}
+	}
 
 	g := semerrgroup.New(ctx.Parallelism)
 	for _, art := range artifacts {
@@ -107,23 +104,81 @@ func (p Pipe) Publish(ctx *context.Context) error {
 	return g.Wait()
 }
 
-// validate checks the conditionally required field combinations documented
-// by the Iru API, so misconfigurations fail before anything is uploaded.
+// effectiveInstallType and effectiveInstallEnforcement return the values the
+// API will end up with: creating applies the documented defaults, updating an
+// existing library item keeps unset fields as they are (returning "").
+func effectiveInstallType(cfg config.Iru) string {
+	if cfg.LibraryItemID == "" {
+		return cmp.Or(cfg.InstallType, defaultInstallType)
+	}
+	return cfg.InstallType
+}
+
+func effectiveInstallEnforcement(cfg config.Iru) string {
+	if cfg.LibraryItemID == "" {
+		return cmp.Or(cfg.InstallEnforcement, defaultInstallEnforcement)
+	}
+	return cfg.InstallEnforcement
+}
+
+// validate checks the field combinations required by the Iru API, so
+// misconfigurations fail before anything is uploaded.
 func validate(cfg config.Iru) error {
-	if cfg.InstallType == "zip" && cfg.UnzipLocation == "" {
+	installType := effectiveInstallType(cfg)
+	enforcement := effectiveInstallEnforcement(cfg)
+	selfService := cfg.ShowInSelfService != nil && *cfg.ShowInSelfService
+
+	if installType == "zip" && cfg.UnzipLocation == "" {
 		return errors.New("install_type is zip, but unzip_location is not set")
 	}
-	if cfg.InstallEnforcement == "continuously_enforce" && cfg.AuditScript == "" {
+	if enforcement == "continuously_enforce" && cfg.AuditScript == "" {
 		return errors.New("install_enforcement is continuously_enforce, but audit_script is not set")
 	}
-	if cfg.ShowInSelfService != nil && *cfg.ShowInSelfService && cfg.SelfServiceCategoryID == "" {
+	if enforcement != "" && enforcement != "continuously_enforce" && cfg.AuditScript != "" {
+		return fmt.Errorf("audit_script is set, but install_enforcement is %s instead of continuously_enforce", enforcement)
+	}
+	if enforcement == "no_enforcement" && !selfService {
+		return errors.New("install_enforcement is no_enforcement, but show_in_self_service is not enabled")
+	}
+	if selfService && cfg.SelfServiceCategoryID == "" {
 		return errors.New("show_in_self_service is enabled, but self_service_category_id is not set")
 	}
 	return nil
 }
 
+// installTypeExts maps each install type to the file extension the Iru API
+// accepts for it.
+var installTypeExts = map[string]string{
+	"package": ".pkg",
+	"zip":     ".zip",
+	"image":   ".dmg",
+}
+
+// validateArtifact ensures the artifact matches the install type, so
+// incompatible files (e.g. Linux binaries or tarballs from a cross-platform
+// release) fail before anything is uploaded.
+func validateArtifact(cfg config.Iru, art *artifact.Artifact) error {
+	installType := effectiveInstallType(cfg)
+	if installType == "" {
+		// Updating with install_type unset keeps the type configured on the
+		// existing library item, which is not known here.
+		return nil
+	}
+	ext, ok := installTypeExts[installType]
+	if !ok {
+		return fmt.Errorf("invalid install_type: %s", installType)
+	}
+	if !strings.HasSuffix(strings.ToLower(art.Name), ext) {
+		return fmt.Errorf(
+			"artifact %q is not compatible with install_type %s: use iru.ids to select only %s artifacts",
+			art.Name, installType, ext,
+		)
+	}
+	return nil
+}
+
 func (p Pipe) publishArtifact(ctx *context.Context, cfg config.Iru, art *artifact.Artifact) error {
-	name, err := tmpl.New(ctx).WithArtifact(art).Apply(cfg.Name)
+	name, err := tmpl.New(ctx).WithArtifact(art).Apply(cmp.Or(cfg.Name, ctx.Config.ProjectName))
 	if err != nil {
 		return fmt.Errorf("could not apply templates to iru.name: %w", err)
 	}
@@ -238,14 +293,27 @@ type customApp struct {
 
 // createOrUpdate creates a new Custom App library item, or, if
 // library_item_id is set, updates the existing one to point at the newly
-// uploaded file. Optional fields are only sent when configured, so updates
-// do not reset settings managed in the Iru dashboard.
+// uploaded file. Creating applies the documented defaults; updates only send
+// the new file plus explicitly configured fields, so they do not reset
+// settings managed in the Iru dashboard.
 func (p Pipe) createOrUpdate(ctx *context.Context, cfg config.Iru, name, fileKey string) (*customApp, error) {
 	form := url.Values{}
-	form.Set("name", name)
 	form.Set("file_key", fileKey)
-	form.Set("install_type", cfg.InstallType)
-	form.Set("install_enforcement", cfg.InstallEnforcement)
+	if cfg.LibraryItemID == "" {
+		form.Set("name", name)
+		form.Set("install_type", effectiveInstallType(cfg))
+		form.Set("install_enforcement", effectiveInstallEnforcement(cfg))
+	} else {
+		if cfg.Name != "" {
+			form.Set("name", name)
+		}
+		if cfg.InstallType != "" {
+			form.Set("install_type", cfg.InstallType)
+		}
+		if cfg.InstallEnforcement != "" {
+			form.Set("install_enforcement", cfg.InstallEnforcement)
+		}
+	}
 	for key, value := range map[string]string{
 		"unzip_location":           cfg.UnzipLocation,
 		"audit_script":             cfg.AuditScript,

--- a/internal/pipe/iru/iru.go
+++ b/internal/pipe/iru/iru.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -52,13 +53,25 @@ func (p Pipe) Publish(ctx *context.Context) error {
 		return pipe.Skip("iru.disable is set")
 	}
 
+	rawItemID := cfg.LibraryItemID
 	if err := t.ApplyAll(
 		&cfg.URL,
 		&cfg.APIToken,
 		&cfg.LibraryItemID,
-		&cfg.SelfServiceCategoryID,
 	); err != nil {
 		return fmt.Errorf("could not apply templates: %w", err)
+	}
+	if rawItemID != "" && cfg.LibraryItemID == "" {
+		// Otherwise this would silently create a new Custom App instead of
+		// updating the intended one.
+		return errors.New("library_item_id templated to an empty string")
+	}
+	if cfg.SelfServiceCategoryID != nil {
+		id, err := t.Apply(*cfg.SelfServiceCategoryID)
+		if err != nil {
+			return fmt.Errorf("could not apply templates: %w", err)
+		}
+		cfg.SelfServiceCategoryID = &id
 	}
 	cfg.URL = strings.TrimRight(cfg.URL, "/")
 	if cfg.URL == "" {
@@ -72,20 +85,27 @@ func (p Pipe) Publish(ctx *context.Context) error {
 		return err
 	}
 
-	artifacts := ctx.Artifacts.Filter(artifact.And(
+	selected := artifact.And(
 		artifact.ByTypes(
 			artifact.UploadableArchive,
 			artifact.UploadableBinary,
-			artifact.UploadableFile,
 		),
 		artifact.ByIDs(cfg.IDs...),
-	)).List()
+	)
+	// Custom Apps only install on macOS, so artifacts built for other
+	// operating systems are filtered out instead of failing the release, the
+	// same way the other OS-specific pipes do it.
+	artifacts := ctx.Artifacts.Filter(artifact.And(selected, artifact.ByGoos("darwin"))).List()
 	if len(artifacts) == 0 {
+		if len(ctx.Artifacts.Filter(selected).List()) > 0 {
+			return pipe.Skip("no macOS artifacts found matching the given filters")
+		}
 		return pipe.Skip("no artifacts found matching the given filters")
 	}
 	if cfg.LibraryItemID != "" && len(artifacts) > 1 {
 		return fmt.Errorf(
-			"library_item_id is set, but %d artifacts matched: use iru.ids to select a single artifact",
+			"library_item_id is set, but %d artifacts matched: a Custom App holds a single file, "+
+				"so use iru.ids to select one artifact, or build a universal binary",
 			len(artifacts),
 		)
 	}
@@ -121,27 +141,79 @@ func effectiveInstallEnforcement(cfg config.Iru) string {
 	return cfg.InstallEnforcement
 }
 
+// knownStr returns the value of an optional string field, and whether that
+// value is known: it is when the field is configured, and when creating, where
+// leaving it out means empty. When updating, an unconfigured field keeps the
+// value of the existing library item, which is not known here.
+func knownStr(s *string, creating bool) (string, bool) {
+	if s != nil {
+		return *s, true
+	}
+	return "", creating
+}
+
+// knownBool is knownStr for optional booleans, which default to false.
+func knownBool(b *bool, creating bool) (bool, bool) {
+	if b != nil {
+		return *b, true
+	}
+	return false, creating
+}
+
 // validate checks the field combinations required by the Iru API, so
-// misconfigurations fail before anything is uploaded.
+// misconfigurations fail before anything is uploaded. Every rule only applies
+// when all the values it involves are known, which means creating is fully
+// validated, while updating rejects the combinations it can actually see.
 func validate(cfg config.Iru) error {
+	creating := cfg.LibraryItemID == ""
 	installType := effectiveInstallType(cfg)
 	enforcement := effectiveInstallEnforcement(cfg)
-	selfService := cfg.ShowInSelfService != nil && *cfg.ShowInSelfService
+	unzipLocation, unzipKnown := knownStr(cfg.UnzipLocation, creating)
+	auditScript, auditKnown := knownStr(cfg.AuditScript, creating)
+	categoryID, categoryKnown := knownStr(cfg.SelfServiceCategoryID, creating)
+	selfService, selfServiceKnown := knownBool(cfg.ShowInSelfService, creating)
+	recommended, recommendedKnown := knownBool(cfg.SelfServiceRecommended, creating)
 
-	if installType == "zip" && cfg.UnzipLocation == "" {
-		return errors.New("install_type is zip, but unzip_location is not set")
+	if installType != "" {
+		if _, ok := installTypeExts[installType]; !ok {
+			return fmt.Errorf("invalid install_type: %s", installType)
+		}
 	}
-	if enforcement == "continuously_enforce" && cfg.AuditScript == "" {
-		return errors.New("install_enforcement is continuously_enforce, but audit_script is not set")
+	if enforcement != "" && !slices.Contains(installEnforcements, enforcement) {
+		return fmt.Errorf("invalid install_enforcement: %s", enforcement)
 	}
-	if enforcement != "" && enforcement != "continuously_enforce" && cfg.AuditScript != "" {
-		return fmt.Errorf("audit_script is set, but install_enforcement is %s instead of continuously_enforce", enforcement)
+	if unzipKnown && installType != "" {
+		if installType == "zip" && unzipLocation == "" {
+			return errors.New("install_type is zip, but unzip_location is not set")
+		}
+		if installType != "zip" && unzipLocation != "" {
+			return fmt.Errorf("unzip_location is set, but install_type is %s instead of zip", installType)
+		}
 	}
-	if enforcement == "no_enforcement" && !selfService {
+	if auditKnown && enforcement != "" {
+		if enforcement == "continuously_enforce" && auditScript == "" {
+			return errors.New("install_enforcement is continuously_enforce, but audit_script is not set")
+		}
+		if enforcement != "continuously_enforce" && auditScript != "" {
+			return fmt.Errorf(
+				"audit_script is set, but install_enforcement is %s instead of continuously_enforce",
+				enforcement,
+			)
+		}
+	}
+	if enforcement == "no_enforcement" && selfServiceKnown && !selfService {
 		return errors.New("install_enforcement is no_enforcement, but show_in_self_service is not enabled")
 	}
-	if selfService && cfg.SelfServiceCategoryID == "" {
-		return errors.New("show_in_self_service is enabled, but self_service_category_id is not set")
+	if recommendedKnown && recommended && selfServiceKnown && !selfService {
+		return errors.New("self_service_recommended is enabled, but show_in_self_service is not enabled")
+	}
+	if categoryKnown && selfServiceKnown {
+		if selfService && categoryID == "" {
+			return errors.New("show_in_self_service is enabled, but self_service_category_id is not set")
+		}
+		if !selfService && categoryID != "" {
+			return errors.New("self_service_category_id is set, but show_in_self_service is not enabled")
+		}
 	}
 	return nil
 }
@@ -154,27 +226,40 @@ var installTypeExts = map[string]string{
 	"image":   ".dmg",
 }
 
-// validateArtifact ensures the artifact matches the install type, so
-// incompatible files (e.g. Linux binaries or tarballs from a cross-platform
-// release) fail before anything is uploaded.
+// installEnforcements lists the enforcement values the Iru API accepts.
+var installEnforcements = []string{"install_once", "continuously_enforce", "no_enforcement"}
+
+// supportedExts lists every extension a Custom App file can have, in a stable
+// order for error messages.
+var supportedExts = []string{".dmg", ".pkg", ".zip"}
+
+// validateArtifact ensures the artifact can be installed as a Custom App, so
+// incompatible files from a cross-platform release fail before anything is
+// uploaded.
 func validateArtifact(cfg config.Iru, art *artifact.Artifact) error {
+	// Updating with install_type unset keeps the type of the existing library
+	// item, which is not known here, so any supported file is accepted.
+	exts := supportedExts
 	installType := effectiveInstallType(cfg)
-	if installType == "" {
-		// Updating with install_type unset keeps the type configured on the
-		// existing library item, which is not known here.
-		return nil
+	if installType != "" {
+		exts = []string{installTypeExts[installType]}
 	}
-	ext, ok := installTypeExts[installType]
-	if !ok {
-		return fmt.Errorf("invalid install_type: %s", installType)
+	name := strings.ToLower(art.Name)
+	for _, ext := range exts {
+		if strings.HasSuffix(name, ext) {
+			return nil
+		}
 	}
-	if !strings.HasSuffix(strings.ToLower(art.Name), ext) {
+	if installType != "" {
 		return fmt.Errorf(
 			"artifact %q is not compatible with install_type %s: use iru.ids to select only %s artifacts",
-			art.Name, installType, ext,
+			art.Name, installType, exts[0],
 		)
 	}
-	return nil
+	return fmt.Errorf(
+		"artifact %q is not a Custom App file: use iru.ids to select only %s artifacts",
+		art.Name, strings.Join(exts, ", "),
+	)
 }
 
 func (p Pipe) publishArtifact(ctx *context.Context, cfg config.Iru, art *artifact.Artifact) error {
@@ -314,20 +399,23 @@ func (p Pipe) createOrUpdate(ctx *context.Context, cfg config.Iru, name, fileKey
 			form.Set("install_enforcement", cfg.InstallEnforcement)
 		}
 	}
-	for key, value := range map[string]string{
+	// Only configured fields are sent, but an explicitly empty value is
+	// configured too: it clears the field on the library item.
+	for key, value := range map[string]*string{
 		"unzip_location":           cfg.UnzipLocation,
 		"audit_script":             cfg.AuditScript,
 		"preinstall_script":        cfg.PreinstallScript,
 		"postinstall_script":       cfg.PostinstallScript,
 		"self_service_category_id": cfg.SelfServiceCategoryID,
 	} {
-		if value != "" {
-			form.Set(key, value)
+		if value != nil {
+			form.Set(key, *value)
 		}
 	}
 	for key, value := range map[string]*bool{
 		"show_in_self_service":     cfg.ShowInSelfService,
 		"self_service_recommended": cfg.SelfServiceRecommended,
+		"active":                   cfg.Active,
 		"restart":                  cfg.Restart,
 	} {
 		if value != nil {

--- a/internal/pipe/iru/iru.go
+++ b/internal/pipe/iru/iru.go
@@ -27,7 +27,10 @@ import (
 )
 
 const (
-	defaultInstallType        = "package"
+	// The API requires install_type and install_enforcement, it does not
+	// default them, so the pipe picks the values that fit a macOS archive
+	// built by GoReleaser.
+	defaultInstallType        = "zip"
 	defaultInstallEnforcement = "install_once"
 	tokenEnvKey               = "IRU_API_TOKEN"
 )
@@ -152,7 +155,7 @@ func knownStr(s *string, creating bool) (string, bool) {
 	return "", creating
 }
 
-// knownBool is knownStr for optional booleans, which default to false.
+// knownBool is knownStr for the optional booleans that default to false.
 func knownBool(b *bool, creating bool) (bool, bool) {
 	if b != nil {
 		return *b, true
@@ -242,7 +245,11 @@ func validateArtifact(cfg config.Iru, art *artifact.Artifact) error {
 	exts := supportedExts
 	installType := effectiveInstallType(cfg)
 	if installType != "" {
-		exts = []string{installTypeExts[installType]}
+		ext, ok := installTypeExts[installType]
+		if !ok {
+			return fmt.Errorf("invalid install_type: %s", installType)
+		}
+		exts = []string{ext}
 	}
 	name := strings.ToLower(art.Name)
 	for _, ext := range exts {

--- a/internal/pipe/iru/iru_test.go
+++ b/internal/pipe/iru/iru_test.go
@@ -1,0 +1,605 @@
+package iru
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/goreleaser/goreleaser/v2/internal/artifact"
+	"github.com/goreleaser/goreleaser/v2/internal/skips"
+	"github.com/goreleaser/goreleaser/v2/internal/testctx"
+	"github.com/goreleaser/goreleaser/v2/internal/testlib"
+	"github.com/goreleaser/goreleaser/v2/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringer(t *testing.T) {
+	require.NotEmpty(t, Pipe{}.String())
+}
+
+func TestContinueOnError(t *testing.T) {
+	require.True(t, Pipe{}.ContinueOnError())
+}
+
+func TestSkip(t *testing.T) {
+	t.Run("skip flag", func(t *testing.T) {
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			Iru: config.Iru{URL: "https://acme.api.kandji.io"},
+		})
+		skips.Set(ctx, skips.Iru)
+		require.True(t, Pipe{}.Skip(ctx))
+	})
+
+	t.Run("skip no url", func(t *testing.T) {
+		ctx := testctx.Wrap(t.Context())
+		require.True(t, Pipe{}.Skip(ctx))
+	})
+
+	t.Run("dont skip", func(t *testing.T) {
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			Iru: config.Iru{URL: "https://acme.api.kandji.io"},
+		})
+		require.False(t, Pipe{}.Skip(ctx))
+	})
+}
+
+func TestDefault(t *testing.T) {
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		ProjectName: "myapp",
+		Iru:         config.Iru{URL: "https://acme.api.kandji.io"},
+	})
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, "myapp", ctx.Config.Iru.Name)
+	require.Equal(t, "package", ctx.Config.Iru.InstallType)
+	require.Equal(t, "install_once", ctx.Config.Iru.InstallEnforcement)
+}
+
+func TestDefaultKeepsUserValues(t *testing.T) {
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		ProjectName: "myapp",
+		Iru: config.Iru{
+			Name:               "Custom Name",
+			APIToken:           "token",
+			InstallType:        "zip",
+			InstallEnforcement: "no_enforcement",
+		},
+	})
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, "Custom Name", ctx.Config.Iru.Name)
+	require.Equal(t, "token", ctx.Config.Iru.APIToken)
+	require.Equal(t, "zip", ctx.Config.Iru.InstallType)
+	require.Equal(t, "no_enforcement", ctx.Config.Iru.InstallEnforcement)
+}
+
+func TestPublishDisabled(t *testing.T) {
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL:     "https://acme.api.kandji.io",
+			Name:    "myapp",
+			Disable: "true",
+		},
+	})
+	testlib.AssertSkipped(t, Pipe{}.Publish(ctx))
+}
+
+func TestPublishMissingToken(t *testing.T) {
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL:  "https://acme.api.kandji.io",
+			Name: "myapp",
+		},
+	})
+	require.ErrorContains(t, Pipe{}.Publish(ctx), "missing API token")
+}
+
+func TestPublishTokenFromEnv(t *testing.T) {
+	srv := newTestServer(t)
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		ProjectName: "myapp",
+		Iru: config.Iru{
+			URL:                srv.URL,
+			Name:               "My App",
+			InstallType:        "package",
+			InstallEnforcement: "install_once",
+		},
+	}, testctx.WithEnv(map[string]string{"IRU_API_TOKEN": "token"}))
+	ctx.Artifacts.Add(testArtifact(t))
+
+	require.NoError(t, Pipe{}.Publish(ctx))
+	require.Equal(t, 1, srv.uploadInits)
+}
+
+func TestPublishNoArtifacts(t *testing.T) {
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL:      "https://acme.api.kandji.io",
+			Name:     "myapp",
+			APIToken: "token",
+		},
+	})
+	testlib.AssertSkipped(t, Pipe{}.Publish(ctx))
+}
+
+func TestPublishUpdateWithMultipleArtifacts(t *testing.T) {
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL:           "https://acme.api.kandji.io",
+			Name:          "myapp",
+			APIToken:      "token",
+			LibraryItemID: "some-id",
+		},
+	})
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name: "a.pkg", Path: "a.pkg", Type: artifact.UploadableFile,
+	})
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name: "b.pkg", Path: "b.pkg", Type: artifact.UploadableFile,
+	})
+	require.ErrorContains(t, Pipe{}.Publish(ctx), "library_item_id is set")
+}
+
+type testServer struct {
+	*httptest.Server
+
+	// mu guards the fields below: the pipe publishes artifacts in
+	// parallel, so handlers run concurrently.
+	mu             sync.Mutex
+	uploadInits    int
+	s3Uploads      int
+	s3Fields       map[string]string
+	s3FileContent  string
+	saveCalls      int
+	saveMethod     string
+	savePath       string
+	saveForm       map[string]string
+	failInitStatus int
+	failS3Status   int
+	failSaveStatus int
+	failSaveTimes  int
+	emptyUploadRes bool
+}
+
+func newTestServer(tb testing.TB) *testServer {
+	tb.Helper()
+	ts := &testServer{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/library/custom-apps/upload", func(w http.ResponseWriter, r *http.Request) {
+		ts.mu.Lock()
+		defer ts.mu.Unlock()
+		ts.uploadInits++
+		if r.Header.Get("Authorization") != "Bearer token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if ts.failInitStatus != 0 {
+			w.WriteHeader(ts.failInitStatus)
+			return
+		}
+		var body struct {
+			Name string `json:"name"`
+		}
+		assert.NoError(tb, json.NewDecoder(r.Body).Decode(&body))
+		assert.NotEmpty(tb, body.Name)
+		if ts.emptyUploadRes {
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte("{}"))
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"post_url": ts.URL + "/s3-upload",
+			"post_data": map[string]string{
+				"key":    "companies/xyz/" + body.Name,
+				"policy": "some-policy",
+			},
+			"file_key": "companies/xyz/" + body.Name,
+		})
+	})
+	mux.HandleFunc("POST /s3-upload", func(w http.ResponseWriter, r *http.Request) {
+		ts.mu.Lock()
+		defer ts.mu.Unlock()
+		ts.s3Uploads++
+		// S3 rejects requests without a Content-Length with a 411.
+		if r.ContentLength <= 0 {
+			w.WriteHeader(http.StatusLengthRequired)
+			return
+		}
+		if ts.failS3Status != 0 {
+			w.WriteHeader(ts.failS3Status)
+			return
+		}
+		if !assert.NoError(tb, r.ParseMultipartForm(1<<20)) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		ts.s3Fields = map[string]string{}
+		for k, v := range r.MultipartForm.Value {
+			ts.s3Fields[k] = v[0]
+		}
+		file, _, err := r.FormFile("file")
+		if !assert.NoError(tb, err) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		content, err := io.ReadAll(file)
+		assert.NoError(tb, err)
+		ts.s3FileContent = string(content)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	saveHandler := func(w http.ResponseWriter, r *http.Request) {
+		ts.mu.Lock()
+		defer ts.mu.Unlock()
+		ts.saveCalls++
+		if r.Header.Get("Authorization") != "Bearer token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if ts.failSaveStatus != 0 {
+			w.WriteHeader(ts.failSaveStatus)
+			return
+		}
+		// Simulates the API rejecting the create right after the S3 upload
+		// with "The upload is still being processed".
+		if ts.failSaveTimes > 0 {
+			ts.failSaveTimes--
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"detail":"The upload is still being processed."}`))
+			return
+		}
+		ts.saveMethod = r.Method
+		ts.savePath = r.URL.Path
+		assert.NoError(tb, r.ParseForm())
+		ts.saveForm = map[string]string{}
+		for k, v := range r.PostForm {
+			ts.saveForm[k] = v[0]
+		}
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusCreated)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"id":   "58429143-b55c-42d3-a9a3-7c699ddd0ce1",
+			"name": ts.saveForm["name"],
+		})
+	}
+	mux.HandleFunc("POST /api/v1/library/custom-apps", saveHandler)
+	mux.HandleFunc("PATCH /api/v1/library/custom-apps/{id}", saveHandler)
+	ts.Server = httptest.NewServer(mux)
+	tb.Cleanup(ts.Close)
+	return ts
+}
+
+const testFileContent = "fake pkg content"
+
+func testArtifact(tb testing.TB) *artifact.Artifact {
+	tb.Helper()
+	// The on-disk file name intentionally differs from the artifact name to
+	// ensure uploads are named after the artifact, not its path.
+	path := filepath.Join(tb.TempDir(), "binary")
+	require.NoError(tb, os.WriteFile(path, []byte(testFileContent), 0o644))
+	return &artifact.Artifact{
+		Name: "myapp.pkg",
+		Path: path,
+		Type: artifact.UploadableArchive,
+		Extra: map[string]any{
+			artifact.ExtraID: "default",
+		},
+	}
+}
+
+func TestPublish(t *testing.T) {
+	srv := newTestServer(t)
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		ProjectName: "myapp",
+		Iru: config.Iru{
+			URL:                   srv.URL,
+			Name:                  "My App {{ .Version }}",
+			APIToken:              "token",
+			InstallType:           "package",
+			InstallEnforcement:    "install_once",
+			ShowInSelfService:     new(true),
+			SelfServiceCategoryID: "cat-id",
+		},
+	}, testctx.WithVersion("1.2.3"))
+	ctx.Artifacts.Add(testArtifact(t))
+
+	require.NoError(t, Pipe{}.Publish(ctx))
+
+	require.Equal(t, 1, srv.uploadInits)
+	require.Equal(t, 1, srv.s3Uploads)
+	require.Equal(t, "companies/xyz/myapp.pkg", srv.s3Fields["key"])
+	require.Equal(t, "some-policy", srv.s3Fields["policy"])
+	require.Equal(t, testFileContent, srv.s3FileContent)
+
+	require.Equal(t, http.MethodPost, srv.saveMethod)
+	require.Equal(t, "/api/v1/library/custom-apps", srv.savePath)
+	require.Equal(t, "My App 1.2.3", srv.saveForm["name"])
+	require.Equal(t, "companies/xyz/myapp.pkg", srv.saveForm["file_key"])
+	require.Equal(t, "package", srv.saveForm["install_type"])
+	require.Equal(t, "install_once", srv.saveForm["install_enforcement"])
+	require.Equal(t, "true", srv.saveForm["show_in_self_service"])
+	require.Equal(t, "cat-id", srv.saveForm["self_service_category_id"])
+	require.NotContains(t, srv.saveForm, "restart")
+	require.NotContains(t, srv.saveForm, "self_service_recommended")
+	require.NotContains(t, srv.saveForm, "unzip_location")
+	require.NotContains(t, srv.saveForm, "preinstall_script")
+}
+
+func TestPublishUpdate(t *testing.T) {
+	srv := newTestServer(t)
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		ProjectName: "myapp",
+		Iru: config.Iru{
+			URL:                srv.URL,
+			Name:               "My App",
+			APIToken:           "token",
+			LibraryItemID:      "some-lib-id",
+			InstallType:        "package",
+			InstallEnforcement: "install_once",
+		},
+	})
+	ctx.Artifacts.Add(testArtifact(t))
+
+	require.NoError(t, Pipe{}.Publish(ctx))
+
+	require.Equal(t, http.MethodPatch, srv.saveMethod)
+	require.Equal(t, "/api/v1/library/custom-apps/some-lib-id", srv.savePath)
+	require.Equal(t, "companies/xyz/myapp.pkg", srv.saveForm["file_key"])
+}
+
+func TestPublishInitUploadError(t *testing.T) {
+	srv := newTestServer(t)
+	srv.failInitStatus = http.StatusBadRequest
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL:      srv.URL,
+			Name:     "My App",
+			APIToken: "token",
+		},
+	})
+	ctx.Artifacts.Add(testArtifact(t))
+
+	require.ErrorContains(t, Pipe{}.Publish(ctx), "could not initialize upload")
+	require.Equal(t, 0, srv.s3Uploads)
+}
+
+func TestPublishValidation(t *testing.T) {
+	for name, cfg := range map[string]config.Iru{
+		"zip without unzip_location": {
+			InstallType: "zip",
+		},
+		"continuously_enforce without audit_script": {
+			InstallEnforcement: "continuously_enforce",
+		},
+		"self service without category": {
+			ShowInSelfService: new(true),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg.URL = "https://acme.api.kandji.io"
+			cfg.APIToken = "token"
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{Iru: cfg})
+			require.ErrorContains(t, Pipe{}.Publish(ctx), "is not set")
+		})
+	}
+}
+
+func TestPublishEmptyTemplatedURL(t *testing.T) {
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL:      "{{ .Env.IRU_URL }}",
+			APIToken: "token",
+		},
+	}, testctx.WithEnv(map[string]string{"IRU_URL": ""}))
+	require.ErrorContains(t, Pipe{}.Publish(ctx), "url templated to an empty string")
+}
+
+func TestPublishCreateRetriesWhileProcessing(t *testing.T) {
+	srv := newTestServer(t)
+	srv.failSaveTimes = 2
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL:      srv.URL,
+			Name:     "My App",
+			APIToken: "token",
+		},
+		Retry: config.Retry{
+			Attempts: 5,
+			Delay:    time.Millisecond,
+			MaxDelay: time.Millisecond,
+		},
+	})
+	ctx.Artifacts.Add(testArtifact(t))
+
+	require.NoError(t, Pipe{}.Publish(ctx))
+	require.Equal(t, http.MethodPost, srv.saveMethod)
+	require.Equal(t, 3, srv.saveCalls)
+}
+
+func TestPublishCreateDoesNotRetryAmbiguousErrors(t *testing.T) {
+	srv := newTestServer(t)
+	srv.failSaveStatus = http.StatusBadGateway
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL:      srv.URL,
+			Name:     "My App",
+			APIToken: "token",
+		},
+		Retry: config.Retry{
+			Attempts: 5,
+			Delay:    time.Millisecond,
+			MaxDelay: time.Millisecond,
+		},
+	})
+	ctx.Artifacts.Add(testArtifact(t))
+
+	require.ErrorContains(t, Pipe{}.Publish(ctx), "could not save custom app")
+	require.Equal(t, 1, srv.saveCalls)
+}
+
+func TestPublishMultipleArtifacts(t *testing.T) {
+	srv := newTestServer(t)
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL:      srv.URL,
+			Name:     "My App {{ .ArtifactName }}",
+			APIToken: "token",
+		},
+	})
+	first := testArtifact(t)
+	second := testArtifact(t)
+	second.Name = "other.pkg"
+	ctx.Artifacts.Add(first)
+	ctx.Artifacts.Add(second)
+
+	require.NoError(t, Pipe{}.Publish(ctx))
+	require.Equal(t, 2, srv.uploadInits)
+	require.Equal(t, 2, srv.s3Uploads)
+}
+
+func TestPublishDisableTemplateError(t *testing.T) {
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL:     "https://acme.api.kandji.io",
+			Disable: "{{ .Nope }}",
+		},
+	})
+	require.ErrorContains(t, Pipe{}.Publish(ctx), "could not evaluate iru.disable")
+}
+
+func TestPublishURLTemplateError(t *testing.T) {
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL: "{{ .Nope }}",
+		},
+	})
+	require.ErrorContains(t, Pipe{}.Publish(ctx), "could not apply templates")
+}
+
+func TestPublishNameTemplateError(t *testing.T) {
+	srv := newTestServer(t)
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL:      srv.URL,
+			Name:     "{{ .Nope }}",
+			APIToken: "token",
+		},
+	})
+	ctx.Artifacts.Add(testArtifact(t))
+	require.ErrorContains(t, Pipe{}.Publish(ctx), "could not apply templates to iru.name")
+}
+
+func TestPublishInvalidUploadResponse(t *testing.T) {
+	srv := newTestServer(t)
+	srv.emptyUploadRes = true
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL:      srv.URL,
+			Name:     "My App",
+			APIToken: "token",
+		},
+	})
+	ctx.Artifacts.Add(testArtifact(t))
+	require.ErrorContains(t, Pipe{}.Publish(ctx), "missing post_url or file_key")
+}
+
+func TestPublishS3UploadError(t *testing.T) {
+	srv := newTestServer(t)
+	srv.failS3Status = http.StatusForbidden
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL:      srv.URL,
+			Name:     "My App",
+			APIToken: "token",
+		},
+	})
+	ctx.Artifacts.Add(testArtifact(t))
+	require.ErrorContains(t, Pipe{}.Publish(ctx), "could not upload file")
+	require.Empty(t, srv.saveMethod)
+}
+
+func TestPublishCreateError(t *testing.T) {
+	srv := newTestServer(t)
+	srv.failSaveStatus = http.StatusForbidden
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL:      srv.URL,
+			Name:     "My App",
+			APIToken: "token",
+		},
+	})
+	ctx.Artifacts.Add(testArtifact(t))
+	require.ErrorContains(t, Pipe{}.Publish(ctx), "could not save custom app")
+}
+
+func TestPublishUpdateError(t *testing.T) {
+	srv := newTestServer(t)
+	srv.failSaveStatus = http.StatusNotFound
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL:           srv.URL,
+			Name:          "My App",
+			APIToken:      "token",
+			LibraryItemID: "some-lib-id",
+		},
+	})
+	ctx.Artifacts.Add(testArtifact(t))
+	require.ErrorContains(t, Pipe{}.Publish(ctx), "could not save custom app")
+}
+
+func TestPublishMissingFile(t *testing.T) {
+	srv := newTestServer(t)
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL:      srv.URL,
+			Name:     "My App",
+			APIToken: "token",
+		},
+	})
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name: "gone.pkg",
+		Path: filepath.Join(t.TempDir(), "does-not-exist"),
+		Type: artifact.UploadableArchive,
+	})
+	require.ErrorContains(t, Pipe{}.Publish(ctx), "could not upload file")
+}
+
+func TestPublishServerUnreachable(t *testing.T) {
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL:      "http://127.0.0.1:1",
+			Name:     "My App",
+			APIToken: "token",
+		},
+	})
+	ctx.Artifacts.Add(testArtifact(t))
+	require.ErrorContains(t, Pipe{}.Publish(ctx), "could not initialize upload")
+}
+
+func TestPublishFilterByIDs(t *testing.T) {
+	srv := newTestServer(t)
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		ProjectName: "myapp",
+		Iru: config.Iru{
+			URL:                srv.URL,
+			Name:               "My App",
+			APIToken:           "token",
+			IDs:                []string{"other"},
+			InstallType:        "package",
+			InstallEnforcement: "install_once",
+		},
+	})
+	art := testArtifact(t)
+	art.Type = artifact.UploadableArchive
+	ctx.Artifacts.Add(art)
+
+	// artifact has ID "default", filter wants "other": nothing matches.
+	testlib.AssertSkipped(t, Pipe{}.Publish(ctx))
+	require.Equal(t, 0, srv.uploadInits)
+}

--- a/internal/pipe/iru/iru_test.go
+++ b/internal/pipe/iru/iru_test.go
@@ -161,7 +161,7 @@ func newTestServer(tb testing.TB) *testServer {
 		assert.NotEmpty(tb, body.Name)
 		if ts.emptyUploadRes {
 			w.WriteHeader(http.StatusCreated)
-			_, _ = w.Write([]byte("{}"))
+			_, _ = io.WriteString(w, "{}")
 			return
 		}
 		w.WriteHeader(http.StatusCreated)
@@ -222,7 +222,7 @@ func newTestServer(tb testing.TB) *testServer {
 		if ts.failSaveTimes > 0 {
 			ts.failSaveTimes--
 			w.WriteHeader(http.StatusServiceUnavailable)
-			_, _ = w.Write([]byte(`{"detail":"The upload is still being processed."}`))
+			_, _ = io.WriteString(w, `{"detail":"The upload is still being processed."}`)
 			return
 		}
 		ts.saveMethod = r.Method

--- a/internal/pipe/iru/iru_test.go
+++ b/internal/pipe/iru/iru_test.go
@@ -50,34 +50,6 @@ func TestSkip(t *testing.T) {
 	})
 }
 
-func TestDefault(t *testing.T) {
-	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
-		ProjectName: "myapp",
-		Iru:         config.Iru{URL: "https://acme.api.kandji.io"},
-	})
-	require.NoError(t, Pipe{}.Default(ctx))
-	require.Equal(t, "myapp", ctx.Config.Iru.Name)
-	require.Equal(t, "package", ctx.Config.Iru.InstallType)
-	require.Equal(t, "install_once", ctx.Config.Iru.InstallEnforcement)
-}
-
-func TestDefaultKeepsUserValues(t *testing.T) {
-	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
-		ProjectName: "myapp",
-		Iru: config.Iru{
-			Name:               "Custom Name",
-			APIToken:           "token",
-			InstallType:        "zip",
-			InstallEnforcement: "no_enforcement",
-		},
-	})
-	require.NoError(t, Pipe{}.Default(ctx))
-	require.Equal(t, "Custom Name", ctx.Config.Iru.Name)
-	require.Equal(t, "token", ctx.Config.Iru.APIToken)
-	require.Equal(t, "zip", ctx.Config.Iru.InstallType)
-	require.Equal(t, "no_enforcement", ctx.Config.Iru.InstallEnforcement)
-}
-
 func TestPublishDisabled(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Iru: config.Iru{
@@ -336,12 +308,9 @@ func TestPublishUpdate(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "myapp",
 		Iru: config.Iru{
-			URL:                srv.URL,
-			Name:               "My App",
-			APIToken:           "token",
-			LibraryItemID:      "some-lib-id",
-			InstallType:        "package",
-			InstallEnforcement: "install_once",
+			URL:           srv.URL,
+			APIToken:      "token",
+			LibraryItemID: "some-lib-id",
 		},
 	})
 	ctx.Artifacts.Add(testArtifact(t))
@@ -351,6 +320,33 @@ func TestPublishUpdate(t *testing.T) {
 	require.Equal(t, http.MethodPatch, srv.saveMethod)
 	require.Equal(t, "/api/v1/library/custom-apps/some-lib-id", srv.savePath)
 	require.Equal(t, "companies/xyz/myapp.pkg", srv.saveForm["file_key"])
+	// Updates only send explicitly configured fields, so settings managed
+	// in the Iru dashboard are kept.
+	require.NotContains(t, srv.saveForm, "name")
+	require.NotContains(t, srv.saveForm, "install_type")
+	require.NotContains(t, srv.saveForm, "install_enforcement")
+}
+
+func TestPublishUpdateSendsExplicitFields(t *testing.T) {
+	srv := newTestServer(t)
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		ProjectName: "myapp",
+		Iru: config.Iru{
+			URL:           srv.URL,
+			Name:          "My App",
+			APIToken:      "token",
+			LibraryItemID: "some-lib-id",
+			InstallType:   "package",
+		},
+	})
+	ctx.Artifacts.Add(testArtifact(t))
+
+	require.NoError(t, Pipe{}.Publish(ctx))
+
+	require.Equal(t, http.MethodPatch, srv.saveMethod)
+	require.Equal(t, "My App", srv.saveForm["name"])
+	require.Equal(t, "package", srv.saveForm["install_type"])
+	require.NotContains(t, srv.saveForm, "install_enforcement")
 }
 
 func TestPublishInitUploadError(t *testing.T) {
@@ -377,6 +373,12 @@ func TestPublishValidation(t *testing.T) {
 		"continuously_enforce without audit_script": {
 			InstallEnforcement: "continuously_enforce",
 		},
+		"audit_script without continuously_enforce": {
+			AuditScript: "#!/bin/zsh",
+		},
+		"no_enforcement without self service": {
+			InstallEnforcement: "no_enforcement",
+		},
 		"self service without category": {
 			ShowInSelfService: new(true),
 		},
@@ -385,9 +387,26 @@ func TestPublishValidation(t *testing.T) {
 			cfg.URL = "https://acme.api.kandji.io"
 			cfg.APIToken = "token"
 			ctx := testctx.WrapWithCfg(t.Context(), config.Project{Iru: cfg})
-			require.ErrorContains(t, Pipe{}.Publish(ctx), "is not set")
+			require.Error(t, Pipe{}.Publish(ctx))
 		})
 	}
+}
+
+func TestPublishArtifactInstallTypeMismatch(t *testing.T) {
+	srv := newTestServer(t)
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL:      srv.URL,
+			APIToken: "token",
+		},
+	})
+	// Default install_type is package, but the artifact is a tarball.
+	art := testArtifact(t)
+	art.Name = "myapp_linux_amd64.tar.gz"
+	ctx.Artifacts.Add(art)
+
+	require.ErrorContains(t, Pipe{}.Publish(ctx), "not compatible with install_type package")
+	require.Equal(t, 0, srv.uploadInits)
 }
 
 func TestPublishEmptyTemplatedURL(t *testing.T) {

--- a/internal/pipe/iru/iru_test.go
+++ b/internal/pipe/iru/iru_test.go
@@ -78,7 +78,8 @@ func TestPublishTokenFromEnv(t *testing.T) {
 		Iru: config.Iru{
 			URL:                srv.URL,
 			Name:               "My App",
-			InstallType:        "package",
+			InstallType:        "zip",
+			UnzipLocation:      new("/Applications"),
 			InstallEnforcement: "install_once",
 		},
 	}, testctx.WithEnv(map[string]string{"IRU_API_TOKEN": "token"}))
@@ -91,9 +92,10 @@ func TestPublishTokenFromEnv(t *testing.T) {
 func TestPublishNoArtifacts(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Iru: config.Iru{
-			URL:      "https://iru.invalid",
-			Name:     "myapp",
-			APIToken: "token",
+			URL:           "https://iru.invalid",
+			Name:          "myapp",
+			APIToken:      "token",
+			UnzipLocation: new("/Applications"),
 		},
 	})
 	testlib.AssertSkipped(t, Pipe{}.Publish(ctx))
@@ -256,7 +258,7 @@ func testArtifact(tb testing.TB) *artifact.Artifact {
 	path := filepath.Join(tb.TempDir(), "binary")
 	require.NoError(tb, os.WriteFile(path, []byte(testFileContent), 0o644))
 	return &artifact.Artifact{
-		Name: "myapp.pkg",
+		Name: "myapp.zip",
 		Path: path,
 		Goos: "darwin",
 		Type: artifact.UploadableArchive,
@@ -274,7 +276,8 @@ func TestPublish(t *testing.T) {
 			URL:                   srv.URL,
 			Name:                  "My App {{ .Version }}",
 			APIToken:              "token",
-			InstallType:           "package",
+			InstallType:           "zip",
+			UnzipLocation:         new("/Applications"),
 			InstallEnforcement:    "install_once",
 			ShowInSelfService:     new(true),
 			SelfServiceCategoryID: new("cat-id"),
@@ -287,22 +290,22 @@ func TestPublish(t *testing.T) {
 
 	require.Equal(t, 1, srv.uploadInits)
 	require.Equal(t, 1, srv.s3Uploads)
-	require.Equal(t, "companies/xyz/myapp.pkg", srv.s3Fields["key"])
+	require.Equal(t, "companies/xyz/myapp.zip", srv.s3Fields["key"])
 	require.Equal(t, "some-policy", srv.s3Fields["policy"])
 	require.Equal(t, testFileContent, srv.s3FileContent)
 
 	require.Equal(t, http.MethodPost, srv.saveMethod)
 	require.Equal(t, "/api/v1/library/custom-apps", srv.savePath)
 	require.Equal(t, "My App 1.2.3", srv.saveForm["name"])
-	require.Equal(t, "companies/xyz/myapp.pkg", srv.saveForm["file_key"])
-	require.Equal(t, "package", srv.saveForm["install_type"])
+	require.Equal(t, "companies/xyz/myapp.zip", srv.saveForm["file_key"])
+	require.Equal(t, "zip", srv.saveForm["install_type"])
 	require.Equal(t, "install_once", srv.saveForm["install_enforcement"])
 	require.Equal(t, "true", srv.saveForm["show_in_self_service"])
 	require.Equal(t, "cat-id", srv.saveForm["self_service_category_id"])
 	require.Equal(t, "false", srv.saveForm["active"])
 	require.NotContains(t, srv.saveForm, "restart")
 	require.NotContains(t, srv.saveForm, "self_service_recommended")
-	require.NotContains(t, srv.saveForm, "unzip_location")
+	require.Equal(t, "/Applications", srv.saveForm["unzip_location"])
 	require.NotContains(t, srv.saveForm, "preinstall_script")
 }
 
@@ -322,7 +325,7 @@ func TestPublishUpdate(t *testing.T) {
 
 	require.Equal(t, http.MethodPatch, srv.saveMethod)
 	require.Equal(t, "/api/v1/library/custom-apps/some-lib-id", srv.savePath)
-	require.Equal(t, "companies/xyz/myapp.pkg", srv.saveForm["file_key"])
+	require.Equal(t, "companies/xyz/myapp.zip", srv.saveForm["file_key"])
 	// Updates only send explicitly configured fields, so settings managed
 	// in the Iru dashboard are kept.
 	require.NotContains(t, srv.saveForm, "name")
@@ -340,7 +343,8 @@ func TestPublishUpdateSendsExplicitFields(t *testing.T) {
 			Name:          "My App",
 			APIToken:      "token",
 			LibraryItemID: "some-lib-id",
-			InstallType:   "package",
+			InstallType:   "zip",
+			Active:        new(true),
 		},
 	})
 	ctx.Artifacts.Add(testArtifact(t))
@@ -349,8 +353,19 @@ func TestPublishUpdateSendsExplicitFields(t *testing.T) {
 
 	require.Equal(t, http.MethodPatch, srv.saveMethod)
 	require.Equal(t, "My App", srv.saveForm["name"])
-	require.Equal(t, "package", srv.saveForm["install_type"])
+	require.Equal(t, "zip", srv.saveForm["install_type"])
+	require.Equal(t, "true", srv.saveForm["active"])
 	require.NotContains(t, srv.saveForm, "install_enforcement")
+}
+
+func TestValidateArtifactInvalidInstallType(t *testing.T) {
+	// Publish validates the install type before this is reached, so this
+	// guards against the extension check silently accepting everything.
+	err := validateArtifact(
+		config.Iru{InstallType: "nope"},
+		&artifact.Artifact{Name: "myapp.zip"},
+	)
+	require.ErrorContains(t, err, "invalid install_type: nope")
 }
 
 func TestPublishInitUploadError(t *testing.T) {
@@ -358,9 +373,10 @@ func TestPublishInitUploadError(t *testing.T) {
 	srv.failInitStatus = http.StatusBadRequest
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Iru: config.Iru{
-			URL:      srv.URL,
-			Name:     "My App",
-			APIToken: "token",
+			URL:           srv.URL,
+			Name:          "My App",
+			APIToken:      "token",
+			UnzipLocation: new("/Applications"),
 		},
 	})
 	ctx.Artifacts.Add(testArtifact(t))
@@ -388,27 +404,27 @@ func TestPublishValidation(t *testing.T) {
 			wantErr: "unzip_location is set, but install_type is package instead of zip",
 		},
 		"continuously_enforce without audit_script": {
-			cfg:     config.Iru{InstallEnforcement: "continuously_enforce"},
+			cfg:     config.Iru{UnzipLocation: new("/Applications"), InstallEnforcement: "continuously_enforce"},
 			wantErr: "install_enforcement is continuously_enforce, but audit_script is not set",
 		},
 		"audit_script without continuously_enforce": {
-			cfg:     config.Iru{AuditScript: new("#!/bin/zsh")},
+			cfg:     config.Iru{UnzipLocation: new("/Applications"), AuditScript: new("#!/bin/zsh")},
 			wantErr: "audit_script is set, but install_enforcement is install_once instead of continuously_enforce",
 		},
 		"no_enforcement without self service": {
-			cfg:     config.Iru{InstallEnforcement: "no_enforcement"},
+			cfg:     config.Iru{UnzipLocation: new("/Applications"), InstallEnforcement: "no_enforcement"},
 			wantErr: "install_enforcement is no_enforcement, but show_in_self_service is not enabled",
 		},
 		"self service without category": {
-			cfg:     config.Iru{ShowInSelfService: new(true)},
+			cfg:     config.Iru{UnzipLocation: new("/Applications"), ShowInSelfService: new(true)},
 			wantErr: "show_in_self_service is enabled, but self_service_category_id is not set",
 		},
 		"category without self service": {
-			cfg:     config.Iru{SelfServiceCategoryID: new("cat-id")},
+			cfg:     config.Iru{UnzipLocation: new("/Applications"), SelfServiceCategoryID: new("cat-id")},
 			wantErr: "self_service_category_id is set, but show_in_self_service is not enabled",
 		},
 		"recommended without self service": {
-			cfg:     config.Iru{SelfServiceRecommended: new(true)},
+			cfg:     config.Iru{UnzipLocation: new("/Applications"), SelfServiceRecommended: new(true)},
 			wantErr: "self_service_recommended is enabled, but show_in_self_service is not enabled",
 		},
 		"invalid install type": {
@@ -572,8 +588,9 @@ func TestPublishSkipsWhenOnlyNonMacOSArtifacts(t *testing.T) {
 	server := newTestServer(t)
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Iru: config.Iru{
-			URL:      server.URL,
-			APIToken: "token",
+			URL:           server.URL,
+			APIToken:      "token",
+			UnzipLocation: new("/Applications"),
 		},
 	})
 	art := testArtifact(t)
@@ -607,16 +624,17 @@ func TestPublishArtifactInstallTypeMismatch(t *testing.T) {
 	srv := newTestServer(t)
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Iru: config.Iru{
-			URL:      srv.URL,
-			APIToken: "token",
+			URL:           srv.URL,
+			APIToken:      "token",
+			UnzipLocation: new("/Applications"),
 		},
 	})
-	// Default install_type is package, but the artifact is a tarball.
+	// Default install_type is zip, but the artifact is a tarball.
 	art := testArtifact(t)
-	art.Name = "myapp_linux_amd64.tar.gz"
+	art.Name = "myapp_darwin_all.tar.gz"
 	ctx.Artifacts.Add(art)
 
-	require.ErrorContains(t, Pipe{}.Publish(ctx), "not compatible with install_type package")
+	require.ErrorContains(t, Pipe{}.Publish(ctx), "not compatible with install_type zip")
 	require.Equal(t, 0, srv.uploadInits)
 }
 
@@ -635,9 +653,10 @@ func TestPublishCreateRetriesWhileProcessing(t *testing.T) {
 	srv.failSaveTimes = 2
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Iru: config.Iru{
-			URL:      srv.URL,
-			Name:     "My App",
-			APIToken: "token",
+			URL:           srv.URL,
+			Name:          "My App",
+			APIToken:      "token",
+			UnzipLocation: new("/Applications"),
 		},
 		Retry: config.Retry{
 			Attempts: 5,
@@ -657,9 +676,10 @@ func TestPublishCreateDoesNotRetryAmbiguousErrors(t *testing.T) {
 	srv.failSaveStatus = http.StatusBadGateway
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Iru: config.Iru{
-			URL:      srv.URL,
-			Name:     "My App",
-			APIToken: "token",
+			URL:           srv.URL,
+			Name:          "My App",
+			APIToken:      "token",
+			UnzipLocation: new("/Applications"),
 		},
 		Retry: config.Retry{
 			Attempts: 5,
@@ -677,14 +697,15 @@ func TestPublishMultipleArtifacts(t *testing.T) {
 	srv := newTestServer(t)
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Iru: config.Iru{
-			URL:      srv.URL,
-			Name:     "My App {{ .ArtifactName }}",
-			APIToken: "token",
+			URL:           srv.URL,
+			Name:          "My App {{ .ArtifactName }}",
+			APIToken:      "token",
+			UnzipLocation: new("/Applications"),
 		},
 	})
 	first := testArtifact(t)
 	second := testArtifact(t)
-	second.Name = "other.pkg"
+	second.Name = "other.zip"
 	ctx.Artifacts.Add(first)
 	ctx.Artifacts.Add(second)
 
@@ -716,9 +737,10 @@ func TestPublishNameTemplateError(t *testing.T) {
 	srv := newTestServer(t)
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Iru: config.Iru{
-			URL:      srv.URL,
-			Name:     "{{ .Nope }}",
-			APIToken: "token",
+			URL:           srv.URL,
+			Name:          "{{ .Nope }}",
+			APIToken:      "token",
+			UnzipLocation: new("/Applications"),
 		},
 	})
 	ctx.Artifacts.Add(testArtifact(t))
@@ -730,9 +752,10 @@ func TestPublishInvalidUploadResponse(t *testing.T) {
 	srv.emptyUploadRes = true
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Iru: config.Iru{
-			URL:      srv.URL,
-			Name:     "My App",
-			APIToken: "token",
+			URL:           srv.URL,
+			Name:          "My App",
+			APIToken:      "token",
+			UnzipLocation: new("/Applications"),
 		},
 	})
 	ctx.Artifacts.Add(testArtifact(t))
@@ -744,9 +767,10 @@ func TestPublishS3UploadError(t *testing.T) {
 	srv.failS3Status = http.StatusForbidden
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Iru: config.Iru{
-			URL:      srv.URL,
-			Name:     "My App",
-			APIToken: "token",
+			URL:           srv.URL,
+			Name:          "My App",
+			APIToken:      "token",
+			UnzipLocation: new("/Applications"),
 		},
 	})
 	ctx.Artifacts.Add(testArtifact(t))
@@ -759,9 +783,10 @@ func TestPublishCreateError(t *testing.T) {
 	srv.failSaveStatus = http.StatusForbidden
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Iru: config.Iru{
-			URL:      srv.URL,
-			Name:     "My App",
-			APIToken: "token",
+			URL:           srv.URL,
+			Name:          "My App",
+			APIToken:      "token",
+			UnzipLocation: new("/Applications"),
 		},
 	})
 	ctx.Artifacts.Add(testArtifact(t))
@@ -787,13 +812,14 @@ func TestPublishMissingFile(t *testing.T) {
 	srv := newTestServer(t)
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Iru: config.Iru{
-			URL:      srv.URL,
-			Name:     "My App",
-			APIToken: "token",
+			URL:           srv.URL,
+			Name:          "My App",
+			APIToken:      "token",
+			UnzipLocation: new("/Applications"),
 		},
 	})
 	ctx.Artifacts.Add(&artifact.Artifact{
-		Name: "gone.pkg",
+		Name: "gone.zip",
 		Path: filepath.Join(t.TempDir(), "does-not-exist"),
 		Goos: "darwin",
 		Type: artifact.UploadableArchive,
@@ -804,9 +830,10 @@ func TestPublishMissingFile(t *testing.T) {
 func TestPublishServerUnreachable(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Iru: config.Iru{
-			URL:      "http://127.0.0.1:1",
-			Name:     "My App",
-			APIToken: "token",
+			URL:           "http://127.0.0.1:1",
+			Name:          "My App",
+			APIToken:      "token",
+			UnzipLocation: new("/Applications"),
 		},
 	})
 	ctx.Artifacts.Add(testArtifact(t))
@@ -822,7 +849,8 @@ func TestPublishFilterByIDs(t *testing.T) {
 			Name:               "My App",
 			APIToken:           "token",
 			IDs:                []string{"other"},
-			InstallType:        "package",
+			InstallType:        "zip",
+			UnzipLocation:      new("/Applications"),
 			InstallEnforcement: "install_once",
 		},
 	})

--- a/internal/pipe/iru/iru_test.go
+++ b/internal/pipe/iru/iru_test.go
@@ -31,7 +31,7 @@ func TestContinueOnError(t *testing.T) {
 func TestSkip(t *testing.T) {
 	t.Run("skip flag", func(t *testing.T) {
 		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
-			Iru: config.Iru{URL: "https://acme.api.kandji.io"},
+			Iru: config.Iru{URL: "https://iru.invalid"},
 		})
 		skips.Set(ctx, skips.Iru)
 		require.True(t, Pipe{}.Skip(ctx))
@@ -44,7 +44,7 @@ func TestSkip(t *testing.T) {
 
 	t.Run("dont skip", func(t *testing.T) {
 		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
-			Iru: config.Iru{URL: "https://acme.api.kandji.io"},
+			Iru: config.Iru{URL: "https://iru.invalid"},
 		})
 		require.False(t, Pipe{}.Skip(ctx))
 	})
@@ -53,7 +53,7 @@ func TestSkip(t *testing.T) {
 func TestPublishDisabled(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Iru: config.Iru{
-			URL:     "https://acme.api.kandji.io",
+			URL:     "https://iru.invalid",
 			Name:    "myapp",
 			Disable: "true",
 		},
@@ -64,7 +64,7 @@ func TestPublishDisabled(t *testing.T) {
 func TestPublishMissingToken(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Iru: config.Iru{
-			URL:  "https://acme.api.kandji.io",
+			URL:  "https://iru.invalid",
 			Name: "myapp",
 		},
 	})
@@ -91,7 +91,7 @@ func TestPublishTokenFromEnv(t *testing.T) {
 func TestPublishNoArtifacts(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Iru: config.Iru{
-			URL:      "https://acme.api.kandji.io",
+			URL:      "https://iru.invalid",
 			Name:     "myapp",
 			APIToken: "token",
 		},
@@ -102,17 +102,17 @@ func TestPublishNoArtifacts(t *testing.T) {
 func TestPublishUpdateWithMultipleArtifacts(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Iru: config.Iru{
-			URL:           "https://acme.api.kandji.io",
+			URL:           "https://iru.invalid",
 			Name:          "myapp",
 			APIToken:      "token",
 			LibraryItemID: "some-id",
 		},
 	})
 	ctx.Artifacts.Add(&artifact.Artifact{
-		Name: "a.pkg", Path: "a.pkg", Type: artifact.UploadableFile,
+		Name: "a.pkg", Path: "a.pkg", Goos: "darwin", Type: artifact.UploadableArchive,
 	})
 	ctx.Artifacts.Add(&artifact.Artifact{
-		Name: "b.pkg", Path: "b.pkg", Type: artifact.UploadableFile,
+		Name: "b.pkg", Path: "b.pkg", Goos: "darwin", Type: artifact.UploadableArchive,
 	})
 	require.ErrorContains(t, Pipe{}.Publish(ctx), "library_item_id is set")
 }
@@ -258,6 +258,7 @@ func testArtifact(tb testing.TB) *artifact.Artifact {
 	return &artifact.Artifact{
 		Name: "myapp.pkg",
 		Path: path,
+		Goos: "darwin",
 		Type: artifact.UploadableArchive,
 		Extra: map[string]any{
 			artifact.ExtraID: "default",
@@ -276,7 +277,8 @@ func TestPublish(t *testing.T) {
 			InstallType:           "package",
 			InstallEnforcement:    "install_once",
 			ShowInSelfService:     new(true),
-			SelfServiceCategoryID: "cat-id",
+			SelfServiceCategoryID: new("cat-id"),
+			Active:                new(false),
 		},
 	}, testctx.WithVersion("1.2.3"))
 	ctx.Artifacts.Add(testArtifact(t))
@@ -297,6 +299,7 @@ func TestPublish(t *testing.T) {
 	require.Equal(t, "install_once", srv.saveForm["install_enforcement"])
 	require.Equal(t, "true", srv.saveForm["show_in_self_service"])
 	require.Equal(t, "cat-id", srv.saveForm["self_service_category_id"])
+	require.Equal(t, "false", srv.saveForm["active"])
 	require.NotContains(t, srv.saveForm, "restart")
 	require.NotContains(t, srv.saveForm, "self_service_recommended")
 	require.NotContains(t, srv.saveForm, "unzip_location")
@@ -325,6 +328,7 @@ func TestPublishUpdate(t *testing.T) {
 	require.NotContains(t, srv.saveForm, "name")
 	require.NotContains(t, srv.saveForm, "install_type")
 	require.NotContains(t, srv.saveForm, "install_enforcement")
+	require.NotContains(t, srv.saveForm, "active")
 }
 
 func TestPublishUpdateSendsExplicitFields(t *testing.T) {
@@ -365,31 +369,238 @@ func TestPublishInitUploadError(t *testing.T) {
 	require.Equal(t, 0, srv.s3Uploads)
 }
 
+// validationCase is a config that must be rejected, along with the message of
+// the rule that has to reject it: asserting the message keeps these tables from
+// passing for another reason, e.g. because no artifact matched.
+type validationCase struct {
+	cfg     config.Iru
+	wantErr string
+}
+
 func TestPublishValidation(t *testing.T) {
-	for name, cfg := range map[string]config.Iru{
+	for name, tt := range map[string]validationCase{
 		"zip without unzip_location": {
-			InstallType: "zip",
+			cfg:     config.Iru{InstallType: "zip"},
+			wantErr: "install_type is zip, but unzip_location is not set",
+		},
+		"unzip_location without zip": {
+			cfg:     config.Iru{InstallType: "package", UnzipLocation: new("/Applications")},
+			wantErr: "unzip_location is set, but install_type is package instead of zip",
 		},
 		"continuously_enforce without audit_script": {
-			InstallEnforcement: "continuously_enforce",
+			cfg:     config.Iru{InstallEnforcement: "continuously_enforce"},
+			wantErr: "install_enforcement is continuously_enforce, but audit_script is not set",
 		},
 		"audit_script without continuously_enforce": {
-			AuditScript: "#!/bin/zsh",
+			cfg:     config.Iru{AuditScript: new("#!/bin/zsh")},
+			wantErr: "audit_script is set, but install_enforcement is install_once instead of continuously_enforce",
 		},
 		"no_enforcement without self service": {
-			InstallEnforcement: "no_enforcement",
+			cfg:     config.Iru{InstallEnforcement: "no_enforcement"},
+			wantErr: "install_enforcement is no_enforcement, but show_in_self_service is not enabled",
 		},
 		"self service without category": {
-			ShowInSelfService: new(true),
+			cfg:     config.Iru{ShowInSelfService: new(true)},
+			wantErr: "show_in_self_service is enabled, but self_service_category_id is not set",
+		},
+		"category without self service": {
+			cfg:     config.Iru{SelfServiceCategoryID: new("cat-id")},
+			wantErr: "self_service_category_id is set, but show_in_self_service is not enabled",
+		},
+		"recommended without self service": {
+			cfg:     config.Iru{SelfServiceRecommended: new(true)},
+			wantErr: "self_service_recommended is enabled, but show_in_self_service is not enabled",
+		},
+		"invalid install type": {
+			cfg:     config.Iru{InstallType: "nope"},
+			wantErr: "invalid install_type: nope",
+		},
+		"invalid install enforcement": {
+			cfg:     config.Iru{InstallEnforcement: "once"},
+			wantErr: "invalid install_enforcement: once",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			cfg.URL = "https://acme.api.kandji.io"
+			cfg := tt.cfg
+			cfg.URL = "https://iru.invalid"
 			cfg.APIToken = "token"
 			ctx := testctx.WrapWithCfg(t.Context(), config.Project{Iru: cfg})
-			require.Error(t, Pipe{}.Publish(ctx))
+			ctx.Artifacts.Add(testArtifact(t))
+
+			require.ErrorContains(t, Pipe{}.Publish(ctx), tt.wantErr)
 		})
 	}
+}
+
+func TestPublishValidationOnUpdate(t *testing.T) {
+	t.Run("companion fields may live on the remote item", func(t *testing.T) {
+		srv := newTestServer(t)
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			Iru: config.Iru{
+				URL:      srv.URL,
+				APIToken: "token",
+				// unzip_location and the Self Service category are not set
+				// here: the existing library item already has them.
+				LibraryItemID:     "some-lib-id",
+				InstallType:       "zip",
+				ShowInSelfService: new(true),
+			},
+		})
+		art := testArtifact(t)
+		art.Name = "myapp.zip"
+		ctx.Artifacts.Add(art)
+
+		require.NoError(t, Pipe{}.Publish(ctx))
+	})
+
+	// Conflicts the pipe can see without knowing the remote item must still
+	// fail before the upload, even when updating.
+	for name, tt := range map[string]validationCase{
+		"zip with cleared unzip_location": {
+			cfg:     config.Iru{InstallType: "zip", UnzipLocation: new("")},
+			wantErr: "install_type is zip, but unzip_location is not set",
+		},
+		"unzip_location with image": {
+			cfg:     config.Iru{InstallType: "image", UnzipLocation: new("/Applications")},
+			wantErr: "unzip_location is set, but install_type is image instead of zip",
+		},
+		"continuously_enforce with cleared audit_script": {
+			cfg:     config.Iru{InstallEnforcement: "continuously_enforce", AuditScript: new("")},
+			wantErr: "install_enforcement is continuously_enforce, but audit_script is not set",
+		},
+		"audit_script with install_once": {
+			cfg:     config.Iru{InstallEnforcement: "install_once", AuditScript: new("#!/bin/zsh")},
+			wantErr: "audit_script is set, but install_enforcement is install_once instead of continuously_enforce",
+		},
+		"no_enforcement with self service off": {
+			cfg:     config.Iru{InstallEnforcement: "no_enforcement", ShowInSelfService: new(false)},
+			wantErr: "install_enforcement is no_enforcement, but show_in_self_service is not enabled",
+		},
+		"self service with cleared category": {
+			cfg:     config.Iru{ShowInSelfService: new(true), SelfServiceCategoryID: new("")},
+			wantErr: "show_in_self_service is enabled, but self_service_category_id is not set",
+		},
+		"category with self service off": {
+			cfg:     config.Iru{ShowInSelfService: new(false), SelfServiceCategoryID: new("cat-id")},
+			wantErr: "self_service_category_id is set, but show_in_self_service is not enabled",
+		},
+		"recommended with self service off": {
+			cfg:     config.Iru{ShowInSelfService: new(false), SelfServiceRecommended: new(true)},
+			wantErr: "self_service_recommended is enabled, but show_in_self_service is not enabled",
+		},
+	} {
+		t.Run("explicit conflict: "+name, func(t *testing.T) {
+			server := newTestServer(t)
+			cfg := tt.cfg
+			cfg.URL = server.URL
+			cfg.APIToken = "token"
+			cfg.LibraryItemID = "some-lib-id"
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{Iru: cfg})
+			ctx.Artifacts.Add(testArtifact(t))
+
+			require.ErrorContains(t, Pipe{}.Publish(ctx), tt.wantErr)
+			require.Equal(t, 0, server.uploadInits)
+		})
+	}
+}
+
+func TestPublishLibraryItemIDTemplatedEmpty(t *testing.T) {
+	server := newTestServer(t)
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL:           server.URL,
+			APIToken:      "token",
+			LibraryItemID: "{{ .Env.ITEM_ID }}",
+		},
+	}, testctx.WithEnv(map[string]string{"ITEM_ID": ""}))
+	ctx.Artifacts.Add(testArtifact(t))
+
+	// Otherwise this would silently create a new Custom App.
+	require.ErrorContains(t, Pipe{}.Publish(ctx), "library_item_id templated to an empty string")
+	require.Equal(t, 0, server.uploadInits)
+}
+
+func TestPublishUpdateClearsExplicitlyEmptyFields(t *testing.T) {
+	server := newTestServer(t)
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL:           server.URL,
+			APIToken:      "token",
+			LibraryItemID: "some-lib-id",
+			AuditScript:   new(""),
+		},
+	})
+	ctx.Artifacts.Add(testArtifact(t))
+
+	require.NoError(t, Pipe{}.Publish(ctx))
+
+	require.Equal(t, http.MethodPatch, server.saveMethod)
+	// An explicitly empty value is sent, so it clears the field.
+	require.Contains(t, server.saveForm, "audit_script")
+	require.Empty(t, server.saveForm["audit_script"])
+	require.NotContains(t, server.saveForm, "preinstall_script")
+}
+
+func TestPublishIgnoresNonMacOSArtifacts(t *testing.T) {
+	server := newTestServer(t)
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL:           server.URL,
+			APIToken:      "token",
+			InstallType:   "zip",
+			UnzipLocation: new("/usr/local/bin"),
+		},
+	})
+	// A cross-platform release: only the darwin artifact is published, the
+	// others are ignored instead of failing the release.
+	mac := testArtifact(t)
+	mac.Name = "myapp_darwin_all.zip"
+	ctx.Artifacts.Add(mac)
+	for _, goos := range []string{"windows", "linux"} {
+		other := testArtifact(t)
+		other.Name = "myapp_" + goos + "_amd64.zip"
+		other.Goos = goos
+		ctx.Artifacts.Add(other)
+	}
+
+	require.NoError(t, Pipe{}.Publish(ctx))
+	require.Equal(t, 1, server.uploadInits)
+	require.Equal(t, "companies/xyz/myapp_darwin_all.zip", server.saveForm["file_key"])
+}
+
+func TestPublishSkipsWhenOnlyNonMacOSArtifacts(t *testing.T) {
+	server := newTestServer(t)
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL:      server.URL,
+			APIToken: "token",
+		},
+	})
+	art := testArtifact(t)
+	art.Name = "myapp_windows_amd64.zip"
+	art.Goos = "windows"
+	ctx.Artifacts.Add(art)
+
+	testlib.AssertSkipped(t, Pipe{}.Publish(ctx))
+	require.Equal(t, 0, server.uploadInits)
+}
+
+func TestPublishArtifactUnsupportedExtOnUpdate(t *testing.T) {
+	server := newTestServer(t)
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Iru: config.Iru{
+			URL:           server.URL,
+			APIToken:      "token",
+			LibraryItemID: "some-lib-id",
+		},
+	})
+	// install_type is unset, but a tarball is never a Custom App file.
+	art := testArtifact(t)
+	art.Name = "myapp_darwin_all.tar.gz"
+	ctx.Artifacts.Add(art)
+
+	require.ErrorContains(t, Pipe{}.Publish(ctx), "is not a Custom App file")
+	require.Equal(t, 0, server.uploadInits)
 }
 
 func TestPublishArtifactInstallTypeMismatch(t *testing.T) {
@@ -485,7 +696,7 @@ func TestPublishMultipleArtifacts(t *testing.T) {
 func TestPublishDisableTemplateError(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Iru: config.Iru{
-			URL:     "https://acme.api.kandji.io",
+			URL:     "https://iru.invalid",
 			Disable: "{{ .Nope }}",
 		},
 	})
@@ -584,6 +795,7 @@ func TestPublishMissingFile(t *testing.T) {
 	ctx.Artifacts.Add(&artifact.Artifact{
 		Name: "gone.pkg",
 		Path: filepath.Join(t.TempDir(), "does-not-exist"),
+		Goos: "darwin",
 		Type: artifact.UploadableArchive,
 	})
 	require.ErrorContains(t, Pipe{}.Publish(ctx), "could not upload file")

--- a/internal/pipe/publish/publish.go
+++ b/internal/pipe/publish/publish.go
@@ -18,6 +18,7 @@ import (
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/docker"
 	dockerv2 "github.com/goreleaser/goreleaser/v2/internal/pipe/docker/v2"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/dockerdigest"
+	"github.com/goreleaser/goreleaser/v2/internal/pipe/iru"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/ko"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/krew"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/mcp"
@@ -48,6 +49,7 @@ func New() Pipe {
 			blob.Pipe{},
 			upload.Pipe{},
 			artifactory.Pipe{},
+			iru.Pipe{},
 			docker.Pipe{},
 			docker.ManifestPipe{},
 			dockerv2.Publish{},

--- a/internal/skips/skips.go
+++ b/internal/skips/skips.go
@@ -37,6 +37,7 @@ const (
 	Notarize       Key = "notarize"
 	Archive        Key = "archive"
 	MCP            Key = "mcp"
+	Iru            Key = "iru"
 	SRPM           Key = "srpm"
 )
 
@@ -134,6 +135,7 @@ var Release = Keys{
 	Notarize,
 	Archive,
 	MCP,
+	Iru,
 }
 
 var Build = Keys{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1386,6 +1386,7 @@ type Project struct {
 	UniversalBinaries []UniversalBinary `yaml:"universal_binaries,omitempty" json:"universal_binaries,omitempty"`
 	UPXs              []UPX             `yaml:"upx,omitempty" json:"upx,omitempty"`
 	MCP               MCP               `yaml:"mcp,omitempty" json:"mcp,omitempty"`
+	Iru               Iru               `yaml:"iru,omitempty" json:"iru,omitempty"`
 	Retry             Retry             `yaml:"retry,omitempty" json:"retry,omitempty"`
 
 	// force the SCM token to use when multiple are set
@@ -1672,4 +1673,24 @@ type MCPPackage struct {
 
 type MCPTransport struct {
 	Type string `yaml:"type,omitempty" json:"type,omitempty" jsonschema:"enum=stdio,enum=streamable-http,enum=sse"`
+}
+
+// Iru publishes artifacts as Custom Apps to iru.com (formerly Kandji).
+type Iru struct {
+	URL                    string   `yaml:"url,omitempty" json:"url,omitempty"`
+	Name                   string   `yaml:"name,omitempty" json:"name,omitempty"`
+	IDs                    []string `yaml:"ids,omitempty" json:"ids,omitempty"`
+	APIToken               string   `yaml:"api_token,omitempty" json:"api_token,omitempty"`
+	LibraryItemID          string   `yaml:"library_item_id,omitempty" json:"library_item_id,omitempty"`
+	InstallType            string   `yaml:"install_type,omitempty" json:"install_type,omitempty" jsonschema:"enum=package,enum=zip,enum=image,default=package"`
+	InstallEnforcement     string   `yaml:"install_enforcement,omitempty" json:"install_enforcement,omitempty" jsonschema:"enum=install_once,enum=continuously_enforce,enum=no_enforcement,default=install_once"`
+	UnzipLocation          string   `yaml:"unzip_location,omitempty" json:"unzip_location,omitempty"`
+	AuditScript            string   `yaml:"audit_script,omitempty" json:"audit_script,omitempty"`
+	PreinstallScript       string   `yaml:"preinstall_script,omitempty" json:"preinstall_script,omitempty"`
+	PostinstallScript      string   `yaml:"postinstall_script,omitempty" json:"postinstall_script,omitempty"`
+	ShowInSelfService      *bool    `yaml:"show_in_self_service,omitempty" json:"show_in_self_service,omitempty"`
+	SelfServiceCategoryID  string   `yaml:"self_service_category_id,omitempty" json:"self_service_category_id,omitempty"`
+	SelfServiceRecommended *bool    `yaml:"self_service_recommended,omitempty" json:"self_service_recommended,omitempty"`
+	Restart                *bool    `yaml:"restart,omitempty" json:"restart,omitempty"`
+	Disable                string   `yaml:"disable,omitempty" json:"disable,omitempty" jsonschema:"oneof_type=string;boolean"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1684,13 +1684,14 @@ type Iru struct {
 	LibraryItemID          string   `yaml:"library_item_id,omitempty" json:"library_item_id,omitempty"`
 	InstallType            string   `yaml:"install_type,omitempty" json:"install_type,omitempty" jsonschema:"enum=package,enum=zip,enum=image,default=package"`
 	InstallEnforcement     string   `yaml:"install_enforcement,omitempty" json:"install_enforcement,omitempty" jsonschema:"enum=install_once,enum=continuously_enforce,enum=no_enforcement,default=install_once"`
-	UnzipLocation          string   `yaml:"unzip_location,omitempty" json:"unzip_location,omitempty"`
-	AuditScript            string   `yaml:"audit_script,omitempty" json:"audit_script,omitempty"`
-	PreinstallScript       string   `yaml:"preinstall_script,omitempty" json:"preinstall_script,omitempty"`
-	PostinstallScript      string   `yaml:"postinstall_script,omitempty" json:"postinstall_script,omitempty"`
+	UnzipLocation          *string  `yaml:"unzip_location,omitempty" json:"unzip_location,omitempty"`
+	AuditScript            *string  `yaml:"audit_script,omitempty" json:"audit_script,omitempty"`
+	PreinstallScript       *string  `yaml:"preinstall_script,omitempty" json:"preinstall_script,omitempty"`
+	PostinstallScript      *string  `yaml:"postinstall_script,omitempty" json:"postinstall_script,omitempty"`
 	ShowInSelfService      *bool    `yaml:"show_in_self_service,omitempty" json:"show_in_self_service,omitempty"`
-	SelfServiceCategoryID  string   `yaml:"self_service_category_id,omitempty" json:"self_service_category_id,omitempty"`
+	SelfServiceCategoryID  *string  `yaml:"self_service_category_id,omitempty" json:"self_service_category_id,omitempty"`
 	SelfServiceRecommended *bool    `yaml:"self_service_recommended,omitempty" json:"self_service_recommended,omitempty"`
+	Active                 *bool    `yaml:"active,omitempty" json:"active,omitempty"`
 	Restart                *bool    `yaml:"restart,omitempty" json:"restart,omitempty"`
 	Disable                string   `yaml:"disable,omitempty" json:"disable,omitempty" jsonschema:"oneof_type=string;boolean"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1682,7 +1682,7 @@ type Iru struct {
 	IDs                    []string `yaml:"ids,omitempty" json:"ids,omitempty"`
 	APIToken               string   `yaml:"api_token,omitempty" json:"api_token,omitempty"`
 	LibraryItemID          string   `yaml:"library_item_id,omitempty" json:"library_item_id,omitempty"`
-	InstallType            string   `yaml:"install_type,omitempty" json:"install_type,omitempty" jsonschema:"enum=package,enum=zip,enum=image,default=package"`
+	InstallType            string   `yaml:"install_type,omitempty" json:"install_type,omitempty" jsonschema:"enum=package,enum=zip,enum=image,default=zip"`
 	InstallEnforcement     string   `yaml:"install_enforcement,omitempty" json:"install_enforcement,omitempty" jsonschema:"enum=install_once,enum=continuously_enforce,enum=no_enforcement,default=install_once"`
 	UnzipLocation          *string  `yaml:"unzip_location,omitempty" json:"unzip_location,omitempty"`
 	AuditScript            *string  `yaml:"audit_script,omitempty" json:"audit_script,omitempty"`

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -25,6 +25,7 @@ import (
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/dockerdigest"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/flatpak"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/gomod"
+	"github.com/goreleaser/goreleaser/v2/internal/pipe/iru"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/ko"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/krew"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/linkedin"
@@ -112,6 +113,7 @@ var Defaulters = []Defaulter{
 	ko.Pipe{},
 	scoop.Pipe{},
 	mcp.Pipe{},
+	iru.Pipe{},
 	discord.Pipe{},
 	reddit.Pipe{},
 	slack.Pipe{},

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -25,7 +25,6 @@ import (
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/dockerdigest"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/flatpak"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/gomod"
-	"github.com/goreleaser/goreleaser/v2/internal/pipe/iru"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/ko"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/krew"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/linkedin"
@@ -113,7 +112,6 @@ var Defaulters = []Defaulter{
 	ko.Pipe{},
 	scoop.Pipe{},
 	mcp.Pipe{},
-	iru.Pipe{},
 	discord.Pipe{},
 	reddit.Pipe{},
 	slack.Pipe{},

--- a/www/content/customization/publish/iru.md
+++ b/www/content/customization/publish/iru.md
@@ -1,0 +1,135 @@
+---
+title: "Iru Custom Apps"
+linkTitle: Iru
+weight: 165
+---
+
+{{< g_version "v2.18" >}}
+
+GoReleaser can publish artifacts as _Custom Apps_ to
+[iru.com](https://www.iru.com) (formerly Kandji) endpoint management, making
+them available for deployment to your managed Macs.
+
+## How it works
+
+Publishing follows the three-step flow of the
+[Iru API](https://api-docs.iru.com): GoReleaser requests pre-signed S3 upload
+details, uploads the file to S3, and then creates (or updates) the Custom App
+library item.
+
+Custom Apps are a macOS-only library item: the supported install types
+(`package`, `zip`, `image`) correspond to `.pkg`, `.zip`, and `.dmg` files,
+and the pre/post install scripts run on the target Mac.
+
+Prerequisites:
+
+- An [Iru API token](https://support.kandji.io/api), read from the
+  `$IRU_API_TOKEN` environment variable by default. Permissions are granted
+  per endpoint, so the token needs the following Library permissions:
+  - `Upload Custom App`: always required.
+  - `Create Custom App`: required when creating a new Custom App on each
+    release (no `library_item_id` set).
+  - `Update Custom App`: required when `library_item_id` is set.
+
+The `iru` section specifies how the Custom App should be created:
+
+```yaml {filename=".goreleaser.yaml"}
+iru:
+  # Your Iru API base URL.
+  # You can find it in Settings > Access, e.g.
+  # US: https://SubDomain.api.kandji.io
+  # EU: https://SubDomain.api.eu.kandji.io
+  #
+  # Required.
+  # Templates: allowed.
+  url: https://mycompany.api.kandji.io
+
+  # Name of the Custom App in the Library.
+  #
+  # If more than one artifact matches, each one is published as its own
+  # Custom App, so make sure the name is unique per artifact, e.g. by using
+  # templates like {{ .Os }} or {{ .Arch }}.
+  #
+  # Default: the project name.
+  # Templates: allowed (artifact fields available).
+  name: "My App {{ .Version }}"
+
+  # IDs of the artifacts to publish.
+  #
+  # Default: all uploadable archives, binaries, and files.
+  ids:
+    - macos-pkg
+
+  # API token.
+  #
+  # Default: the $IRU_API_TOKEN environment variable.
+  # Templates: allowed.
+  api_token: "{{ .Env.MY_IRU_TOKEN }}"
+
+  # ID of an existing Custom App library item to update instead of creating
+  # a new one on every release.
+  #
+  # When set, exactly one artifact must match the given ids.
+  #
+  # Templates: allowed.
+  library_item_id: 58429143-b55c-42d3-a9a3-7c699ddd0ce1
+
+  # How the file should be installed.
+  #
+  # Valid options: package, zip, image.
+  # Default: package.
+  install_type: package
+
+  # Installation enforcement.
+  #
+  # Valid options: install_once, continuously_enforce, no_enforcement.
+  # Default: install_once.
+  install_enforcement: install_once
+
+  # Path to extract a zip file to.
+  #
+  # Required if install_type is zip.
+  unzip_location: /Applications
+
+  # Audit script.
+  #
+  # Required if install_enforcement is continuously_enforce.
+  audit_script: ""
+
+  # Script to run before the install.
+  preinstall_script: ""
+
+  # Script to run after the install.
+  postinstall_script: ""
+
+  # Whether to show the app in Self Service.
+  #
+  # If not set, the field is not sent, so updates keep whatever is
+  # configured in the Iru dashboard.
+  show_in_self_service: false
+
+  # Self Service category ID to display the app in.
+  #
+  # Required if show_in_self_service is true.
+  # Templates: allowed.
+  self_service_category_id: ""
+
+  # Whether to flag the app as recommended in Self Service.
+  #
+  # If not set, the field is not sent, so updates keep whatever is
+  # configured in the Iru dashboard.
+  self_service_recommended: false
+
+  # Whether to restart the device after a successful install.
+  #
+  # If not set, the field is not sent, so updates keep whatever is
+  # configured in the Iru dashboard.
+  restart: false
+
+  # Whether to disable this feature.
+  #
+  # Templates: allowed.
+  disable: "{{ .IsSnapshot }}"
+```
+
+{{< g_templates >}}

--- a/www/content/customization/publish/iru.md
+++ b/www/content/customization/publish/iru.md
@@ -69,12 +69,15 @@ iru:
   # ID of an existing Custom App library item to update instead of creating
   # a new one on every release.
   #
-  # When set, exactly one artifact must match the given ids.
+  # When set, exactly one artifact must match the given ids. Updates only
+  # send the new file plus explicitly set fields, so unset fields keep
+  # whatever is configured in the Iru dashboard.
   #
   # Templates: allowed.
   library_item_id: 58429143-b55c-42d3-a9a3-7c699ddd0ce1
 
-  # How the file should be installed.
+  # How the file should be installed. All selected artifacts must have the
+  # matching file extension (.pkg, .zip, or .dmg).
   #
   # Valid options: package, zip, image.
   # Default: package.

--- a/www/content/customization/publish/iru.md
+++ b/www/content/customization/publish/iru.md
@@ -56,7 +56,11 @@ iru:
 
   # IDs of the artifacts to publish.
   #
-  # Default: all uploadable archives, binaries, and files.
+  # Custom Apps only install on macOS, so artifacts for other operating
+  # systems are ignored. Each selected artifact must have the extension
+  # matching install_type, e.g. .pkg for the default install_type.
+  #
+  # Default: all uploadable archives and binaries.
   ids:
     - macos-pkg
 
@@ -69,15 +73,16 @@ iru:
   # ID of an existing Custom App library item to update instead of creating
   # a new one on every release.
   #
-  # When set, exactly one artifact must match the given ids. Updates only
-  # send the new file plus explicitly set fields, so unset fields keep
-  # whatever is configured in the Iru dashboard.
+  # A Custom App holds a single file, so exactly one artifact must match:
+  # for a multi-architecture macOS build, either select one artifact with
+  # ids, or build a universal binary.
+  # See "Updating an existing Custom App" below.
   #
   # Templates: allowed.
   library_item_id: 58429143-b55c-42d3-a9a3-7c699ddd0ce1
 
-  # How the file should be installed. All selected artifacts must have the
-  # matching file extension (.pkg, .zip, or .dmg).
+  # How the file should be installed. Selected artifacts must have the
+  # matching file extension: .pkg, .zip, or .dmg.
   #
   # Valid options: package, zip, image.
   # Default: package.
@@ -91,12 +96,13 @@ iru:
 
   # Path to extract a zip file to.
   #
-  # Required if install_type is zip.
+  # Required if install_type is zip, and only allowed with it.
   unzip_location: /Applications
 
   # Audit script.
   #
-  # Required if install_enforcement is continuously_enforce.
+  # Required if install_enforcement is continuously_enforce, and only
+  # allowed with it.
   audit_script: ""
 
   # Script to run before the install.
@@ -107,26 +113,26 @@ iru:
 
   # Whether to show the app in Self Service.
   #
-  # If not set, the field is not sent, so updates keep whatever is
-  # configured in the Iru dashboard.
+  # Required if install_enforcement is no_enforcement.
   show_in_self_service: false
 
   # Self Service category ID to display the app in.
   #
-  # Required if show_in_self_service is true.
+  # Required if show_in_self_service is true, and only allowed with it.
   # Templates: allowed.
   self_service_category_id: ""
 
   # Whether to flag the app as recommended in Self Service.
   #
-  # If not set, the field is not sent, so updates keep whatever is
-  # configured in the Iru dashboard.
+  # Requires show_in_self_service.
   self_service_recommended: false
 
-  # Whether to restart the device after a successful install.
+  # Whether the Custom App is active and installable.
   #
-  # If not set, the field is not sent, so updates keep whatever is
-  # configured in the Iru dashboard.
+  # Default: true.
+  active: true
+
+  # Whether to restart the device after a successful install.
   restart: false
 
   # Whether to disable this feature.
@@ -134,5 +140,16 @@ iru:
   # Templates: allowed.
   disable: "{{ .IsSnapshot }}"
 ```
+
+### Updating an existing Custom App
+
+By default, each release creates a new Custom App. Set `library_item_id` to
+update an existing one instead: the file is uploaded as usual, and the
+library item is then updated to point at it.
+
+Updates only send the fields you configured, so everything you leave out
+keeps the value it has in Iru. That also means an empty value is sent when
+you set one explicitly, which clears the field, e.g. `audit_script: ""`
+removes the audit script of an existing item.
 
 {{< g_templates >}}

--- a/www/content/customization/publish/iru.md
+++ b/www/content/customization/publish/iru.md
@@ -4,7 +4,7 @@ linkTitle: Iru
 weight: 165
 ---
 
-{{< g_version "v2.18" >}}
+{{< g_version "v2.18-unreleased" >}}
 
 GoReleaser can publish artifacts as _Custom Apps_ to
 [iru.com](https://www.iru.com) (formerly Kandji) endpoint management, making

--- a/www/content/customization/publish/iru.md
+++ b/www/content/customization/publish/iru.md
@@ -58,7 +58,7 @@ iru:
   #
   # Custom Apps only install on macOS, so artifacts for other operating
   # systems are ignored. Each selected artifact must have the extension
-  # matching install_type, e.g. .pkg for the default install_type.
+  # matching install_type, i.e. .zip by default.
   #
   # Default: all uploadable archives and binaries.
   ids:
@@ -84,11 +84,17 @@ iru:
   # How the file should be installed. Selected artifacts must have the
   # matching file extension: .pkg, .zip, or .dmg.
   #
+  # The API requires this field, GoReleaser defaults it to zip, which fits
+  # a macOS zip archive from the archives section. Set package or image
+  # when you publish a .pkg or .dmg.
+  #
   # Valid options: package, zip, image.
-  # Default: package.
-  install_type: package
+  # Default: zip.
+  install_type: zip
 
   # Installation enforcement.
+  #
+  # The API requires this field, GoReleaser defaults it.
   #
   # Valid options: install_once, continuously_enforce, no_enforcement.
   # Default: install_once.
@@ -129,7 +135,7 @@ iru:
 
   # Whether the Custom App is active and installable.
   #
-  # Default: true.
+  # Default: true, applied by the API when creating.
   active: true
 
   # Whether to restart the device after a successful install.

--- a/www/static/schema.json
+++ b/www/static/schema.json
@@ -2169,6 +2169,82 @@
 				"additionalProperties": false,
 				"type": "object"
 			},
+			"Iru": {
+				"properties": {
+					"url": {
+						"type": "string"
+					},
+					"name": {
+						"type": "string"
+					},
+					"ids": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"api_token": {
+						"type": "string"
+					},
+					"library_item_id": {
+						"type": "string"
+					},
+					"install_type": {
+						"type": "string",
+						"enum": [
+							"package",
+							"zip",
+							"image"
+						],
+						"default": "package"
+					},
+					"install_enforcement": {
+						"type": "string",
+						"enum": [
+							"install_once",
+							"continuously_enforce",
+							"no_enforcement"
+						],
+						"default": "install_once"
+					},
+					"unzip_location": {
+						"type": "string"
+					},
+					"audit_script": {
+						"type": "string"
+					},
+					"preinstall_script": {
+						"type": "string"
+					},
+					"postinstall_script": {
+						"type": "string"
+					},
+					"show_in_self_service": {
+						"type": "boolean"
+					},
+					"self_service_category_id": {
+						"type": "string"
+					},
+					"self_service_recommended": {
+						"type": "boolean"
+					},
+					"restart": {
+						"type": "boolean"
+					},
+					"disable": {
+						"oneOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "boolean"
+							}
+						]
+					}
+				},
+				"additionalProperties": false,
+				"type": "object"
+			},
 			"Ko": {
 				"properties": {
 					"id": {
@@ -3990,6 +4066,9 @@
 					},
 					"mcp": {
 						"$ref": "#/$defs/MCP"
+					},
+					"iru": {
+						"$ref": "#/$defs/Iru"
 					},
 					"retry": {
 						"$ref": "#/$defs/Retry"

--- a/www/static/schema.json
+++ b/www/static/schema.json
@@ -2228,6 +2228,9 @@
 					"self_service_recommended": {
 						"type": "boolean"
 					},
+					"active": {
+						"type": "boolean"
+					},
 					"restart": {
 						"type": "boolean"
 					},

--- a/www/static/schema.json
+++ b/www/static/schema.json
@@ -2196,7 +2196,7 @@
 							"zip",
 							"image"
 						],
-						"default": "package"
+						"default": "zip"
 					},
 					"install_enforcement": {
 						"type": "string",


### PR DESCRIPTION
<!-- If applied, this commit will... -->

Add a new `iru` publisher that uploads artifacts as Custom Apps to iru.com endpoint management. It follows the documented three-step flow (pre-signed S3 upload, then create or update of the library item) and supports updating an existing Custom App via `library_item_id`.

<!-- Why is this change being made? -->

We deploy internal macOS CLI tools to our managed Macs via Iru. Publishing them manually on every release is error prone. This makes it a regular GoReleaser publish step. Since we already use GoReleaser to publish our Docker images, this keeps the whole release in a single tool and a single `.goreleaser.yaml`, instead of maintaining a custom upload script next to it.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

[Iru Endpoint Management API Documentation](https://api-docs.iru.com)
