### PR TITLE
feat: add /.well-known/security.txt (RFC 9116)

### DIFF
--- a/www/static/.well-known/security.txt
+++ b/www/static/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: https://github.com/goreleaser/goreleaser/security/advisories/new
+Policy: https://github.com/goreleaser/goreleaser/blob/main/SECURITY.md
+Preferred-Languages: en
+Canonical: https://goreleaser.com/.well-known/security.txt
+Expires: 2027-01-01T00:00:00.000Z


### PR DESCRIPTION
Hi, and thank you for GoReleaser.

This adds a machine-readable `/.well-known/security.txt` (RFC 9116) to the site's `www/static/` dir, so it serves at `https://goreleaser.com/.well-known/security.txt` (currently 404). It points automated tooling at the disclosure channel your `SECURITY.md` already documents (GitHub Security Advisories):

```
Contact: https://github.com/goreleaser/goreleaser/security/advisories/new
Policy: https://github.com/goreleaser/goreleaser/blob/main/SECURITY.md
Preferred-Languages: en
Canonical: https://goreleaser.com/.well-known/security.txt
Expires: 2027-01-01T00:00:00.000Z
```

I verified the `www/static/` passthrough serves at the site root (e.g. `goreleaser.com/favicon.ico` and `/card.png` both return 200), so this file will be served at the well-known path. RFC 9116 recommends refreshing `Expires` at least annually — feel free to adjust.

Per your AI usage guidelines: AI assistance was used to identify this and draft the file (the commit carries an `Assisted-by` marker). I fully reviewed the change and verified the live 404, the serving passthrough, and the SECURITY.md channel myself.
