### PR TITLE
feat: allow PR creation to use a different auth token

### DIFF
--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -188,7 +188,11 @@ func doPublish(ctx *context.Context, formula *artifact.Artifact, cl client.Clien
 	}
 
 	log.Info("brews.pull_request enabled, creating a PR")
-	pcl, ok := cl.(client.PullRequestOpener)
+	prcl, err := client.NewIfToken(ctx, cl, brew.Repository.PullRequest.Token)
+	if err != nil {
+		return err
+	}
+	pcl, ok := prcl.(client.PullRequestOpener)
 	if !ok {
 		return errors.New("client does not support pull requests")
 	}

--- a/internal/pipe/cask/cask.go
+++ b/internal/pipe/cask/cask.go
@@ -201,7 +201,11 @@ func doPublish(ctx *context.Context, cask *artifact.Artifact, cl client.Client) 
 	}
 
 	log.Info("homebrew_casks.pull_request enabled, creating a PR")
-	pcl, ok := cl.(client.PullRequestOpener)
+	prcl, err := client.NewIfToken(ctx, cl, brew.Repository.PullRequest.Token)
+	if err != nil {
+		return err
+	}
+	pcl, ok := prcl.(client.PullRequestOpener)
 	if !ok {
 		return errors.New("client does not support pull requests")
 	}

--- a/internal/pipe/krew/krew.go
+++ b/internal/pipe/krew/krew.go
@@ -347,7 +347,11 @@ func doPublish(ctx *context.Context, manifest *artifact.Artifact, cl client.Clie
 	}
 
 	log.Info("krews.pull_request enabled, creating a PR")
-	pcl, ok := cl.(client.PullRequestOpener)
+	prcl, err := client.NewIfToken(ctx, cl, cfg.Repository.PullRequest.Token)
+	if err != nil {
+		return err
+	}
+	pcl, ok := prcl.(client.PullRequestOpener)
 	if !ok {
 		return errors.New("client does not support pull requests")
 	}

--- a/internal/pipe/nix/nix.go
+++ b/internal/pipe/nix/nix.go
@@ -435,7 +435,11 @@ func doPublish(ctx *context.Context, hasher fileHasher, cl client.Client, pkg *a
 	}
 
 	log.Info("nix.pull_request enabled, creating a PR")
-	pcl, ok := cl.(client.PullRequestOpener)
+	prcl, err := client.NewIfToken(ctx, cl, nix.Repository.PullRequest.Token)
+	if err != nil {
+		return err
+	}
+	pcl, ok := prcl.(client.PullRequestOpener)
 	if !ok {
 		return errors.New("client does not support pull requests")
 	}

--- a/internal/pipe/scoop/scoop.go
+++ b/internal/pipe/scoop/scoop.go
@@ -269,7 +269,11 @@ func doPublish(ctx *context.Context, manifest *artifact.Artifact, cl client.Clie
 	}
 
 	log.Info("scoop.pull_request enabled, creating a PR")
-	pcl, ok := cl.(client.PullRequestOpener)
+	prcl, err := client.NewIfToken(ctx, cl, scoop.Repository.PullRequest.Token)
+	if err != nil {
+		return err
+	}
+	pcl, ok := prcl.(client.PullRequestOpener)
 	if !ok {
 		return errors.New("client does not support pull requests")
 	}

--- a/internal/pipe/winget/winget.go
+++ b/internal/pipe/winget/winget.go
@@ -360,7 +360,11 @@ func doPublish(ctx *context.Context, cl client.Client, wingets []*artifact.Artif
 	}
 
 	log.Info("winget.pull_request enabled, creating a PR")
-	pcl, ok := cl.(client.PullRequestOpener)
+	prcl, err := client.NewIfToken(ctx, cl, winget.Repository.PullRequest.Token)
+	if err != nil {
+		return err
+	}
+	pcl, ok := prcl.(client.PullRequestOpener)
 	if !ok {
 		return errors.New("client does not support pull requests")
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,6 +108,7 @@ type PullRequest struct {
 	Enabled bool            `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	Base    PullRequestBase `yaml:"base,omitempty" json:"base,omitempty"`
 	Draft   bool            `yaml:"draft,omitempty" json:"draft,omitempty"`
+	Token   string          `yaml:"token,omitempty" json:"token,omitempty"`
 }
 
 // HomebrewDependency represents Homebrew dependency.

--- a/www/content/includes/repository.md
+++ b/www/content/includes/repository.md
@@ -48,6 +48,12 @@
         # Whether to open the PR as a draft or not.
         draft: true
 
+        # An optional token that can be provided for opening the pull request.
+        #
+        # Templates: allowed.
+        # {{< g_inline_version "v2.18-unreleased" >}}
+        token: "{{ .Env.GITHUB_PERSONAL_AUTH_TOKEN }}"
+
         # If the pull request template has checkboxes, enabling this will
         # check all of them.
         #

--- a/www/static/schema.json
+++ b/www/static/schema.json
@@ -4106,6 +4106,9 @@
 					},
 					"draft": {
 						"type": "boolean"
+					},
+					"token": {
+						"type": "string"
 					}
 				},
 				"additionalProperties": false,


### PR DESCRIPTION
This change adds support for providing a token to the `PullRequest` configuration, which will be used for opening the PR _only_. This utilizes the same patterns used for creating a client with a different auth token in `RepoRef`.

My use case is that I have a GitHub org which has classic PATs disallowed at the org level, so we can only use app installations or fine-grained tokens. This works for almost everything goreleaser does, except for opening PRs into public repos we don't control such as [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs), this can only be accomplished using a classic PAT. If we use the fine-grained token to write to our fork, and use the PAT to open the PR from the fork to the upstream, we can keep our "allow classic PAT" setting disabled at the org level. I tested this scenario with a local build, where the [fork](https://github.com/DopplerTest/winget-pkgs) was in an org with these restrictive settings ([generated PR](https://github.com/emily-curry/winget-pkgs/pull/1)).

I looked into adding tests, but `client.NewIfToken` won't create another mock client, so it'll try to create a real PR if I set the token property. There weren't any existing tests that I saw which tested the branching behavior if `RepoRef.Token` was set, and I didn't want to change the shared test utilities as that might make this more difficult to review, but I can look into it more if necessary. Thanks for all your work on this project!
