### PR TITLE
fix(notary): poll notarization status every 10s, not 10ns

### DIFF
--- a/internal/pipe/notary/macos.go
+++ b/internal/pipe/notary/macos.go
@@ -113,7 +113,7 @@ func signAndNotarize(ctx *context.Context, cfg config.MacOSSignNotarize) error {
 			cfg.Notarize.Key,
 		).WithStatusConfig(notary.StatusConfig{
 			Timeout: cfg.Notarize.Timeout,
-			Poll:    10,
+			Poll:    10 * time.Second,
 			Wait:    cfg.Notarize.Wait,
 		})
 


### PR DESCRIPTION
Poll the Apple notarization status every 10 seconds instead of every 10 nanoseconds while waiting.

`notary.StatusConfig.Poll` is a `time.Duration`, so the literal `Poll: 10` was a **10ns** sleep between status checks. With `wait: true`, GoReleaser polled App Store Connect in a near-tight loop, quickly exhausting Apple's hourly request limit and failing with `429 RATE_LIMIT` (or hitting `context deadline exceeded`). The value is now `10 * time.Second`, matching quill's own default poll interval. The rest of `WithStatusConfig` is kept so the user-configured `timeout`/`wait` (and the derived token lifetime) still apply.

Closes #6722
