### PR TITLE
Anchor goarm64 validation regex to reject invalid values

### DIFF
--- a/internal/builders/golang/targets.go
+++ b/internal/builders/golang/targets.go
@@ -421,7 +421,7 @@ var (
 	validGoamd64   = []string{"v1", "v2", "v3", "v4"}
 	validGo386     = []string{"sse2", "softfloat"}
 	validGoarm     = regexp.MustCompile(`^(5(,softfloat)?|[67](,softfloat|,hardfloat)?)$`)
-	validGoarm64   = regexp.MustCompile(`(v8\.[0-9]|v9\.[0-5])((,lse|,crypto)?)+`)
+	validGoarm64   = regexp.MustCompile(`^(v8\.[0-9]|v9\.[0-5])(,lse|,crypto)*$`)
 	validGomips    = []string{"hardfloat", "softfloat"}
 	validGoppc64   = []string{"power8", "power9", "power10"}
 	validGoriscv64 = []string{"rva20u64", "rva22u64", "rva23u64"}

--- a/internal/builders/golang/targets_test.go
+++ b/internal/builders/golang/targets_test.go
@@ -203,6 +203,17 @@ func TestAllBuildTargets(t *testing.T) {
 		})
 		require.EqualError(t, err, "invalid goamd64: invalid")
 	})
+
+	t.Run("invalid goarm64", func(t *testing.T) {
+		for _, v := range []string{"v8.10", "v9.6", "v8.1,bogus", "garbage v8.1", "v8.1 junk", "xxv8.1xx"} {
+			_, err := listTargets(config.Build{
+				Goos:    []string{"linux"},
+				Goarch:  []string{"arm64"},
+				Goarm64: []string{v},
+			})
+			require.EqualError(t, err, "invalid goarm64: "+v)
+		}
+	})
 }
 
 func TestGoosGoarchCombos(t *testing.T) {


### PR DESCRIPTION
The `validGoarm64` regular expression is missing `^`/`$` anchors, so `MatchString` succeeds whenever a valid GOARM64 token appears anywhere as a substring. Invalid values therefore pass validation and are handed straight to the Go compiler, defeating the early validation this function exists to provide.

Every sibling validator is strict: `validGoamd64`, `validGo386`, `validGomips`, `validGoppc64` and `validGoriscv64` use exact `slices.Contains`, and `validGoarm` is anchored (`^...$`). `validGoarm64` was the lone unanchored one.

Current behavior:

```
v8.10        -> accepted  (out of range; Go's max is v8.9)
v8.1,bogus   -> accepted  (invalid extension)
garbage v8.1 -> accepted  (junk prefix)
v8.1 junk    -> accepted  (junk suffix)
xxv8.1xx     -> accepted  (embedded)
```

The tell-tale asymmetry: `v8.10` is accepted (it contains the substring `v8.1`) while `v9.6` is correctly rejected (no valid substring exists).

Anchoring the regex rejects all of the above while keeping every valid value (`v8.0`–`v8.9`, `v9.0`–`v9.5`, optionally followed by `,lse` and/or `,crypto`). The `((,lse|,crypto)?)+` group is also simplified to the equivalent `(,lse|,crypto)*`.

Adds an `invalid goarm64` test covering the previously-accepted invalid values.
