### PR TITLE
fix: do not panic decoding a commit whose message contains a log marker

### DIFF
--- a/internal/pipe/changelog/changelog.go
+++ b/internal/pipe/changelog/changelog.go
@@ -551,31 +551,42 @@ const (
 		commitDivider
 )
 
+// between returns the text enclosed by the open and close markers, or an empty
+// string if either is missing. The close marker is looked up after the open one
+// so a commit message containing a literal marker cannot make the bounds cross.
+func between(line, open, close string) string {
+	start := strings.Index(line, open)
+	if start < 0 {
+		return ""
+	}
+	start += len(open)
+	end := strings.Index(line[start:], close)
+	if end < 0 {
+		return ""
+	}
+	return line[start : start+end]
+}
+
 func decode(line string) Item {
 	var (
-		shaOpenIdx          = strings.Index(line, shaOpen) + len(shaOpen)
-		shaCloseIdx         = strings.Index(line, shaClose)
-		messageOpenIdx      = strings.Index(line, messageOpen) + len(messageOpen)
-		messageCloseIdx     = strings.Index(line, messageClose)
-		messageBodyOpenIdx  = strings.Index(line, messageBodyOpen) + len(messageBodyOpen)
-		messageBodyCloseIdx = strings.Index(line, messageBodyClose)
-		authorOpenIdx       = strings.Index(line, authorOpen) + len(authorOpen)
-		authorCloseIdx      = strings.Index(line, authorClose)
-		emailOpenIdx        = strings.Index(line, emailOpen) + len(emailOpen)
-		emailCloseIdx       = strings.Index(line, emailClose)
+		sha         = between(line, shaOpen, shaClose)
+		message     = between(line, messageOpen, messageClose)
+		messageBody = between(line, messageBodyOpen, messageBodyClose)
+		author      = between(line, authorOpen, authorClose)
+		email       = between(line, emailOpen, emailClose)
 	)
 
 	return Item{
-		SHA:     line[shaOpenIdx:shaCloseIdx],
-		Message: line[messageOpenIdx:messageCloseIdx],
+		SHA:     sha,
+		Message: message,
 		Authors: append(
 			[]Author{{
-				Name:  line[authorOpenIdx:authorCloseIdx],
-				Email: line[emailOpenIdx:emailCloseIdx],
+				Name:  author,
+				Email: email,
 			}},
-			changelog.ExtractCoAuthors(line[messageBodyOpenIdx:messageBodyCloseIdx])...,
+			changelog.ExtractCoAuthors(messageBody)...,
 		),
-		AuthorName:  line[authorOpenIdx:authorCloseIdx],
-		AuthorEmail: line[emailOpenIdx:emailCloseIdx],
+		AuthorName:  author,
+		AuthorEmail: email,
 	}
 }

--- a/internal/pipe/changelog/decode_test.go
+++ b/internal/pipe/changelog/decode_test.go
@@ -1,0 +1,41 @@
+package changelog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecode(t *testing.T) {
+	line := func(message, body, author, email string) string {
+		return shaOpen + "abc123" + shaClose +
+			messageOpen + message + messageClose +
+			messageBodyOpen + body + messageBodyClose +
+			authorOpen + author + authorClose +
+			emailOpen + email + emailClose
+	}
+
+	t.Run("well formed", func(t *testing.T) {
+		item := decode(line("fix: something", "", "Someone", "someone@example.com"))
+		require.Equal(t, "abc123", item.SHA)
+		require.Equal(t, "fix: something", item.Message)
+		require.Equal(t, "Someone", item.AuthorName)
+		require.Equal(t, "someone@example.com", item.AuthorEmail)
+	})
+
+	t.Run("subject containing a marker", func(t *testing.T) {
+		// git puts the subject in verbatim, so a commit that mentions one of
+		// the markers used to move a closing index before its opening one
+		item := decode(line("fix: stop emitting </goreleaser_email>", "", "Someone", "someone@example.com"))
+		require.Equal(t, "abc123", item.SHA)
+		require.Equal(t, "someone@example.com", item.AuthorEmail)
+	})
+
+	t.Run("missing markers", func(t *testing.T) {
+		item := decode(shaOpen + "abc123" + shaClose + messageOpen + "fix: something" + messageClose)
+		require.Equal(t, "abc123", item.SHA)
+		require.Equal(t, "fix: something", item.Message)
+		require.Empty(t, item.AuthorName)
+		require.Empty(t, item.AuthorEmail)
+	})
+}


### PR DESCRIPTION
`decode()` builds every field from raw `strings.Index` results:

```go
messageOpenIdx  = strings.Index(line, messageOpen) + len(messageOpen)
emailCloseIdx   = strings.Index(line, emailClose)
...
Email: line[emailOpenIdx:emailCloseIdx],
```

Two ways that blows up, and the git log line is built from `%s` and `%b`, so the contents are whatever people wrote in their commits:

- a commit whose subject or body contains one of the markers, say `fix: stop emitting </goreleaser_email>`, puts the closing index before the opening one: `panic: runtime error: slice bounds out of range [233:78]`
- a missing marker gives `Index` = -1, so the slice ends at -1: `panic: runtime error: slice bounds out of range [:-1]`

Either one takes down `goreleaser release` at changelog time, which is a bad place to crash since it happens mid-release. The first is the realistic one: someone writes a commit about goreleaser's own log format and the next release panics.

The fix pulls the extraction into a small `between(line, open, close)` helper that returns an empty string when a marker is missing, and searches for the closing marker after the opening one so the bounds cannot cross. `decode` then reads as five `between` calls.

Tests in a new `decode_test.go`: a well formed line, a subject containing `</goreleaser_email>`, and a line missing the author and email markers. The middle one panics on main with the bounds error above; the last one panics with `[:-1]`. `go test ./internal/pipe/changelog/` is green.

AI disclosure, per CONTRIBUTING: I used Claude Code while working on this. The commit carries an `Assisted-by` trailer. I understand the change, wrote and ran the tests myself, and confirmed both panics against an unmodified tree before fixing them.
