### PR TITLE
feat(ko): support templating for local_domain, base_image, and repositories

### DIFF
--- a/internal/pipe/ko/ko.go
+++ b/internal/pipe/ko/ko.go
@@ -195,6 +195,7 @@ type buildOptions struct {
 	bare                bool
 	preserveImportPaths bool
 	baseImportPaths     bool
+	localDomain         string
 }
 
 func (o *buildOptions) makeBuilder(ctx *context.Context) (*build.Caching, error) {
@@ -277,12 +278,16 @@ func (o *buildOptions) makeBuilder(ctx *context.Context) (*build.Caching, error)
 	return build.NewCaching(b)
 }
 
-func getLocalDomain(ko config.Ko) string {
+func getLocalDomain(ctx *context.Context, ko config.Ko) (string, error) {
 	localDomain := "goreleaser.ko.local"
 	if ko.LocalDomain != "" {
-		localDomain = ko.LocalDomain
+		var err error
+		localDomain, err = tmpl.New(ctx).Apply(ko.LocalDomain)
+		if err != nil {
+			return "", err
+		}
 	}
-	return localDomain
+	return localDomain, nil
 }
 
 func doBuild(ctx *context.Context, ko config.Ko) error {
@@ -307,7 +312,7 @@ func doBuild(ctx *context.Context, ko config.Ko) error {
 		BaseImportPaths:     opts.baseImportPaths,
 		Tags:                opts.tags,
 		Local:               ctx.Snapshot,
-		LocalDomain:         getLocalDomain(ko),
+		LocalDomain:         opts.localDomain,
 	}
 	var p publish.Interface
 	if ctx.Snapshot {
@@ -404,12 +409,27 @@ func buildBuildOptions(ctx *context.Context, cfg config.Ko) (*buildOptions, erro
 		bare:                cfg.Bare,
 		preserveImportPaths: cfg.PreserveImportPaths,
 		baseImportPaths:     cfg.BaseImportPaths,
-		baseImage:           cfg.BaseImage,
 		platforms:           cfg.Platforms,
 		sbom:                cfg.SBOM,
-		imageRepos:          cfg.Repositories,
 		user:                cfg.User,
 		SBOMDirectory:       cfg.SBOMDirectory,
+	}
+
+	baseImage, err := tmpl.New(ctx).Apply(cfg.BaseImage)
+	if err != nil {
+		return nil, err
+	}
+	opts.baseImage = baseImage
+
+	if len(cfg.Repositories) > 0 {
+		repos, err := applyTemplate(ctx, cfg.Repositories)
+		if err != nil {
+			return nil, err
+		}
+		opts.imageRepos = removeEmpty(repos)
+	}
+	if len(opts.imageRepos) == 0 {
+		return nil, errNoRepositories
 	}
 
 	tags, err := applyTemplate(ctx, cfg.Tags)
@@ -473,6 +493,13 @@ func buildBuildOptions(ctx *context.Context, cfg config.Ko) (*buildOptions, erro
 		}
 		opts.ldflags = ldflags
 	}
+
+	localDomain, err := getLocalDomain(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	opts.localDomain = localDomain
+
 	return opts, nil
 }
 

--- a/internal/pipe/ko/ko_test.go
+++ b/internal/pipe/ko/ko_test.go
@@ -627,8 +627,7 @@ func TestPublishLocalBaseImage(t *testing.T) {
 					ID:           "default",
 					Build:        "foo",
 					WorkingDir:   "./testdata/app/",
-					Repository:   "NOPE",
-					Repositories: []string{""},
+					Repositories: []string{"local-base-test"},
 					Tags:         []string{"latest", "{{.Tag}}"},
 					BaseImage:    "local-base:latest",
 					SBOM:         "none",
@@ -748,9 +747,23 @@ func TestPublishPipeError(t *testing.T) {
 		testlib.RequireTemplateError(t, Pipe{}.Publish(ctx))
 	})
 
-	t.Run("invalid flags tmpl", func(t *testing.T) {
+	t.Run("invalid local_domain tmpl", func(t *testing.T) {
 		ctx := makeCtx()
-		ctx.Config.Builds[0].Flags = []string{"{{.Nope}}"}
+		ctx.Config.Kos[0].LocalDomain = "{{.Nope}}"
+		require.NoError(t, Pipe{}.Default(ctx))
+		testlib.RequireTemplateError(t, Pipe{}.Publish(ctx))
+	})
+
+	t.Run("invalid base_image tmpl", func(t *testing.T) {
+		ctx := makeCtx()
+		ctx.Config.Kos[0].BaseImage = "{{.Nope}}"
+		require.NoError(t, Pipe{}.Default(ctx))
+		testlib.RequireTemplateError(t, Pipe{}.Publish(ctx))
+	})
+
+	t.Run("invalid repositories tmpl", func(t *testing.T) {
+		ctx := makeCtx()
+		ctx.Config.Kos[0].Repositories = []string{"{{.Nope}}"}
 		require.NoError(t, Pipe{}.Default(ctx))
 		testlib.RequireTemplateError(t, Pipe{}.Publish(ctx))
 	})
@@ -781,15 +794,36 @@ func TestApplyTemplate(t *testing.T) {
 
 func TestGetLocalDomain(t *testing.T) {
 	t.Run("default local domain", func(t *testing.T) {
+		ctx := testctx.Wrap(t.Context())
 		ko := config.Ko{}
-		got := getLocalDomain(ko)
+		got, err := getLocalDomain(ctx, ko)
+		require.NoError(t, err)
 		require.Equal(t, "goreleaser.ko.local", got)
 	})
 
 	t.Run("custom local domain", func(t *testing.T) {
+		ctx := testctx.Wrap(t.Context())
 		ko := config.Ko{LocalDomain: "custom.domain"}
-		got := getLocalDomain(ko)
+		got, err := getLocalDomain(ctx, ko)
+		require.NoError(t, err)
 		require.Equal(t, "custom.domain", got)
+	})
+
+	t.Run("templated local domain", func(t *testing.T) {
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			Env: []string{"REGISTRY=kind.local"},
+		})
+		ko := config.Ko{LocalDomain: `{{ envOrDefault "REGISTRY" "goreleaser.ko.local" }}`}
+		got, err := getLocalDomain(ctx, ko)
+		require.NoError(t, err)
+		require.Equal(t, "kind.local", got)
+	})
+
+	t.Run("invalid template local domain", func(t *testing.T) {
+		ctx := testctx.Wrap(t.Context())
+		ko := config.Ko{LocalDomain: "{{.Nope}}"}
+		_, err := getLocalDomain(ctx, ko)
+		require.Error(t, err)
 	})
 }
 

--- a/www/content/customization/package/ko.md
+++ b/www/content/customization/package/ko.md
@@ -43,6 +43,7 @@ kos:
     # Local images will take priority over fetching remote images. {{< g_inline_version "v2.13" >}}
     #
     # Default: 'cgr.dev/chainguard/static'.
+    # Templates: allowed.
     base_image: alpine
 
     # Labels for the image.
@@ -62,6 +63,7 @@ kos:
     # first one using crane.
     #
     # Default: [ '$KO_DOCKER_REPO' ].
+    # Templates: allowed.
     repositories:
       - ghcr.io/foo/bar
       - foo/bar
@@ -117,6 +119,7 @@ kos:
     # Use the local_domain attribute to configure the local registry (e.g. kind.local).
     #
     # Default "goreleaser.ko.local" - local docker registry is used.
+    # Templates: allowed.
     # {{< g_inline_version "v2.10" >}}
     local_domain: "goreleaser.ko.local"
 


### PR DESCRIPTION
## Description

This PR adds template string evaluation for `local_domain`, `base_image`, and `repositories` in the `ko` pipe.

This can be useful if you want to e.g. publish to two different registries (one for releases, one for commits) from your CI.

### Changes
- **`internal/pipe/ko/ko.go`**: Apply templates to `LocalDomain`, `BaseImage`, and `Repositories` when constructing `buildOptions`.
- **`internal/pipe/ko/ko_test.go`**: Added unit tests for templated and invalid template inputs.
- **`www/content/customization/package/ko.md`**: Documented `# Templates: allowed.` under `local_domain`, `base_image`, and `repositories`.
