### PR TITLE
docs(dockers_v2): clarify that build and push are a single step

### DIFF
--- a/internal/pipe/docker/v2/docker.go
+++ b/internal/pipe/docker/v2/docker.go
@@ -69,7 +69,23 @@ func (Base) Skip(ctx *context.Context) bool {
 }
 
 // Skip implements Skipper.
-func (p Snapshot) Skip(ctx *context.Context) bool { return p.Base.Skip(ctx) || !ctx.Snapshot }
+func (p Snapshot) Skip(ctx *context.Context) bool {
+	if p.Base.Skip(ctx) {
+		return true
+	}
+	if ctx.Snapshot {
+		return false
+	}
+	if skips.Any(ctx, skips.Publish) {
+		log.Warn(
+			logext.Keyword("dockers_v2") +
+				logext.Warning(" builds and pushes images in a single step, so no images will be built while publishing is skipped, check ") +
+				logext.URL("https://goreleaser.com/customization/package/dockers_v2/#building-and-pushing-are-a-single-step") +
+				logext.Warning(" for more info"),
+		)
+	}
+	return true
+}
 
 // Default implements defaults.Defaulter.
 func (Base) Default(ctx *context.Context) error {

--- a/internal/pipe/docker/v2/docker_test.go
+++ b/internal/pipe/docker/v2/docker_test.go
@@ -55,6 +55,18 @@ func TestSkip(t *testing.T) {
 		})
 		require.True(t, Snapshot{}.Skip(ctx))
 	})
+	t.Run("snapshot skip non snapshot with publish skipped", func(t *testing.T) {
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			DockersV2: []config.DockerV2{{}},
+		}, testctx.Skip(skips.Publish))
+		require.True(t, Snapshot{}.Skip(ctx))
+	})
+	t.Run("snapshot skip docker skipped", func(t *testing.T) {
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			DockersV2: []config.DockerV2{{}},
+		}, testctx.Skip(skips.Docker), testctx.Snapshot)
+		require.True(t, Snapshot{}.Skip(ctx))
+	})
 }
 
 func TestDefault(t *testing.T) {

--- a/www/content/customization/general/partial.md
+++ b/www/content/customization/general/partial.md
@@ -27,6 +27,19 @@ GGOOS=windows goreleaser release --clean --split
 Note that this step will push your Docker images as well.
 Docker manifests are not created yet, though.
 
+> [!IMPORTANT]
+> **Docker images**
+>
+> The above is true for `dockers`/`docker_manifests` only.
+>
+> With [`dockers_v2`](/customization/package/dockers_v2/), nothing is built in
+> this step: since `docker buildx` builds and pushes the manifest in a single
+> run, the images are built and pushed in the merge step, which is when all the
+> artifacts for all the platforms are available.
+>
+> This means the machine running the merge step needs to have `docker buildx`
+> set up as well.
+
 - In the first example, it'll build for the current `GOOS` (as returned by
   `runtime.GOOS`).
 - In the second, it'll use the informed `GOOS`. This env will also bleed to
@@ -52,7 +65,8 @@ This last step will run some extra things that were not run during the previous
 step:
 
 - merge previous contexts and artifacts lists
-- pull previously built images
+- pull previously built images (`dockers`)
+- build and push the Docker images (`dockers_v2`)
 - create the source archive (if enabled)
 - checksum all artifacts
 - sign artifacts (according to configuration)

--- a/www/content/customization/package/dockers_v2.md
+++ b/www/content/customization/package/dockers_v2.md
@@ -232,6 +232,31 @@ dockers_v2:
 
 {{< g_templates >}}
 
+## Building and pushing are a single step
+
+Docker buildx builds and pushes the manifest in a single `docker buildx build
+--push` run, as it can't create a multi-platform manifest locally without
+pushing it.
+
+Because of that, `dockers_v2` images are built in the **publish** phase, not in
+the build phase (which is what `dockers` used to do).
+
+In practice, this means that anything that skips publishing will also not build
+your images:
+
+- `goreleaser build`
+- `goreleaser release --skip=publish` (as well as `--skip=docker`)
+- `goreleaser release --prepare`{{< g_inline_pro >}}
+- `goreleaser release --split`{{< g_inline_pro >}}
+- `goreleaser release --single-target`{{< g_inline_pro >}}
+
+The images are then built and pushed later, when you run `goreleaser publish`,
+`goreleaser continue`, or `goreleaser continue --merge`{{< g_inline_pro >}}.
+
+> [!TIP]
+> If you want to build the images without pushing them, e.g. to verify that your
+> `Dockerfile` works, run a [snapshot build](#testing-locally).
+
 ## Testing locally
 
 Docker buildx won't allow us to build a manifest without pushing it.

--- a/www/content/resources/deprecations.md
+++ b/www/content/resources/deprecations.md
@@ -238,6 +238,24 @@ Then, instead of building the images, pushing them, and then building the
 manifests and pushing them, we will now run a single `docker buildx build` with
 the given platforms, which will build and publish the manifest and SBOM.
 
+> [!IMPORTANT]
+> **Images are now built in the publish phase**
+>
+> Since `docker buildx` can't create a multi-platform manifest locally without
+> pushing it, building and pushing became a single step, which runs in the
+> **publish** phase.
+>
+> This means that commands that skip publishing — `goreleaser build`,
+> `goreleaser release --skip=publish`, and, on Pro, `goreleaser release` with
+> `--prepare`, `--split`, or `--single-target` — will not build your images
+> anymore. They'll be built and pushed later, by `goreleaser publish`,
+> `goreleaser continue`, or `goreleaser continue --merge`.
+>
+> To build the images without pushing them, run a snapshot build, e.g.
+> `goreleaser release --snapshot`. See
+> [testing locally](/customization/package/dockers_v2/#testing-locally) for
+> details.
+
 {{< tabs >}}
 {{< tab "Before" >}}
 


### PR DESCRIPTION
Document that `dockers_v2` builds and pushes images in a single step, and warn
when that step is skipped along with publishing.

`docker buildx` can't create a multi-platform manifest locally without pushing
it, so `dockers_v2` runs a single `docker buildx build --push` **in the publish
phase** — unlike `dockers`, which built in the build phase and pushed later.

That means anything skipping publishing (`--skip=publish`, and, on Pro,
`--prepare`, `--split`, `--single-target`) doesn't build images either, and
until now it did so completely silently, which looked like a bug.

### Docs

- **`dockers_v2`**: new "Building and pushing are a single step" section listing
  every command that skips it, and pointing at `--snapshot` for local testing.
- **`deprecations#dockers`** (the anchor the `dockers` phase-out warning links
  to): the same, framed as a behavior change from v1.
- **Split & merge**: `dockers_v2` builds nothing during the split runs — images
  are built and pushed during the merge step, which is when artifacts for all
  platforms are available. The merge machine therefore needs `buildx` set up.

### Warning

`dockers_v2` configured + not a snapshot + publishing skipped now logs:

```
• dockers_v2 builds and pushes images in a single step, so no images will be
  built while publishing is skipped, check https://goreleaser.com/customization/package/dockers_v2/#building-and-pushing-are-a-single-step for more info
```

Snapshot builds are unaffected.

Closes #6734
