### PR TITLE
fix(cask): emit Casks that pass brew style

### DIFF
--- a/internal/pipe/cask/cask.go
+++ b/internal/pipe/cask/cask.go
@@ -465,7 +465,31 @@ func dataFor(ctx *context.Context, cfg config.HomebrewCask, cl client.ReleaseURL
 	return result, nil
 }
 
+// archStanzaRank orders packages so the generated `on_*` blocks come out in
+// Homebrew's canonical stanza order, which puts arm before intel:
+//
+//	ON_SYSTEM_METHODS_STANZA_ORDER = [:arm, :intel, ...]
+//
+// (Homebrew/rubocops/cask/constants/stanza.rb). Sorting the arch strings
+// alphabetically put amd64 first, so every generated Cask emitted `on_intel`
+// before `on_arm` and tripped Cask/StanzaOrder.
+func archStanzaRank(arch string) int {
+	switch arch {
+	case "all":
+		return 0
+	case "arm64":
+		return 1
+	case "amd64":
+		return 2
+	default:
+		return 3
+	}
+}
+
 func compareByArch(a, b releasePackage) int {
+	if c := cmp.Compare(archStanzaRank(a.Arch), archStanzaRank(b.Arch)); c != 0 {
+		return c
+	}
 	return cmp.Compare(a.Arch, b.Arch)
 }
 

--- a/internal/pipe/cask/templates/cask.rb
+++ b/internal/pipe/cask/templates/cask.rb
@@ -13,13 +13,12 @@ cask "{{ .Name }}" do
   on_macos do
   {{- include "macos_packages" . | indent 2 }}
   end
-  {{ end }}
-
-  {{ if .LinuxPackages }}
+  {{- end }}
+  {{- if .LinuxPackages }}
   on_linux do
   {{- include "linux_packages" . | indent 2 }}
   end
-  {{ end }}
+  {{- end }}
 
   name "{{ .Name }}"
   desc "{{ .Description }}"
@@ -105,11 +104,16 @@ cask "{{ .Name }}" do
 
   {{ zap .Zap }}
 
-  {{ with .Caveats -}}
+  {{- with .Caveats }}
+
   caveats <<~EOS
     {{- range (split .) }}
     {{ . -}}
     {{- end }}
   EOS
   {{- end }}
+{{- /*
+  No blank line before `end`: rubocop's Layout/EmptyLinesAroundBlockBody
+  rejects one, and it fired on every Cask GoReleaser generated.
+*/}}
 end

--- a/internal/pipe/cask/testdata/TestFullCask.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullCask.rb.golden
@@ -21,7 +21,6 @@ cask "test" do
       url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_arm64.tar.gz"
     end
   end
-
   on_linux do
     on_intel do
       sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67"

--- a/internal/pipe/cask/testdata/TestFullCaskLinuxOnly.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullCaskLinuxOnly.rb.golden
@@ -29,5 +29,4 @@ cask "test" do
   zsh_completion "mybin.zsh"
 
   # No zap stanza required
-
 end

--- a/internal/pipe/cask/testdata/TestFullCaskMacOSOnly.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullCaskMacOSOnly.rb.golden
@@ -29,5 +29,4 @@ cask "test" do
   zsh_completion "mybin.zsh"
 
   # No zap stanza required
-
 end

--- a/internal/pipe/cask/testdata/TestFullPipe/custom_block.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/custom_block.rb.golden
@@ -5,16 +5,15 @@ cask "custom_block" do
   version "1.0.1"
 
   on_macos do
-    on_intel do
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-      url "https://dummyhost/download/v#{version}/bin.tgz"
-    end
     on_arm do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.txz"
     end
+    on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
+    end
   end
-
   on_linux do
     on_intel do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/internal/pipe/cask/testdata/TestFullPipe/custom_block_url.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/custom_block_url.rb.golden
@@ -35,15 +35,6 @@ cask "custom_block_url" do
   version "1.0.1"
 
   on_macos do
-    on_intel do
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-      url "#{GitHubHelper.release_asset_url("v#{version}", "bin.tgz")}",
-        header: [
-          "Accept: application/octet-stream",
-          "Authorization: Bearer #{GitHubHelper.token}",
-          "X-GitHub-Api-Version: 2022-11-28",
-        ]
-    end
     on_arm do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "#{GitHubHelper.release_asset_url("v#{version}", "bin.txz")}",
@@ -53,8 +44,16 @@ cask "custom_block_url" do
           "X-GitHub-Api-Version: 2022-11-28",
         ]
     end
+    on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "#{GitHubHelper.release_asset_url("v#{version}", "bin.tgz")}",
+        header: [
+          "Accept: application/octet-stream",
+          "Authorization: Bearer #{GitHubHelper.token}",
+          "X-GitHub-Api-Version: 2022-11-28",
+        ]
+    end
   end
-
   on_linux do
     on_intel do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/internal/pipe/cask/testdata/TestFullPipe/default.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/default.rb.golden
@@ -3,16 +3,15 @@ cask "default" do
   version "1.0.1"
 
   on_macos do
-    on_intel do
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-      url "https://dummyhost/download/v#{version}/bin.tgz"
-    end
     on_arm do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.txz"
     end
+    on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
+    end
   end
-
   on_linux do
     on_intel do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/internal/pipe/cask/testdata/TestFullPipe/default_gitlab.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/default_gitlab.rb.golden
@@ -3,16 +3,15 @@ cask "default_gitlab" do
   version "1.0.1"
 
   on_macos do
-    on_intel do
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-      url "https://dummyhost/download/v#{version}/bin.tgz"
-    end
     on_arm do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.txz"
     end
+    on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
+    end
   end
-
   on_linux do
     on_intel do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/internal/pipe/cask/testdata/TestFullPipe/generate_completions.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/generate_completions.rb.golden
@@ -3,16 +3,15 @@ cask "generate_completions" do
   version "1.0.1"
 
   on_macos do
-    on_intel do
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-      url "https://dummyhost/download/v#{version}/bin.tgz"
-    end
     on_arm do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.txz"
     end
+    on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
+    end
   end
-
   on_linux do
     on_intel do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/internal/pipe/cask/testdata/TestFullPipe/generate_completions_default_executable.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/generate_completions_default_executable.rb.golden
@@ -3,16 +3,15 @@ cask "generate_completions_default_executable" do
   version "1.0.1"
 
   on_macos do
-    on_intel do
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-      url "https://dummyhost/download/v#{version}/bin.tgz"
-    end
     on_arm do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.txz"
     end
+    on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
+    end
   end
-
   on_linux do
     on_intel do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/internal/pipe/cask/testdata/TestFullPipe/git_remote.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/git_remote.rb.golden
@@ -3,16 +3,15 @@ cask "git_remote" do
   version "1.0.1"
 
   on_macos do
-    on_intel do
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-      url "https://dummyhost/download/v#{version}/bin.tgz"
-    end
     on_arm do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.txz"
     end
+    on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
+    end
   end
-
   on_linux do
     on_intel do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/internal/pipe/cask/testdata/TestFullPipe/hooks_templated.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/hooks_templated.rb.golden
@@ -3,16 +3,15 @@ cask "hooks_templated" do
   version "1.0.1"
 
   on_macos do
-    on_intel do
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-      url "https://dummyhost/download/v#{version}/bin.tgz"
-    end
     on_arm do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.txz"
     end
+    on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
+    end
   end
-
   on_linux do
     on_intel do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/internal/pipe/cask/testdata/TestFullPipe/manpages_glob.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/manpages_glob.rb.golden
@@ -3,16 +3,15 @@ cask "manpages_glob" do
   version "1.0.1"
 
   on_macos do
-    on_intel do
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-      url "https://dummyhost/download/v#{version}/bin.tgz"
-    end
     on_arm do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.txz"
     end
+    on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
+    end
   end
-
   on_linux do
     on_intel do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/internal/pipe/cask/testdata/TestFullPipe/many-dependencies-and-conflicts.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/many-dependencies-and-conflicts.rb.golden
@@ -3,16 +3,15 @@ cask "many-dependencies-and-conflicts" do
   version "1.0.1"
 
   on_macos do
-    on_intel do
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-      url "https://dummyhost/download/v#{version}/bin.tgz"
-    end
     on_arm do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.txz"
     end
+    on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
+    end
   end
-
   on_linux do
     on_intel do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/internal/pipe/cask/testdata/TestFullPipe/open_pr.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/open_pr.rb.golden
@@ -3,16 +3,15 @@ cask "open_pr" do
   version "1.0.1"
 
   on_macos do
-    on_intel do
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-      url "https://dummyhost/download/v#{version}/bin.tgz"
-    end
     on_arm do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.txz"
     end
+    on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
+    end
   end
-
   on_linux do
     on_intel do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/internal/pipe/cask/testdata/TestFullPipe/uninstall.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/uninstall.rb.golden
@@ -3,16 +3,15 @@ cask "uninstall" do
   version "1.0.1"
 
   on_macos do
-    on_intel do
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-      url "https://dummyhost/download/v#{version}/bin.tgz"
-    end
     on_arm do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.txz"
     end
+    on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
+    end
   end
-
   on_linux do
     on_intel do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/internal/pipe/cask/testdata/TestFullPipe/url_parameters_curl.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/url_parameters_curl.rb.golden
@@ -3,19 +3,6 @@ cask "url_parameters_curl" do
   version "1.0.1"
 
   on_macos do
-    on_intel do
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-      url "https://dummyhost/download/v#{version}/bin.tgz",
-        using: :homebrew_curl,
-        cookies: {
-          "license" => "accept",
-        },
-        referer: "https://example-url-parameters.com/",
-        header: [
-          "Accept: application/octet-stream",
-        ],
-        user_agent: "GoReleaser"
-    end
     on_arm do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.txz",
@@ -29,8 +16,20 @@ cask "url_parameters_curl" do
         ],
         user_agent: "GoReleaser"
     end
+    on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz",
+        using: :homebrew_curl,
+        cookies: {
+          "license" => "accept",
+        },
+        referer: "https://example-url-parameters.com/",
+        header: [
+          "Accept: application/octet-stream",
+        ],
+        user_agent: "GoReleaser"
+    end
   end
-
   on_linux do
     on_intel do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/internal/pipe/cask/testdata/TestFullPipe/url_parameters_post.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/url_parameters_post.rb.golden
@@ -3,18 +3,6 @@ cask "url_parameters_post" do
   version "1.0.1"
 
   on_macos do
-    on_intel do
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-      url "https://dummyhost/download/v#{version}/bin.tgz",
-        verified: "https://dummyhost/download/",
-        using: :post,
-        header: [
-          "Accept: application/octet-stream",
-        ],
-        data: {
-          "payload" => "hello_world",
-        }
-    end
     on_arm do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.txz",
@@ -27,8 +15,19 @@ cask "url_parameters_post" do
           "payload" => "hello_world",
         }
     end
+    on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz",
+        verified: "https://dummyhost/download/",
+        using: :post,
+        header: [
+          "Accept: application/octet-stream",
+        ],
+        data: {
+          "payload" => "hello_world",
+        }
+    end
   end
-
   on_linux do
     on_intel do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/internal/pipe/cask/testdata/TestFullPipe/valid_repository_templates.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/valid_repository_templates.rb.golden
@@ -3,16 +3,15 @@ cask "valid_repository_templates" do
   version "1.0.1"
 
   on_macos do
-    on_intel do
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-      url "https://dummyhost/download/v#{version}/bin.tgz"
-    end
     on_arm do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.txz"
     end
+    on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
+    end
   end
-
   on_linux do
     on_intel do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/internal/pipe/cask/testdata/TestFullPipe/zap.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/zap.rb.golden
@@ -3,16 +3,15 @@ cask "zap" do
   version "1.0.1"
 
   on_macos do
-    on_intel do
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-      url "https://dummyhost/download/v#{version}/bin.tgz"
-    end
     on_arm do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.txz"
     end
+    on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin.tgz"
+    end
   end
-
   on_linux do
     on_intel do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/internal/pipe/cask/testdata/TestGenerateCompletionsFromExecutable.rb.golden
+++ b/internal/pipe/cask/testdata/TestGenerateCompletionsFromExecutable.rb.golden
@@ -12,7 +12,6 @@ cask "test" do
       url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_arm64.tar.gz"
     end
   end
-
   on_linux do
     on_intel do
       sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67"
@@ -42,5 +41,4 @@ cask "test" do
   generate_completions_from_executable "bin/myapp"
 
   # No zap stanza required
-
 end

--- a/internal/pipe/cask/testdata/TestGenerateCompletionsFromExecutableAllOptions.rb.golden
+++ b/internal/pipe/cask/testdata/TestGenerateCompletionsFromExecutableAllOptions.rb.golden
@@ -12,7 +12,6 @@ cask "test" do
       url "https://github.com/caarlos0/test/releases/download/v0.1.3/test_Darwin_arm64.tar.gz"
     end
   end
-
   on_linux do
     on_intel do
       sha256 "1633f61598ab0791e213135923624eb342196b3494909c91899bcd0560f84c67"
@@ -45,5 +44,4 @@ cask "test" do
     shells: [:bash, :zsh, :fish, :pwsh]
 
   # No zap stanza required
-
 end

--- a/internal/pipe/cask/testdata/TestRunPipeBinaryRelease.rb.golden
+++ b/internal/pipe/cask/testdata/TestRunPipeBinaryRelease.rb.golden
@@ -19,5 +19,4 @@ cask "foo" do
   manpage "man/foo.1.gz"
 
   # No zap stanza required
-
 end

--- a/internal/pipe/cask/testdata/TestRunPipeNameTemplate.rb.golden
+++ b/internal/pipe/cask/testdata/TestRunPipeNameTemplate.rb.golden
@@ -29,5 +29,4 @@ cask "foo_is_bar" do
   binary "foo"
 
   # No zap stanza required
-
 end

--- a/internal/pipe/cask/testdata/TestRunPipePullRequest.rb.golden
+++ b/internal/pipe/cask/testdata/TestRunPipePullRequest.rb.golden
@@ -19,5 +19,4 @@ cask "foo" do
   manpage "man/foo.1.gz"
 
   # No zap stanza required
-
 end

--- a/internal/pipe/cask/testdata/TestRunPipeUniversalBinary.rb.golden
+++ b/internal/pipe/cask/testdata/TestRunPipeUniversalBinary.rb.golden
@@ -18,5 +18,4 @@ cask "unibin" do
   binary "unibin"
 
   # No zap stanza required
-
 end

--- a/internal/pipe/cask/testdata/TestRunPipeUniversalBinaryNotReplacing.rb.golden
+++ b/internal/pipe/cask/testdata/TestRunPipeUniversalBinaryNotReplacing.rb.golden
@@ -3,13 +3,13 @@ cask "unibin" do
   version "1.0.1"
 
   on_macos do
-    on_intel do
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-      url "https://dummyhost/download/v#{version}/bin_amd64.tar.gz"
-    end
     on_arm do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin_arm64.tar.gz"
+    end
+    on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin_amd64.tar.gz"
     end
   end
 
@@ -24,5 +24,4 @@ cask "unibin" do
   binary "unibin"
 
   # No zap stanza required
-
 end

--- a/internal/pipe/cask/testdata/TestRunPipeWrappedIn.rb.golden
+++ b/internal/pipe/cask/testdata/TestRunPipeWrappedIn.rb.golden
@@ -3,20 +3,19 @@ cask "wrappedin" do
   version "1.0.1"
 
   on_macos do
-    on_intel do
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-      url "https://dummyhost/download/v#{version}/bin_amd64.tar.gz"
-      rename "wrappedin_1.0.1_darwin_amd64/wrappedin", "wrappedin"
-      rename "wrappedin_1.0.1_darwin_amd64/other", "other"
-    end
     on_arm do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin_arm64.tar.gz"
       rename "wrappedin_1.0.1_darwin_arm64/wrappedin", "wrappedin"
       rename "wrappedin_1.0.1_darwin_arm64/other", "other"
     end
+    on_intel do
+      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      url "https://dummyhost/download/v#{version}/bin_amd64.tar.gz"
+      rename "wrappedin_1.0.1_darwin_amd64/wrappedin", "wrappedin"
+      rename "wrappedin_1.0.1_darwin_amd64/other", "other"
+    end
   end
-
   on_linux do
     on_intel do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
@@ -38,5 +37,4 @@ cask "wrappedin" do
   binary "other"
 
   # No zap stanza required
-
 end


### PR DESCRIPTION
Generated Casks now pass `brew style` for two rules they previously always
tripped — output the user has no template control over.

**Why:** `brew style` failed on every Cask GoReleaser emits.

`on_arm` must precede `on_intel`. Homebrew's canonical order is

```ruby
ON_SYSTEM_METHODS_STANZA_ORDER = [:arm, :intel, ...]
```

(`rubocops/cask/constants/stanza.rb`). Packages were sorted by comparing the
arch strings, and `"amd64" < "arm64"`, so `on_intel` always came first and
`Cask/StanzaOrder` complained. Now sorted by an explicit stanza rank.

`Layout/EmptyLinesAroundBlockBody` rejects a blank line before a block's `end`,
and the template left one — with no caveats, `{{ with .Caveats -}}` still
emitted its leading newlines. The `on_macos` and `on_linux` blocks were also
separated by a blank line, though every `on_*` method belongs to a single
`Cask/StanzaGrouping` group.

## Measured, not assumed

`brew style --cask` over all 27 generated fixtures, before and after, on
Homebrew 6.0.9:

| cop | before | after |
|---|---:|---:|
| `Layout/EmptyLinesAroundBlockBody` | **10** | **0** |
| `Cask/StanzaGrouping` | 52 | 52 |
| `Layout/FirstArrayElementIndentation` | 72 | 72 |
| `Layout/HashAlignment` | 71 | 71 |
| `Layout/ArgumentAlignment` | 37 | 37 |
| `Cask/HomepageUrlStyling` | 21 | 21 |
| `Cask/ArrayAlphabetization` | 16 | 16 |
| `Sorbet/BlockMethodDefinition` | 4 | 4 |

Nothing else moves. Goldens regenerated with
`go test ./internal/pipe/cask/ -update`; reverting the source with the goldens
kept fails the suite showing `on_intel` first and the trailing blank line, so
the fixtures pin the change rather than restate it.

`go test ./internal/pipe/cask/... ./internal/pipe/brew/...` pass, `go build ./...`,
`go vet` and `gofmt -l` clean.

## Two things I want to flag rather than let you find

**`Cask/StanzaOrder` does not fire on my Homebrew 6.0.9** for `on_*` nested
inside `on_macos`/`on_linux` — the reporter saw it on 6.0.15. So the ordering
half is verified against the documented constant and the regenerated fixtures,
not against a local `brew style` run. If you would rather see that half proven
against 6.0.15 before merging, say so and I will get on that version.

**The remaining 52 `Cask/StanzaGrouping` offences are pre-existing and left
alone.** They concern blank lines between other stanza groups and need a wider
pass over the template than a bug fix should carry. Happy to follow up.

## AI disclosure

Per CONTRIBUTING.md: **AI was used.** This change was written with Claude Code,
and the commit carries an `Assisted-by:` marker. The before/after `brew style`
numbers, the test runs and the revert check above are real runs on my machine,
not generated text.

In the interest of your "agents pretending to be a human" rule: I am a human
contributor using an assistant, this is not an unattended bot posting on random
repositories, and I will respond to review. Close it if the disclosure still
puts it outside what you want.

Fixes #6747
