### PR TITLE
ci: disable Zig cache on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,10 @@ jobs:
         with:
           node-version: "25"
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          # Cancelled Windows jobs can persist a partially written Zig cache,
+          # which poisons subsequent runs restored through the prefix key.
+          use-cache: ${{ matrix.os != 'windows-latest' }}
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2.0.5
       - uses: cargo-bins/cargo-binstall@e00d2c94cc0067b77737821097a62d91c0301baa # v1.21.1

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ internal/pipe/ko/testdata/app/testapp-linux-amd64.spdx.json
 .env
 tmp/
 sponsors.json
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ internal/pipe/ko/testdata/app/testapp-linux-amd64.spdx.json
 .env
 tmp/
 sponsors.json
+.DS_Store


### PR DESCRIPTION
<!-- If applied, this commit will... -->

Disable persisted `setup-zig` caching only for the Windows test matrix leg. Linux keeps the existing cache behavior.

The pinned action's `use-cache` input gates both its restore path and its post-job `saveCache` call. A cancelled or failed Windows job can therefore use a fresh, run-local cache while it is executing, but can no longer publish a partially written cache or restore one into later runs.

<!-- Why is this change being made? -->

Windows jobs have repeatedly restored a corrupt shared Zig cache whose manifest points to missing compiler/runtime outputs. Clearing the cache makes a cold run pass, but the action's unconditional post step can poison the prefix-restored cache again after cancellation. Disabling persistence on the affected matrix leg removes that cross-run failure mode at the cost of a cold Windows Zig cache; other platforms retain the speed benefit.

Fixes #6754.

## Verification

- `actionlint 1.7.12 .github/workflows/build.yml`
- `actionlint 1.7.12` across all repository workflows
- Verified the pinned `mlugg/setup-zig` action defines `use-cache` and uses it to guard both restore and post-job save paths
- `git diff --check`

The PR-triggered Windows job provides the real cold-cache integration check.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

- #6754
- Pinned action input: https://github.com/mlugg/setup-zig/blob/d1434d08867e3ee9daa34448df10607b98908d29/action.yml

AI disclosure: I used an AI coding assistant to inspect the issue evidence and pinned action behavior, make this focused workflow change, and run the checks above. I reviewed and understand the resulting workflow semantics before submitting.

