### PR TITLE
docs: use formats plural syntax

### DIFF
--- a/www/content/customization/package/archives.md
+++ b/www/content/customization/package/archives.md
@@ -288,7 +288,7 @@ will probably look like this:
 ```yaml {filename=".goreleaser.yaml"}
 archives:
   # Note: Replace gz with xz for xz.
-  - format: gz
+  - formats: ["gz"]
     files:
       - none*
 ```
@@ -307,7 +307,7 @@ so by setting `format` to `binary`:
 
 ```yaml {filename=".goreleaser.yaml"}
 archives:
-  - format: binary
+  - formats: ["binary"]
 ```
 
 You can then set a custom `name_template`, which will be the name used when


### PR DESCRIPTION
I believe this bottom part of the archives doc was never updated to use the plural syntax for formats.