### PR TITLE
fix(notarize): cap macOS notarization timeout at 20m

### DIFF
--- a/internal/pipe/notary/macos.go
+++ b/internal/pipe/notary/macos.go
@@ -18,6 +18,12 @@ import (
 	"github.com/goreleaser/quill/quill/pki/load"
 )
 
+// maxNotarizeTimeout is the maximum allowed notarization timeout.
+//
+// Apple's App Store Connect API rejects tokens with a lifetime greater than 20
+// minutes, and the token lifetime is derived from this timeout.
+const maxNotarizeTimeout = 20 * time.Minute
+
 type MacOS struct{}
 
 func (MacOS) String() string { return "sign & notarize macOS binaries" }
@@ -31,6 +37,13 @@ func (MacOS) Default(ctx *context.Context) error {
 		n := &ctx.Config.Notarize.MacOS[i]
 		if n.Notarize.Timeout == 0 {
 			n.Notarize.Timeout = 10 * time.Minute
+		}
+		if n.Notarize.Timeout > maxNotarizeTimeout {
+			return fmt.Errorf(
+				"timeout must be at most %s, got %s: Apple rejects authentication tokens with longer lifetimes",
+				maxNotarizeTimeout,
+				n.Notarize.Timeout,
+			)
 		}
 		if len(n.IDs) == 0 {
 			n.IDs = []string{ctx.Config.ProjectName}

--- a/internal/pipe/notary/macos_test.go
+++ b/internal/pipe/notary/macos_test.go
@@ -58,6 +58,11 @@ func TestMacOSDefault(t *testing.T) {
 				{
 					IDs: []string{"hi"},
 				},
+				{
+					Notarize: config.MacOSNotarize{
+						Timeout: maxNotarizeTimeout,
+					},
+				},
 			},
 		},
 	})
@@ -82,7 +87,30 @@ func TestMacOSDefault(t *testing.T) {
 				Timeout: 10 * time.Minute,
 			},
 		},
+		{
+			IDs: []string{"foo"},
+			Notarize: config.MacOSNotarize{
+				Timeout: maxNotarizeTimeout,
+			},
+		},
 	}, ctx.Config.Notarize.MacOS)
+}
+
+func TestMacOSDefaultTimeoutTooBig(t *testing.T) {
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		ProjectName: "foo",
+		Notarize: config.Notarize{
+			MacOS: []config.MacOSSignNotarize{
+				{
+					Notarize: config.MacOSNotarize{
+						Timeout: 21 * time.Minute,
+					},
+				},
+			},
+		},
+	})
+
+	require.ErrorContains(t, MacOS{}.Default(ctx), "timeout must be at most 20m0s, got 21m0s")
 }
 
 func TestMacOSRun(t *testing.T) {

--- a/www/content/customization/sign/notarize.md
+++ b/www/content/customization/sign/notarize.md
@@ -132,7 +132,13 @@ notarize:
         # Beware of the overall `--timeout` time.
         # This only has any effect if `wait` is true.
         #
+        # Apple derives the lifetime of the App Store Connect authentication
+        # token from this value, and rejects tokens that live for too long, so
+        # this is capped at `20m`. Setting anything above that will fail the
+        # configuration validation.
+        #
         # Default: 10m.
+        # Maximum: 20m.
         timeout: 20m
 ```
 


### PR DESCRIPTION
Cap the macOS notarization `timeout` at `20m`, failing configuration validation with an actionable error when it is exceeded, and document the new maximum.

<!-- Why is this change being made? -->

Quill derives the App Store Connect authentication token lifetime from the configured notarization timeout:

```go
func (c *NotarizeConfig) WithStatusConfig(cfg notary.StatusConfig) *NotarizeConfig {
	c.StatusConfig = cfg
	c.TokenConfig.TokenLifetime = cfg.Timeout + (2 * time.Minute)
	return c
}
```

Apple [rejects tokens with a lifetime greater than 20 minutes](https://developer.apple.com/documentation/appstoreconnectapi/generating-tokens-for-api-requests), so raising `timeout` past that made every submission fail with:

```
⨯ release failed after 25s   error=dist/foo_darwin_arm64_v8.0/foo: unable to start submission: http status="401 Unauthorized"
```

Nothing in that error points at the timeout, so the natural reaction is to go hunting for malformed keys and certificates instead.

The check runs during defaulting, so the problem now surfaces on `goreleaser check` — before a release starts — with a message that says what to do:

```
⨯ configuration is invalid: sign & notarize macOS binaries: timeout must be at most 20m0s, got 1h0m0s: Apple rejects authentication tokens with longer lifetimes
```

### Changes

- `internal/pipe/notary/macos.go`: new `maxNotarizeTimeout` constant; `Default` errors when the configured timeout exceeds it.
- `internal/pipe/notary/macos_test.go`: `20m` is accepted, `21m` is rejected.
- `www/content/customization/sign/notarize.md`: documents `Maximum: 20m` and why it exists.

### Note

Because quill adds 2 minutes, an allowed `20m` timeout still yields a 22-minute token. That is above Apple's documented limit on paper, but is the value the reporter confirmed working in practice — dropping the cap to `18m` would make it strictly in-spec if this ever proves to be a problem.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

Closes #6757
