### PR TITLE
Use correct script for debconf

### DIFF
--- a/www/content/resources/cookbooks/debconf-templates.md
+++ b/www/content/resources/cookbooks/debconf-templates.md
@@ -45,10 +45,12 @@ if [ "$RET" = "false" ]; then
 fi
 ```
 
-Include `templates` in `.goreleaser.yaml`:
+Include `templates` in `.goreleaser.yaml`, and add `debconf` to `predepends`:
 
 ```yaml
     deb:
+      predepends:
+        - debconf
       scripts:
         config: ./deb/config.sh
         templates: ./deb/templates

--- a/www/content/resources/cookbooks/debconf-templates.md
+++ b/www/content/resources/cookbooks/debconf-templates.md
@@ -22,13 +22,14 @@ Description: Poor misguided one. Why are you installing this package?
  discover the error in your ways.
 ```
 
-Maintainer script file that will trigger questions, usually its `postinst` because all package files are already installed:
+Maintainer script file that will trigger questions, usually called `config.sh`:
 
 ```sh
 #!/bin/sh -e
 
 # Source debconf library.
 . /usr/share/debconf/confmodule
+db_version 2.0
 
 # Do you like debian?
 db_input high foo/like_debian || true
@@ -44,15 +45,12 @@ if [ "$RET" = "false" ]; then
 fi
 ```
 
-Include `templates` and `postinst` in `.goreleaser.yaml`:
+Include `templates` in `.goreleaser.yaml`:
 
 ```yaml
-    overrides:
-      deb:
-        scripts:
-          postinstall: ./deb/postinst
     deb:
       scripts:
+        config: ./deb/config.sh
         templates: ./deb/templates
 ```
 


### PR DESCRIPTION
Putting the debconf questions in the postinst script was a workaround for a bug in goreleaser (#5487). That bug was fixed long ago, so the questions can now be asked in their proper place.