### PR TITLE
fix(srpm): make documented rpm fields actually configurable

### DIFF
--- a/internal/pipe/srpm/srpm_test.go
+++ b/internal/pipe/srpm/srpm_test.go
@@ -64,9 +64,7 @@ func TestRunPipe(t *testing.T) {
 		ProjectName: "example",
 		Dist:        dist,
 		SRPM: config.SRPM{
-			NFPMRPM: config.NFPMRPM{
-				Summary: "Example summary",
-			},
+			Summary:         "Example summary",
 			Enabled:         true,
 			ImportPath:      "github.com/example/example",
 			License:         "MIT",
@@ -129,7 +127,7 @@ func TestRunPipeConventionalFileName(t *testing.T) {
 		ProjectName: "example",
 		Dist:        dist,
 		SRPM: config.SRPM{
-			NFPMRPM:          config.NFPMRPM{Summary: "Example summary"},
+			Summary:          "Example summary",
 			Enabled:          true,
 			ImportPath:       "github.com/example/example",
 			License:          "MIT",
@@ -185,7 +183,7 @@ func TestRunPipeContentsTemplates(t *testing.T) {
 		ProjectName: "example",
 		Dist:        dist,
 		SRPM: config.SRPM{
-			NFPMRPM:    config.NFPMRPM{Summary: "Example summary"},
+			Summary:    "Example summary",
 			Enabled:    true,
 			ImportPath: "github.com/example/example",
 			License:    "MIT",
@@ -233,7 +231,7 @@ func TestRunPipeContentsInvalidMTime(t *testing.T) {
 		ProjectName: "example",
 		Dist:        dist,
 		SRPM: config.SRPM{
-			NFPMRPM:    config.NFPMRPM{Summary: "Example summary"},
+			Summary:    "Example summary",
 			Enabled:    true,
 			ImportPath: "github.com/example/example",
 			License:    "MIT",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -981,7 +981,10 @@ type NFPMContent struct {
 
 // SRPM config.
 type SRPM struct {
-	NFPMRPM
+	Summary          string            `yaml:"summary,omitempty" json:"summary,omitempty"`
+	Group            string            `yaml:"group,omitempty" json:"group,omitempty"`
+	Compression      string            `yaml:"compression,omitempty" json:"compression,omitempty"`
+	Signature        NFPMRPMSignature  `yaml:"signature,omitempty" json:"signature,omitempty"`
 	Enabled          bool              `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	PackageName      string            `yaml:"package_name,omitempty" json:"package_name,omitempty"`
 	Epoch            string            `yaml:"epoch,omitempty" json:"epoch,omitempty"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -592,10 +592,10 @@ type Hook struct {
 // FormatOverride is used to specify a custom format for a specific GOOS.
 type FormatOverride struct {
 	Goos    string      `yaml:"goos,omitempty" json:"goos,omitempty"`
-	Formats StringArray `yaml:"formats,omitempty" json:"formats,omitempty" jsonschema:"enum=tar,enum=tgz,enum=tar.gz,enum=zip,enum=gz,enum=tar.xz,enum=txz,enum=binary,enum=none,default=tar.gz"`
+	Formats StringArray `yaml:"formats,omitempty" json:"formats,omitempty" jsonschema:"enum=tar,enum=tgz,enum=tar.gz,enum=zip,enum=gz,enum=tar.xz,enum=txz,enum=tar.zst,enum=tzst,enum=xz,enum=binary,enum=none,default=tar.gz"`
 
 	// Deprecated: use [Formats] instead.
-	Format string `yaml:"format,omitempty" json:"format,omitempty" jsonschema:"enum=tar,enum=tgz,enum=tar.gz,enum=zip,enum=gz,enum=tar.xz,enum=txz,enum=binary,enum=none,default=tar.gz,deprecated=true"`
+	Format string `yaml:"format,omitempty" json:"format,omitempty" jsonschema:"enum=tar,enum=tgz,enum=tar.gz,enum=zip,enum=gz,enum=tar.xz,enum=txz,enum=tar.zst,enum=tzst,enum=xz,enum=binary,enum=none,default=tar.gz,deprecated=true"`
 }
 
 // File is a file inside an archive.
@@ -646,7 +646,7 @@ type Archive struct {
 	IDs                       []string         `yaml:"ids,omitempty" json:"ids,omitempty"`
 	BuildsInfo                FileInfo         `yaml:"builds_info,omitempty" json:"builds_info,omitempty"`
 	NameTemplate              string           `yaml:"name_template,omitempty" json:"name_template,omitempty"`
-	Formats                   StringArray      `yaml:"formats,omitempty" json:"formats,omitempty" jsonschema:"enum=tar,enum=tgz,enum=tar.gz,enum=zip,enum=gz,enum=tar.xz,enum=txz,enum=binary,default=tar.gz"`
+	Formats                   StringArray      `yaml:"formats,omitempty" json:"formats,omitempty" jsonschema:"enum=tar,enum=tgz,enum=tar.gz,enum=zip,enum=gz,enum=tar.xz,enum=txz,enum=tar.zst,enum=tzst,enum=xz,enum=binary,default=tar.gz"`
 	FormatOverrides           []FormatOverride `yaml:"format_overrides,omitempty" json:"format_overrides,omitempty"`
 	WrapInDirectory           string           `yaml:"wrap_in_directory,omitempty" json:"wrap_in_directory,omitempty" jsonschema:"oneof_type=string;boolean"`
 	StripBinaryDirectory      bool             `yaml:"strip_binary_directory,omitempty" json:"strip_binary_directory,omitempty"`
@@ -655,7 +655,7 @@ type Archive struct {
 	AllowDifferentBinaryCount bool             `yaml:"allow_different_binary_count,omitempty" json:"allow_different_binary_count,omitempty"`
 
 	// Deprecated: use [Formats] instead.
-	Format string `yaml:"format,omitempty" json:"format,omitempty" jsonschema:"enum=tar,enum=tgz,enum=tar.gz,enum=zip,enum=gz,enum=tar.xz,enum=txz,enum=binary,default=tar.gz,deprecated=true"`
+	Format string `yaml:"format,omitempty" json:"format,omitempty" jsonschema:"enum=tar,enum=tgz,enum=tar.gz,enum=zip,enum=gz,enum=tar.xz,enum=txz,enum=tar.zst,enum=tzst,enum=xz,enum=binary,default=tar.gz,deprecated=true"`
 
 	// Deprecated: use [IDs] instead.
 	Builds []string `yaml:"builds,omitempty" json:"builds,omitempty" jsonschema:"deprecated=true"`

--- a/www/static/schema.json
+++ b/www/static/schema.json
@@ -378,6 +378,9 @@
 							"gz",
 							"tar.xz",
 							"txz",
+							"tar.zst",
+							"tzst",
+							"xz",
 							"binary"
 						],
 						"default": "tar.gz"
@@ -1556,6 +1559,9 @@
 							"gz",
 							"tar.xz",
 							"txz",
+							"tar.zst",
+							"tzst",
+							"xz",
 							"binary",
 							"none"
 						],

--- a/www/static/schema.json
+++ b/www/static/schema.json
@@ -4457,21 +4457,6 @@
 					"signature": {
 						"$ref": "#/$defs/NFPMRPMSignature"
 					},
-					"scripts": {
-						"$ref": "#/$defs/NFPMRPMScripts"
-					},
-					"prefixes": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					},
-					"packager": {
-						"type": "string"
-					},
-					"buildhost": {
-						"type": "string"
-					},
 					"enabled": {
 						"type": "boolean"
 					},
@@ -4506,6 +4491,9 @@
 						"type": "string"
 					},
 					"url": {
+						"type": "string"
+					},
+					"packager": {
 						"type": "string"
 					},
 					"description": {


### PR DESCRIPTION
Makes the documented `srpm` RPM fields actually configurable, and adds the missing archive formats to the JSON schema.

### `srpm`: make documented RPM fields configurable

`config.SRPM` embedded `NFPMRPM`, which is not a valid YAML/JSON layout for these
options: the embedded struct is not inlined, so `summary`, `group`,
`compression` and `signature` could never be set from the config file even
though they are documented.

Replaced the embedding with the four fields that are actually meaningful for
source RPMs (`summary`, `group`, `compression`, `signature`), which also drops
the ones that don't apply (`scripts`, `prefixes`, `packager`, `buildhost`).

### `archives`: add missing formats to the JSON schema

`tar.zst`, `tzst` and `xz` are supported by the archive pipe but were missing
from the `jsonschema` enums for `archives.formats`, `archives.format` and
`archives.format_overrides`, so valid configs were flagged as invalid by
editors.
