### PR TITLE
fix(docker): add gpg-agent to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apk add --no-cache bash \
 	git \
 	git-lfs \
 	gpg \
+	gpg-agent \
 	mercurial \
 	make \
 	openssh-client \


### PR DESCRIPTION
Add `gpg-agent` to the Docker image.

Alpine's `gpg` package ships only the frontend, without the agent. Importing a **secret** key requires it, so `gpg --batch --import` inside the image fails:

```
gpg: error running '/usr/bin/gpg-agent': probably not installed
gpg: can't connect to the gpg-agent: Configuration error
gpg: error getting the KEK: No agent running
```

Since signing is a first-class GoReleaser feature, users shouldn't have to `apk add --no-cache gpg-agent` before they can use it.

Verified `gpg-agent` 2.4.9-r0 exists in Alpine v3.23 and provides `/usr/bin/gpg-agent` — the exact path gpg was looking for.

Closes https://github.com/goreleaser/goreleaser/discussions/6745
