### PR TITLE
fix(tmpl): register the documented join template function

### DIFF
--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -289,6 +289,7 @@ func (t *Template) Apply(s string) (string, error) {
 			"dir":            filepath.Dir,
 			"base":           filepath.Base,
 			"abs":            filepath.Abs,
+			"join":           filepath.Join,
 			"incmajor":       incMajor,
 			"incminor":       incMinor,
 			"incpatch":       incPatch,

--- a/internal/tmpl/tmpl_test.go
+++ b/internal/tmpl/tmpl_test.go
@@ -336,6 +336,11 @@ func TestFuncMap(t *testing.T) {
 			Name:     "abs",
 			Expected: filepath.Join(wd, "file"),
 		},
+		{
+			Template: `{{ join "a" "b" ".." "c" }}`,
+			Name:     "join",
+			Expected: filepath.Join("a", "c"),
+		},
 	} {
 		out, err := New(ctx).Apply(tc.Template)
 		require.NoError(t, err)


### PR DESCRIPTION
The `join` template function is documented but not registered, so any config using it fails.

`www/content/customization/general/templates.md:176` lists it alongside `dir`, `base` and `abs`:

```
| `join "a" "b"` | joins any number of path elements into a single path. See Join |
```

But `internal/tmpl/tmpl.go` never adds it to the FuncMap:

```
$ cat .goreleaser.yaml
checksum:
  name_template: '{{ join "sub" ".." "checksums" }}.txt'

$ goreleaser release --snapshot --clean
⨯ release failed  error=template: failed to apply "{{ join \"sub\" \"..\" \"checksums\" }}.txt": function "join" not defined
```

After:

```
• release succeeded after 0s   ->  dist/checksums.txt
```

The docs row was added in 16debcb ("docs: many fixes"), and `git log -S'"join"' -- internal/tmpl/tmpl.go` returns nothing, so the documentation shipped ahead of the code rather than the function being removed.

## The fix

One line, `"join": filepath.Join`, placed next to the other three `path/filepath` wrappers it was documented beside. That is the function the docs point at, so no behaviour needed deciding.

## Testing

A case in the existing `TestFuncMap` table in `internal/tmpl/tmpl_test.go`, next to the `abs` case. It uses `{{ join "a" "b" ".." "c" }}` so the assertion also pins that `filepath.Join` cleans the result rather than concatenating, which is the part of `Join` a user would actually rely on here.

Dropping the FuncMap line while keeping the test fails it:

```
--- FAIL: TestFuncMap ... function "join" not defined
```

`gofumpt -l` clean, `go vet` clean, `golangci-lint run --tests` reports 0 issues. The full `go test ./internal/... ./pkg/... ./cmd/...` has one pre-existing failure, `internal/builders/node TestBuild`, which needs Node >= v25.5.0 and fails identically on a clean tree here.

*AI disclosure, per the AI usage guidelines in CONTRIBUTING: I used an AI assistant (Claude Code) on this, and the commit carries an `Assisted-by` trailer. I built goreleaser from main, reproduced the failure with the config above, and ran the before and after and the revert check myself. I understand the change and take ownership of it.*
