### PR TITLE
fix(changelog): a commit matching two include filters is listed twice

### DIFF
--- a/internal/pipe/changelog/changelog.go
+++ b/internal/pipe/changelog/changelog.go
@@ -310,15 +310,16 @@ func formatEntries(ctx *context.Context, entries []Item) ([]string, error) {
 func filterEntries(ctx *context.Context, entries []Item) ([]Item, error) {
 	filters := ctx.Config.Changelog.Filters
 	if len(filters.Include) > 0 {
-		var newEntries []Item
+		res := make([]*regexp.Regexp, 0, len(filters.Include))
 		for _, filter := range filters.Include {
 			r, err := regexp.Compile(filter)
 			if err != nil {
 				return entries, err
 			}
-			newEntries = append(newEntries, keep(r, entries)...)
+			res = append(res, r)
 		}
-		return newEntries, nil
+		// an entry matching several includes must still be listed once
+		return keepAny(res, entries), nil
 	}
 	for _, filter := range filters.Exclude {
 		r, err := regexp.Compile(filter)
@@ -345,9 +346,11 @@ func sortEntries(ctx *context.Context, entries []Item) []Item {
 	return entries
 }
 
-func keep(filter *regexp.Regexp, entries []Item) (result []Item) {
+func keepAny(filters []*regexp.Regexp, entries []Item) (result []Item) {
 	for _, entry := range entries {
-		if filter.MatchString(entry.Message) {
+		if slices.ContainsFunc(filters, func(r *regexp.Regexp) bool {
+			return r.MatchString(entry.Message)
+		}) {
 			result = append(result, entry)
 		}
 	}

--- a/internal/pipe/changelog/changelog.go
+++ b/internal/pipe/changelog/changelog.go
@@ -310,16 +310,16 @@ func formatEntries(ctx *context.Context, entries []Item) ([]string, error) {
 func filterEntries(ctx *context.Context, entries []Item) ([]Item, error) {
 	filters := ctx.Config.Changelog.Filters
 	if len(filters.Include) > 0 {
-		res := make([]*regexp.Regexp, 0, len(filters.Include))
+		includes := make([]*regexp.Regexp, 0, len(filters.Include))
 		for _, filter := range filters.Include {
 			r, err := regexp.Compile(filter)
 			if err != nil {
 				return entries, err
 			}
-			res = append(res, r)
+			includes = append(includes, r)
 		}
 		// an entry matching several includes must still be listed once
-		return keepAny(res, entries), nil
+		return keepAny(includes, entries), nil
 	}
 	for _, filter := range filters.Exclude {
 		r, err := regexp.Compile(filter)

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -230,6 +230,33 @@ func TestChangelogInclude(t *testing.T) {
 	require.NotEmpty(t, string(bts))
 }
 
+func TestChangelogIncludeOverlapping(t *testing.T) {
+	folder := testlib.Mktmp(t)
+	testlib.GitInit(t)
+	testlib.GitCommit(t, "first")
+	testlib.GitTag(t, "v0.0.1")
+	testlib.GitCommit(t, "feat: add parser")
+	testlib.GitCommit(t, "fix: crash on empty")
+	testlib.GitTag(t, "v0.0.2")
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Dist: folder,
+		Changelog: config.Changelog{
+			Use: "git",
+			Filters: config.Filters{
+				Include: []string{
+					"^feat:",
+					"parser",
+				},
+			},
+		},
+	}, testctx.WithCurrentTag("v0.0.2"), testctx.WithPreviousTag("v0.0.1"))
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, 1, strings.Count(ctx.ReleaseNotes, "feat: add parser"))
+	require.NotContains(t, ctx.ReleaseNotes, "fix: crash on empty")
+}
+
 func TestChangelogForGitlab(t *testing.T) {
 	folder := testlib.Mktmp(t)
 	testlib.GitInit(t)


### PR DESCRIPTION
A commit that matches more than one `changelog.filters.include` pattern is listed once per matching pattern.

```yaml
changelog:
  use: git
  filters:
    include:
      - '^feat:'
      - 'parser'
```

Against a range containing one commit, `feat: add parser`:

```
before:
## Changelog
* f2ddf71 feat: add parser
* f2ddf71 feat: add parser

after:
## Changelog
* f2ddf71 feat: add parser
```

Overlapping includes are easy to write without noticing, since each pattern is individually reasonable. A conventional-commit prefix plus a keyword or a scope is enough.

## Cause

`filterEntries` looped over the patterns and appended the full match set of each:

```go
for _, filter := range filters.Include {
	r, err := regexp.Compile(filter)
	...
	newEntries = append(newEntries, keep(r, entries)...)
}
```

So the result is a concatenation of per-pattern matches rather than the subset of entries matching any pattern.

## The fix

Compile the patterns first, then walk the entries once and keep an entry if any pattern matches. `keep` becomes `keepAny` and takes the compiled set; it had no other callers.

## One visible side effect, please look at this

Output is now in commit order rather than grouped by which filter matched.

With disjoint filters whose order disagrees with commit order, this reorders the changelog. Two commits, `feat: alpha` older and `docs: beta` newer, with `include: ['^feat:', '^docs:']`:

```
before:  * feat: alpha
         * docs: beta

after:   * docs: beta
         * feat: alpha
```

I believe commit order is correct, because it is what the unfiltered path and the `exclude` path already produce, so today `include` is the only filter that reorders. But it is a user-visible change to generated release notes and it is your call, not mine. If you would rather preserve grouping-by-filter, dedup while keeping the old append order is a small change and I am happy to send that instead.

## Testing

`TestChangelogIncludeOverlapping` in `internal/pipe/changelog/changelog_test.go`, following the shape of the neighbouring `TestChangelogInclude`. Two commits, two overlapping includes, asserting the matching one appears exactly once and the non-matching one not at all.

Reverting the source while keeping the test:

```
--- FAIL: TestChangelogIncludeOverlapping
    expected: 1
    actual  : 2
```

`gofumpt -l` clean, `go vet` clean, `golangci-lint run --tests --config ./.golangci.yaml` reports 0 issues. The full `go test ./internal/... ./pkg/... ./cmd/...` has one pre-existing failure, `internal/builders/node TestBuild`, which needs Node >= v25.5.0 and fails identically on a clean tree here.

*AI disclosure, per the AI usage guidelines in CONTRIBUTING: I used an AI assistant (Claude Code) on this, and the commit carries an `Assisted-by` trailer. I built goreleaser from main and produced every before and after above by running the two binaries against real git repositories, including the reordering case. I understand the change and take ownership of it.*
