### PR TITLE
fix(winget): count arm64 in the duplicate-archive check

### DIFF
--- a/internal/pipe/winget/winget.go
+++ b/internal/pipe/winget/winget.go
@@ -604,9 +604,8 @@ func makeInstaller(ctx *context.Context, winget config.Winget, archives []*artif
 			installer.Commands = []string{cmd}
 		}
 		installer.Installers = append(installer.Installers, item)
-		// count every supported architecture: a manifest may only have one
-		// installer per architecture.
-		archCounts[archive.Goarch]++
+		// a manifest may only have one installer per architecture.
+		archCounts[item.Architecture]++
 	}
 
 	if binaryCount > 0 && zipCount > 0 {

--- a/internal/pipe/winget/winget.go
+++ b/internal/pipe/winget/winget.go
@@ -571,7 +571,8 @@ func makeInstaller(ctx *context.Context, winget config.Winget, archives []*artif
 		},
 	}
 
-	var amd64Count, i386count, zipCount, binaryCount int
+	var zipCount, binaryCount int
+	archCounts := map[string]int{}
 	for _, archive := range archives {
 		sha256, err := archive.Checksum("sha256")
 		if err != nil {
@@ -603,20 +604,19 @@ func makeInstaller(ctx *context.Context, winget config.Winget, archives []*artif
 			installer.Commands = []string{cmd}
 		}
 		installer.Installers = append(installer.Installers, item)
-		switch archive.Goarch {
-		case "386":
-			i386count++
-		case "amd64":
-			amd64Count++
-		}
+		// count every supported architecture: a manifest may only have one
+		// installer per architecture.
+		archCounts[archive.Goarch]++
 	}
 
 	if binaryCount > 0 && zipCount > 0 {
 		return Installer{}, errMixedFormats
 	}
 
-	if i386count > 1 || amd64Count > 1 {
-		return Installer{}, errMultipleArchives
+	for _, count := range archCounts {
+		if count > 1 {
+			return Installer{}, errMultipleArchives
+		}
 	}
 
 	return installer, nil

--- a/internal/pipe/winget/winget_test.go
+++ b/internal/pipe/winget/winget_test.go
@@ -1150,7 +1150,7 @@ func TestMakeInstallerMultipleArchivesSameArch(t *testing.T) {
 				ProjectName: "foo",
 			}, testctx.WithVersion("1.2.1"))
 
-			archives := make([]*artifact.Artifact, 0, 2)
+			var archives []*artifact.Artifact
 			for _, id := range []string{"a", "b"} {
 				path := filepath.Join(folder, "foo_"+id+".zip")
 				require.NoError(t, os.WriteFile(path, []byte("fake"), 0o644))
@@ -1161,15 +1161,14 @@ func TestMakeInstallerMultipleArchivesSameArch(t *testing.T) {
 					Goarch: goarch,
 					Type:   artifact.UploadableArchive,
 					Extra: map[string]any{
-						artifact.ExtraID:        id,
-						artifact.ExtraFormat:    "zip",
-						artifact.ExtraBinaries:  []string{"foo.exe"},
-						artifact.ExtraWrappedIn: "",
+						artifact.ExtraID:       id,
+						artifact.ExtraFormat:   "zip",
+						artifact.ExtraBinaries: []string{"foo.exe"},
 					},
 				})
 			}
 
-			_, err := makeInstaller(ctx, config.Winget{Goamd64: "v1"}, archives)
+			_, err := makeInstaller(ctx, config.Winget{}, archives)
 			require.ErrorIs(t, err, errMultipleArchives)
 		})
 	}

--- a/internal/pipe/winget/winget_test.go
+++ b/internal/pipe/winget/winget_test.go
@@ -1141,6 +1141,40 @@ func TestErrNoArchivesFound(t *testing.T) {
 	}, "no zip archives found matching goos=[windows] goarch=[amd64 386] goamd64=v1 ids=[foo bar]")
 }
 
+func TestMakeInstallerMultipleArchivesSameArch(t *testing.T) {
+	for _, goarch := range []string{"amd64", "386", "arm64"} {
+		t.Run(goarch, func(t *testing.T) {
+			folder := t.TempDir()
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+				Dist:        folder,
+				ProjectName: "foo",
+			}, testctx.WithVersion("1.2.1"))
+
+			archives := make([]*artifact.Artifact, 0, 2)
+			for _, id := range []string{"a", "b"} {
+				path := filepath.Join(folder, "foo_"+id+".zip")
+				require.NoError(t, os.WriteFile(path, []byte("fake"), 0o644))
+				archives = append(archives, &artifact.Artifact{
+					Name:   "foo_" + id + ".zip",
+					Path:   path,
+					Goos:   "windows",
+					Goarch: goarch,
+					Type:   artifact.UploadableArchive,
+					Extra: map[string]any{
+						artifact.ExtraID:        id,
+						artifact.ExtraFormat:    "zip",
+						artifact.ExtraBinaries:  []string{"foo.exe"},
+						artifact.ExtraWrappedIn: "",
+					},
+				})
+			}
+
+			_, err := makeInstaller(ctx, config.Winget{Goamd64: "v1"}, archives)
+			require.ErrorIs(t, err, errMultipleArchives)
+		})
+	}
+}
+
 func TestDefault(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "foo",


### PR DESCRIPTION
The winget duplicate-archive guard only counts `386` and `amd64`, so two `windows/arm64` archives slip through and produce a manifest with two `arm64` installers.

```go
switch archive.Goarch {
case "386":
    i386count++
case "amd64":
    amd64Count++
}
...
if i386count > 1 || amd64Count > 1 {
    return Installer{}, errMultipleArchives
}
```

`arm64` has been in the artifact filter since `0f5b0583` ("feat(winget): support arm64"), which added `artifact.ByGoarch("arm64")` at line 206 but did not add it to these counters. So the arch reaches `installer.Installers` and is never counted.

Calling `makeInstaller` with two `windows/arm64` zips:

```
before:  err = <nil>
         Installers:
         - Architecture: arm64
           ...
         - Architecture: arm64
           ...

after:   err = found multiple archives for the same platform, please consider filtering by id
         Installers: []
```

A winget manifest may only carry one installer per architecture, so the `before` output is invalid and fails validation downstream rather than at build time.

## The fix

Replace the two fixed counters with a `map[string]int` keyed by `archive.Goarch`, so every architecture that reaches the installer list is counted. Adding a new arch to the filter can no longer silently skip the check.

## Verification

`TestMakeInstallerMultipleArchivesSameArch` with a subtest per arch (`amd64`, `386`, `arm64`).

Reverting only the guard to the old two-arch form fails it, and fails it *only* on arm64:

```
--- FAIL: TestMakeInstallerMultipleArchivesSameArch
    --- PASS: TestMakeInstallerMultipleArchivesSameArch/amd64
    --- PASS: TestMakeInstallerMultipleArchivesSameArch/386
    --- FAIL: TestMakeInstallerMultipleArchivesSameArch/arm64
        Error: Expected error with "found multiple archives for the same platform, please consider filtering by id" in chain but got nil.
```

The two passing subtests are the point: they pin the existing behaviour while arm64 isolates the gap.

`go build ./...`, `go vet`, `gofmt -l` are clean, and `internal/pipe/winget`, `internal/pipe/archive` and `internal/artifact` all pass.

One note: CONTRIBUTING asks for `task ci`, which I did not run in full because it pulls in Docker, snapcraft and cosign suites. The winget package is pure functions over config structs, so the targeted runs above are the meaningful signal for this change.

*Disclosure: written with AI assistance (Claude Code). I confirmed arm64 is in the artifact filter, produced the before/after by calling makeInstaller directly, and ran the mutation check myself.*
