### PR TITLE
fix(krew): apply the documented goarm default

### DIFF
--- a/internal/pipe/krew/krew.go
+++ b/internal/pipe/krew/krew.go
@@ -18,6 +18,7 @@ import (
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/client"
 	"github.com/goreleaser/goreleaser/v2/internal/commitauthor"
+	"github.com/goreleaser/goreleaser/v2/internal/experimental"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe"
 	"github.com/goreleaser/goreleaser/v2/internal/tmpl"
 	"github.com/goreleaser/goreleaser/v2/internal/yaml"
@@ -54,6 +55,9 @@ func (Pipe) Default(ctx *context.Context) error {
 		}
 		if krew.Goamd64 == "" {
 			krew.Goamd64 = "v1"
+		}
+		if krew.Goarm == "" {
+			krew.Goarm = experimental.DefaultGOARM()
 		}
 	}
 

--- a/internal/pipe/krew/krew_test.go
+++ b/internal/pipe/krew/krew_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/client"
+	"github.com/goreleaser/goreleaser/v2/internal/experimental"
 	"github.com/goreleaser/goreleaser/v2/internal/golden"
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/internal/testlib"
@@ -981,6 +982,62 @@ func TestDefault(t *testing.T) {
 	require.NotEmpty(t, ctx.Config.Krews[0].CommitAuthor.Email)
 	require.NotEmpty(t, ctx.Config.Krews[0].CommitMessageTemplate)
 	require.Equal(t, "foo/bar", ctx.Config.Krews[0].Repository.Git.URL)
+	require.Equal(t, "v1", ctx.Config.Krews[0].Goamd64)
+	require.Equal(t, experimental.DefaultGOARM(), ctx.Config.Krews[0].Goarm)
+}
+
+// TestRunPipeDefaultGoarm ensures that, when goarm is not set, arm archives
+// built with the default GOARM are still included in the manifest.
+func TestRunPipeDefaultGoarm(t *testing.T) {
+	folder := t.TempDir()
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Dist:        folder,
+		ProjectName: "foo",
+		Krews: []config.Krew{
+			{
+				Name:             "foo",
+				ShortDescription: "Short desc",
+				Description:      "Desc",
+				Homepage:         "https://goreleaser.com",
+				Repository: config.RepoRef{
+					Owner: "test",
+					Name:  "test",
+				},
+			},
+		},
+		GitHubURLs: config.GitHubURLs{Download: "https://github.com"},
+		Release: config.Release{
+			GitHub: config.Repo{Owner: "test", Name: "test"},
+		},
+	}, testctx.GitHubTokenType, testctx.WithVersion("1.0.1"), testctx.WithCurrentTag("v1.0.1"))
+
+	for _, goarm := range []string{"6", "7"} {
+		name := "armv" + goarm + ".tar.gz"
+		path := filepath.Join(folder, name)
+		ctx.Artifacts.Add(&artifact.Artifact{
+			Name:   name,
+			Path:   path,
+			Goos:   "linux",
+			Goarch: "arm",
+			Goarm:  goarm,
+			Type:   artifact.UploadableArchive,
+			Extra: map[string]any{
+				artifact.ExtraID:       "armv" + goarm,
+				artifact.ExtraFormat:   "tar.gz",
+				artifact.ExtraBinaries: []string{"foo"},
+			},
+		})
+		f, err := os.Create(path)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+	}
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, runAll(ctx, client.NewMock()))
+
+	bts, err := os.ReadFile(filepath.Join(folder, "krew", "foo.yaml"))
+	require.NoError(t, err)
+	require.Contains(t, string(bts), "armv"+experimental.DefaultGOARM()+".tar.gz")
 }
 
 func TestGHFolder(t *testing.T) {


### PR DESCRIPTION
The krew docs give `goarm` a `Default: 6`, but the pipe never applies it.

With `goarm` unset and a build producing only 32-bit arm archives, the whole
release fails:

```
before:
  • krew plugin manifest
  ⨯ release failed after 1s      error=no archives found
$ ls dist/krew
ls: cannot access 'dist/krew': No such file or directory

after:
  • krew plugin manifest
    • writing                    manifest=dist/krew/krewdemo.yaml
      uri: .../krewdemo_0.0.0-SNAPSHOT-none_linux_armv6.tar.gz
      selector: matchLabels: {os: linux, arch: arm}
```

In a mixed build the failure is quieter: `artifact.ByGoarm("")` matches nothing,
so the armv6 archive is simply missing from the manifest.

## The fix

Three lines in `Default()`, the same ones brew already has at `brew.go:72`:

```go
if krew.Goarm == "" {
    krew.Goarm = experimental.DefaultGOARM()
}
```

Going through `experimental.DefaultGOARM()` rather than a literal `"6"` keeps it
consistent with brew, including under the `defaultgoarm` experiment.

## Verification

`TestDefault` gains the goarm assertion, and `TestRunPipeDefaultGoarm` builds an
arm-only project end to end.

Removing the three lines fails both, one on the default and one on the symptom:

```
--- FAIL: TestDefault
    Error: Not equal: expected: "6"  actual  : ""
--- FAIL: TestRunPipeDefaultGoarm
    Error: Received unexpected error: no archives found
```

No golden file changed, because every existing krew test either sets `goarm`
explicitly or uses non-arm artifacts.

`go test ./internal/... ./pkg/...` is ok everywhere except
`internal/builders/node`, whose `TestBuild` needs Node >= v25.5.0 and this host
has v24.19.0. I confirmed by stashing that it fails identically on unmodified
`main`. `go build`, `go vet`, `gofmt`, `gofumpt` clean, and
`golangci-lint run internal/pipe/krew/...` reports 0 issues.

I did not run `task ci` in full: it pulls in Docker, snapcraft and cosign.

*Disclosure: written with AI assistance (Claude Code). I produced the before and after by running binaries built from each tree against a real arm-only project, and ran the mutation check myself.*
