### PR TITLE
fix(nfpm): record the conventional extension, not the format name

### DIFF
--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -673,7 +673,7 @@ func create(ctx *context.Context, fpm config.NFPM, format string, artifacts []*a
 		Extra: map[string]any{
 			artifact.ExtraID:     fpm.ID,
 			artifact.ExtraFormat: format,
-			artifact.ExtraExt:    "." + format,
+			artifact.ExtraExt:    ext,
 			extraFiles:           contents,
 		},
 	})

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -424,7 +424,6 @@ func TestRunPipe(t *testing.T) {
 	for _, pkg := range packages {
 		format := pkg.Format()
 		require.NotEmpty(t, format)
-		require.Equal(t, "."+pkg.Format(), pkg.Ext())
 		arch := pkg.Goarch
 		if pkg.Goarm != "" {
 			arch += "v" + pkg.Goarm
@@ -445,6 +444,7 @@ func TestRunPipe(t *testing.T) {
 				ext = packager.ConventionalExtension()
 			}
 		}
+		require.Equal(t, ext, pkg.Ext())
 
 		switch pkg.Goos {
 		case "linux":
@@ -1553,6 +1553,55 @@ func TestAPKSpecificScriptsConfig(t *testing.T) {
 
 		require.NoError(t, Pipe{}.Run(ctx))
 	})
+}
+
+func TestExtIsConventionalExtension(t *testing.T) {
+	dist := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0o755))
+	binPath := filepath.Join(dist, "mybin", "mybin")
+	require.NoError(t, os.WriteFile(binPath, []byte("fake binary"), 0o755))
+
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Dist:        dist,
+		ProjectName: "mybin",
+		NFPMs: []config.NFPM{
+			{
+				ID:         "someid",
+				Maintainer: "me",
+				Formats:    []string{"archlinux", "rpm", "deb", "termux.deb"},
+			},
+		},
+	}, testctx.WithVersion("1.0.0"), testctx.WithCurrentTag("v1.0.0"))
+	for _, goos := range []string{"linux", "android"} {
+		ctx.Artifacts.Add(&artifact.Artifact{
+			Name:   "mybin",
+			Path:   binPath,
+			Goarch: "amd64",
+			Goos:   goos,
+			Type:   artifact.Binary,
+			Extra: map[string]any{
+				artifact.ExtraID: "default",
+			},
+		})
+	}
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Run(ctx))
+
+	got := map[string]string{}
+	for _, pkg := range ctx.Artifacts.Filter(artifact.ByType(artifact.LinuxPackage)).List() {
+		got[pkg.Format()] = pkg.Ext()
+	}
+	require.Equal(t, map[string]string{
+		"archlinux":  ".pkg.tar.zst",
+		"rpm":        ".rpm",
+		"deb":        ".deb",
+		"termux.deb": ".termux.deb",
+	}, got)
+
+	// the Ext extra field is what `ByExt` (e.g. uploads.exts) filters on, so
+	// it must match the actual file extension.
+	require.Len(t, ctx.Artifacts.Filter(artifact.ByExt("pkg.tar.zst")).List(), 1)
 }
 
 func TestIPKSpecificConfig(t *testing.T) {


### PR DESCRIPTION
nfpm records the artifact's `Ext` as `"." + format`, but writes the file with the
packager's conventional extension. For `archlinux` the two disagree.

```
$ goreleaser release --snapshot --clean     # formats: [archlinux]
before:
mybin_0.0.0-SNAPSHOT-none_linux_amd64.pkg.tar.zst  ->  .archlinux

after:
mybin_0.0.0-SNAPSHOT-none_linux_amd64.pkg.tar.zst  ->  .pkg.tar.zst
```

Two consequences: `{{ .ArtifactExt }}` renders `.archlinux`, which is not the
extension of anything on disk, and the documented `exts:` filter on uploads and
artifactory goes through `artifact.ByExt`, so it never matches an archlinux
package at all.

## Cause

`create` already computes the right value a few lines above, to build the
filename:

```go
ext := "." + format
if packager, err := nfpm.Get(format); err == nil {
    if packager, ok := packager.(nfpm.PackagerWithExtension); ok {
        ext = packager.ConventionalExtension()
    }
}
...
if !strings.HasSuffix(packageFilename, ext) {
    packageFilename += ext
}
```

but then sets the extra field from `format` again rather than from `ext`. The
other formats are unaffected because their conventional extension happens to
equal `"." + format`.

## The fix

One line: use `ext`, the value the filename was built from.

## Verification

`TestExtIsConventionalExtension` asserts the `Ext` of all four formats, including
`termux.deb` which shares the dotted-name shape, and that
`artifact.ByExt("pkg.tar.zst")` finds the package, since that filter is the
user-visible consequence.

Reverting the one line fails it:

```
expected: map[string]string{"archlinux":".pkg.tar.zst", "deb":".deb", "rpm":".rpm", "termux.deb":".termux.deb"}
actual  : map[string]string{"archlinux":".archlinux", "deb":".deb", "rpm":".rpm", "termux.deb":".termux.deb"}
```

One note on the existing suite. `TestRunPipe` asserted
`require.Equal(t, "."+pkg.Format(), pkg.Ext())`, which encoded the bug, so it
would have gone red. It already computes the conventional extension a few lines
down for the filename check, so I moved the assertion to compare against that
same value. It now fails under the mutation too:

```
--- FAIL: TestRunPipe
    expected: ".pkg.tar.zst"
    actual  : ".archlinux"
```

`internal/pipe/nfpm`, `internal/pipe/archive`, `internal/pipe/checksums`,
`internal/pipe/sbom`, `internal/artifact`, `internal/http` and `internal/tmpl`
all pass. `go build`, `go vet`, `gofmt`, `gofumpt` clean.

On the full `go test ./internal/...`: the only failure is
`internal/builders/node` `TestBuild`, which needs Node >= v25.5.0 against
v24.19.0 here, and fails identically on unmodified `main`.

I did not run `task ci` in full: it pulls in Docker, snapcraft and cosign.

*Disclosure: written with AI assistance (Claude Code). I produced the before and after by running real binaries with `--snapshot`, and ran the mutation check myself.*
