### PR TITLE
fix(milestone): a milestone with close disabled stops the ones after it

### DIFF
--- a/internal/pipe/milestone/milestone.go
+++ b/internal/pipe/milestone/milestone.go
@@ -54,11 +54,15 @@ func (Pipe) Publish(ctx *context.Context) error {
 }
 
 func doPublish(ctx *context.Context, vcsClient client.Client) error {
+	// even if one of them is not set to close, we still go through all of them,
+	// and return the skips all at once in the end.
+	skips := pipe.SkipMemento{}
 	for i := range ctx.Config.Milestones {
 		milestone := &ctx.Config.Milestones[i]
 
 		if !milestone.Close {
-			return pipe.Skip("closing not enabled")
+			skips.Remember(pipe.Skip("closing not enabled"))
+			continue
 		}
 
 		name, err := tmpl.New(ctx).Apply(milestone.NameTemplate)
@@ -88,5 +92,5 @@ func doPublish(ctx *context.Context, vcsClient client.Client) error {
 		}
 	}
 
-	return nil
+	return skips.Evaluate()
 }

--- a/internal/pipe/milestone/milestone_test.go
+++ b/internal/pipe/milestone/milestone_test.go
@@ -151,6 +151,28 @@ func TestPublishCloseEnabled(t *testing.T) {
 	require.Equal(t, "v1.0.0", client.ClosedMilestone)
 }
 
+func TestPublishCloseSomeDisabled(t *testing.T) {
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Milestones: []config.Milestone{
+			{
+				Close: false,
+			},
+			{
+				Close:        true,
+				NameTemplate: defaultNameTemplate,
+				Repo: config.Repo{
+					Name:  "configrepo",
+					Owner: "configowner",
+				},
+			},
+		},
+	}, testctx.WithCurrentTag("v1.0.0"))
+
+	client := client.NewMock()
+	testlib.AssertSkipped(t, doPublish(ctx, client))
+	require.Equal(t, "v1.0.0", client.ClosedMilestone)
+}
+
 func TestPublishCloseError(t *testing.T) {
 	config := config.Project{
 		Milestones: []config.Milestone{


### PR DESCRIPTION
The docs say "You can have multiple milestone configs", but the first entry with
`close: false` ends the loop, so every milestone after it is silently never
closed.

Two milestones configured, the first with `close: false`, the second with
`close: true`, run against a fake GitHub API:

```
before:
  • milestones
    • pipe skipped or partially skipped   reason=closing not enabled
API calls: (none)

after:
  • milestones
    • closing milestone   milestone=v1.0.0 repo=goreleaser/testrepo
    • pipe skipped or partially skipped   reason=closing not enabled
API log:
GET   /api/v3/repos/goreleaser/testrepo/milestones
PATCH /api/v3/repos/goreleaser/testrepo/milestones/1 {"number":1,"state":"closed","title":"v1.0.0"}
```

Order is what decides it: put the closing milestone first and it works, put it
second and it does not, with no error either way.

## Cause

`doPublish` returns out of the loop instead of moving to the next entry:

```go
for i := range ctx.Config.Milestones {
    milestone := &ctx.Config.Milestones[i]
    if !milestone.Close {
        return pipe.Skip("closing not enabled")
    }
```

## The fix

Remember the skip and continue, which is the pattern the repo already uses for
exactly this situation in `brew`, `aur`, `cask` and `docker`:

```go
skips := pipe.SkipMemento{}
...
    skips.Remember(pipe.Skip("closing not enabled"))
    continue
...
return skips.Evaluate()
```

Using `SkipMemento` rather than dropping the skip keeps the reporting identical
when no milestone closes: `TestPublishCloseDisabled` is unchanged and still
passes, and the run still prints "closing not enabled".

## Verification

`TestPublishCloseSomeDisabled` configures a non-closing milestone followed by a
closing one and asserts the second is closed.

Reverting `continue` back to `return pipe.Skip(...)` fails it:

```
--- FAIL: TestPublishCloseSomeDisabled
    milestone_test.go:173:
        Error: Not equal:
               expected: "v1.0.0"
               actual  : ""
```

`internal/pipe/milestone` and `internal/pipe/publish` pass. `go build ./...`,
`go vet ./internal/...` and `gofmt -l internal/` are clean.

On the wider run, `go test ./internal/...` is ok except `internal/builders/node`
`TestBuild`, which needs Node >= v25.5.0 against v24.19.0 here and fails
identically on unmodified `main`.

I did not run `task ci` in full: it pulls in Docker, snapcraft and cosign.

*Disclosure: written with AI assistance (Claude Code). I produced the before and after by running real binaries against a fake GitHub API and reading its request log, and ran the mutation check myself.*
