### PR TITLE
fix(git): tag templates strip apostrophes from the message

### DIFF
--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -260,8 +260,11 @@ func getSummary(ctx *context.Context) (string, error) {
 }
 
 func getTagWithFormat(ctx *context.Context, tag, format string) (string, error) {
-	out, err := git.Run(ctx, "tag", "-l", "--format='%("+format+")'", tag)
-	return strings.TrimSpace(strings.TrimSuffix(strings.ReplaceAll(out, "'", ""), "\n\n")), err
+	// the format is not quoted on purpose: git would print the quotes
+	// verbatim, and stripping them afterwards would also strip any
+	// apostrophes the tag message itself contains.
+	out, err := git.Run(ctx, "tag", "-l", "--format=%("+format+")", tag)
+	return strings.TrimSpace(out), err
 }
 
 func getTag(ctx *context.Context, excluding []string) (string, error) {

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -53,6 +53,19 @@ func TestAnnotatedTags(t *testing.T) {
 	require.Equal(t, "v0.0.1", ctx.Git.Summary)
 }
 
+func TestAnnotatedTagsWithApostrophes(t *testing.T) {
+	testlib.Mktmp(t)
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
+	testlib.GitCommit(t, "commit1")
+	testlib.GitAnnotatedTag(t, "v0.0.1", "don't break it\n\nit's the user's message")
+	ctx := testctx.Wrap(t.Context())
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, "don't break it", ctx.Git.TagSubject)
+	require.Equal(t, "don't break it\n\nit's the user's message", ctx.Git.TagContents)
+	require.Equal(t, "it's the user's message", ctx.Git.TagBody)
+}
+
 func TestBranch(t *testing.T) {
 	testlib.Mktmp(t)
 	testlib.GitInit(t)


### PR DESCRIPTION
`.TagSubject`, `.TagContents` and `.TagBody` silently drop every apostrophe from
an annotated tag message.

Tag created with `git tag -a v1.0.2 -m "don't break it"`, config
`archives: name_template: 'sub-{{ .TagSubject }}'`:

```
before: sub-dont break it.tar.gz
after:  sub-don't break it.tar.gz
```

## Cause

The format string passed to git is quoted:

```go
out, err := git.Run(ctx, "tag", "-l", "--format='%("+format+")'", tag)
return strings.TrimSpace(strings.TrimSuffix(strings.ReplaceAll(out, "'", ""), "\n\n")), err
```

git is executed directly here, not through a shell, so those quotes are part of
the format and git prints them verbatim:

```
$ git tag -l --format="'%(contents:subject)'" v1.0.2
'don't break it'

$ git tag -l --format="%(contents:subject)" v1.0.2
don't break it
```

The `ReplaceAll(out, "'", "")` exists to clean up those stray quotes, but it
cannot distinguish them from the user's own apostrophes, so it removes both.

## The fix

Drop the quoting, and with it the stripping. `TrimSpace` already covers the
trailing newlines that `TrimSuffix(out, "\n\n")` handled, so that goes too.

## Verification

`TestAnnotatedTagsWithApostrophes` creates a tag whose subject and body both
contain apostrophes and checks all three fields.

Reverting to the quoted format plus `ReplaceAll` fails it:

```
--- FAIL: TestAnnotatedTagsWithApostrophes
    expected: "don't break it"
    actual  : "dont break it"
```

`internal/pipe/git`, `internal/tmpl` and `pkg/context` pass. `go build ./...`,
`go vet`, `gofmt -l` clean.

On the wider run, `go test ./internal/... ./pkg/...` is ok except
`internal/builders/node` `TestBuild`, which needs Node >= v25.5.0 against
v24.19.0 here and fails identically on unmodified `main`.

I did not run `task ci` in full: it pulls in Docker, snapcraft and cosign.

## One thing worth your call

This is a behaviour change for anyone whose tag messages contain apostrophes:
they now appear in the output where they used to vanish. I checked every consumer
of these three fields (`internal/tmpl` and `pkg/context` only) and none relies on
the stripping. The docs describe these as "as reported by
`git tag -l --format='%(contents)'`", so preserving the text is the documented
intent, but it does change what those users get.

*Disclosure: written with AI assistance (Claude Code). I produced the before and after by running real binaries against a tagged repo, and confirmed git's own behaviour with the two commands shown above rather than reasoning about it. I ran the mutation check myself.*
