### PR TITLE
fix(snapcraft): assumes, hooks and plugs are dropped when apps is omitted

### DIFF
--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -303,6 +303,10 @@ func create(ctx *context.Context, snap config.Snapcraft, arch string, binaries [
 		metadata.Name = snap.Name
 	}
 
+	metadata.Assumes = snap.Assumes
+	metadata.Hooks = snap.Hooks
+	metadata.Plugs = snap.Plugs
+
 	for targetPath, layout := range snap.Layout {
 		metadata.Layout[targetPath] = LayoutMetadata{
 			Symlink:  layout.Symlink,
@@ -398,9 +402,6 @@ func create(ctx *context.Context, snap config.Snapcraft, arch string, binaries [
 		}
 
 		metadata.Apps[name] = appMetadata
-		metadata.Assumes = snap.Assumes
-		metadata.Hooks = snap.Hooks
-		metadata.Plugs = snap.Plugs
 	}
 
 	out, err := yaml.Marshal(metadata)

--- a/internal/pipe/snapcraft/snapcraft_test.go
+++ b/internal/pipe/snapcraft/snapcraft_test.go
@@ -339,6 +339,60 @@ func TestRunPipeMetadata(t *testing.T) {
 	require.Equal(t, "$SNAP_DATA/etc", metadata.Layout["/etc/testprojectname"].Bind)
 }
 
+func TestRunPipeMetadataWithoutApps(t *testing.T) {
+	testlib.SkipIfWindows(t, "snap doesn't work in windows")
+	fakeSnapcraft(t)
+	folder := t.TempDir()
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		ProjectName: "testprojectname",
+		Dist:        dist,
+		Snapcrafts: []config.Snapcraft{
+			{
+				NameTemplate: "foo_{{.Arch}}",
+				Summary:      "test summary",
+				Description:  "test description",
+				Assumes:      []string{"snapd2.38"},
+				Hooks: map[string]any{
+					"install": []string{"network"},
+				},
+				Plugs: map[string]any{
+					"personal-files": map[string]any{
+						"read": []string{"$HOME/test"},
+					},
+				},
+				IDs:              []string{"foo"},
+				ChannelTemplates: []string{"stable"},
+			},
+		},
+	}, testctx.WithCurrentTag("v1.2.3"), testctx.WithVersion("1.2.3"))
+
+	addBinaries(t, ctx, "foo", dist)
+	require.NoError(t, Pipe{}.Run(ctx))
+	yamlFile, err := os.ReadFile(filepath.Join(dist, "foo_amd64", "prime", "meta", "snap.yaml"))
+	require.NoError(t, err)
+	var metadata Metadata
+	err = yaml.Unmarshal(yamlFile, &metadata)
+	require.NoError(t, err)
+	require.Equal(t, []string{"snapd2.38"}, metadata.Assumes)
+	require.Equal(t, map[string]any{"install": []any{"network"}}, metadata.Hooks)
+	require.Equal(t, map[string]any{"read": []any{"$HOME/test"}}, metadata.Plugs["personal-files"])
+}
+
+// fakeSnapcraft puts a no-op `snapcraft` executable in the PATH, so tests that
+// only care about the generated metadata don't need a real snapcraft install.
+func fakeSnapcraft(tb testing.TB) {
+	tb.Helper()
+	dir := tb.TempDir()
+	require.NoError(tb, os.WriteFile(
+		filepath.Join(dir, "snapcraft"),
+		[]byte("#!/bin/sh\nexit 0\n"),
+		0o755,
+	))
+	tb.Setenv("PATH", dir)
+}
+
 func TestNoSnapcraftInPath(t *testing.T) {
 	t.Setenv("PATH", "")
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{


### PR DESCRIPTION
`assumes`, `hooks` and `plugs` are silently dropped from the generated snap
whenever the optional `apps:` section is omitted.

Config with all three set and no `apps:`, run with
`goreleaser release --snapshot --clean`:

```
before (prime/meta/snap.yaml):     after:
name: snapdemo                     name: snapdemo
...                                ...
architectures:                     architectures:
  - amd64                            - amd64
apps:                              assumes:
  snapdemo:                          - snapd2.38
    command: snapdemo              apps:
(assumes, hooks, plugs missing)      snapdemo:
                                       command: snapdemo
                                   hooks:
                                     install:
                                       - network
                                   plugs:
                                     personal-files:
                                       read:
                                         - $HOME/.foo
```

The docs say of `apps:` that "It is optional", and when it is omitted GoReleaser
synthesizes a default app, so a config that never mentions `apps` is normal
usage.

## Cause

The three fields are assigned inside the loop over the configured apps:

```go
for name, config := range snap.Apps {
    ...
    metadata.Apps[name] = appMetadata
    metadata.Assumes = snap.Assumes
    metadata.Hooks = snap.Hooks
    metadata.Plugs = snap.Plugs
}
```

With no `apps:` in the config, `snap.Apps` is empty and the loop body never runs.
The default app is added elsewhere, so the snap still builds, just without the
three top-level options.

## The fix

Move the three assignments out of the loop, next to the other top-level metadata.
They do not depend on the loop variable, so nothing else changes.

## Verification

`TestRunPipeMetadataWithoutApps` builds a snap from a config with all three
options and no `apps:`, then reads back the generated `meta/snap.yaml`.

Moving the assignments back inside the loop fails it:

```
--- FAIL: TestRunPipeMetadataWithoutApps
    expected: []string{"snapd2.38"}
    actual  : []string(nil)
```

One note on the test: the existing snapcraft tests all skip when `snapcraft` is
not installed, which would have made this one skip here and in most CI. The
metadata is written before snapcraft is invoked, so the new test puts a small
no-op `snapcraft` stub on PATH and therefore actually runs.

`internal/pipe/snapcraft`, `ko`, `sign`, `notary`, `docker` and `pkg/config` all
pass. `go build ./...`, `go vet`, `gofmt`, `gofumpt` clean, and
`golangci-lint run ./internal/pipe/snapcraft/...` reports 0 issues. No testdata
golden references `snap.yaml`, so nothing needed regenerating.

On the wider run, `go test ./internal/... ./pkg/...` is ok except
`internal/builders/node` `TestBuild`, which needs Node >= v25.5.0 against
v24.19.0 here and fails identically on unmodified `main`.

I did not run `task ci` in full: it pulls in Docker, snapcraft and cosign.

*Disclosure: written with AI assistance (Claude Code). I produced the before and after by running real binaries with a stub snapcraft on PATH and reading the generated snap.yaml, and ran the mutation check myself.*
