### PR TITLE
fix(flatpak): a disabled flatpak stops the ones after it

### DIFF
--- a/internal/pipe/flatpak/flatpak.go
+++ b/internal/pipe/flatpak/flatpak.go
@@ -103,12 +103,20 @@ func (Pipe) Default(ctx *context.Context) error {
 
 // Run the pipe.
 func (Pipe) Run(ctx *context.Context) error {
+	// even if one of them is disabled, we still go through all of them, and
+	// return the skips all at once in the end.
+	skips := pipe.SkipMemento{}
 	for _, fp := range ctx.Config.Flatpaks {
-		if err := doRun(ctx, fp); err != nil {
+		err := doRun(ctx, fp)
+		if err != nil && pipe.IsSkip(err) {
+			skips.Remember(err)
+			continue
+		}
+		if err != nil {
 			return err
 		}
 	}
-	return nil
+	return skips.Evaluate()
 }
 
 func doRun(ctx *context.Context, fp config.Flatpak) error {

--- a/internal/pipe/flatpak/flatpak_test.go
+++ b/internal/pipe/flatpak/flatpak_test.go
@@ -108,6 +108,37 @@ func TestRunPipeDisabledTemplate(t *testing.T) {
 	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
 }
 
+func TestRunPipeSomeDisabled(t *testing.T) {
+	testlib.OnlyOnLinux(t, "flatpak only works on linux")
+	testlib.CheckPath(t, "flatpak-builder")
+	testlib.CheckPath(t, "flatpak")
+	dist := filepath.Join(t.TempDir(), "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+
+	disabled := validFlatpak()
+	disabled.ID = "disabled"
+	disabled.Disable = "true"
+
+	enabled := validFlatpak()
+	enabled.ID = "enabled"
+	enabled.NameTemplate = "foo_{{.Arch}}"
+	enabled.AppID = "org.example.MyBin"
+	enabled.IDs = []string{"foo"}
+
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		ProjectName: "mybin",
+		Dist:        dist,
+		Flatpaks:    []config.Flatpak{disabled, enabled},
+	}, testctx.WithCurrentTag("v1.2.3"), testctx.WithVersion("1.2.3"))
+
+	addBinaries(t, ctx, "foo", filepath.Join(dist, "foo"))
+	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
+
+	list := ctx.Artifacts.Filter(artifact.ByType(artifact.Flatpak)).List()
+	require.NotEmpty(t, list, "the flatpak after the disabled one should have been built")
+	require.Equal(t, "enabled", artifact.ExtraOr(*list[0], artifact.ExtraID, ""))
+}
+
 func TestRunPipeInvalidNameTemplate(t *testing.T) {
 	testlib.OnlyOnLinux(t, "flatpak only works on linux")
 	testlib.CheckPath(t, "flatpak-builder")


### PR DESCRIPTION
## What's broken

`flatpak` takes a list of configs, each with its own `id`, but the first entry with `disable: true` returns out of the loop, so every flatpak after it is silently never built. No error either way, so it looks like it worked.

Same shape as the milestone fix in #6778.

## Repro

Two flatpak configs, the disabled one first, run against stub `flatpak` and `flatpak-builder` that log their calls:

```
before:
  • flatpak packages
    • pipe skipped or partially skipped   reason=configuration is disabled
tool calls: (none)

after:
  • flatpak packages
    • creating bundle  arch=x86_64 flatpak=foo_..._amd64.flatpak
    • pipe skipped or partially skipped   reason=configuration is disabled
tool calls:
CALL flatpak-builder --force-clean --arch=x86_64 --repo=repo build com.example.Second.json
CALL flatpak build-bundle --arch=x86_64 repo foo_..._amd64.flatpak com.example.Second
```

Order decides it: put the enabled one first and it works.

## The fix

`pipe.SkipMemento`, the same way `brew`, `nix`, `scoop`, `winget` and the others already do it. Skips are collected and returned together, real errors still return immediately.

## Verification

`TestRunPipeSomeDisabled` configures a disabled flatpak followed by an enabled one and asserts the second produced an artifact. Reverting `Run` to the old loop fails it with `Should NOT be empty`.

It gates on `flatpak-builder` and `flatpak` in `$PATH` like the other run tests here, so it skips on a bare machine. I ran it both ways, and the mutation output above comes from the stubbed run. All 13 tests in the package pass, `go test ./internal/pipe/...`, `gofmt` and `go vet` clean.
