### PR TITLE
fix(nfpm): overrides ignore package_name, epoch, release and prerelease

### DIFF
--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -308,7 +308,7 @@ func create(ctx *context.Context, fpm config.NFPM, format string, artifacts []*a
 		return err
 	}
 
-	packageName, err := tmpl.New(ctx).Apply(fpm.PackageName)
+	packageName, err := tmpl.New(ctx).Apply(overridden.PackageName)
 	if err != nil {
 		return err
 	}
@@ -316,8 +316,8 @@ func create(ctx *context.Context, fpm config.NFPM, format string, artifacts []*a
 	t := tmpl.New(ctx).
 		WithArtifact(artifacts[0]).
 		WithExtraFields(tmpl.Fields{
-			"Release":     fpm.Release,
-			"Epoch":       fpm.Epoch,
+			"Release":     overridden.Release,
+			"Epoch":       overridden.Epoch,
 			"PackageName": packageName,
 		})
 
@@ -470,10 +470,10 @@ func create(ctx *context.Context, fpm config.NFPM, format string, artifacts []*a
 		Version:         ctx.Version,
 		Section:         fpm.Section,
 		Priority:        fpm.Priority,
-		Epoch:           fpm.Epoch,
-		Release:         fpm.Release,
-		Prerelease:      fpm.Prerelease,
-		VersionMetadata: fpm.VersionMetadata,
+		Epoch:           overridden.Epoch,
+		Release:         overridden.Release,
+		Prerelease:      overridden.Prerelease,
+		VersionMetadata: overridden.VersionMetadata,
 		Maintainer:      fpm.Maintainer,
 		Description:     fpm.Description,
 		Vendor:          fpm.Vendor,

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -1604,6 +1604,68 @@ func TestExtIsConventionalExtension(t *testing.T) {
 	require.Len(t, ctx.Artifacts.Filter(artifact.ByExt("pkg.tar.zst")).List(), 1)
 }
 
+func TestOverridesVersionFields(t *testing.T) {
+	dist := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0o755))
+	binPath := filepath.Join(dist, "mybin", "mybin")
+	require.NoError(t, os.WriteFile(binPath, []byte("fake binary"), 0o755))
+
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Dist:        dist,
+		ProjectName: "mybin",
+		NFPMs: []config.NFPM{
+			{
+				ID:         "someid",
+				Maintainer: "me",
+				Formats:    []string{"deb", "rpm"},
+				NFPMOverridables: config.NFPMOverridables{
+					FileNameTemplate: "{{ .PackageName }}_e{{ .Epoch }}_r{{ .Release }}_" +
+						"{{ trimsuffix .ConventionalFileName .ConventionalExtension }}",
+					PackageName:     "mybin",
+					Epoch:           "1",
+					Release:         "1",
+					Prerelease:      "alpha1",
+					VersionMetadata: "top",
+				},
+				Overrides: map[string]config.NFPMOverridables{
+					"rpm": {
+						PackageName:     "mybin-rpm",
+						Epoch:           "7",
+						Release:         "9",
+						Prerelease:      "beta1",
+						VersionMetadata: "git",
+					},
+				},
+			},
+		},
+	}, testctx.WithVersion("1.0.0"), testctx.WithCurrentTag("v1.0.0"))
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name:   "mybin",
+		Path:   binPath,
+		Goarch: "amd64",
+		Goos:   "linux",
+		Type:   artifact.Binary,
+		Extra: map[string]any{
+			artifact.ExtraID: "default",
+		},
+	})
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Run(ctx))
+
+	// .PackageName, .Epoch and .Release come from the template fields, while
+	// the conventional file name is built by nfpm out of the package name,
+	// prerelease, version metadata and release.
+	got := map[string]string{}
+	for _, pkg := range ctx.Artifacts.Filter(artifact.ByType(artifact.LinuxPackage)).List() {
+		got[pkg.Format()] = pkg.Name
+	}
+	require.Equal(t, map[string]string{
+		"deb": "mybin_e1_r1_mybin_1.0.0~alpha1+top-1_amd64.deb",
+		"rpm": "mybin-rpm_e7_r9_mybin-rpm-1.0.0~beta1+git-9.x86_64.rpm",
+	}, got)
+}
+
 func TestIPKSpecificConfig(t *testing.T) {
 	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")


### PR DESCRIPTION
## What's broken

`nfpms.overrides.<format>` silently ignores `package_name`, `epoch`, `release`, `prerelease` and `version_metadata`. `create()` builds a merged `overridden` but then reads those five off the un-merged `fpm`.

All five are fields of `NFPMOverridables`, and `www/static/schema.json` accepts them under `overrides`, so they are written without any warning and dropped.

## Repro

A config with top level `epoch: 1`, `release: 1`, `prerelease: alpha1`, `version_metadata: top`, plus an `overrides.rpm` block changing all five:

```
before:
  creating  package=nfpmdemo  format=rpm  file=dist/nfpmdemo_..._amd64.rpm
  rpm lead: nfpmdemo-0.0.0~alpha1+top-1

after:
  creating  package=nfpmdemo-rpm  format=rpm  file=dist/nfpmdemo-rpm_..._amd64.rpm
  rpm lead: nfpmdemo-rpm-0.0.0~beta1+git-9
```

The deb package, which has no override block, is unaffected either way.

## The fix

Read those five from `overridden` instead of `fpm`, in the three places they are used.

## Verification

`TestOverridesVersionFields` configures all five at the top level and overrides them for rpm only, then asserts on both output names. Reverting the three spots fails it, and the deb entry stays correct under the mutation, which isolates the override path.

The test needs no external binary, since nfpm is a library, so it runs rather than skipping.

`go test ./internal/pipe/nfpm/` passes. `go test ./internal/...` has one failure, `builders/node TestBuild`, which needs Node >= v25.5.0 and fails identically on a clean `main` here. `golangci-lint run ./internal/pipe/nfpm/...` reports nothing, `gofmt` and `go vet` clean.

I did not run `task ci` in full, since it pulls Docker, snapcraft and cosign.
