### PR TITLE
fix(brew): a formula without a repository stops the ones after it

### DIFF
--- a/internal/pipe/brew/brew.go
+++ b/internal/pipe/brew/brew.go
@@ -99,13 +99,20 @@ func (Pipe) Publish(ctx *context.Context) error {
 }
 
 func runAll(ctx *context.Context, cli client.ReleaseURLTemplater) error {
+	// even if one of them is skipped, we still go through all of them, and
+	// return the skips all at once in the end.
+	skips := pipe.SkipMemento{}
 	for _, brew := range ctx.Config.Brews {
 		err := doRun(ctx, brew, cli)
+		if err != nil && pipe.IsSkip(err) {
+			skips.Remember(err)
+			continue
+		}
 		if err != nil {
 			return err
 		}
 	}
-	return nil
+	return skips.Evaluate()
 }
 
 func publishAll(ctx *context.Context, cli client.Client) error {

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -1310,6 +1310,64 @@ func TestRunSkipNoName(t *testing.T) {
 	testlib.AssertSkipped(t, runAll(ctx, client))
 }
 
+func TestRunPipeNoRepoNameDoesNotStopOthers(t *testing.T) {
+	folder := t.TempDir()
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Dist:        folder,
+		ProjectName: "foo",
+		Brews: []config.Homebrew{
+			{
+				Name: "skipped",
+				Repository: config.RepoRef{
+					Owner: "foo",
+				},
+			},
+			{
+				Name:    "runs",
+				Goamd64: "v1",
+				Repository: config.RepoRef{
+					Owner: "foo",
+					Name:  "bar",
+				},
+				IDs: []string{"foo"},
+			},
+		},
+	}, testctx.WithCurrentTag("v1.0.1"), testctx.WithVersion("1.0.1"))
+
+	path := filepath.Join(folder, "bin.tar.gz")
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name:    "bin.tar.gz",
+		Path:    path,
+		Goos:    "darwin",
+		Goarch:  "amd64",
+		Goamd64: "v1",
+		Type:    artifact.UploadableArchive,
+		Extra: map[string]any{
+			artifact.ExtraID:       "foo",
+			artifact.ExtraFormat:   "tar.gz",
+			artifact.ExtraBinaries: []string{"foo"},
+		},
+	})
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Empty(t, ctx.Config.Brews[0].Repository.Name)
+
+	client := client.NewMock()
+	testlib.AssertSkipped(t, runAll(ctx, client))
+
+	formulae := ctx.Artifacts.Filter(artifact.ByType(artifact.BrewFormula)).List()
+	require.Len(t, formulae, 1)
+	require.Equal(t, "runs.rb", formulae[0].Name)
+	_, err = os.Stat(formulae[0].Path)
+	require.NoError(t, err)
+
+	brew := artifact.MustExtra[config.Homebrew](*formulae[0], brewConfigExtra)
+	require.Equal(t, []string{"foo"}, brew.IDs)
+}
+
 func TestInstalls(t *testing.T) {
 	t.Run("provided", func(t *testing.T) {
 		install, err := installs(


### PR DESCRIPTION
## What's broken

`runAll` stops at the first `doRun` error. `doRun` returns `pipe.Skip("brew.repository.name is not set")` when a formula has no `repository.name`, and `Default` does not fill that field in.

That means one skipped `brews` entry prevents every later entry from generating its formula. `doRun` has no other `pipe.Skip` return path.

## Repro

The regression test puts a brew without `repository.name` before a valid brew. Before the `runAll` fix, the skipped entry returned early and no formula artifact was created for the valid entry:

```console
$ TMPDIR=$PWD/.tmp GOTMPDIR=$PWD/.tmp go test ./internal/pipe/brew -run TestRunPipeNoRepoNameDoesNotStopOthers -count=1
--- FAIL: TestRunPipeNoRepoNameDoesNotStopOthers (0.00s)
    brew_test.go:1362: 
        	Error Trace:	/Users/carlos/Developer/worktrees/goreleaser/fix-brew-skip/internal/pipe/brew/brew_test.go:1362
        	Error:      	"[]" should have 1 item(s), but has 0
        	Test:       	TestRunPipeNoRepoNameDoesNotStopOthers
FAIL
FAIL	github.com/goreleaser/goreleaser/v2/internal/pipe/brew	0.534s
FAIL
```

## The fix

Use `pipe.SkipMemento` in `runAll`, matching `publishAll` in the same file: remember skip errors, keep processing the remaining formulas, return all skips at the end, and still return real errors immediately.

## Verification

```console
$ TMPDIR=$PWD/.tmp GOTMPDIR=$PWD/.tmp go test ./internal/pipe/brew -run TestRunPipeNoRepoNameDoesNotStopOthers -count=1
ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/brew	0.398s

$ TMPDIR=$PWD/.tmp GOTMPDIR=$PWD/.tmp GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all go test ./internal/pipe/brew/...
ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/brew	0.521s

$ gofmt -l internal/pipe/brew/brew.go internal/pipe/brew/brew_test.go

$ TMPDIR=$PWD/.tmp GOTMPDIR=$PWD/.tmp GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all go vet ./internal/pipe/brew/...
```
