### PR TITLE
fix(snapcraft): a disabled snap stops the ones after it

### DIFF
--- a/internal/pipe/snapcraft/snapcraft.go
+++ b/internal/pipe/snapcraft/snapcraft.go
@@ -158,13 +158,20 @@ func (Pipe) Default(ctx *context.Context) error {
 
 // Run the pipe.
 func (Pipe) Run(ctx *context.Context) error {
+	// even if one of them is disabled, we still go through all of them, and
+	// return the skips all at once in the end.
+	skips := pipe.SkipMemento{}
 	for _, snap := range ctx.Config.Snapcrafts {
-		// TODO: deal with pipe.skip?
-		if err := doRun(ctx, snap); err != nil {
+		err := doRun(ctx, snap)
+		if err != nil && pipe.IsSkip(err) {
+			skips.Remember(err)
+			continue
+		}
+		if err != nil {
 			return err
 		}
 	}
-	return nil
+	return skips.Evaluate()
 }
 
 func doRun(ctx *context.Context, snap config.Snapcraft) error {

--- a/internal/pipe/snapcraft/snapcraft_test.go
+++ b/internal/pipe/snapcraft/snapcraft_test.go
@@ -48,6 +48,46 @@ func TestRunPipeMissingInfo(t *testing.T) {
 	}
 }
 
+func TestRunPipeSomeDisabled(t *testing.T) {
+	testlib.SkipIfWindows(t, "snap doesn't work in windows")
+	fakeSnapcraft(t)
+	folder := t.TempDir()
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		ProjectName: "mybin",
+		Dist:        dist,
+		Snapcrafts: []config.Snapcraft{
+			{
+				NameTemplate:     "disabled_{{.Arch}}",
+				Summary:          "test summary",
+				Description:      "test description",
+				Publish:          true,
+				IDs:              []string{"disabled"},
+				ChannelTemplates: []string{"stable"},
+				Disable:          "true",
+			},
+			{
+				NameTemplate:     "enabled_{{.Arch}}",
+				Summary:          "test summary",
+				Description:      "test description",
+				Publish:          true,
+				IDs:              []string{"enabled"},
+				ChannelTemplates: []string{"stable"},
+			},
+		},
+	}, testctx.WithCurrentTag("v1.2.3"), testctx.WithVersion("1.2.3"))
+
+	addBinaries(t, ctx, "enabled", dist)
+	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
+	list := ctx.Artifacts.Filter(artifact.And(
+		artifact.ByType(artifact.PublishableSnapcraft),
+		artifact.ByGoarch("amd64"),
+	)).List()
+	require.Len(t, list, 1)
+	require.Equal(t, "enabled_amd64.snap", list[0].Name)
+}
+
 func TestRunPipe(t *testing.T) {
 	testlib.SkipIfWindows(t, "snap doesn't work in windows")
 	testlib.CheckPath(t, "snapcraft")


### PR DESCRIPTION
## What's broken

`snapcraft` takes a list of configs, each with its own `id`, but the first entry with `disable: true` returns out of the loop, so every snapcraft after it is silently never built. No error either way, so it looks like it worked.

`doRun` can also skip when both summary and description are empty, with the same loop shape.

## Repro

`TestRunPipeSomeDisabled` configures a disabled snapcraft first and an enabled snapcraft second. With the new test present and `Run` reverted to the old loop:

```
$ go test ./internal/pipe/snapcraft -run TestRunPipeSomeDisabled -count=1
--- FAIL: TestRunPipeSomeDisabled (0.00s)
    snapcraft_test.go:87: 
        	Error Trace:	/Users/carlos/Developer/worktrees/goreleaser/fix-snapcraft-skip/internal/pipe/snapcraft/snapcraft_test.go:87
        	Error:      	"[]" should have 1 item(s), but has 0
        	Test:       	TestRunPipeSomeDisabled
FAIL
FAIL	github.com/goreleaser/goreleaser/v2/internal/pipe/snapcraft	0.168s
FAIL
```

After the fix:

```
$ go test ./internal/pipe/snapcraft -run TestRunPipeSomeDisabled -count=1
ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/snapcraft	0.209s
```

## The fix

`pipe.SkipMemento`, the same way `brew`, `nix`, `scoop`, `winget` and the others already do it. Skips are collected and returned together, real errors still return immediately.

I left `Publish` alone. `push` returns nil or regular errors from `snapcraft upload`/retry wrapping, not `pipe.Skip`.

## Verification

```
$ go test ./internal/pipe/snapcraft/...
ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/snapcraft	(cached)

$ gofmt -l internal/pipe/snapcraft/snapcraft.go internal/pipe/snapcraft/snapcraft_test.go

$ go vet ./internal/pipe/snapcraft/...
```

I am on macOS and `snapcraft` is not in `$PATH`, so the neighboring real snapcraft run test skips via `testlib.CheckPath`. The new regression uses the existing `fakeSnapcraft` helper and does run locally.
