### PR TITLE
fix(cask): a cask without a repository stops the ones after it

### DIFF
--- a/internal/pipe/cask/cask.go
+++ b/internal/pipe/cask/cask.go
@@ -112,13 +112,20 @@ func (Pipe) Publish(ctx *context.Context) error {
 }
 
 func runAll(ctx *context.Context, cli client.ReleaseURLTemplater) error {
+	// even if one of them is skipped, we still go through all of them, and
+	// return the skips all at once in the end.
+	skips := pipe.SkipMemento{}
 	for _, brew := range ctx.Config.Casks {
 		err := doRun(ctx, brew, cli)
+		if err != nil && pipe.IsSkip(err) {
+			skips.Remember(err)
+			continue
+		}
 		if err != nil {
 			return err
 		}
 	}
-	return nil
+	return skips.Evaluate()
 }
 
 func publishAll(ctx *context.Context, cli client.Client) error {

--- a/internal/pipe/cask/cask_test.go
+++ b/internal/pipe/cask/cask_test.go
@@ -1271,6 +1271,59 @@ func TestRunSkipNoName(t *testing.T) {
 	testlib.AssertSkipped(t, runAll(ctx, client))
 }
 
+func TestRunPipeSomeSkipped(t *testing.T) {
+	folder := t.TempDir()
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Dist:        folder,
+		ProjectName: "foo",
+		Casks: []config.HomebrewCask{
+			{
+				Name: "skipped",
+			},
+			{
+				Name:        "bar",
+				Description: "Bar",
+				Homepage:    "https://goreleaser.com",
+				Repository: config.RepoRef{
+					Owner: "foo",
+					Name:  "bar",
+				},
+				IDs:      []string{"foo"},
+				Binaries: []string{"foo"},
+			},
+		},
+	}, testctx.WithVersion("1.0.1"), testctx.WithCurrentTag("v1.0.1"))
+
+	path := filepath.Join(folder, "bin.tar.gz")
+	require.NoError(t, os.WriteFile(path, []byte("foo"), 0o644))
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name:    "bin.tar.gz",
+		Path:    path,
+		Goos:    "darwin",
+		Goarch:  "amd64",
+		Goamd64: "v1",
+		Type:    artifact.UploadableArchive,
+		Extra: map[string]any{
+			artifact.ExtraID:       "foo",
+			artifact.ExtraFormat:   "tar.gz",
+			artifact.ExtraBinaries: []string{"foo"},
+		},
+	})
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Empty(t, ctx.Config.Casks[0].Repository.Name)
+
+	testlib.AssertSkipped(t, runAll(ctx, client.NewMock()))
+
+	casks := ctx.Artifacts.Filter(artifact.ByType(artifact.BrewCask)).List()
+	require.Len(t, casks, 1, "second cask should have run")
+	require.Equal(t, "bar.rb", casks[0].Name)
+
+	brew := artifact.MustExtra[config.HomebrewCask](*casks[0], brewConfigExtra)
+	require.Equal(t, []string{"foo"}, brew.IDs)
+	require.Equal(t, "bar", brew.Name)
+}
+
 func TestRunPipeUniversalBinary(t *testing.T) {
 	folder := t.TempDir()
 	ctx := testctx.WrapWithCfg(t.Context(),


### PR DESCRIPTION
## What's broken

`homebrew_casks` runs every configured cask in `runAll`, but it returned immediately on any error. `doRun` returns `pipe.Skip("homebrew_casks.repository.name is not set")` when a cask has no `repository.name`, and `Pipe{}.Default` does not fill that field. That made one skipped cask silently stop every cask after it.

`doRun` only has that one `pipe.Skip` path. The other cask skips are in `publishAll`, which already used `pipe.SkipMemento`.

## Repro

Added `TestRunPipeSomeSkipped`: the first cask has no `repository.name`, the second cask is configured with `name: bar` and `ids: [foo]`.

Before the `runAll` fix:

```console
$ go test -count=1 -run TestRunPipeSomeSkipped ./internal/pipe/cask/...
--- FAIL: TestRunPipeSomeSkipped (0.00s)
    cask_test.go:1319:
        	Error Trace:	/Users/carlos/Developer/worktrees/goreleaser/fix-cask-skip/internal/pipe/cask/cask_test.go:1319
        	Error:      	"[]" should have 1 item(s), but has 0
        	Test:       	TestRunPipeSomeSkipped
        	Messages:   	second cask should have run
FAIL
FAIL	github.com/goreleaser/goreleaser/v2/internal/pipe/cask	0.377s
FAIL
```

The skip was returned, but the second cask never produced its `artifact.BrewCask`.

## The fix

Mirror `publishAll`: `runAll` now stores skipped casks in `pipe.SkipMemento`, keeps processing the list, returns real errors immediately, and evaluates the collected skips at the end.

## Verification

```console
$ go test -count=1 -run TestRunPipeSomeSkipped ./internal/pipe/cask/...
ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/cask	0.240s
```

```console
$ gofmt -l internal/pipe/cask/cask.go internal/pipe/cask/cask_test.go
```

```console
$ go vet ./internal/pipe/cask/...
```
