### PR TITLE
fix(upload): a misconfigured upload stops the others

### DIFF
--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -179,6 +179,10 @@ func Upload(ctx *context.Context, uploads []config.Upload, kind string, check Re
 }
 
 func uploadOne(ctx *context.Context, upload config.Upload, kind string, check ResponseChecker) error {
+	if err := CheckConfig(ctx, &upload, kind); err != nil {
+		return err
+	}
+
 	skip, err := tmpl.New(ctx).Bool(upload.Skip)
 	if err != nil {
 		return err

--- a/internal/pipe/artifactory/artifactory.go
+++ b/internal/pipe/artifactory/artifactory.go
@@ -8,7 +8,6 @@ import (
 	h "net/http"
 
 	"github.com/goreleaser/goreleaser/v2/internal/http"
-	"github.com/goreleaser/goreleaser/v2/internal/pipe"
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
 )
 
@@ -33,14 +32,6 @@ func (Pipe) Default(ctx *context.Context) error {
 //
 // Docs: https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-Example-DeployinganArtifact
 func (Pipe) Publish(ctx *context.Context) error {
-	// Check requirements for every instance we have configured.
-	// If not fulfilled, we can skip this pipeline
-	for _, instance := range ctx.Config.Artifactories {
-		if skip := http.CheckConfig(ctx, &instance, "artifactory"); skip != nil {
-			return pipe.Skip(skip.Error())
-		}
-	}
-
 	return http.Upload(ctx, ctx.Config.Artifactories, "artifactory", checkResponse)
 }
 

--- a/internal/pipe/artifactory/artifactory_test.go
+++ b/internal/pipe/artifactory/artifactory_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
+	"github.com/goreleaser/goreleaser/v2/internal/pipe"
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/internal/testlib"
 	"github.com/goreleaser/goreleaser/v2/pkg/config"
@@ -288,6 +289,53 @@ func TestRunPipe_ModeArchive(t *testing.T) {
 	require.True(t, ok, "tar.gz file was not uploaded")
 	_, ok = uploads.Load("deb")
 	require.True(t, ok, "deb file was not uploaded")
+}
+
+func TestRunPipe_MisconfiguredArtifactoryDoesNotStopOthers(t *testing.T) {
+	var uploads sync.Map
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	file := filepath.Join(t.TempDir(), "bin.tar.gz")
+	require.NoError(t, os.WriteFile(file, []byte("archive"), 0o644))
+
+	mux.HandleFunc("/uploads/bin.tar.gz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		uploads.Store("targz", true)
+	})
+
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		ProjectName: "goreleaser",
+		Artifactories: []config.Upload{
+			{
+				Name:     "missing-secret",
+				Mode:     "archive",
+				Target:   server.URL + "/missing/",
+				Username: "deployuser",
+			},
+			{
+				Name:     "production",
+				Mode:     "archive",
+				Target:   server.URL + "/uploads/",
+				Username: "deployuser",
+			},
+		},
+		Archives: []config.Archive{{}},
+		Env:      []string{"ARTIFACTORY_PRODUCTION_SECRET=secret"},
+	})
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Type: artifact.UploadableArchive,
+		Name: "bin.tar.gz",
+		Path: file,
+	})
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	err := Pipe{}.Publish(ctx)
+	require.Error(t, err)
+	require.True(t, pipe.IsSkip(err), err)
+	_, ok := uploads.Load("targz")
+	require.True(t, ok, "the upload after the misconfigured one should have run")
 }
 
 func TestRunPipe_ArtifactoryDown(t *testing.T) {

--- a/internal/pipe/upload/upload.go
+++ b/internal/pipe/upload/upload.go
@@ -6,7 +6,6 @@ import (
 	h "net/http"
 
 	"github.com/goreleaser/goreleaser/v2/internal/http"
-	"github.com/goreleaser/goreleaser/v2/internal/pipe"
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
 )
 
@@ -24,14 +23,6 @@ func (Pipe) Default(ctx *context.Context) error {
 
 // Publish artifacts.
 func (Pipe) Publish(ctx *context.Context) error {
-	// Check requirements for every instance we have configured.
-	// If not fulfilled, we can skip this pipeline
-	for _, instance := range ctx.Config.Uploads {
-		if skip := http.CheckConfig(ctx, &instance, "upload"); skip != nil {
-			return pipe.Skip(skip.Error())
-		}
-	}
-
 	return http.Upload(ctx, ctx.Config.Uploads, "upload", func(res *h.Response) error {
 		if c := res.StatusCode; c < 200 || 299 < c {
 			return fmt.Errorf("unexpected http response status: %s", res.Status)

--- a/internal/pipe/upload/upload_test.go
+++ b/internal/pipe/upload/upload_test.go
@@ -190,6 +190,54 @@ func TestRunPipe_ModeArchive(t *testing.T) {
 	require.True(t, ok, "deb file was not uploaded")
 }
 
+func TestRunPipe_MisconfiguredUploadDoesNotStopOthers(t *testing.T) {
+	var uploads sync.Map
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	file := filepath.Join(t.TempDir(), "bin.tar.gz")
+	require.NoError(t, os.WriteFile(file, []byte("archive"), 0o644))
+
+	mux.HandleFunc("/uploads/bin.tar.gz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		uploads.Store("targz", true)
+	})
+
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		ProjectName: "goreleaser",
+		Uploads: []config.Upload{
+			{
+				Method:   http.MethodPut,
+				Name:     "missing-secret",
+				Mode:     "archive",
+				Target:   server.URL + "/missing/",
+				Username: "deployuser",
+			},
+			{
+				Method:   http.MethodPut,
+				Name:     "production",
+				Mode:     "archive",
+				Target:   server.URL + "/uploads/",
+				Username: "deployuser",
+			},
+		},
+		Archives: []config.Archive{{}},
+		Env:      []string{"UPLOAD_PRODUCTION_SECRET=secret"},
+	})
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Type: artifact.UploadableArchive,
+		Name: "bin.tar.gz",
+		Path: file,
+	})
+
+	err := Pipe{}.Publish(ctx)
+	require.Error(t, err)
+	require.True(t, pipe.IsSkip(err), err)
+	_, ok := uploads.Load("targz")
+	require.True(t, ok, "the upload after the misconfigured one should have run")
+}
+
 func TestRunPipe_ModeBinary_CustomArtifactName(t *testing.T) {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)


### PR DESCRIPTION
## What's broken

`upload` and `artifactory` take lists of configs, but both pipes validated every config up front, before calling `http.Upload`:

```go
for _, instance := range ctx.Config.Uploads {
	if skip := http.CheckConfig(ctx, &instance, "upload"); skip != nil {
		return pipe.Skip(skip.Error())
	}
}
```

So a single misconfigured entry, for example `username` set but `UPLOAD_<NAME>_SECRET` missing from the environment, skips the whole pipe. The other, perfectly configured uploads are silently never uploaded. Only the misconfigured one is named in the skip message.

`http.Upload` already collects per-config skips with `pipe.SkipMemento`. The pre-check loops bypassed it.

Same shape as the flatpak fix in #6781 and the milestone one in #6778.

## Repro

Two configs, the misconfigured one first, the valid one second, pointed at an `httptest` server. Against the pre-fix code, the valid one never uploads:

```
--- FAIL: TestRunPipe_MisconfiguredUploadDoesNotStopOthers (0.00s)
    upload_test.go:238:
        Error:      Should be true
        Messages:   the upload after the misconfigured one should have run
FAIL    github.com/goreleaser/goreleaser/v2/internal/pipe/upload       0.335s
--- FAIL: TestRunPipe_MisconfiguredArtifactoryDoesNotStopOthers (0.00s)
    artifactory_test.go:338:
        Error:      Should be true
        Messages:   the upload after the misconfigured one should have run
FAIL    github.com/goreleaser/goreleaser/v2/internal/pipe/artifactory  0.335s
```

Note the `require.True(t, pipe.IsSkip(err))` assertion above that line still passes pre-fix, so what the test isolates is exactly the dropped upload, not a change in the returned error.

Order decides it: put the valid config first and it uploads.

## The fix

Move `http.CheckConfig` into `uploadOne` and drop the whole-pipe pre-check loops from both pipes. A misconfigured entry now skips only itself, and the existing `pipe.SkipMemento` in `http.Upload` collects the skips. Real, non-skip errors still return immediately.

The check goes at the top of `uploadOne`, before the `skip` template and before the mode switch, which preserves the previous behaviour for an invalid `mode`: `CheckConfig` still turns it into a skip rather than letting the later mode switch return a hard error.

## Verification

```
$ go test -count=1 ./internal/http/... ./internal/pipe/upload/... ./internal/pipe/artifactory/...
ok  	github.com/goreleaser/goreleaser/v2/internal/http	0.264s
ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/upload	0.168s
ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/artifactory	0.167s
```

`gofmt -l` and `go vet` on the three packages are clean, and `golangci-lint run` reports 0 issues.

`CheckConfig` is now only called from `uploadOne`. It stays exported because it has its own direct test coverage in `internal/http`.

Docs: `www/content/customization/publish/upload.md` and `.../artifactory.md` document the secret names and `skip`, not the whole-pipe skip, so nothing needed changing there.
