### PR TITLE
fix(krew): a manifest without a name stops the ones after it

### DIFF
--- a/internal/pipe/krew/krew.go
+++ b/internal/pipe/krew/krew.go
@@ -74,13 +74,20 @@ func (Pipe) Run(ctx *context.Context) error {
 }
 
 func runAll(ctx *context.Context, cli client.ReleaseURLTemplater) error {
+	// even if one of them is skipped, we still go through all of them, and
+	// return the skips all at once in the end.
+	skips := pipe.SkipMemento{}
 	for _, krew := range ctx.Config.Krews {
 		err := doRun(ctx, krew, cli)
+		if err != nil && pipe.IsSkip(err) {
+			skips.Remember(err)
+			continue
+		}
 		if err != nil {
 			return err
 		}
 	}
-	return nil
+	return skips.Evaluate()
 }
 
 func doRun(ctx *context.Context, krew config.Krew, cl client.ReleaseURLTemplater) error {

--- a/internal/pipe/krew/krew_test.go
+++ b/internal/pipe/krew/krew_test.go
@@ -1070,6 +1070,56 @@ func TestRunSkipNoName(t *testing.T) {
 	testlib.AssertSkipped(t, runAll(ctx, client))
 }
 
+func TestRunPipeSomeSkipped(t *testing.T) {
+	folder := t.TempDir()
+	ctx := testctx.WrapWithCfg(t.Context(),
+		config.Project{
+			Dist: folder,
+			Krews: []config.Krew{
+				{
+					Description:      "Some desc",
+					ShortDescription: "Short desc",
+				},
+				{
+					Name:             "working",
+					Description:      "Some desc",
+					ShortDescription: "Short desc",
+					IDs:              []string{"foo"},
+				},
+			},
+		},
+		testctx.WithCurrentTag("v1.0.1"),
+		testctx.WithVersion("1.0.1"))
+
+	path := filepath.Join(folder, "bin.tar.gz")
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name:    "bin.tar.gz",
+		Path:    path,
+		Goos:    "darwin",
+		Goarch:  "amd64",
+		Goamd64: "v1",
+		Type:    artifact.UploadableArchive,
+		Extra: map[string]any{
+			artifact.ExtraID:       "foo",
+			artifact.ExtraFormat:   "tar.gz",
+			artifact.ExtraBinaries: []string{"foo"},
+		},
+	})
+
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Empty(t, ctx.Config.Krews[0].Name)
+	testlib.AssertSkipped(t, runAll(ctx, client.NewMock()))
+
+	manifests := ctx.Artifacts.Filter(artifact.ByType(artifact.KrewPluginManifest)).List()
+	require.Len(t, manifests, 1)
+	require.Equal(t, "working.yaml", manifests[0].Name)
+	require.Equal(t, []string{"foo"}, artifact.MustExtra[config.Krew](*manifests[0], krewConfigExtra).IDs)
+}
+
 func manifestName(tb testing.TB) string {
 	tb.Helper()
 	return path.Base(tb.Name())


### PR DESCRIPTION
## What's broken

`krews` takes a list of manifest configs, but `runAll` returned immediately when one entry returned `pipe.Skip`. A manifest without a `name` could skip the pipe and silently prevent every manifest after it from being generated.

`Pipe{}.Default` only copies `project_name` into an empty krew name. If `project_name` is empty too, `doRun` still reaches `pipe.Skip("krew: manifest name is not set")`. The description and short description checks are hard errors and still abort immediately.

## Repro

Two krew configs, the first without `name`, the second valid:

```
krews:
  - description: Some desc
    short_description: Short desc
  - name: working
    description: Some desc
    short_description: Short desc
    ids: [foo]
```

Before the fix, the skip from the first config stops the second manifest from being added:

```
go test ./internal/pipe/krew -run TestRunPipeSomeSkipped -count=1
--- FAIL: TestRunPipeSomeSkipped (0.00s)
    krew_test.go:1118: 
        	Error Trace:	/Users/carlos/Developer/worktrees/goreleaser/fix-krew-skip/internal/pipe/krew/krew_test.go:1118
        	Error:      	"[]" should have 1 item(s), but has 0
        	Test:       	TestRunPipeSomeSkipped
FAIL
FAIL	github.com/goreleaser/goreleaser/v2/internal/pipe/krew	0.355s
FAIL
```

## The fix

`pipe.SkipMemento`, same as `publishAll` in this file. Skips are remembered and returned together after the loop. Real errors still return immediately.

## Verification

`TestRunPipeSomeSkipped` configures a skipped krew followed by a valid one, calls `Pipe{}.Default`, asserts the first name is still empty, asserts `runAll` returns a skip, and asserts the second produced one `artifact.KrewPluginManifest` named `working.yaml` for id `foo`.

```
go test ./internal/pipe/krew -run TestRunPipeSomeSkipped -count=1
ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/krew	0.244s
```

The hard-error cases still pass:

```
go test ./internal/pipe/krew -run 'TestFullPipe/(no desc|no short desc)$' -count=1
ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/krew	0.225s
```

Package verification passed with the local Git bare-repository safety override needed by the existing `git_remote` test:

```
GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all go test ./internal/pipe/krew/...
ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/krew	0.537s
```

`gofmt -l internal/pipe/krew/krew.go internal/pipe/krew/krew_test.go` and `go vet ./internal/pipe/krew/...` produced no output.
