### PR TITLE
fix(nix): a skipped nix entry stops the ones after it

### DIFF
--- a/internal/pipe/nix/nix.go
+++ b/internal/pipe/nix/nix.go
@@ -114,13 +114,20 @@ func (p Pipe) Publish(ctx *context.Context) error {
 }
 
 func (p Pipe) runAll(ctx *context.Context, cli client.ReleaseURLTemplater) error {
+	// even if one of them is skipped, we still go through all of them, and
+	// return the skips all at once in the end.
+	skips := pipe.SkipMemento{}
 	for _, nix := range ctx.Config.Nix {
 		err := p.doRun(ctx, nix, cli)
+		if err != nil && pipe.IsSkip(err) {
+			skips.Remember(err)
+			continue
+		}
 		if err != nil {
 			return err
 		}
 	}
-	return nil
+	return skips.Evaluate()
 }
 
 func (p Pipe) publishAll(ctx *context.Context, cli client.Client) error {

--- a/internal/pipe/nix/nix_test.go
+++ b/internal/pipe/nix/nix_test.go
@@ -630,6 +630,65 @@ func TestRunSkipNoNix(t *testing.T) {
 	testlib.AssertSkipped(t, p.Run(ctx))
 }
 
+func TestRunPipeSomeSkipped(t *testing.T) {
+	folder := t.TempDir()
+	ctx := testctx.WrapWithCfg(
+		t.Context(),
+		config.Project{
+			Dist:        folder,
+			ProjectName: "foo",
+			Nix: []config.Nix{
+				{
+					// no repository.name: gets skipped.
+					Name: "skipped",
+				},
+				{
+					Name: "bar",
+					IDs:  []string{"foo"},
+					Repository: config.RepoRef{
+						Owner: "foo",
+						Name:  "bar",
+					},
+				},
+			},
+		},
+		testctx.WithVersion("1.0.0"),
+		testctx.WithCurrentTag("v1.0.0"),
+	)
+
+	for _, goarch := range []string{"amd64", "arm64"} {
+		name := "foo_linux_" + goarch + ".tar.gz"
+		path := filepath.Join(folder, "dist", name)
+		ctx.Artifacts.Add(&artifact.Artifact{
+			Name:   name,
+			Path:   path,
+			Goos:   "linux",
+			Goarch: goarch,
+			Type:   artifact.UploadableArchive,
+			Extra: map[string]any{
+				artifact.ExtraID:        "foo",
+				artifact.ExtraFormat:    "tar.gz",
+				artifact.ExtraBinaries:  []string{"foo"},
+				artifact.ExtraWrappedIn: "",
+			},
+		})
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		f, err := os.Create(path)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+	}
+
+	p := Pipe{alwaysZeroHasher{}}
+	require.NoError(t, p.Default(ctx))
+	testlib.AssertSkipped(t, p.runAll(ctx, client.NewMock()))
+	require.Len(
+		t,
+		ctx.Artifacts.Filter(artifact.ByType(artifact.Nixpkg)).List(),
+		1,
+		"second nix package should have run",
+	)
+}
+
 func TestErrNoArchivesFound(t *testing.T) {
 	require.EqualError(t, errNoArchivesFound{
 		goamd64: "v1",


### PR DESCRIPTION
`runAll` returns on the first error, so a nix entry that gets skipped (no `repository.name`) aborts every nix entry after it in the same release. With two entries where only the first lacks a repository name, the second never gets written:

```
before   • pipe skipped or partially skipped   reason=repository name is not set
         dist/nix: (no files)

after    • writing   nixpkg=dist/nix/pkgs/second/default.nix
         • pipe skipped or partially skipped   reason=repository name is not set
```

It now collects skips in a `pipe.SkipMemento` and evaluates them at the end, which is what cask (#6785), brew (#6783), krew (#6787), flatpak (#6781) and snapcraft (#6784) already do. `publishAll` in this same file was already written that way, only `runAll` was missed.

Test added in `nix_test.go`; reverting the change fails it with "second nix package should have run". It runs without any external binary, using the package's existing `alwaysZeroHasher`. `go test ./internal/pipe/nix/...` passes, gofmt and vet clean.

AI disclosure: written with Claude Code. I ran the release binary before and after and checked the mutation myself.