### PR TITLE
fix(blob): honor s3_force_path_style without a custom endpoint

### DIFF
--- a/internal/pipe/blob/blob_test.go
+++ b/internal/pipe/blob/blob_test.go
@@ -193,11 +193,12 @@ func TestURL(t *testing.T) {
 	})
 
 	t.Run("s3 force path style false with endpoint", func(t *testing.T) {
+		forcePathStyle := false
 		url, err := urlFor(testctx.Wrap(t.Context()), config.Blob{
 			Bucket:           "foo",
 			Provider:         "s3",
 			Endpoint:         "s3.foobar.com",
-			S3ForcePathStyle: &[]bool{false}[0],
+			S3ForcePathStyle: &forcePathStyle,
 		})
 		require.NoError(t, err)
 		require.Equal(t, "s3://foo?endpoint=s3.foobar.com&s3ForcePathStyle=false", url)

--- a/internal/pipe/blob/blob_test.go
+++ b/internal/pipe/blob/blob_test.go
@@ -2,6 +2,7 @@ package blob
 
 import (
 	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
@@ -170,6 +171,36 @@ func TestURL(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, "gs://foo", url)
+	})
+
+	t.Run("s3 force path style without endpoint", func(t *testing.T) {
+		for _, forcePathStyle := range []bool{true, false} {
+			t.Run(strconv.FormatBool(forcePathStyle), func(t *testing.T) {
+				url, err := urlFor(testctx.Wrap(t.Context()), config.Blob{
+					Bucket:           "foo",
+					Provider:         "s3",
+					Region:           "us-west-1",
+					S3ForcePathStyle: &forcePathStyle,
+				})
+				require.NoError(t, err)
+				require.Equal(
+					t,
+					"s3://foo?region=us-west-1&s3ForcePathStyle="+strconv.FormatBool(forcePathStyle),
+					url,
+				)
+			})
+		}
+	})
+
+	t.Run("s3 force path style false with endpoint", func(t *testing.T) {
+		url, err := urlFor(testctx.Wrap(t.Context()), config.Blob{
+			Bucket:           "foo",
+			Provider:         "s3",
+			Endpoint:         "s3.foobar.com",
+			S3ForcePathStyle: &[]bool{false}[0],
+		})
+		require.NoError(t, err)
+		require.Equal(t, "s3://foo?endpoint=s3.foobar.com&s3ForcePathStyle=false", url)
 	})
 
 	t.Run("s3 no opts", func(t *testing.T) {

--- a/internal/pipe/blob/upload.go
+++ b/internal/pipe/blob/upload.go
@@ -61,10 +61,8 @@ func urlFor(ctx *context.Context, conf config.Blob) (string, error) {
 
 	switch {
 	case conf.S3ForcePathStyle != nil:
-		// explicitly set, always honor it.
 		query.Add("s3ForcePathStyle", strconv.FormatBool(*conf.S3ForcePathStyle))
 	case endpoint != "":
-		// a custom endpoint implies path style.
 		query.Add("s3ForcePathStyle", "true")
 	}
 

--- a/internal/pipe/blob/upload.go
+++ b/internal/pipe/blob/upload.go
@@ -57,11 +57,15 @@ func urlFor(ctx *context.Context, conf config.Blob) (string, error) {
 	}
 	if endpoint != "" {
 		query.Add("endpoint", endpoint)
-		if conf.S3ForcePathStyle == nil {
-			query.Add("s3ForcePathStyle", "true")
-		} else {
-			query.Add("s3ForcePathStyle", strconv.FormatBool(*conf.S3ForcePathStyle))
-		}
+	}
+
+	switch {
+	case conf.S3ForcePathStyle != nil:
+		// explicitly set, always honor it.
+		query.Add("s3ForcePathStyle", strconv.FormatBool(*conf.S3ForcePathStyle))
+	case endpoint != "":
+		// a custom endpoint implies path style.
+		query.Add("s3ForcePathStyle", "true")
 	}
 
 	region, err := tmpl.New(ctx).Apply(conf.Region)

--- a/www/content/customization/publish/blob.md
+++ b/www/content/customization/publish/blob.md
@@ -96,9 +96,10 @@ blobs:
       - src: LICENSE.tpl
         dst: LICENSE.txt
 
-    # Allow to disable `s3ForcePathStyle`.
+    # Whether to use path-style addressing (`s3ForcePathStyle`).
+    # Requires provider to be `s3`.
     #
-    # Default: true.
+    # Default: true if `endpoint` is set, otherwise the AWS SDK default.
     s3_force_path_style: false
 
     # ACL to be applied to all files in this configuration.


### PR DESCRIPTION
`s3_force_path_style` is only applied when `endpoint` is also set, so setting it against a plain AWS S3 bucket does nothing and goreleaser keeps using virtual-host addressing. Running `Publish()` against a local S3 with `s3_force_path_style: true` and no `endpoint`:

```
before   bucketURL: s3://mybucket?region=us-east-1
         request:   mybucket.localhost:44415 /d/a.tar.gz     (virtual-host, field ignored)

after    bucketURL: s3://mybucket?region=us-east-1&s3ForcePathStyle=true
         request:   localhost:35747 /mybucket/d/a.tar.gz     (path style, as configured)
```

The parameter is now added whenever the field is set explicitly. A custom endpoint still implies path style when the field is omitted, so config that does not set it is unaffected: the existing `s3_no_opts` and `s3_with_opts` cases produce the same URL as before.

I also corrected the docs line for the field. It said "Default: true", which only held when `endpoint` was set.

Test added in `blob_test.go` covering the field set to true and false without an endpoint; reverting the change fails both. `go test ./internal/pipe/blob/...` passes, along with upload and artifactory. gofmt and vet clean. No schema change, the field type is unchanged.

AI disclosure: written with Claude Code. I ran the before/after against a local S3 and checked the mutation myself.