### PR TITLE
fix(sign): artifacts: none masks real signing failures

### DIFF
--- a/internal/pipe/sign/sign.go
+++ b/internal/pipe/sign/sign.go
@@ -84,7 +84,9 @@ func (Pipe) Default(ctx *context.Context) error {
 
 // Run executes the Pipe.
 func (Pipe) Run(ctx *context.Context) error {
-	g := semerrgroup.New(ctx.Parallelism)
+	// skip-aware so that a config with `artifacts: none` doesn't mask the
+	// errors of the other configs, and doesn't prevent the refresh below.
+	g := semerrgroup.NewSkipAware(semerrgroup.New(ctx.Parallelism))
 	for i := range ctx.Config.Signs {
 		cfg := ctx.Config.Signs[i]
 		g.Go(func() error {
@@ -126,11 +128,15 @@ func (Pipe) Run(ctx *context.Context) error {
 			return sign(ctx, cfg, ctx.Artifacts.Filter(artifact.And(filters...)).List())
 		})
 	}
-	if err := g.Wait(); err != nil {
+	err := g.Wait()
+	if err != nil && !pipe.IsSkip(err) {
 		return err
 	}
 
-	return ctx.Artifacts.Refresh()
+	if rerr := ctx.Artifacts.Refresh(); rerr != nil {
+		return rerr
+	}
+	return err
 }
 
 func sign(ctx *context.Context, cfg config.Sign, artifacts []*artifact.Artifact) error {

--- a/internal/pipe/sign/sign_binary.go
+++ b/internal/pipe/sign/sign_binary.go
@@ -65,7 +65,9 @@ func (BinaryPipe) Default(ctx *context.Context) error {
 
 // Run signs and pushes the binary images signatures.
 func (BinaryPipe) Run(ctx *context.Context) error {
-	g := semerrgroup.New(ctx.Parallelism)
+	// skip-aware so that a config with `artifacts: none` doesn't mask the
+	// errors of the other configs.
+	g := semerrgroup.NewSkipAware(semerrgroup.New(ctx.Parallelism))
 	for i := range ctx.Config.BinarySigns {
 		cfg := ctx.Config.BinarySigns[i]
 		g.Go(func() error {

--- a/internal/pipe/sign/sign_binary_test.go
+++ b/internal/pipe/sign/sign_binary_test.go
@@ -41,6 +41,28 @@ func TestBinarySignDisabled(t *testing.T) {
 	require.EqualError(t, err, "artifact signing is disabled")
 }
 
+func TestBinarySignDisabledDoesNotStopOthers(t *testing.T) {
+	dist := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dist, "bin"), []byte("foo"), 0o644))
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Dist: dist,
+		BinarySigns: []config.BinarySign{
+			{ID: "disabled", Artifacts: "none"},
+			{ID: "enabled", Artifacts: "binary", Cmd: "false"},
+		},
+	})
+	ctx.Parallelism = 1
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name: "bin",
+		Path: filepath.Join(dist, "bin"),
+		Type: artifact.Binary,
+	})
+
+	require.NoError(t, BinaryPipe{}.Default(ctx))
+	err := BinaryPipe{}.Run(ctx)
+	require.ErrorContains(t, err, "exit status 1")
+}
+
 func TestBinarySignInvalidOption(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		BinarySigns: []config.BinarySign{

--- a/internal/pipe/sign/sign_docker.go
+++ b/internal/pipe/sign/sign_docker.go
@@ -49,7 +49,9 @@ func (DockerPipe) Default(ctx *context.Context) error {
 
 // Publish signs and pushes the docker images signatures.
 func (DockerPipe) Publish(ctx *context.Context) error {
-	g := semerrgroup.New(ctx.Parallelism)
+	// skip-aware so that a config with `artifacts: none` doesn't mask the
+	// errors of the other configs.
+	g := semerrgroup.NewSkipAware(semerrgroup.New(ctx.Parallelism))
 	for i := range ctx.Config.DockerSigns {
 		cfg := ctx.Config.DockerSigns[i]
 		g.Go(func() error {

--- a/internal/pipe/sign/sign_docker_test.go
+++ b/internal/pipe/sign/sign_docker_test.go
@@ -42,6 +42,26 @@ func TestDockerSignDisabled(t *testing.T) {
 	require.EqualError(t, err, "artifact signing is disabled")
 }
 
+func TestDockerSignDisabledDoesNotStopOthers(t *testing.T) {
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Dist: t.TempDir(),
+		DockerSigns: []config.Sign{
+			{ID: "disabled", Artifacts: "none"},
+			{ID: "enabled", Artifacts: "images", Cmd: "false"},
+		},
+	})
+	ctx.Parallelism = 1
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name: "img",
+		Path: "img",
+		Type: artifact.DockerImage,
+	})
+
+	require.NoError(t, DockerPipe{}.Default(ctx))
+	err := DockerPipe{}.Publish(ctx)
+	require.ErrorContains(t, err, "exit status 1")
+}
+
 func TestDockerSignInvalidArtifacts(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		DockerSigns: []config.Sign{

--- a/internal/pipe/sign/sign_test.go
+++ b/internal/pipe/sign/sign_test.go
@@ -89,6 +89,28 @@ func TestSignDisabled(t *testing.T) {
 	require.EqualError(t, err, "artifact signing is disabled")
 }
 
+func TestSignDisabledDoesNotStopOthers(t *testing.T) {
+	dist := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dist, "artifact1"), []byte("foo"), 0o644))
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Dist: dist,
+		Signs: []config.Sign{
+			{ID: "disabled", Artifacts: "none"},
+			{ID: "enabled", Artifacts: "all", Cmd: "false"},
+		},
+	})
+	ctx.Parallelism = 1
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name: "artifact1",
+		Path: filepath.Join(dist, "artifact1"),
+		Type: artifact.UploadableArchive,
+	})
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	err := Pipe{}.Run(ctx)
+	require.ErrorContains(t, err, "exit status 1")
+}
+
 func TestSignInvalidArtifacts(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{Signs: []config.Sign{{Artifacts: "foo"}}})
 	err := Pipe{}.Run(ctx)


### PR DESCRIPTION
In `signs`, `binary_signs` and `docker_signs`, an entry with `artifacts: none` returns a skip into a plain errgroup, so that skip becomes the group's result and hides real signing failures from the other entries in the same list. The release then exits 0 with unsigned artifacts.

With `signs: [{artifacts: none}, {artifacts: checksum, cmd: sh, args: ["-c","exit 7"]}]`:

```
before   • signing artifacts
           • pipe skipped or partially skipped   reason=artifact signing is disabled
         • release succeeded after 0s                                        exit=0

after    • signing artifacts
         x release failed   error=exit status 7  message=could not sign artifact  cmd=sh   exit=1
```

The three groups are now wrapped in `semerrgroup.NewSkipAware`, which sbom, blob, ko, notary and docker already use. In `signs`, `ctx.Artifacts.Refresh()` was also being skipped in that case, so signatures produced by the other entries were not registered; it now runs, and the skip is still returned afterwards.

One test per pipe, using `cmd: false` so no cosign, syft or gon is needed. Reverting the three wrappers fails all three with `"artifact signing is disabled" does not contain "exit status 1"`. sign, sbom and notary suites pass, gofmt and vet clean.

AI disclosure: written with Claude Code. I ran the release binary before and after and checked the mutations myself.