### PR TITLE
fix(aur): expand description templates before escaping quotes

### DIFF
--- a/internal/pipe/aur/aur.go
+++ b/internal/pipe/aur/aur.go
@@ -104,9 +104,7 @@ func doRun(ctx *context.Context, aur config.AUR, cl client.ReleaseURLTemplater) 
 		&aur.Name,
 		&aur.Directory,
 		&aur.SkipUpload,
-		// needs to be evaluated here so `quoteField` sees the final value:
-		// the whole file is templated again later, and by then it is too late
-		// to escape quotes coming from the template result.
+		// must be expanded here so `quoteField` sees the final value.
 		&aur.Description,
 	); err != nil {
 		return err
@@ -290,7 +288,7 @@ func applyTemplate(ctx *context.Context, tpl string, data templateData) (string,
 func toPkgBuildArray(ss []string) string {
 	result := make([]string, 0, len(ss))
 	for _, s := range ss {
-		result = append(result, fmt.Sprintf("'%s'", s))
+		result = append(result, quoteField(s))
 	}
 	return strings.Join(result, " ")
 }

--- a/internal/pipe/aur/aur.go
+++ b/internal/pipe/aur/aur.go
@@ -104,6 +104,10 @@ func doRun(ctx *context.Context, aur config.AUR, cl client.ReleaseURLTemplater) 
 		&aur.Name,
 		&aur.Directory,
 		&aur.SkipUpload,
+		// needs to be evaluated here so `quoteField` sees the final value:
+		// the whole file is templated again later, and by then it is too late
+		// to escape quotes coming from the template result.
+		&aur.Description,
 	); err != nil {
 		return err
 	}

--- a/internal/pipe/aur/aur_test.go
+++ b/internal/pipe/aur/aur_test.go
@@ -927,6 +927,9 @@ func TestRunPipeTemplatedDescriptionWithQuotes(t *testing.T) {
 			ProjectName: "foo",
 			AURs: []config.AUR{{
 				Description: "{{ .Env.DESC }}",
+				Homepage:    "https://example.com/~o'brien",
+				License:     "Nobody's",
+				Provides:    []string{"fo'o", "bar"},
 			}},
 			Env: []string{`DESC=Let's go`},
 		},
@@ -960,4 +963,7 @@ func TestRunPipeTemplatedDescriptionWithQuotes(t *testing.T) {
 	bts, err := os.ReadFile(filepath.Join(folder, "aur", "foo-bin.pkgbuild"))
 	require.NoError(t, err)
 	require.Contains(t, string(bts), `pkgdesc="Let's go"`)
+	require.Contains(t, string(bts), `url="https://example.com/~o'brien"`)
+	require.Contains(t, string(bts), `license=("Nobody's")`)
+	require.Contains(t, string(bts), `provides=("fo'o" 'bar')`)
 }

--- a/internal/pipe/aur/aur_test.go
+++ b/internal/pipe/aur/aur_test.go
@@ -917,3 +917,47 @@ func requireEqualRepoFiles(tb testing.TB, distDir, repoDir, name, url string) {
 		".SRCINFO": filepath.Join(distDir, "aur", name+"-bin.srcinfo"),
 	})
 }
+
+func TestRunPipeTemplatedDescriptionWithQuotes(t *testing.T) {
+	folder := t.TempDir()
+	ctx := testctx.WrapWithCfg(
+		t.Context(),
+		config.Project{
+			Dist:        folder,
+			ProjectName: "foo",
+			AURs: []config.AUR{{
+				Description: "{{ .Env.DESC }}",
+			}},
+			Env: []string{`DESC=Let's go`},
+		},
+		testctx.GitHubTokenType,
+		testctx.WithVersion("1.2.1"),
+		testctx.WithCurrentTag("v1.2.1"),
+		testctx.WithSemver(1, 2, 1, ""),
+	)
+
+	path := filepath.Join(folder, "foo_linux_amd64")
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name:    "foo_linux_amd64",
+		Path:    path,
+		Goos:    "linux",
+		Goarch:  "amd64",
+		Goamd64: "v1",
+		Type:    artifact.UploadableBinary,
+		Extra: map[string]any{
+			artifact.ExtraID:     "foo",
+			artifact.ExtraFormat: "binary",
+			artifact.ExtraBinary: "foo",
+		},
+	})
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, runAll(ctx, client.NewMock()))
+
+	bts, err := os.ReadFile(filepath.Join(folder, "aur", "foo-bin.pkgbuild"))
+	require.NoError(t, err)
+	require.Contains(t, string(bts), `pkgdesc="Let's go"`)
+}

--- a/internal/pipe/aur/tmpl.go
+++ b/internal/pipe/aur/tmpl.go
@@ -40,9 +40,9 @@ pkgname='{{ .Name }}'
 pkgver={{ .Version }}
 pkgrel={{ .Rel }}
 pkgdesc={{ quoteField .Desc }}
-url='{{ .Homepage }}'
+url={{ quoteField .Homepage }}
 arch=({{ pkgArray .Arches }})
-license=('{{ .License }}')
+license=({{ quoteField .License }})
 {{- with .Provides }}
 provides=({{ pkgArray . }})
 {{- end }}

--- a/internal/pipe/aursources/aursources.go
+++ b/internal/pipe/aursources/aursources.go
@@ -107,9 +107,7 @@ func doRun(ctx *context.Context, aur config.AURSource, cl client.ReleaseURLTempl
 		&aur.Name,
 		&aur.Directory,
 		&aur.SkipUpload,
-		// needs to be evaluated here so `quoteField` sees the final value:
-		// the whole file is templated again later, and by then it is too late
-		// to escape quotes coming from the template result.
+		// must be expanded here so `quoteField` sees the final value.
 		&aur.Description,
 	); err != nil {
 		return err
@@ -258,7 +256,7 @@ func applyTemplate(ctx *context.Context, tpl string, data templateData) (string,
 func toPkgBuildArray(ss []string) string {
 	result := make([]string, 0, len(ss))
 	for _, s := range ss {
-		result = append(result, fmt.Sprintf("'%s'", s))
+		result = append(result, quoteField(s))
 	}
 	return strings.Join(result, " ")
 }

--- a/internal/pipe/aursources/aursources.go
+++ b/internal/pipe/aursources/aursources.go
@@ -107,6 +107,10 @@ func doRun(ctx *context.Context, aur config.AURSource, cl client.ReleaseURLTempl
 		&aur.Name,
 		&aur.Directory,
 		&aur.SkipUpload,
+		// needs to be evaluated here so `quoteField` sees the final value:
+		// the whole file is templated again later, and by then it is too late
+		// to escape quotes coming from the template result.
+		&aur.Description,
 	); err != nil {
 		return err
 	}

--- a/internal/pipe/aursources/aursources_test.go
+++ b/internal/pipe/aursources/aursources_test.go
@@ -833,3 +833,43 @@ func requireEqualRepoFiles(tb testing.TB, distDir, repoDir, name, url string) {
 		".SRCINFO": filepath.Join(distDir, "aur", name+".srcinfo"),
 	})
 }
+
+func TestRunPipeTemplatedDescriptionWithQuotes(t *testing.T) {
+	folder := t.TempDir()
+	ctx := testctx.WrapWithCfg(
+		t.Context(),
+		config.Project{
+			Dist:        folder,
+			ProjectName: "foo",
+			AURSources: []config.AURSource{{
+				Description: "{{ .Env.DESC }}",
+			}},
+			Env: []string{`DESC=Let's go`},
+		},
+		testctx.GitHubTokenType,
+		testctx.WithVersion("1.2.1"),
+		testctx.WithCurrentTag("v1.2.1"),
+		testctx.WithSemver(1, 2, 1, ""),
+	)
+
+	path := filepath.Join(folder, "foo.tar.gz")
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name: "foo.tar.gz",
+		Path: path,
+		Type: artifact.UploadableSourceArchive,
+		Extra: map[string]any{
+			artifact.ExtraID:     "foo",
+			artifact.ExtraFormat: "tar.gz",
+		},
+	})
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, runAll(ctx, client.NewMock()))
+
+	bts, err := os.ReadFile(filepath.Join(folder, "aur", "foo.pkgbuild"))
+	require.NoError(t, err)
+	require.Contains(t, string(bts), `pkgdesc="Let's go"`)
+}

--- a/internal/pipe/aursources/aursources_test.go
+++ b/internal/pipe/aursources/aursources_test.go
@@ -843,6 +843,9 @@ func TestRunPipeTemplatedDescriptionWithQuotes(t *testing.T) {
 			ProjectName: "foo",
 			AURSources: []config.AURSource{{
 				Description: "{{ .Env.DESC }}",
+				Homepage:    "https://example.com/~o'brien",
+				License:     "Nobody's",
+				Provides:    []string{"fo'o", "bar"},
 			}},
 			Env: []string{`DESC=Let's go`},
 		},
@@ -872,4 +875,7 @@ func TestRunPipeTemplatedDescriptionWithQuotes(t *testing.T) {
 	bts, err := os.ReadFile(filepath.Join(folder, "aur", "foo.pkgbuild"))
 	require.NoError(t, err)
 	require.Contains(t, string(bts), `pkgdesc="Let's go"`)
+	require.Contains(t, string(bts), `url="https://example.com/~o'brien"`)
+	require.Contains(t, string(bts), `license=("Nobody's")`)
+	require.Contains(t, string(bts), `provides=("fo'o" 'bar')`)
 }

--- a/internal/pipe/aursources/tmpl.go
+++ b/internal/pipe/aursources/tmpl.go
@@ -42,9 +42,9 @@ pkgname='{{ .Name }}'
 pkgver={{ .Version }}
 pkgrel={{ .Rel }}
 pkgdesc={{ quoteField .Desc }}
-url='{{ .Homepage }}'
+url={{ quoteField .Homepage }}
 arch=({{ pkgArray .Arches }})
-license=('{{ .License }}')
+license=({{ quoteField .License }})
 {{- with .Provides }}
 provides=({{ pkgArray . }})
 {{- end }}


### PR DESCRIPTION
Both `aur.md` and `aursources.md` document `description` as `Templates: allowed`, but neither pipe expands it before the PKGBUILD is built, so `quoteField` escapes the raw `{{ ... }}` string instead of the final value. When the template result contains an apostrophe, the generated PKGBUILD is not valid shell.

With `description: "{{ .Env.DESC }}"` and `DESC=Let's go`:

```
before   pkgdesc='Let's go'
after    pkgdesc="Let's go"

$ bash -n PKGBUILD
before   exit=2   unexpected EOF while looking for matching `''
after    exit=0
```

The fix adds `&aur.Description` to the existing `tmpl.ApplyAll` in `doRun`, in both pipes. It has to happen there rather than later, because the whole file is templated again afterwards and by then the quoting decision has already been made.

The hardcoded version of this case is already covered by `simple-quote-inside-description`; only the templated one was missing. One test per pipe, both fail on revert with `does not contain "pkgdesc=\"Let's go\""`. aur and aursources suites pass, gofmt and vet clean. No docs or schema change, the docs were already correct.

AI disclosure: written with Claude Code. I ran the release binary before and after, checked the mutation, and validated the output with `bash -n` myself.