### PR TITLE
fix(chocolatey): error on multiple archives for the same platform

### DIFF
--- a/internal/pipe/chocolatey/chocolatey.go
+++ b/internal/pipe/chocolatey/chocolatey.go
@@ -18,7 +18,12 @@ import (
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
 )
 
-var errNoWindowsArchive = errors.New("chocolatey requires at least one windows archive")
+var (
+	errNoWindowsArchive = errors.New("chocolatey requires at least one windows archive")
+	// a chocolateyinstall.ps1 may only have one url/checksum pair per
+	// architecture.
+	errMultipleArchives = errors.New("found multiple archives for the same platform, please consider filtering by id")
+)
 
 // nuget package extension.
 const nupkgFormat = "nupkg"
@@ -291,6 +296,7 @@ func dataFor(ctx *context.Context, cl client.ReleaseURLTemplater, choco config.C
 		choco.URLTemplate = url
 	}
 
+	archCounts := map[string]int{}
 	for _, artifact := range artifacts {
 		sum, err := artifact.Checksum("sha256")
 		if err != nil {
@@ -309,6 +315,13 @@ func dataFor(ctx *context.Context, cl client.ReleaseURLTemplater, choco config.C
 		}
 
 		result.Packages = append(result.Packages, pkg)
+		archCounts[artifact.Goarch]++
+	}
+
+	for _, count := range archCounts {
+		if count > 1 {
+			return templateData{}, errMultipleArchives
+		}
 	}
 
 	return result, nil

--- a/internal/pipe/chocolatey/chocolatey_test.go
+++ b/internal/pipe/chocolatey/chocolatey_test.go
@@ -230,6 +230,38 @@ func Test_buildTemplate(t *testing.T) {
 	golden.RequireEqualExt(t, out, ".script.ps1")
 }
 
+func Test_dataForMultipleArchivesSameArch(t *testing.T) {
+	folder := t.TempDir()
+	file := filepath.Join(folder, "archive")
+	require.NoError(t, os.WriteFile(file, []byte("lorem ipsum"), 0o644))
+
+	for _, goarch := range []string{"386", "amd64"} {
+		t.Run(goarch, func(t *testing.T) {
+			ctx := testctx.Wrap(t.Context(), testctx.WithVersion("1.0.0"), testctx.WithCurrentTag("v1.0.0"))
+			artifacts := []*artifact.Artifact{
+				{
+					Name:    "client_1.0.0_windows_" + goarch + ".zip",
+					Goos:    "windows",
+					Goarch:  goarch,
+					Goamd64: "v1",
+					Path:    file,
+				},
+				{
+					Name:    "server_1.0.0_windows_" + goarch + ".zip",
+					Goos:    "windows",
+					Goarch:  goarch,
+					Goamd64: "v1",
+					Path:    file,
+				},
+			}
+
+			data, err := dataFor(ctx, client.NewMock(), config.Chocolatey{Name: "app"}, artifacts)
+			require.ErrorIs(t, err, errMultipleArchives)
+			require.Empty(t, data.Packages)
+		})
+	}
+}
+
 func TestPublish(t *testing.T) {
 	folder := t.TempDir()
 	file := filepath.Join(folder, "archive")

--- a/www/content/customization/package/chocolatey.md
+++ b/www/content/customization/package/chocolatey.md
@@ -25,6 +25,8 @@ chocolateys:
     # IDs of the archives to use.
     # Empty means all IDs.
     # Attention: archives must not be in the 'binary' format.
+    # A package can only have one archive per architecture, so if your build
+    # produces several Windows archives for the same GOARCH, filter them here.
     ids:
       - foo
       - bar


### PR DESCRIPTION
chocolatey has no duplicate-archive guard, so two Windows archives with the same GOARCH both get written into `chocolateyinstall.ps1`, producing a hashtable with duplicate `url64bit` and `checksum64` keys. PowerShell fails on that at runtime, and goreleaser reports success.

Calling `doRun` with a client and a server zip, both windows/amd64:

```
before   err: <nil>
         $packageArgs = @{
             url64bit   = '.../client_1.0.0_windows_amd64.zip'
             checksum64 = '5e2bf5...'
             url64bit   = '.../server_1.0.0_windows_amd64.zip'   <- duplicate key
             checksum64 = '5e2bf5...'
         }

after    err: found multiple archives for the same platform, please consider filtering by id
         no chocolateyinstall.ps1 written
```

winget and scoop both guard this already, chocolatey was the one that did not. This is also the exact case scoop's error page tells users to fix with `ids`, so I added two lines about it under `ids` in the docs.

I used a plain error rather than `pipe.Skip`, matching this pipe's existing `errNoWindowsArchive`, though winget uses a skip for its equivalent. Say the word if you would rather have it skip.

Test added covering 386 and amd64; removing the guard fails both. chocolatey and scoop suites pass, gofmt and vet clean. No `choco` binary needed, the pipe's `cmder` is faked.

AI disclosure: written with Claude Code. I ran the before/after and checked the mutation myself.