### PR TITLE
fix(healthcheck): register upx and makeself dependency checkers

### DIFF
--- a/internal/pipe/makeself/makeself.go
+++ b/internal/pipe/makeself/makeself.go
@@ -38,6 +38,9 @@ func (Pipe) Skip(ctx *context.Context) bool {
 	return skips.Any(ctx, skips.Makeself) || len(ctx.Config.Makeselfs) == 0
 }
 
+// Dependencies returns the binaries this pipe needs.
+func (Pipe) Dependencies(*context.Context) []string { return []string{"makeself"} }
+
 // Default sets the pipe defaults.
 func (Pipe) Default(ctx *context.Context) error {
 	ids := ids.New("makeselfs")

--- a/internal/pipe/makeself/makeself_test.go
+++ b/internal/pipe/makeself/makeself_test.go
@@ -22,6 +22,10 @@ func TestDescription(t *testing.T) {
 	require.Equal(t, "makeself packages", Pipe{}.String())
 }
 
+func TestDependencies(t *testing.T) {
+	require.Equal(t, []string{"makeself"}, Pipe{}.Dependencies(testctx.Wrap(t.Context())))
+}
+
 func TestSkip(t *testing.T) {
 	t.Run("skip", func(t *testing.T) {
 		ctx := testctx.Wrap(t.Context(), testctx.Skip(skips.Makeself))

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -9,10 +9,12 @@ import (
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/docker"
 	dockerv2 "github.com/goreleaser/goreleaser/v2/internal/pipe/docker/v2"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/flatpak"
+	"github.com/goreleaser/goreleaser/v2/internal/pipe/makeself"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/nix"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/sbom"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/sign"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/snapcraft"
+	"github.com/goreleaser/goreleaser/v2/internal/pipe/upx"
 	"github.com/goreleaser/goreleaser/v2/pkg/build"
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
 )
@@ -59,6 +61,8 @@ var DependencyCheckers = []DependencyChecker{
 	chocolatey.Pipe{},
 	nix.New(),
 	flatpak.Pipe{},
+	makeself.Pipe{},
+	upx.Pipe{},
 }
 
 type system struct{}

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/pkg/config"
+	"github.com/goreleaser/goreleaser/v2/pkg/context"
 	"github.com/stretchr/testify/require"
 
 	// langs to init.
@@ -59,4 +60,25 @@ func TestHealthCheckers(t *testing.T) {
 
 func TestDependencyCheckers(t *testing.T) {
 	require.NotEmpty(t, DependencyCheckers)
+}
+
+// Pipes that document requiring an external binary in $PATH must be part of
+// the dependency checkers, otherwise `goreleaser healthcheck` reports a clean
+// bill of health for a config that cannot run.
+func TestDependencyCheckersCoverExternalBinaries(t *testing.T) {
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Makeselfs: []config.Makeself{{Script: "install.sh"}},
+		UPXs:      []config.UPX{{Enabled: "true"}},
+	})
+	var tools []string
+	for _, hc := range DependencyCheckers {
+		if skipper, ok := hc.(interface {
+			Skip(*context.Context) bool
+		}); ok && skipper.Skip(ctx) {
+			continue
+		}
+		tools = append(tools, hc.Dependencies(ctx)...)
+	}
+	require.Contains(t, tools, "makeself")
+	require.Contains(t, tools, "upx")
 }


### PR DESCRIPTION
`goreleaser healthcheck` reports a clean bill of health for configs using `upx` or `makeselfs`, even though both docs pages say the binary has to be in `$PATH`. Neither pipe is registered in `healthcheck.DependencyCheckers`, so the command that exists to catch a missing tool stays silent about these two.

Same config, neither binary installed:

```
before   • ✓ git
         • ✓ go
         • done!                                      exit 0

after    • ✓ git
         • ✓ go
         • ⚠ makeself - not present in path
         • ⚠ upx - not present in path
         x command failed   error=one or more checks failed    exit 1
```

`upx.Pipe` already implemented `Dependencies()`, it was just never registered, so that was dead code. makeself had none and now has one. A config with neither section is unaffected, which I checked separately.

The new test in `pkg/healthcheck` asserts the behaviour rather than a hardcoded list: it walks the registered checkers, skips the ones whose `Skip` returns true for the config, and requires the tools to show up. srpm, makeself, upx and healthcheck suites pass, gofmt and vet clean.

This touches `pkg/healthcheck` as well as the two pipes, since that is where the registry lives.

AI disclosure: written with Claude Code. I ran healthcheck before and after and checked the mutation myself.