### PR TITLE
fix(mcp): mcp.disable is documented but never read

### DIFF
--- a/internal/pipe/mcp/mcp.go
+++ b/internal/pipe/mcp/mcp.go
@@ -9,10 +9,12 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/internal/deprecate"
 	"github.com/goreleaser/goreleaser/v2/internal/logext"
+	"github.com/goreleaser/goreleaser/v2/internal/pipe"
 	"github.com/goreleaser/goreleaser/v2/internal/retryx"
 	"github.com/goreleaser/goreleaser/v2/internal/skips"
 	"github.com/goreleaser/goreleaser/v2/internal/tmpl"
@@ -67,8 +69,20 @@ func (Pipe) Default(ctx *context.Context) error {
 }
 
 func (p Pipe) Publish(ctx *context.Context) error {
-	warnExperimental()
 	mcp := ctx.Config.MCP
+
+	disable, err := tmpl.New(ctx).Apply(mcp.Disable)
+	if err != nil {
+		return fmt.Errorf("could not evaluate mcp.disable: %w", err)
+	}
+	if strings.TrimSpace(disable) == "true" {
+		return pipe.Skip("mcp.disable is set")
+	}
+	if strings.TrimSpace(disable) == "auto" && ctx.Semver.Prerelease != "" {
+		return pipe.Skip("prerelease detected with 'auto' disable, skipping mcp publish")
+	}
+
+	warnExperimental()
 
 	if err := tmpl.New(ctx).ApplyAll(
 		&mcp.Name,

--- a/internal/pipe/mcp/mcp_test.go
+++ b/internal/pipe/mcp/mcp_test.go
@@ -285,6 +285,105 @@ func TestPublishWithTemplates(t *testing.T) {
 	require.NoError(t, pipe.Publish(ctx))
 }
 
+func TestPublishDisabled(t *testing.T) {
+	for name, disable := range map[string]string{
+		"true":     "true",
+		"template": "{{ .Env.NOPE }}",
+	} {
+		t.Run(name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+				t.Error("should not have published anything")
+			}))
+			defer srv.Close()
+
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+				MCP: config.MCP{
+					MCPDetails: config.MCPDetails{
+						Name:    "test-server",
+						Title:   "Test Server",
+						Disable: disable,
+						Auth: config.MCPAuth{
+							Type: "none",
+						},
+					},
+				},
+			}, testctx.WithEnv(map[string]string{"NOPE": "true"}))
+			ctx.Version = "1.0.0"
+
+			p := &Pipe{registry: srv.URL}
+			p.authProviderFn = func(_, _, _ string) (auth.Provider, error) {
+				return &mockAuthProvider{token: "test-token"}, nil
+			}
+			require.NoError(t, p.Default(ctx))
+			testlib.AssertSkipped(t, p.Publish(ctx))
+		})
+	}
+
+	t.Run("auto on a prerelease", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			t.Error("should not have published anything")
+		}))
+		defer srv.Close()
+
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			MCP: config.MCP{
+				MCPDetails: config.MCPDetails{
+					Name:    "test-server",
+					Title:   "Test Server",
+					Disable: "auto",
+					Auth: config.MCPAuth{
+						Type: "none",
+					},
+				},
+			},
+		}, testctx.WithSemver(1, 0, 0, "rc1"))
+		ctx.Version = "1.0.0-rc1"
+
+		p := &Pipe{registry: srv.URL}
+		p.authProviderFn = func(_, _, _ string) (auth.Provider, error) {
+			return &mockAuthProvider{token: "test-token"}, nil
+		}
+		require.NoError(t, p.Default(ctx))
+		testlib.AssertSkipped(t, p.Publish(ctx))
+	})
+
+	t.Run("not disabled", func(t *testing.T) {
+		var published bool
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			published = true
+			w.WriteHeader(http.StatusCreated)
+			assert.NoError(t, json.NewEncoder(w).Encode(apiv0.ServerResponse{
+				Meta: apiv0.ResponseMeta{
+					Official: &apiv0.RegistryExtensions{Status: "pending"},
+				},
+			}))
+		}))
+		defer srv.Close()
+
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			MCP: config.MCP{
+				MCPDetails: config.MCPDetails{
+					Name:    "test-server",
+					Title:   "Test Server",
+					Disable: "false",
+					Auth: config.MCPAuth{
+						Type: "none",
+					},
+				},
+			},
+		})
+		ctx.Version = "1.0.0"
+
+		p := &Pipe{registry: srv.URL}
+		p.authProviderFn = func(_, _, _ string) (auth.Provider, error) {
+			return &mockAuthProvider{token: "test-token"}, nil
+		}
+		require.NoError(t, p.Default(ctx))
+		require.NoError(t, p.Publish(ctx))
+		require.True(t, published)
+	})
+}
+
 func TestPublishInvalidTemplate(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		MCP: config.MCP{


### PR DESCRIPTION
`mcp.disable` is documented, present in `config.MCPDetails`, and accepted by `schema.json`, but `internal/pipe/mcp/mcp.go` never reads it. Setting it has no effect and the publish runs anyway.

From `www/content/customization/publish/mcp.md`:

> Setting this will prevent GoReleaser from actually trying to publish the server manifest - instead, the manifest file will be stored in the dist directory only [...] If set to auto, the manifest will not be published in case there is an indicator for prerelease in the tag

The field is currently only ever written to, in the `mcp.github` deprecation migration.

Before, with `mcp.disable: true`:

```
• mcp registry
  • mcp is experimental and subject to change
⨯ release failed after 0s
  │ * mcp registry: could not get token: failed to get anonymous token (status 404)
```

After:

```
• mcp registry
  • pipe skipped or partially skipped   reason=mcp.disable is set
• release succeeded after 0s
```

Both documented forms are handled, `true` and `auto` on a prerelease, using the same two-line shape as `brew.skip_upload`, `docker_manifest.skip_push` and the other seven pipes that implement `auto`.

One deliberate change beyond the skip: `warnExperimental()` now runs after the disable check, so a disabled MCP config no longer prints the experimental warning. Happy to move it back if you would rather it always warn.

AI-assisted: written with Claude Code, reviewed and tested by me before sending.
