### PR TITLE
fix(winget): a skipped winget entry stops the ones after it

### DIFF
--- a/internal/pipe/winget/winget.go
+++ b/internal/pipe/winget/winget.go
@@ -103,13 +103,20 @@ func (p Pipe) Publish(ctx *context.Context) error {
 }
 
 func (p Pipe) runAll(ctx *context.Context, cli client.ReleaseURLTemplater) error {
+	// even if one of them is skipped, we still go through all of them, and
+	// return the skips all at once in the end.
+	skips := pipe.SkipMemento{}
 	for _, winget := range ctx.Config.Winget {
 		err := p.doRun(ctx, winget, cli)
+		if err != nil && pipe.IsSkip(err) {
+			skips.Remember(err)
+			continue
+		}
 		if err != nil {
 			return err
 		}
 	}
-	return nil
+	return skips.Evaluate()
 }
 
 func (p Pipe) doRun(ctx *context.Context, winget config.Winget, cl client.ReleaseURLTemplater) error {

--- a/internal/pipe/winget/winget_test.go
+++ b/internal/pipe/winget/winget_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/client"
 	"github.com/goreleaser/goreleaser/v2/internal/golden"
+	"github.com/goreleaser/goreleaser/v2/internal/pipe"
 	"github.com/goreleaser/goreleaser/v2/internal/skips"
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/pkg/config"
@@ -1132,6 +1133,70 @@ func TestRunNoArtifactsOnInvalidAdditionalLocale(t *testing.T) {
 		artifact.WingetDefaultLocale,
 		artifact.WingetLocale,
 	)).List())
+}
+
+func TestRunPipeSkippedWingetDoesNotStopOthers(t *testing.T) {
+	folder := t.TempDir()
+	ctx := testctx.WrapWithCfg(t.Context(),
+		config.Project{
+			Dist:        folder,
+			ProjectName: "foo",
+			Winget: []config.Winget{
+				{
+					// no license: skipped.
+					Name:             "skipped",
+					Publisher:        "Foo",
+					ShortDescription: "foo bar zaz",
+					IDs:              []string{"foo"},
+					Repository: config.RepoRef{
+						Owner: "foo",
+						Name:  "bar",
+					},
+				},
+				{
+					Name:             "valid",
+					Publisher:        "Foo",
+					License:          "MIT",
+					ShortDescription: "foo bar zaz",
+					IDs:              []string{"foo"},
+					Repository: config.RepoRef{
+						Owner: "foo",
+						Name:  "bar",
+					},
+				},
+			},
+		},
+		testctx.WithVersion("1.2.1"),
+		testctx.WithCurrentTag("v1.2.1"),
+		testctx.WithSemver(1, 2, 1, ""),
+		testctx.WithDate(time.Date(2023, 6, 12, 20, 32, 10, 12, time.Local)))
+
+	path := filepath.Join(folder, "dist/foo_windows_amd64v1.zip")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("fake"), 0o644))
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name:    "foo_windows_amd64v1.zip",
+		Path:    path,
+		Goos:    "windows",
+		Goarch:  "amd64",
+		Goamd64: "v1",
+		Type:    artifact.UploadableArchive,
+		Extra: map[string]any{
+			artifact.ExtraID:        "foo",
+			artifact.ExtraFormat:    "zip",
+			artifact.ExtraBinaries:  []string{"foo.exe"},
+			artifact.ExtraWrappedIn: "",
+		},
+	})
+
+	p := Pipe{}
+	require.NoError(t, p.Default(ctx))
+
+	err := p.runAll(ctx, client.NewMock())
+	require.True(t, pipe.IsSkip(err), "expected a skip error, got %v", err)
+
+	// the entry after the skipped one must still have produced its manifests.
+	require.Len(t, ctx.Artifacts.Filter(artifact.ByType(artifact.WingetVersion)).List(), 1)
 }
 
 func TestErrNoArchivesFound(t *testing.T) {


### PR DESCRIPTION
`winget.runAll` returns on the first error, including `pipe.Skip`, so a winget entry that skips takes every later entry with it and their manifests are never generated. An entry skips when it is missing `license`, `publisher`, `short_description` or `repository.name`, or when `package_identifier` is invalid.

With two entries where only the first is missing a license:

```
before:
  • winget
    • pipe skipped or partially skipped    reason=winget.license is required
  (no dist/winget/*.yaml produced at all)

after:
  • winget
    • writing   path=dist/winget/manifests/f/Foo/valid/1.0.0/Foo.valid.yaml
    • writing   path=.../Foo.valid.installer.yaml
    • writing   path=.../Foo.valid.locale.en-US.yaml
    • pipe skipped or partially skipped    reason=winget.license is required
```

The fix is `pipe.SkipMemento`, the same change already merged for brew (#6783), snapcraft (#6784), cask (#6785), upload (#6786), krew (#6787) and nix (#6788). `publishAll` in this same file already does it this way, `runAll` was the last place in winget that did not.

AI-assisted: written with Claude Code, reviewed and tested by me before sending.
