### PR TITLE
fix(dockers/v2): annotation scopes

### DIFF
--- a/internal/pipe/docker/v2/docker.go
+++ b/internal/pipe/docker/v2/docker.go
@@ -371,7 +371,9 @@ func makeArgs(ctx *context.Context, d config.DockerV2, extraArgs []string) (dock
 	}
 	if len(d.Platforms) > 1 {
 		for i := 1; i < len(annotationFlags); i += 2 {
-			annotationFlags[i] = "index:" + strings.TrimPrefix(annotationFlags[i], "index:")
+			if !hasAnnotationScope(annotationFlags[i]) {
+				annotationFlags[i] = "index:" + annotationFlags[i]
+			}
 		}
 	}
 
@@ -574,6 +576,18 @@ func parsePlatform(p string) platform {
 		result.arm = strings.TrimPrefix(parts[2], "v")
 	}
 	return result
+}
+
+// hasAnnotationScope reports whether a `key=value` annotation already carries a
+// buildx scope prefix.
+//
+// buildx parses annotations as `[type:]key=value`, taking everything before the
+// first colon of the key as the scope list, so a colon there means the user
+// picked the scopes themselves. Invalid scopes are passed through as-is for
+// buildx to report.
+func hasAnnotationScope(annotation string) bool {
+	key, _, _ := strings.Cut(annotation, "=")
+	return strings.Contains(key, ":")
 }
 
 // tplMapFlags templates all keys and values in the given map, returning a

--- a/internal/pipe/docker/v2/docker.go
+++ b/internal/pipe/docker/v2/docker.go
@@ -578,16 +578,34 @@ func parsePlatform(p string) platform {
 	return result
 }
 
+// annotationScopes are the annotation types buildx accepts, optionally
+// qualified with a platform, e.g. `manifest[linux/amd64]`.
+var annotationScopes = []string{
+	"index",
+	"manifest",
+	"index-descriptor",
+	"manifest-descriptor",
+}
+
 // hasAnnotationScope reports whether a `key=value` annotation already carries a
 // buildx scope prefix.
 //
-// buildx parses annotations as `[type:]key=value`, taking everything before the
-// first colon of the key as the scope list, so a colon there means the user
-// picked the scopes themselves. Invalid scopes are passed through as-is for
-// buildx to report.
+// buildx parses annotations as `[types:]key=value`, in which types is a
+// comma-separated list of [annotationScopes]. Keys with any other prefix are
+// scoped by us, as buildx would reject them.
 func hasAnnotationScope(annotation string) bool {
 	key, _, _ := strings.Cut(annotation, "=")
-	return strings.Contains(key, ":")
+	scopes, _, ok := strings.Cut(key, ":")
+	if !ok {
+		return false
+	}
+	for scope := range strings.SplitSeq(scopes, ",") {
+		scope, _, _ = strings.Cut(scope, "[")
+		if !slices.Contains(annotationScopes, scope) {
+			return false
+		}
+	}
+	return true
 }
 
 // tplMapFlags templates all keys and values in the given map, returning a

--- a/internal/pipe/docker/v2/docker_integration_test.go
+++ b/internal/pipe/docker/v2/docker_integration_test.go
@@ -286,13 +286,14 @@ func TestPublish(t *testing.T) {
 			if desc.Platform == nil || desc.Platform.Architecture == "unknown" {
 				continue
 			}
+			plat := desc.Platform.OS + "/" + desc.Platform.Architecture
 			manifest := inspectManifest(t, "localhost:5060/foo@"+desc.Digest.String())
 			require.Equal(t, map[string]string{
 				"org.opencontainers.image.revision": "abc123",
-			}, manifest.Annotations, "platform %s", desc.Platform)
-			annotated = append(annotated, desc.Platform.String())
+			}, manifest.Annotations, "platform %s", plat)
+			annotated = append(annotated, plat)
 		}
-		require.Equal(t, []string{"linux/amd64", "linux/arm64"}, annotated)
+		require.ElementsMatch(t, []string{"linux/amd64", "linux/arm64"}, annotated)
 
 		require.True(t, hasSBOM(t, "localhost:5060/foo:v1.0.0"))
 	})

--- a/internal/pipe/docker/v2/docker_integration_test.go
+++ b/internal/pipe/docker/v2/docker_integration_test.go
@@ -207,7 +207,8 @@ func TestPublish(t *testing.T) {
 						"org.opencontainers.image.licenses": "MIT",
 					},
 					Annotations: map[string]string{
-						"index:org.opencontainers.image.description": "My multi-arch image",
+						"index:org.opencontainers.image.description":       "My multi-arch image",
+						"index,manifest:org.opencontainers.image.revision": "abc123",
 					},
 				},
 				{
@@ -274,10 +275,24 @@ func TestPublish(t *testing.T) {
 			require.NotEmpty(t, artifact.ExtraOr(*img, artifact.ExtraDigest, ""))
 		}
 
-		manifest := inspectManifest(t, "localhost:5060/foo:v1.0.0")
+		idx := inspectIndex(t, "localhost:5060/foo:v1.0.0")
 		require.Equal(t, map[string]string{
 			"org.opencontainers.image.description": "My multi-arch image",
-		}, manifest.Annotations)
+			"org.opencontainers.image.revision":    "abc123",
+		}, idx.Annotations)
+
+		var annotated []string
+		for _, desc := range idx.Manifests {
+			if desc.Platform == nil || desc.Platform.Architecture == "unknown" {
+				continue
+			}
+			manifest := inspectManifest(t, "localhost:5060/foo@"+desc.Digest.String())
+			require.Equal(t, map[string]string{
+				"org.opencontainers.image.revision": "abc123",
+			}, manifest.Annotations, "platform %s", desc.Platform)
+			annotated = append(annotated, desc.Platform.String())
+		}
+		require.Equal(t, []string{"linux/amd64", "linux/arm64"}, annotated)
 
 		require.True(t, hasSBOM(t, "localhost:5060/foo:v1.0.0"))
 	})
@@ -420,6 +435,20 @@ func inspectImage(tb testing.TB, image string) []inspectResponse {
 
 func inspectManifest(tb testing.TB, image string) v1.Manifest {
 	tb.Helper()
+	var t v1.Manifest
+	require.NoError(tb, json.Unmarshal(inspectRaw(tb, image), &t))
+	return t
+}
+
+func inspectIndex(tb testing.TB, image string) v1.IndexManifest {
+	tb.Helper()
+	var t v1.IndexManifest
+	require.NoError(tb, json.Unmarshal(inspectRaw(tb, image), &t))
+	return t
+}
+
+func inspectRaw(tb testing.TB, image string) []byte {
+	tb.Helper()
 	out, err := exec.CommandContext(
 		tb.Context(),
 		"docker",
@@ -430,10 +459,7 @@ func inspectManifest(tb testing.TB, image string) v1.Manifest {
 		image,
 	).CombinedOutput()
 	require.NoError(tb, err, "output: %s", string(out))
-
-	var t v1.Manifest
-	require.NoError(tb, json.Unmarshal(out, &t))
-	return t
+	return out
 }
 
 func hasSBOM(tb testing.TB, image string) bool {

--- a/internal/pipe/docker/v2/docker_test.go
+++ b/internal/pipe/docker/v2/docker_test.go
@@ -306,6 +306,16 @@ func TestMakeArgsAnnotationScopes(t *testing.T) {
 			platforms:   multi,
 			expect:      []string{"index:foo=https://example.com"},
 		},
+		"unknown scope is part of the key": {
+			annotations: map[string]string{"bogus:foo": "bar"},
+			platforms:   multi,
+			expect:      []string{"index:bogus:foo=bar"},
+		},
+		"one unknown scope in the list invalidates it": {
+			annotations: map[string]string{"index,bogus:foo": "bar"},
+			platforms:   multi,
+			expect:      []string{"index:index,bogus:foo=bar"},
+		},
 		"single platform is left alone": {
 			annotations: map[string]string{"foo": "bar"},
 			platforms:   []string{"linux/amd64"},

--- a/internal/pipe/docker/v2/docker_test.go
+++ b/internal/pipe/docker/v2/docker_test.go
@@ -258,6 +258,84 @@ func TestMakeArgs(t *testing.T) {
 	})
 }
 
+func TestMakeArgsAnnotationScopes(t *testing.T) {
+	multi := []string{"linux/amd64", "linux/arm64"}
+	for name, tt := range map[string]struct {
+		annotations map[string]string
+		platforms   []string
+		expect      []string
+	}{
+		"unscoped defaults to index": {
+			annotations: map[string]string{"foo": "bar"},
+			platforms:   multi,
+			expect:      []string{"index:foo=bar"},
+		},
+		"explicit index is not doubled": {
+			annotations: map[string]string{"index:foo": "bar"},
+			platforms:   multi,
+			expect:      []string{"index:foo=bar"},
+		},
+		"manifest scope is kept": {
+			annotations: map[string]string{"manifest:foo": "bar"},
+			platforms:   multi,
+			expect:      []string{"manifest:foo=bar"},
+		},
+		"multiple scopes are kept": {
+			annotations: map[string]string{"index,manifest:foo": "bar"},
+			platforms:   multi,
+			expect:      []string{"index,manifest:foo=bar"},
+		},
+		"platform qualified scope is kept": {
+			annotations: map[string]string{"manifest[linux/amd64]:foo": "bar"},
+			platforms:   multi,
+			expect:      []string{"manifest[linux/amd64]:foo=bar"},
+		},
+		"descriptor scopes are kept": {
+			annotations: map[string]string{
+				"index-descriptor:foo":    "bar",
+				"manifest-descriptor:baz": "qux",
+			},
+			platforms: multi,
+			expect: []string{
+				"index-descriptor:foo=bar",
+				"manifest-descriptor:baz=qux",
+			},
+		},
+		"colon in value is not a scope": {
+			annotations: map[string]string{"foo": "https://example.com"},
+			platforms:   multi,
+			expect:      []string{"index:foo=https://example.com"},
+		},
+		"single platform is left alone": {
+			annotations: map[string]string{"foo": "bar"},
+			platforms:   []string{"linux/amd64"},
+			expect:      []string{"foo=bar"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			da, err := makeArgs(testctx.Wrap(t.Context()), config.DockerV2{
+				Dockerfile:  "Dockerfile",
+				Images:      []string{"ghcr.io/foo/bar"},
+				Tags:        []string{"latest"},
+				Platforms:   tt.platforms,
+				Annotations: tt.annotations,
+			}, nil)
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, annotationsOf(da.args))
+		})
+	}
+}
+
+func annotationsOf(args []string) []string {
+	var result []string
+	for i, arg := range args {
+		if arg == "--annotation" {
+			result = append(result, args[i+1])
+		}
+	}
+	return result
+}
+
 func TestDisable(t *testing.T) {
 	t.Run("disabled", func(t *testing.T) {
 		ctx := testctx.WrapWithCfg(t.Context(), config.Project{

--- a/www/content/customization/package/dockers_v2.md
+++ b/www/content/customization/package/dockers_v2.md
@@ -123,6 +123,8 @@ dockers_v2:
 
     # Annotations to be added to the image.
     #
+    # Keys may carry a scope prefix, see "Annotation scopes" below.
+    #
     # Items with empty keys or values will be ignored.
     #
     # Templates: allowed.
@@ -137,6 +139,9 @@ dockers_v2:
       # You can also use `.BaseImage` and `.BaseImageDigest`. {{< g_inline_version "v2.16" >}}
       "org.opencontainers.image.base.name": "{{.BaseImage}}"
       "org.opencontainers.image.base.digest": "{{.BaseImageDigest}}"
+
+      # Keys may be scoped to where the annotation lands. {{< g_inline_version "v2.18" >}}
+      "index,manifest:org.opencontainers.image.licenses": "MIT"
 
     # Platforms to build.
     #
@@ -397,6 +402,44 @@ docker run --privileged --rm tonistiigi/binfmt --install all
 ```
 
 For what it's worth, this feature was built and tested with buildx v0.24.0.
+
+## Annotation scopes
+
+Annotation keys may be prefixed with the scopes `buildx` should apply them to,
+using its `[type:]key=value` syntax. {{< g_inline_version "v2.18" >}}
+
+The available scopes are:
+
+- `index`: the image index, i.e. the multi-platform manifest list.
+- `manifest`: each per-platform image manifest.
+- `index-descriptor` and `manifest-descriptor`: the descriptors that point to
+  them.
+
+Scopes may be comma-separated, and each one may be qualified with a platform:
+
+```yaml {filename=".goreleaser.yaml"}
+dockers_v2:
+  - annotations:
+      # Index only, the default on multi-platform builds.
+      "org.opencontainers.image.description": "My software"
+
+      # Index and every per-platform manifest.
+      "index,manifest:org.opencontainers.image.revision": "{{.FullCommit}}"
+
+      # The linux/amd64 manifest only.
+      "manifest[linux/amd64]:com.example.arch": "amd64"
+```
+
+On multi-platform builds, keys without a scope default to `index:`, so that
+tools which inspect the tag itself (such as `docker buildx imagetools inspect`)
+see them. Note this differs from a plain `docker buildx build`, which annotates
+the per-platform manifests instead.
+
+Scope your keys with `manifest` if you need consumers that resolve a tag down to
+a single platform, such as `docker pull`, to see the annotations.
+
+Everything before the first colon of a key is handed to `buildx` as given, so
+an invalid scope is reported by `buildx` itself.
 
 ## Docker manifests vs Docker images
 

--- a/www/content/customization/package/dockers_v2.md
+++ b/www/content/customization/package/dockers_v2.md
@@ -140,7 +140,7 @@ dockers_v2:
       "org.opencontainers.image.base.name": "{{.BaseImage}}"
       "org.opencontainers.image.base.digest": "{{.BaseImageDigest}}"
 
-      # Keys may be scoped to where the annotation lands. {{< g_inline_version "v2.18" >}}
+      # Keys may be scoped to where the annotation lands. {{< g_inline_version "v2.18-unreleased" >}}
       "index,manifest:org.opencontainers.image.licenses": "MIT"
 
     # Platforms to build.
@@ -406,7 +406,7 @@ For what it's worth, this feature was built and tested with buildx v0.24.0.
 ## Annotation scopes
 
 Annotation keys may be prefixed with the scopes `buildx` should apply them to,
-using its `[type:]key=value` syntax. {{< g_inline_version "v2.18" >}}
+using its `[type:]key=value` syntax. {{< g_inline_version "v2.18-unreleased" >}}
 
 The available scopes are:
 
@@ -438,8 +438,8 @@ the per-platform manifests instead.
 Scope your keys with `manifest` if you need consumers that resolve a tag down to
 a single platform, such as `docker pull`, to see the annotations.
 
-Everything before the first colon of a key is handed to `buildx` as given, so
-an invalid scope is reported by `buildx` itself.
+Only the scopes above are recognized: any other prefix is part of the key
+itself.
 
 See: [Docker Docs: Annotations > Specify annotation level](https://docs.docker.com/build/metadata/annotations/#specify-annotation-level)
 

--- a/www/content/customization/package/dockers_v2.md
+++ b/www/content/customization/package/dockers_v2.md
@@ -441,6 +441,8 @@ a single platform, such as `docker pull`, to see the annotations.
 Everything before the first colon of a key is handed to `buildx` as given, so
 an invalid scope is reported by `buildx` itself.
 
+See: [Docker Docs: Annotations > Specify annotation level](https://docs.docker.com/build/metadata/annotations/#specify-annotation-level)
+
 ## Docker manifests vs Docker images
 
 This will always use `docker buildx`, which, by default, builds Docker


### PR DESCRIPTION
If applied, this commit will...

...honor buildx annotation scope prefixes in `dockers_v2.annotations`, so
`manifest:`, `index,manifest:`, the `-descriptor` variants and
platform-qualified scopes reach the platform manifests instead of being mangled
into the image index.

On multi-platform builds every annotation was rewritten to
`index:<whatever the user wrote>`, with only a literal `index:` stripped first.
buildx cuts an annotation key at its **first** colon, so any other prefix wasn't
ignored — it was absorbed into the key:

| Config key | Flag emitted (before) | Result (before) |
| --- | --- | --- |
| `foo` | `index:foo=v` | index annotation `foo` ✅ |
| `index:foo` | `index:foo=v` | index annotation `foo` ✅ |
| `manifest:foo` | `index:manifest:foo=v` | index key **`manifest:foo`** ❌ |
| `index,manifest:foo` | `index:index,manifest:foo=v` | index key **`index,manifest:foo`** ❌ |
| `manifest[linux/amd64]:foo` | `index:manifest[linux/amd64]:foo=v` | index key **`manifest[linux/amd64]:foo`** ❌ |

The fix defaults to `index:` only when the key carries no scope of its own:

```go
if len(d.Platforms) > 1 {
	for i := 1; i < len(annotationFlags); i += 2 {
		if !hasAnnotationScope(annotationFlags[i]) {
			annotationFlags[i] = "index:" + annotationFlags[i]
		}
	}
}
```

Deliberately **not** changed: the `index:` default itself. It comes from #6053
so that multi-arch annotations are visible to
`docker buildx imagetools inspect`, and changing it would alter manifest content
for every existing user. Unscoped and `index:`-scoped keys emit byte-identical
flags to before, which the existing `TestMakeArgs` assertions pin.

A scope is only recognized when every comma-separated entry is one of buildx's
four types (`index`, `manifest`, `index-descriptor`, `manifest-descriptor`),
optionally platform-qualified. Anything else (e.g. `bogus:foo`) is treated as
part of the key and still gets the `index:` default, rather than reaching buildx
as an `unknown annotation type`.

**Tests**

- `TestMakeArgsAnnotationScopes` — table over all four scope types, comma-separated
  lists, platform-qualified scopes, unknown scopes, colon-in-value,
  single-platform, plus the unscoped and `index:` cases as regression guards.
- `TestPublish` — annotates with `index,manifest:` and asserts the key lands on
  the index *and* on each per-platform manifest (`linux/amd64`, `linux/arm64`)
  against a real registry. Verified to fail without the fix.

**Docs**: new "Annotation scopes" section in `dockers_v2.md`, including the note
that the unscoped default here is `index:` — the inverse of plain
`docker buildx build`.

<!-- Why is this change being made? -->

Annotations scoped to the platform manifests were unreachable: whatever prefix
you wrote, the annotation landed only on the OCI image index, under a corrupted
key.

Anything that resolves a single-platform manifest directly (`docker pull`,
`crane manifest`, and registry-scanning tooling generally) therefore sees no
annotations at all. In our case a proxy resolves the `linux/amd64` manifest, so
`org.opencontainers.image.revision` never arrived and commit-to-deploy
attribution broke — with no error anywhere to point at, since the flag was
accepted and the release succeeded.

One clarification on the issue as I filed it: I wrote that the prefix "is parsed
and stripped from the resulting annotation key correctly". That's wrong. The keys
are silently **corrupted**. The updated integration test fails on `main` with:

```
expected: map[string]string{"org.opencontainers.image.description":"My multi-arch image", "org.opencontainers.image.revision":"abc123"}
actual  : map[string]string{"index,manifest:org.opencontainers.image.revision":"abc123", "org.opencontainers.image.description":"My multi-arch image"}
```

Confirmed independently with a real multi-platform OCI export on buildx v0.36.0:
passing prefixes through unmangled routes them correctly (`index,manifest:` →
index + both platform manifests, `manifest:` → platform manifests only), so
buildx needs no help beyond being handed the flag as written.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

- Closes #6799
- #6053 — the PR that introduced the `index:` default, preserved here
- [buildx `ParseAnnotations`](https://github.com/docker/buildx/blob/master/util/buildflags/export.go) — cuts the key at the first colon
- [Docker docs: Annotations → Specify annotation level](https://docs.docker.com/build/metadata/annotations/#specify-annotation-level)
- [OCI image spec: annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md)

