### PR TITLE
fix(config): type retry durations as strings in schema

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1202,8 +1202,8 @@ type Checksum struct {
 // Added in v2.12.
 type Retry struct {
 	Attempts uint          `yaml:"attempts,omitempty" json:"attempts,omitempty"`
-	Delay    time.Duration `yaml:"delay,omitempty" json:"delay,omitempty"`
-	MaxDelay time.Duration `yaml:"max_delay,omitempty" json:"max_delay,omitempty"`
+	Delay    time.Duration `yaml:"delay,omitempty" json:"delay,omitempty" jsonschema:"type=string"`
+	MaxDelay time.Duration `yaml:"max_delay,omitempty" json:"max_delay,omitempty" jsonschema:"type=string"`
 }
 
 // Docker image config.


### PR DESCRIPTION
## Problem

According to schema.json `retry.delay` and `retry.max_delay` should have an integer type value. `time.Duration` is internally an `int64`, so schema reflection otherwise emits "type": "integer"

Screenshot:
<img width="1137" height="338" alt="Screenshot From 2026-08-21 02-15-30" src="https://github.com/user-attachments/assets/bfcc649d-e538-412b-9d94-555a5300d4e7" />

But expected values are `10s` or `5m` e.g. `time.Duration` should be a string-like value.

## Proposed solution

Describe `retry.delay` and `retry.max_delay` as strings in the generated JSON schema.
