### PR TITLE
feat: update to Go 1.27

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.24"
+  go: "1.27"
 linters:
   enable:
     - bodyclose

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ By participating in this project, you agree to abide our
 Prerequisites:
 
 - [Task](https://taskfile.dev/installation)
-- [Go 1.26+](https://go.dev/doc/install)
+- [Go 1.27+](https://go.dev/doc/install)
 
 Other things you might need to run some of the tests (they should get
 automatically skipped if a needed tool isn't present):

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM gcr.io/projectsigstore/cosign:v3.1.3@sha256:9e5c2f2edc34351160407ca3416c618
 FROM docker:29.5.3-cli-alpine3.23@sha256:873de13208aab9c1de73fe984fd45883e01464fcfcc85efa20aa56a9ccfe7aa6 AS docker
 FROM docker/buildx-bin:0.36.1@sha256:1f2f6b2be4a2511ada67336e76892f1a588c89746009dd4b21069e4d867465be AS buildx
 
-FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2
+FROM golang:1.27.0-alpine@sha256:4c9fe60190a2a3350ddc51de80d0224b8a6698d12bdfc999fee45ea9d6c46dbc
 
 ARG TARGETPLATFORM
 

--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,19 @@
 module github.com/goreleaser/goreleaser/v2
 
-go 1.26.5
+go 1.27.0
 
 require (
 	charm.land/lipgloss/v2 v2.0.6
 	code.gitea.io/sdk/gitea v0.25.1
 	dario.cat/mergo v1.0.2
+	github.com/BurntSushi/toml v1.6.0
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/agnivade/levenshtein v1.2.1
 	github.com/atc0005/go-teams-notify/v2 v2.14.0
 	github.com/avast/retry-go/v4 v4.7.0
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.3.12
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.12.0
+	github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb
 	github.com/bluesky-social/indigo v0.0.0-20240813042137-4006c0eca043
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/caarlos0/go-reddit/v3 v3.0.1
@@ -23,10 +25,11 @@ require (
 	github.com/dghubble/go-twitter v0.0.0-20211115160449-93a8679adecb
 	github.com/dghubble/oauth1 v0.7.3
 	github.com/distribution/distribution/v3 v3.1.1
+	github.com/docker/go-units v0.5.0
+	github.com/gobwas/glob v0.2.3
 	github.com/google/go-containerregistry v0.21.9
 	github.com/google/go-github/v89 v89.0.0
 	github.com/google/ko v0.19.1
-	github.com/google/uuid v1.6.0
 	github.com/goreleaser/fileglob v1.4.0
 	github.com/goreleaser/go-shellwords v1.0.13
 	github.com/goreleaser/nfpm/v2 v2.47.0
@@ -34,6 +37,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/invopop/jsonschema v0.14.0
 	github.com/jarcoal/httpmock v1.4.2
+	github.com/klauspost/compress v1.19.2
 	github.com/klauspost/pgzip v1.2.6
 	github.com/mattn/go-mastodon v0.0.13
 	github.com/mitchellh/go-homedir v1.1.0
@@ -54,91 +58,12 @@ require (
 	golang.org/x/text v0.41.0
 	golang.org/x/tools v0.48.0
 	gopkg.in/mail.v2 v2.3.1
+	lukechampine.com/blake3 v1.4.1
 )
 
 require (
 	al.essio.dev/pkg/shellescape v1.6.0 // indirect
 	cel.dev/expr v0.25.1 // indirect
-	cloud.google.com/go/monitoring v1.25.0 // indirect
-	github.com/42wim/httpsig v1.2.4 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.5.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/signin v1.5.5 // indirect
-	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
-	github.com/charmbracelet/colorprofile v0.4.3 // indirect
-	github.com/charmbracelet/ultraviolet v0.0.0-20260811164956-006e29f97886 // indirect
-	github.com/charmbracelet/x/exp/charmtone v0.0.0-20250603201427-c31516f43444 // indirect
-	github.com/charmbracelet/x/term v0.2.2 // indirect
-	github.com/charmbracelet/x/termios v0.1.1 // indirect
-	github.com/charmbracelet/x/windows v0.2.2 // indirect
-	github.com/clipperhouse/displaywidth v0.11.0 // indirect
-	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
-	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
-	github.com/containerd/errdefs v1.0.0 // indirect
-	github.com/containerd/errdefs/pkg v0.3.0 // indirect
-	github.com/coreos/go-oidc/v3 v3.20.0 // indirect
-	github.com/digitorus/pkcs7 v0.0.0-20250730155240-ffadbf3f398c // indirect
-	github.com/digitorus/timestamp v0.0.0-20250524132541-c45532741eea // indirect
-	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
-	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
-	github.com/go-openapi/runtime/server-middleware v0.30.0 // indirect
-	github.com/go-openapi/swag/cmdutils v0.26.0 // indirect
-	github.com/go-openapi/swag/conv v0.27.3 // indirect
-	github.com/go-openapi/swag/fileutils v0.27.3 // indirect
-	github.com/go-openapi/swag/jsonname v0.26.0 // indirect
-	github.com/go-openapi/swag/jsonutils v0.27.3 // indirect
-	github.com/go-openapi/swag/loading v0.27.3 // indirect
-	github.com/go-openapi/swag/mangling v0.27.3 // indirect
-	github.com/go-openapi/swag/netutils v0.26.0 // indirect
-	github.com/go-openapi/swag/pools v0.27.3 // indirect
-	github.com/go-openapi/swag/stringutils v0.27.3 // indirect
-	github.com/go-openapi/swag/typeutils v0.27.3 // indirect
-	github.com/go-openapi/swag/yamlutils v0.27.3 // indirect
-	github.com/google/certificate-transparency-go v1.3.3 // indirect
-	github.com/in-toto/attestation v1.2.0 // indirect
-	github.com/in-toto/in-toto-golang v0.11.0 // indirect
-	github.com/moby/moby/api v1.55.0 // indirect
-	github.com/moby/moby/client v0.5.1 // indirect
-	github.com/moby/sys/user v0.4.0 // indirect
-	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/oklog/ulid/v2 v2.1.1 // indirect
-	github.com/onsi/gomega v1.39.1 // indirect
-	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
-	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
-	github.com/prometheus/otlptranslator v1.0.0 // indirect
-	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
-	github.com/shibumi/go-pathspec v1.3.0 // indirect
-	github.com/sigstore/cosign/v3 v3.1.1 // indirect
-	github.com/sigstore/rekor-tiles/v2 v2.2.2-0.20260601073857-5d098a2b6443 // indirect
-	github.com/sigstore/sigstore-go v1.2.1 // indirect
-	github.com/sigstore/timestamp-authority/v2 v2.1.2 // indirect
-	github.com/spiffe/go-spiffe/v2 v2.7.0 // indirect
-	github.com/theupdateframework/go-tuf/v2 v2.4.2 // indirect
-	github.com/transparency-dev/formats v0.1.1 // indirect
-	github.com/transparency-dev/merkle v0.0.2 // indirect
-	github.com/wagoodman/go-progress v0.0.0-20230925121702-07e42b3cdba0 // indirect
-	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
-	go.digitalxero.dev/go-msix v0.3.1 // indirect
-	go.mozilla.org/pkcs7 v0.9.0 // indirect
-	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/contrib/bridges/prometheus v0.67.0 // indirect
-	go.opentelemetry.io/contrib/detectors/gcp v1.43.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.18.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0 // indirect
-	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.18.0 // indirect
-	go.opentelemetry.io/otel/log v0.19.0 // indirect
-	go.opentelemetry.io/otel/sdk/log v0.19.0 // indirect
-	go.yaml.in/yaml/v2 v2.4.4 // indirect
-	go.yaml.in/yaml/v4 v4.0.0-rc.6 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/klog/v2 v2.140.0 // indirect
-)
-
-require (
 	cloud.google.com/go v0.123.0 // indirect
 	cloud.google.com/go/auth v0.20.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
@@ -146,12 +71,16 @@ require (
 	cloud.google.com/go/iam v1.11.0 // indirect
 	cloud.google.com/go/kms v1.33.0 // indirect
 	cloud.google.com/go/longrunning v1.2.0 // indirect
+	cloud.google.com/go/monitoring v1.25.0 // indirect
 	cloud.google.com/go/storage v1.62.2 // indirect
+	github.com/42wim/httpsig v1.2.4 // indirect
 	github.com/AlekSi/pointer v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.5.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
@@ -163,7 +92,9 @@ require (
 	github.com/Azure/go-autorest/logger v0.2.2 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.1 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 // indirect
-	github.com/BurntSushi/toml v1.6.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
@@ -188,6 +119,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.37 // indirect
 	github.com/aws/aws-sdk-go-v2/service/kms v1.52.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/signin v1.5.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.33.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.5 // indirect
@@ -196,30 +128,45 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blacktop/go-dwarf v1.0.14 // indirect
 	github.com/blacktop/go-macho v1.1.263 // indirect
-	github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/carlmjohnson/versioninfo v0.22.5 // indirect
 	github.com/cavaliergopher/cpio v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/charmbracelet/colorprofile v0.4.3 // indirect
+	github.com/charmbracelet/ultraviolet v0.0.0-20260811164956-006e29f97886 // indirect
 	github.com/charmbracelet/x/ansi v0.11.8 // indirect
+	github.com/charmbracelet/x/exp/charmtone v0.0.0-20250603201427-c31516f43444 // indirect
+	github.com/charmbracelet/x/term v0.2.2 // indirect
+	github.com/charmbracelet/x/termios v0.1.1 // indirect
+	github.com/charmbracelet/x/windows v0.2.2 // indirect
+	github.com/clipperhouse/displaywidth v0.11.0 // indirect
+	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
+	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
 	github.com/containerd/continuity v0.4.5 // indirect
+	github.com/containerd/errdefs v1.0.0 // indirect
+	github.com/containerd/errdefs/pkg v0.3.0 // indirect
+	github.com/coreos/go-oidc/v3 v3.20.0 // indirect
 	github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/davidmz/go-pageant v1.0.2 // indirect
 	github.com/dghubble/sling v1.4.0 // indirect
+	github.com/digitorus/pkcs7 v0.0.0-20250730155240-ffadbf3f398c // indirect
+	github.com/digitorus/timestamp v0.0.0-20250524132541-c45532741eea // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/cli v29.6.2+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.5 // indirect
 	github.com/docker/go-connections v0.7.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
-	github.com/docker/go-units v0.5.0
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
+	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
+	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
@@ -238,21 +185,35 @@ require (
 	github.com/go-openapi/jsonreference v1.0.0 // indirect
 	github.com/go-openapi/loads v0.25.0 // indirect
 	github.com/go-openapi/runtime v0.32.3 // indirect
+	github.com/go-openapi/runtime/server-middleware v0.30.0 // indirect
 	github.com/go-openapi/spec v0.22.9 // indirect
 	github.com/go-openapi/strfmt v0.27.0 // indirect
 	github.com/go-openapi/swag v0.26.0 // indirect
+	github.com/go-openapi/swag/cmdutils v0.26.0 // indirect
+	github.com/go-openapi/swag/conv v0.27.3 // indirect
+	github.com/go-openapi/swag/fileutils v0.27.3 // indirect
+	github.com/go-openapi/swag/jsonname v0.26.0 // indirect
+	github.com/go-openapi/swag/jsonutils v0.27.3 // indirect
+	github.com/go-openapi/swag/loading v0.27.3 // indirect
+	github.com/go-openapi/swag/mangling v0.27.3 // indirect
+	github.com/go-openapi/swag/netutils v0.26.0 // indirect
+	github.com/go-openapi/swag/pools v0.27.3 // indirect
+	github.com/go-openapi/swag/stringutils v0.27.3 // indirect
+	github.com/go-openapi/swag/typeutils v0.27.3 // indirect
+	github.com/go-openapi/swag/yamlutils v0.27.3 // indirect
 	github.com/go-openapi/validate v0.26.1 // indirect
 	github.com/go-restruct/restruct v1.2.0-alpha // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
-	github.com/gobwas/glob v0.2.3
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
+	github.com/google/certificate-transparency-go v1.3.3 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/rpmpack v0.7.1 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/google/wire v0.7.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.17 // indirect
 	github.com/googleapis/gax-go/v2 v2.23.0 // indirect
@@ -266,6 +227,8 @@ require (
 	github.com/hashicorp/go-version v1.9.0 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
+	github.com/in-toto/attestation v1.2.0 // indirect
+	github.com/in-toto/in-toto-golang v0.11.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect
 	github.com/ipfs/go-block-format v0.2.0 // indirect
@@ -283,7 +246,6 @@ require (
 	github.com/jbenet/goprocess v0.1.4 // indirect
 	github.com/jedisct1/go-minisign v0.0.0-20241212093149-d2f9f49435c7 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
-	github.com/klauspost/compress v1.19.2
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.1 // indirect
@@ -293,8 +255,12 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
+	github.com/moby/moby/api v1.55.0 // indirect
+	github.com/moby/moby/client v0.5.1 // indirect
+	github.com/moby/sys/user v0.4.0 // indirect
 	github.com/moby/term v0.5.2 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
+	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/mango v0.2.0 // indirect
 	github.com/muesli/mango-pflag v0.1.0 // indirect
 	github.com/multiformats/go-base32 v0.1.0 // indirect
@@ -303,31 +269,42 @@ require (
 	github.com/multiformats/go-multihash v0.2.3 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/oklog/ulid/v2 v2.1.1 // indirect
+	github.com/onsi/gomega v1.39.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/runc v1.3.6 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/polydawn/refmt v0.89.1-0.20221221234430-40501e09de1f // indirect
 	github.com/prometheus/client_golang v1.24.1 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
+	github.com/prometheus/otlptranslator v1.0.0 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/sassoftware/relic v7.2.1+incompatible // indirect
 	github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.11.0 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
+	github.com/shibumi/go-pathspec v1.3.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
+	github.com/sigstore/cosign/v3 v3.1.1 // indirect
 	github.com/sigstore/protobuf-specs v0.5.1 // indirect
 	github.com/sigstore/rekor v1.5.2 // indirect
+	github.com/sigstore/rekor-tiles/v2 v2.2.2-0.20260601073857-5d098a2b6443 // indirect
 	github.com/sigstore/sigstore v1.10.8 // indirect
+	github.com/sigstore/sigstore-go v1.2.1 // indirect
+	github.com/sigstore/timestamp-authority/v2 v2.1.2 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
@@ -335,35 +312,54 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spf13/viper v1.21.0 // indirect
+	github.com/spiffe/go-spiffe/v2 v2.7.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/theupdateframework/go-tuf v0.7.0 // indirect
+	github.com/theupdateframework/go-tuf/v2 v2.4.2 // indirect
 	github.com/tomnomnom/linkheader v0.0.0-20250811210735-e5fe3b51442e // indirect
+	github.com/transparency-dev/formats v0.1.1 // indirect
+	github.com/transparency-dev/merkle v0.0.2 // indirect
+	github.com/wagoodman/go-progress v0.0.0-20230925121702-07e42b3cdba0 // indirect
 	github.com/whyrusleeping/cbor-gen v0.1.3-0.20240731173018-74d74643234c // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
 	gitlab.com/digitalxero/go-conventional-commit v1.0.7 // indirect
+	go.digitalxero.dev/go-msix v0.3.1 // indirect
+	go.mozilla.org/pkcs7 v0.9.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/contrib/bridges/prometheus v0.67.0 // indirect
+	go.opentelemetry.io/contrib/detectors/gcp v1.43.0 // indirect
 	go.opentelemetry.io/contrib/exporters/autoexport v0.67.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.68.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0 // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.18.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.42.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.42.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.66.0 // indirect
+	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.18.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.42.0 // indirect
+	go.opentelemetry.io/otel/log v0.19.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
+	go.opentelemetry.io/otel/sdk/log v0.19.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.28.0 // indirect
+	go.yaml.in/yaml/v2 v2.4.4 // indirect
+	go.yaml.in/yaml/v4 v4.0.0-rc.6 // indirect
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
@@ -378,7 +374,8 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	lukechampine.com/blake3 v1.4.1
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/klog/v2 v2.140.0 // indirect
 	sigs.k8s.io/kind v0.32.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 	software.sslmate.com/src/go-pkcs12 v0.7.3 // indirect

--- a/internal/builders/base/build_test.go
+++ b/internal/builders/base/build_test.go
@@ -126,18 +126,16 @@ func TestChTimes(t *testing.T) {
 
 func TestTemplateEnv(t *testing.T) {
 	build := config.Build{
-		BuildDetails: config.BuildDetails{
-			Env: []string{
-				"FOO={{.Env.FU}}",
-				"BAR={{.Env.FOO}}_{{.Env.FU}}",
-				`OS={{- if eq .Os "windows" -}}
+		Env: []string{
+			"FOO={{.Env.FU}}",
+			"BAR={{.Env.FOO}}_{{.Env.FU}}",
+			`OS={{- if eq .Os "windows" -}}
 					w
 				{{- else if eq .Os "darwin" -}}
 					d
 				{{- else if eq .Os "linux" -}}
 					l
 				{{- end -}}`,
-			},
 		},
 	}
 	tpl := tmpl.New(testctx.Wrap(t.Context())).SetEnv("FU=foobar").WithArtifact(&artifact.Artifact{

--- a/internal/builders/bun/build_test.go
+++ b/internal/builders/bun/build_test.go
@@ -97,9 +97,7 @@ func TestWithDefaults(t *testing.T) {
 			Dir:     ".",
 			Main:    ".",
 			Targets: defaultTargets(),
-			BuildDetails: config.BuildDetails{
-				Flags: []string{"--compile"},
-			},
+			Flags:   []string{"--compile"},
 		}, build)
 	})
 

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -656,27 +656,23 @@ func TestBuild(t *testing.T) {
 					{
 						Goos:   "linux",
 						Goarch: "amd64",
-						BuildDetails: config.BuildDetails{
-							Env: []string{"TEST_O=1"},
-						},
+						Env:    []string{"TEST_O=1"},
 					},
 				},
-				BuildDetails: config.BuildDetails{
-					Env: []string{
-						"GO111MODULE=off",
-						`TEST_T={{- if eq .Os "windows" -}}
+				Env: []string{
+					"GO111MODULE=off",
+					`TEST_T={{- if eq .Os "windows" -}}
 						w
 						{{- else if eq .Os "darwin" -}}
 						d
 						{{- else if eq .Os "linux" -}}
 						l
 						{{- end -}}`,
-					},
-					Asmflags: []string{".=", "all="},
-					Gcflags:  []string{"all="},
-					Flags:    []string{"{{.Env.GO_FLAGS}}"},
-					Tags:     []string{"osusergo", "netgo", "static_build"},
 				},
+				Asmflags: []string{".=", "all="},
+				Gcflags:  []string{"all="},
+				Flags:    []string{"{{.Env.GO_FLAGS}}"},
+				Tags:     []string{"osusergo", "netgo", "static_build"},
 			},
 		},
 	}, testctx.WithCurrentTag("v5.6.7"), testctx.WithVersion("v5.6.7"))
@@ -987,9 +983,7 @@ func TestBuildInvalidEnv(t *testing.T) {
 					runtimeTarget,
 				},
 				Tool: "go",
-				BuildDetails: config.BuildDetails{
-					Env: []string{"GO111MODULE={{ .Nope }}"},
-				},
+				Env:  []string{"GO111MODULE={{ .Nope }}"},
 			},
 		},
 	}, testctx.WithCurrentTag("5.6.7"))
@@ -1021,9 +1015,7 @@ func TestBuildCodeInSubdir(t *testing.T) {
 				},
 				Tool:    "go",
 				Command: "build",
-				BuildDetails: config.BuildDetails{
-					Env: []string{"GO111MODULE=off"},
-				},
+				Env:     []string{"GO111MODULE=off"},
 			},
 		},
 	}, testctx.WithCurrentTag("5.6.7"))
@@ -1050,9 +1042,7 @@ func TestBuildWithDotGoDir(t *testing.T) {
 				Targets: []string{runtimeTarget},
 				Tool:    "go",
 				Command: "build",
-				BuildDetails: config.BuildDetails{
-					Env: []string{"GO111MODULE=off"},
-				},
+				Env:     []string{"GO111MODULE=off"},
 			},
 		},
 	}, testctx.WithCurrentTag("5.6.7"))
@@ -1072,10 +1062,8 @@ func TestBuildFailed(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds: []config.Build{
 			{
-				ID: "buildid",
-				BuildDetails: config.BuildDetails{
-					Flags: []string{"-flag-that-dont-exists-to-force-failure"},
-				},
+				ID:    "buildid",
+				Flags: []string{"-flag-that-dont-exists-to-force-failure"},
 				Targets: []string{
 					runtimeTarget,
 				},
@@ -1098,10 +1086,8 @@ func TestRunInvalidAsmflags(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds: []config.Build{
 			{
-				Binary: "nametest",
-				BuildDetails: config.BuildDetails{
-					Asmflags: []string{"{{.Version}"},
-				},
+				Binary:   "nametest",
+				Asmflags: []string{"{{.Version}"},
 				Targets: []string{
 					runtimeTarget,
 				},
@@ -1121,10 +1107,8 @@ func TestRunInvalidGcflags(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds: []config.Build{
 			{
-				Binary: "nametest",
-				BuildDetails: config.BuildDetails{
-					Gcflags: []string{"{{.Version}"},
-				},
+				Binary:  "nametest",
+				Gcflags: []string{"{{.Version}"},
 				Targets: []string{
 					runtimeTarget,
 				},
@@ -1144,11 +1128,9 @@ func TestRunInvalidLdflags(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds: []config.Build{
 			{
-				Binary: "nametest",
-				BuildDetails: config.BuildDetails{
-					Flags:   []string{"-v"},
-					Ldflags: []string{"-s -w -X main.version={{.Version}"},
-				},
+				Binary:  "nametest",
+				Flags:   []string{"-v"},
+				Ldflags: []string{"-s -w -X main.version={{.Version}"},
 				Targets: []string{
 					runtimeTarget,
 				},
@@ -1169,9 +1151,7 @@ func TestRunInvalidFlags(t *testing.T) {
 		Builds: []config.Build{
 			{
 				Binary: "nametest",
-				BuildDetails: config.BuildDetails{
-					Flags: []string{"{{.Env.GOOS}"},
-				},
+				Flags:  []string{"{{.Env.GOOS}"},
 				Targets: []string{
 					runtimeTarget,
 				},
@@ -1242,11 +1222,9 @@ func TestBuildTests(t *testing.T) {
 	writeTest(t, folder)
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds: []config.Build{{
-			Binary:  "foo.test",
-			Command: "test",
-			BuildDetails: config.BuildDetails{
-				Flags: []string{"-c"},
-			},
+			Binary:      "foo.test",
+			Command:     "test",
+			Flags:       []string{"-c"},
 			NoMainCheck: true,
 		}},
 	}, testctx.WithCurrentTag("5.6.7"))
@@ -1325,9 +1303,7 @@ func TestRunPipeWithMainFuncNotInMainGoFile(t *testing.T) {
 				Targets: []string{
 					runtimeTarget,
 				},
-				BuildDetails: config.BuildDetails{
-					Env: []string{"GO111MODULE=off"},
-				},
+				Env:     []string{"GO111MODULE=off"},
 				Tool:    "go",
 				Command: "build",
 			},
@@ -1414,12 +1390,10 @@ func TestBuildModTimestamp(t *testing.T) {
 					"linux_mips_softfloat",
 					"linux_mips64le_softfloat",
 				},
-				BuildDetails: config.BuildDetails{
-					Env:      []string{"GO111MODULE=off"},
-					Asmflags: []string{".=", "all="},
-					Gcflags:  []string{"all="},
-					Flags:    []string{"{{.Env.GO_FLAGS}}"},
-				},
+				Env:          []string{"GO111MODULE=off"},
+				Asmflags:     []string{".=", "all="},
+				Gcflags:      []string{"all="},
+				Flags:        []string{"{{.Env.GO_FLAGS}}"},
 				ModTimestamp: fmt.Sprintf("%d", modTime.Unix()),
 				Tool:         "go",
 				Command:      "build",
@@ -1489,17 +1463,15 @@ func TestBuildGoBuildLine(t *testing.T) {
 
 	t.Run("full", func(t *testing.T) {
 		requireEqualCmd(t, config.Build{
-			Main: ".",
-			BuildDetails: config.BuildDetails{
-				Asmflags: []string{"asmflag1", "asmflag2"},
-				Gcflags:  []string{"gcflag1", "gcflag2"},
-				Flags:    []string{"-flag1", "-flag2"},
-				Tags:     []string{"tag1", "tag2"},
-				Ldflags:  []string{"ldflag1", "ldflag2"},
-			},
-			Binary:  "foo",
-			Tool:    "{{ .Env.GOBIN }}",
-			Command: "build",
+			Main:     ".",
+			Asmflags: []string{"asmflag1", "asmflag2"},
+			Gcflags:  []string{"gcflag1", "gcflag2"},
+			Flags:    []string{"-flag1", "-flag2"},
+			Tags:     []string{"tag1", "tag2"},
+			Ldflags:  []string{"ldflag1", "ldflag2"},
+			Binary:   "foo",
+			Tool:     "{{ .Env.GOBIN }}",
+			Command:  "build",
 		}, []string{
 			"go", "build",
 			"-flag1", "-flag2",
@@ -1513,25 +1485,21 @@ func TestBuildGoBuildLine(t *testing.T) {
 
 	t.Run("with overrides", func(t *testing.T) {
 		requireEqualCmd(t, config.Build{
-			Main: ".",
-			BuildDetails: config.BuildDetails{
-				Asmflags: []string{"asmflag1", "asmflag2"},
-				Gcflags:  []string{"gcflag1", "gcflag2"},
-				Flags:    []string{"-flag1", "-flag2"},
-				Tags:     []string{"tag1", "tag2"},
-				Ldflags:  []string{"ldflag1", "ldflag2"},
-			},
+			Main:     ".",
+			Asmflags: []string{"asmflag1", "asmflag2"},
+			Gcflags:  []string{"gcflag1", "gcflag2"},
+			Flags:    []string{"-flag1", "-flag2"},
+			Tags:     []string{"tag1", "tag2"},
+			Ldflags:  []string{"ldflag1", "ldflag2"},
 			BuildDetailsOverrides: []config.BuildDetailsOverride{
 				{
-					Goos:   "linux",
-					Goarch: "amd64",
-					BuildDetails: config.BuildDetails{
-						Asmflags: []string{"asmflag3"},
-						Gcflags:  []string{"gcflag3"},
-						Flags:    []string{"-flag3"},
-						Tags:     []string{"tag3"},
-						Ldflags:  []string{"ldflag3"},
-					},
+					Goos:     "linux",
+					Goarch:   "amd64",
+					Asmflags: []string{"asmflag3"},
+					Gcflags:  []string{"gcflag3"},
+					Flags:    []string{"-flag3"},
+					Tags:     []string{"tag3"},
+					Ldflags:  []string{"ldflag3"},
 				},
 			},
 			Tool:    "go",
@@ -1563,9 +1531,7 @@ func TestBuildGoBuildLine(t *testing.T) {
 			Tool:    "go",
 			Command: "test",
 			Binary:  "foo.test",
-			BuildDetails: config.BuildDetails{
-				Flags: []string{"-c"},
-			},
+			Flags:   []string{"-c"},
 		}, strings.Fields("go test -c -o foo.test ."))
 	})
 
@@ -1580,10 +1546,8 @@ func TestBuildGoBuildLine(t *testing.T) {
 
 	t.Run("ldflags1", func(t *testing.T) {
 		requireEqualCmd(t, config.Build{
-			Main: ".",
-			BuildDetails: config.BuildDetails{
-				Ldflags: []string{"-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.builtBy=goreleaser"},
-			},
+			Main:    ".",
+			Ldflags: []string{"-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.builtBy=goreleaser"},
 			Tool:    "go",
 			Command: "build",
 			Binary:  "foo",
@@ -1596,10 +1560,8 @@ func TestBuildGoBuildLine(t *testing.T) {
 
 	t.Run("ldflags2", func(t *testing.T) {
 		requireEqualCmd(t, config.Build{
-			Main: ".",
-			BuildDetails: config.BuildDetails{
-				Ldflags: []string{"-s -w", "-X main.version={{.Version}}"},
-			},
+			Main:    ".",
+			Ldflags: []string{"-s -w", "-X main.version={{.Version}}"},
 			Tool:    "go",
 			Binary:  "foo",
 			Command: "build",
@@ -1789,18 +1751,14 @@ func TestOverrides(t *testing.T) {
 			dets, err := withOverrides(
 				testctx.Wrap(t.Context()),
 				config.Build{
-					BuildDetails: config.BuildDetails{
-						Ldflags: []string{"original"},
-						Env:     []string{"BAR=foo", "FOO=bar"},
-					},
+					Ldflags: []string{"original"},
+					Env:     []string{"BAR=foo", "FOO=bar"},
 					BuildDetailsOverrides: []config.BuildDetailsOverride{
 						{
-							Goos:   "linux",
-							Goarch: arch,
-							BuildDetails: config.BuildDetails{
-								Ldflags: []string{"overridden"},
-								Env:     []string{"FOO=overridden"},
-							},
+							Goos:    "linux",
+							Goarch:  arch,
+							Ldflags: []string{"overridden"},
+							Env:     []string{"FOO=overridden"},
 						},
 					},
 				}, mustParse(t, "linux_"+arch),
@@ -1818,14 +1776,12 @@ func TestOverrides(t *testing.T) {
 				BuildDetails: config.BuildDetails{},
 				BuildDetailsOverrides: []config.BuildDetailsOverride{
 					{
-						Goos:   "linux",
-						Goarch: "amd64",
-						BuildDetails: config.BuildDetails{
-							Ldflags:  []string{"overridden"},
-							Tags:     []string{"tag1"},
-							Asmflags: []string{"asm1"},
-							Gcflags:  []string{"gcflag1"},
-						},
+						Goos:     "linux",
+						Goarch:   "amd64",
+						Ldflags:  []string{"overridden"},
+						Tags:     []string{"tag1"},
+						Asmflags: []string{"asm1"},
+						Gcflags:  []string{"gcflag1"},
 					},
 				},
 			}, mustParse(t, "linux_amd64"),
@@ -1844,17 +1800,13 @@ func TestOverrides(t *testing.T) {
 		dets, err := withOverrides(
 			testctx.Wrap(t.Context()),
 			config.Build{
-				BuildDetails: config.BuildDetails{
-					Ldflags:  []string{"original"},
-					Asmflags: []string{"asm1"},
-				},
+				Ldflags:  []string{"original"},
+				Asmflags: []string{"asm1"},
 				BuildDetailsOverrides: []config.BuildDetailsOverride{
 					{
-						Goos:   "{{ .Runtime.Goos }}",
-						Goarch: "{{ .Runtime.Goarch }}",
-						BuildDetails: config.BuildDetails{
-							Ldflags: []string{"overridden"},
-						},
+						Goos:    "{{ .Runtime.Goos }}",
+						Goarch:  "{{ .Runtime.Goarch }}",
+						Ldflags: []string{"overridden"},
 					},
 				},
 			}, mustParse(t, runtimeTarget),
@@ -1885,17 +1837,13 @@ func TestOverrides(t *testing.T) {
 		dets, err := withOverrides(
 			testctx.Wrap(t.Context()),
 			config.Build{
-				BuildDetails: config.BuildDetails{
-					Ldflags: []string{"original"},
-				},
+				Ldflags: []string{"original"},
 				BuildDetailsOverrides: []config.BuildDetailsOverride{
 					{
 						Goos:    "linux",
 						Goarch:  "arm64",
 						Goarm64: "v8.0",
-						BuildDetails: config.BuildDetails{
-							Ldflags: []string{"overridden"},
-						},
+						Ldflags: []string{"overridden"},
 					},
 				},
 			}, mustParse(t, "linux_arm64_v8.0"),
@@ -1911,16 +1859,12 @@ func TestOverrides(t *testing.T) {
 		dets, err := withOverrides(
 			testctx.Wrap(t.Context()),
 			config.Build{
-				BuildDetails: config.BuildDetails{
-					Ldflags: []string{"original"},
-				},
+				Ldflags: []string{"original"},
 				BuildDetailsOverrides: []config.BuildDetailsOverride{
 					{
-						Goos:   "linux",
-						Goarch: "arm64",
-						BuildDetails: config.BuildDetails{
-							Ldflags: []string{"overridden"},
-						},
+						Goos:    "linux",
+						Goarch:  "arm64",
+						Ldflags: []string{"overridden"},
 					},
 				},
 			}, mustParse(t, "linux_arm64_v8.0"),
@@ -1936,17 +1880,13 @@ func TestOverrides(t *testing.T) {
 		dets, err := withOverrides(
 			testctx.Wrap(t.Context()),
 			config.Build{
-				BuildDetails: config.BuildDetails{
-					Ldflags: []string{"original"},
-				},
+				Ldflags: []string{"original"},
 				BuildDetailsOverrides: []config.BuildDetailsOverride{
 					{
-						Goos:   "linux",
-						Goarch: "arm",
-						Goarm:  "6",
-						BuildDetails: config.BuildDetails{
-							Ldflags: []string{"overridden"},
-						},
+						Goos:    "linux",
+						Goarch:  "arm",
+						Goarm:   "6",
+						Ldflags: []string{"overridden"},
 					},
 				},
 			}, mustParse(t, "linux_arm_6"),
@@ -1962,16 +1902,12 @@ func TestOverrides(t *testing.T) {
 		dets, err := withOverrides(
 			testctx.Wrap(t.Context()),
 			config.Build{
-				BuildDetails: config.BuildDetails{
-					Ldflags: []string{"original"},
-				},
+				Ldflags: []string{"original"},
 				BuildDetailsOverrides: []config.BuildDetailsOverride{
 					{
-						Goos:   "linux",
-						Goarch: "arm",
-						BuildDetails: config.BuildDetails{
-							Ldflags: []string{"overridden"},
-						},
+						Goos:    "linux",
+						Goarch:  "arm",
+						Ldflags: []string{"overridden"},
 					},
 				},
 			}, mustParse(t, "linux_arm_6"),
@@ -1987,17 +1923,13 @@ func TestOverrides(t *testing.T) {
 		dets, err := withOverrides(
 			testctx.Wrap(t.Context()),
 			config.Build{
-				BuildDetails: config.BuildDetails{
-					Ldflags: []string{"original"},
-				},
+				Ldflags: []string{"original"},
 				BuildDetailsOverrides: []config.BuildDetailsOverride{
 					{
-						Goos:   "linux",
-						Goarch: "mips",
-						Gomips: "softfloat",
-						BuildDetails: config.BuildDetails{
-							Ldflags: []string{"overridden"},
-						},
+						Goos:    "linux",
+						Goarch:  "mips",
+						Gomips:  "softfloat",
+						Ldflags: []string{"overridden"},
 					},
 				},
 			}, mustParse(t, "linux_mips_softfloat"),
@@ -2013,16 +1945,12 @@ func TestOverrides(t *testing.T) {
 		dets, err := withOverrides(
 			testctx.Wrap(t.Context()),
 			config.Build{
-				BuildDetails: config.BuildDetails{
-					Ldflags: []string{"original"},
-				},
+				Ldflags: []string{"original"},
 				BuildDetailsOverrides: []config.BuildDetailsOverride{
 					{
-						Goos:   "linux",
-						Goarch: "mips",
-						BuildDetails: config.BuildDetails{
-							Ldflags: []string{"overridden"},
-						},
+						Goos:    "linux",
+						Goarch:  "mips",
+						Ldflags: []string{"overridden"},
 					},
 				},
 			}, mustParse(t, "linux_mips_hardfloat"),
@@ -2038,17 +1966,13 @@ func TestOverrides(t *testing.T) {
 		dets, err := withOverrides(
 			testctx.Wrap(t.Context()),
 			config.Build{
-				BuildDetails: config.BuildDetails{
-					Ldflags: []string{"original"},
-				},
+				Ldflags: []string{"original"},
 				BuildDetailsOverrides: []config.BuildDetailsOverride{
 					{
 						Goos:      "linux",
 						Goarch:    "riscv64",
 						Goriscv64: "rva22u64",
-						BuildDetails: config.BuildDetails{
-							Ldflags: []string{"overridden"},
-						},
+						Ldflags:   []string{"overridden"},
 					},
 				},
 			}, mustParse(t, "linux_riscv64_rva22u64"),
@@ -2064,17 +1988,13 @@ func TestOverrides(t *testing.T) {
 		dets, err := withOverrides(
 			testctx.Wrap(t.Context()),
 			config.Build{
-				BuildDetails: config.BuildDetails{
-					Ldflags: []string{"original"},
-				},
+				Ldflags: []string{"original"},
 				BuildDetailsOverrides: []config.BuildDetailsOverride{
 					{
 						Goos:      "linux",
 						Goarch:    "riscv64",
 						Goriscv64: "rva22u64",
-						BuildDetails: config.BuildDetails{
-							Ldflags: []string{"overridden"},
-						},
+						Ldflags:   []string{"overridden"},
 					},
 				},
 			}, mustParse(t, "linux_riscv64_rva22u64"),
@@ -2090,17 +2010,13 @@ func TestOverrides(t *testing.T) {
 		dets, err := withOverrides(
 			testctx.Wrap(t.Context()),
 			config.Build{
-				BuildDetails: config.BuildDetails{
-					Ldflags: []string{"original"},
-				},
+				Ldflags: []string{"original"},
 				BuildDetailsOverrides: []config.BuildDetailsOverride{
 					{
-						Goos:   "linux",
-						Goarch: "386",
-						Go386:  "sse2",
-						BuildDetails: config.BuildDetails{
-							Ldflags: []string{"overridden"},
-						},
+						Goos:    "linux",
+						Goarch:  "386",
+						Go386:   "sse2",
+						Ldflags: []string{"overridden"},
 					},
 				},
 			}, mustParse(t, "linux_386_sse2"),
@@ -2116,17 +2032,13 @@ func TestOverrides(t *testing.T) {
 		dets, err := withOverrides(
 			testctx.Wrap(t.Context()),
 			config.Build{
-				BuildDetails: config.BuildDetails{
-					Ldflags: []string{"original"},
-				},
+				Ldflags: []string{"original"},
 				BuildDetailsOverrides: []config.BuildDetailsOverride{
 					{
-						Goos:   "linux",
-						Goarch: "386",
-						Go386:  "sse2",
-						BuildDetails: config.BuildDetails{
-							Ldflags: []string{"overridden"},
-						},
+						Goos:    "linux",
+						Goarch:  "386",
+						Go386:   "sse2",
+						Ldflags: []string{"overridden"},
 					},
 				},
 			}, mustParse(t, "linux_386_sse2"),

--- a/internal/builders/node/build_test.go
+++ b/internal/builders/node/build_test.go
@@ -85,7 +85,7 @@ func TestWithDefaults(t *testing.T) {
 
 	t.Run("rejects flags", func(t *testing.T) {
 		_, err := Default.WithDefaults(config.Build{
-			BuildDetails: config.BuildDetails{Flags: []string{"--x"}},
+			Flags: []string{"--x"},
 		})
 		require.ErrorContains(t, err, "flags is not supported")
 	})

--- a/internal/builders/poetry/build_test.go
+++ b/internal/builders/poetry/build_test.go
@@ -97,16 +97,12 @@ func TestBuild(t *testing.T) {
 			{
 				ID:           "proj-wheel",
 				ModTimestamp: fmt.Sprintf("%d", modTime.Unix()),
-				BuildDetails: config.BuildDetails{
-					Buildmode: "wheel",
-				},
+				Buildmode:    "wheel",
 			},
 			{
 				ID:           "proj-sdist",
 				ModTimestamp: fmt.Sprintf("%d", modTime.Unix()),
-				BuildDetails: config.BuildDetails{
-					Buildmode: "sdist",
-				},
+				Buildmode:    "sdist",
 			},
 		},
 	})
@@ -191,16 +187,12 @@ func TestBuildSpecificModes(t *testing.T) {
 			{
 				ID:           "wheel",
 				ModTimestamp: fmt.Sprintf("%d", modTime.Unix()),
-				BuildDetails: config.BuildDetails{
-					Buildmode: "wheel",
-				},
+				Buildmode:    "wheel",
 			},
 			{
 				ID:           "sdist",
 				ModTimestamp: fmt.Sprintf("%d", modTime.Unix()),
-				BuildDetails: config.BuildDetails{
-					Buildmode: "sdist",
-				},
+				Buildmode:    "sdist",
 			},
 		},
 	})

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -33,9 +33,7 @@ func TestWithDefaults(t *testing.T) {
 			Command: "zigbuild",
 			Dir:     ".",
 			Targets: defaultTargets(),
-			BuildDetails: config.BuildDetails{
-				Flags: []string{"--release"},
-			},
+			Flags:   []string{"--release"},
 		}, build)
 	})
 
@@ -98,8 +96,8 @@ members = ["crate-a", "crate-b", "crate-c"]
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist: "dist",
 		Builds: []config.Build{{
-			Dir:          ".",
-			BuildDetails: config.BuildDetails{Flags: []string{"--release"}},
+			Dir:   ".",
+			Flags: []string{"--release"},
 		}},
 	})
 
@@ -147,9 +145,7 @@ func TestBuild(t *testing.T) {
 				Dir:          ".",
 				Targets:      []string{target},
 				ModTimestamp: fmt.Sprintf("%d", modTime.Unix()),
-				BuildDetails: config.BuildDetails{
-					Flags: []string{"--release"},
-				},
+				Flags:        []string{"--release"},
 			},
 		},
 	})
@@ -235,9 +231,7 @@ func TestBuildArm(t *testing.T) {
 				Dir:          ".",
 				Targets:      []string{target},
 				ModTimestamp: fmt.Sprintf("%d", modTime.Unix()),
-				BuildDetails: config.BuildDetails{
-					Flags: []string{"--release"},
-				},
+				Flags:        []string{"--release"},
 			},
 		},
 	})

--- a/internal/builders/rust/targets.go
+++ b/internal/builders/rust/targets.go
@@ -73,11 +73,10 @@ func stripGlibcVersion(target string) (string, bool) {
 		return target, false
 	}
 	// only gnu-based ABIs use glibc (not gnullvm which is Windows/LLVM)
-	lastDash := strings.LastIndex(prefix, "-")
-	if lastDash == -1 {
+	_, abi, found := strings.CutLast(prefix, "-")
+	if !found {
 		return target, false
 	}
-	abi := prefix[lastDash+1:]
 	if strings.HasPrefix(abi, "gnu") && abi != "gnullvm" {
 		return prefix, true
 	}

--- a/internal/builders/uv/build_test.go
+++ b/internal/builders/uv/build_test.go
@@ -95,16 +95,12 @@ func TestBuild(t *testing.T) {
 			{
 				ID:           "proj-wheel",
 				ModTimestamp: fmt.Sprintf("%d", modTime.Unix()),
-				BuildDetails: config.BuildDetails{
-					Buildmode: "wheel",
-				},
+				Buildmode:    "wheel",
 			},
 			{
 				ID:           "proj-sdist",
 				ModTimestamp: fmt.Sprintf("%d", modTime.Unix()),
-				BuildDetails: config.BuildDetails{
-					Buildmode: "sdist",
-				},
+				Buildmode:    "sdist",
 			},
 		},
 	})
@@ -187,16 +183,12 @@ func TestBuildSpecificModes(t *testing.T) {
 			{
 				ID:           "wheel",
 				ModTimestamp: fmt.Sprintf("%d", modTime.Unix()),
-				BuildDetails: config.BuildDetails{
-					Buildmode: "wheel",
-				},
+				Buildmode:    "wheel",
 			},
 			{
 				ID:           "sdist",
 				ModTimestamp: fmt.Sprintf("%d", modTime.Unix()),
-				BuildDetails: config.BuildDetails{
-					Buildmode: "sdist",
-				},
+				Buildmode:    "sdist",
 			},
 		},
 	})

--- a/internal/builders/zig/build_test.go
+++ b/internal/builders/zig/build_test.go
@@ -72,9 +72,7 @@ func TestWithDefaults(t *testing.T) {
 			Command: "build",
 			Dir:     ".",
 			Targets: defaultTargets(),
-			BuildDetails: config.BuildDetails{
-				Flags: []string{"-Doptimize=ReleaseSafe"},
-			},
+			Flags:   []string{"-Doptimize=ReleaseSafe"},
 		}, build)
 	})
 
@@ -128,11 +126,9 @@ func TestBuild(t *testing.T) {
 				ID:           "default",
 				Dir:          "./proj/",
 				ModTimestamp: fmt.Sprintf("%d", modTime.Unix()),
-				BuildDetails: config.BuildDetails{
-					Flags: []string{"-Doptimize={{.Env.OPTIM}}"},
-					Env: []string{
-						"OPTIM={{.Env.OPTIMIZE_FOR}}",
-					},
+				Flags:        []string{"-Doptimize={{.Env.OPTIM}}"},
+				Env: []string{
+					"OPTIM={{.Env.OPTIMIZE_FOR}}",
 				},
 			},
 		},

--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -847,7 +847,7 @@ func (c *githubClient) getMilestoneByTitle(ctx *context.Context, repo Repo, titl
 	c.checkRateLimit(ctx)
 	// The GitHub API/SDK does not provide lookup by title functionality currently.
 	opts := &github.MilestoneListOptions{
-		ListOptions: github.ListOptions{PerPage: 100},
+		PerPage: 100,
 	}
 
 	for {

--- a/internal/pipe/bluesky/bluesky.go
+++ b/internal/pipe/bluesky/bluesky.go
@@ -134,8 +134,7 @@ func (p Pipe) Announce(ctx *context.Context) error {
 // xrpcHTTP wraps an xrpc.Error with retryx.HTTP so that status-code-based
 // retry classification works for Bluesky SDK calls.
 func xrpcHTTP(err error) error {
-	var xe *xrpc.Error
-	if errors.As(err, &xe) {
+	if xe, ok := errors.AsType[*xrpc.Error](err); ok {
 		return retryx.HTTP(err, &http.Response{StatusCode: xe.StatusCode})
 	}
 	return err

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -95,10 +95,8 @@ func TestBuild(t *testing.T) {
 			{
 				Builder: "fake",
 				Binary:  "testing.v{{.Version}}",
-				BuildDetails: config.BuildDetails{
-					Flags: []string{"-n"},
-					Env:   []string{"BLAH=1"},
-				},
+				Flags:   []string{"-n"},
+				Env:     []string{"BLAH=1"},
 			},
 		},
 	}
@@ -122,10 +120,8 @@ func TestRunPipe(t *testing.T) {
 			{
 				Builder: "fake",
 				Binary:  "testing",
-				BuildDetails: config.BuildDetails{
-					Flags:   []string{"-v"},
-					Ldflags: []string{"-X main.test=testing"},
-				},
+				Flags:   []string{"-v"},
+				Ldflags: []string{"-X main.test=testing"},
 				Targets: []string{"linux_amd64"},
 			},
 		},
@@ -149,11 +145,9 @@ func TestRunFullPipe(t *testing.T) {
 				ID:      "build1",
 				Builder: "fake",
 				Binary:  "testing",
-				BuildDetails: config.BuildDetails{
-					Flags:   []string{"-v"},
-					Ldflags: []string{"-X main.test=testing"},
-					Env:     []string{"THE_OS={{ .Os }}"},
-				},
+				Flags:   []string{"-v"},
+				Ldflags: []string{"-X main.test=testing"},
+				Env:     []string{"THE_OS={{ .Os }}"},
 				Hooks: config.BuildHookConfig{
 					Pre: []config.Hook{
 						{Cmd: testlib.Touch(pre)},
@@ -192,10 +186,8 @@ func TestRunFullPipeFail(t *testing.T) {
 			{
 				Builder: "fakeFail",
 				Binary:  "testing",
-				BuildDetails: config.BuildDetails{
-					Flags:   []string{"-v"},
-					Ldflags: []string{"-X main.test=testing"},
-				},
+				Flags:   []string{"-v"},
+				Ldflags: []string{"-X main.test=testing"},
 				Hooks: config.BuildHookConfig{
 					Pre: []config.Hook{
 						{Cmd: testlib.Touch(pre)},
@@ -293,10 +285,8 @@ func TestDefaultExpandEnv(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds: []config.Build{
 			{
-				BuildDetails: config.BuildDetails{
-					Env: []string{
-						"XFOO=bar_$XBAR",
-					},
+				Env: []string{
+					"XFOO=bar_$XBAR",
 				},
 			},
 		},
@@ -377,13 +367,11 @@ func TestDefaultPartialBuilds(t *testing.T) {
 				Main:   "./cmd/main.go",
 			},
 			{
-				ID:     "build2",
-				Binary: "foo",
-				Dir:    "baz",
-				BuildDetails: config.BuildDetails{
-					Ldflags: []string{"-s -w"},
-				},
-				Goarch: []string{"386"},
+				ID:      "build2",
+				Binary:  "foo",
+				Dir:     "baz",
+				Ldflags: []string{"-s -w"},
+				Goarch:  []string{"386"},
 			},
 		},
 	})
@@ -766,9 +754,7 @@ func TestRunHookFailWithLogs(t *testing.T) {
 			{
 				Builder: "fakeFail",
 				Binary:  "testing",
-				BuildDetails: config.BuildDetails{
-					Flags: []string{"-v"},
-				},
+				Flags:   []string{"-v"},
 				Hooks: config.BuildHookConfig{
 					Pre: []config.Hook{
 						{Cmd: "sh -c 'echo foo; exit 1'"},

--- a/internal/pipe/cask/cask_test.go
+++ b/internal/pipe/cask/cask_test.go
@@ -56,19 +56,17 @@ func TestSimpleName(t *testing.T) {
 }
 
 var defaultTemplateData = templateData{
-	HomebrewCask: config.HomebrewCask{
-		Description: "Some desc",
-		Homepage:    "https://google.com",
-		Binaries:    []string{"mybin"},
-		Completions: config.HomebrewCaskCompletions{
-			Fish: "mybin.fish",
-			Bash: "mybin.bash",
-			Zsh:  "mybin.zsh",
-		},
-		Manpages: []string{
-			"mybin.1.gz",
-			"mybin2.1.gz",
-		},
+	Description: "Some desc",
+	Homepage:    "https://google.com",
+	Binaries:    []string{"mybin"},
+	Completions: config.HomebrewCaskCompletions{
+		Fish: "mybin.fish",
+		Bash: "mybin.bash",
+		Zsh:  "mybin.zsh",
+	},
+	Manpages: []string{
+		"mybin.1.gz",
+		"mybin2.1.gz",
 	},
 	Name:                 "test",
 	Version:              "0.1.3",

--- a/internal/pipe/ko/ko.go
+++ b/internal/pipe/ko/ko.go
@@ -379,6 +379,10 @@ func findBuild(ctx *context.Context, ko config.Ko) (config.Build, error) {
 
 func buildBuildOptions(ctx *context.Context, cfg config.Ko) (*buildOptions, error) {
 	localImportPath := cfg.Main
+	if localImportPath == "" {
+		// ko.main is optional, and go1.27+ rejects an empty package pattern.
+		localImportPath = "."
+	}
 
 	dir := filepath.Clean(cfg.WorkingDir)
 	if dir == "." {

--- a/internal/pipe/ko/ko_test.go
+++ b/internal/pipe/ko/ko_test.go
@@ -45,13 +45,11 @@ func TestDefault(t *testing.T) {
 		ProjectName: "test",
 		Builds: []config.Build{
 			{
-				ID:  "test",
-				Dir: ".",
-				BuildDetails: config.BuildDetails{
-					Ldflags: []string{"{{.Env.LDFLAGS}}"},
-					Flags:   []string{"{{.Env.FLAGS}}"},
-					Env:     []string{"SOME_ENV={{.Env.LE_ENV}}"},
-				},
+				ID:      "test",
+				Dir:     ".",
+				Ldflags: []string{"{{.Env.LDFLAGS}}"},
+				Flags:   []string{"{{.Env.FLAGS}}"},
+				Env:     []string{"SOME_ENV={{.Env.LE_ENV}}"},
 			},
 		},
 		Kos: []config.Ko{
@@ -280,12 +278,10 @@ func TestPublishPipeSuccess(t *testing.T) {
 				ProjectName: "test",
 				Builds: []config.Build{
 					{
-						ID: "foo",
-						BuildDetails: config.BuildDetails{
-							Ldflags: []string{"-s", "-w"},
-							Flags:   []string{"-tags", "netgo"},
-							Env:     []string{"GOCACHE=" + gocacheOnce()},
-						},
+						ID:      "foo",
+						Ldflags: []string{"-s", "-w"},
+						Flags:   []string{"-tags", "netgo"},
+						Env:     []string{"GOCACHE=" + gocacheOnce()},
 					},
 				},
 				Kos: []config.Ko{
@@ -455,12 +451,10 @@ func TestSnapshot(t *testing.T) {
 		ProjectName: "test",
 		Builds: []config.Build{
 			{
-				ID: "foo",
-				BuildDetails: config.BuildDetails{
-					Ldflags: []string{"-s", "-w"},
-					Flags:   []string{"-tags", "netgo"},
-					Env:     []string{"GOCACHE=" + gocacheOnce()},
-				},
+				ID:      "foo",
+				Ldflags: []string{"-s", "-w"},
+				Flags:   []string{"-tags", "netgo"},
+				Env:     []string{"GOCACHE=" + gocacheOnce()},
 			},
 		},
 		Kos: []config.Ko{
@@ -492,12 +486,10 @@ func TestDisable(t *testing.T) {
 		ProjectName: "test",
 		Builds: []config.Build{
 			{
-				ID: "foo",
-				BuildDetails: config.BuildDetails{
-					Ldflags: []string{"-s", "-w"},
-					Flags:   []string{"-tags", "netgo"},
-					Env:     []string{"GOCACHE=" + gocacheOnce()},
-				},
+				ID:      "foo",
+				Ldflags: []string{"-s", "-w"},
+				Flags:   []string{"-tags", "netgo"},
+				Env:     []string{"GOCACHE=" + gocacheOnce()},
 			},
 		},
 		Kos: []config.Ko{

--- a/internal/pipe/ko/ko_test.go
+++ b/internal/pipe/ko/ko_test.go
@@ -148,6 +148,19 @@ func TestSkip(t *testing.T) {
 	})
 }
 
+func TestBuildBuildOptionsEmptyMain(t *testing.T) {
+	// ko.main is optional: an empty main must still resolve the package in
+	// the working directory.
+	ctx := testctx.Wrap(t.Context())
+	opts, err := buildBuildOptions(ctx, config.Ko{
+		ID:           "default",
+		WorkingDir:   "./testdata/app/",
+		Repositories: []string{"localhost:5000/goreleasertest/testapp"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "testapp", opts.importPath)
+}
+
 func TestPublishPipeNoMatchingBuild(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds: []config.Build{

--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -481,122 +481,120 @@ func create(ctx *context.Context, fpm config.NFPM, format string, artifacts []*a
 		License:         fpm.License,
 		Changelog:       fpm.Changelog,
 		MTime:           fpm.ParsedMTime,
-		Overridables: nfpm.Overridables{
-			Umask:      overridden.Umask,
-			Conflicts:  overridden.Conflicts,
-			Depends:    overridden.Dependencies,
-			Recommends: overridden.Recommends,
-			Provides:   overridden.Provides,
-			Suggests:   overridden.Suggests,
-			Replaces:   overridden.Replaces,
-			Contents:   contents,
-			Scripts: nfpm.Scripts{
-				PreInstall:  overridden.Scripts.PreInstall,
-				PostInstall: overridden.Scripts.PostInstall,
-				PreRemove:   overridden.Scripts.PreRemove,
-				PostRemove:  overridden.Scripts.PostRemove,
+		Umask:           overridden.Umask,
+		Conflicts:       overridden.Conflicts,
+		Depends:         overridden.Dependencies,
+		Recommends:      overridden.Recommends,
+		Provides:        overridden.Provides,
+		Suggests:        overridden.Suggests,
+		Replaces:        overridden.Replaces,
+		Contents:        contents,
+		Scripts: nfpm.Scripts{
+			PreInstall:  overridden.Scripts.PreInstall,
+			PostInstall: overridden.Scripts.PostInstall,
+			PreRemove:   overridden.Scripts.PreRemove,
+			PostRemove:  overridden.Scripts.PostRemove,
+		},
+		Deb: nfpm.Deb{
+			ArchVariant: debArchVariant(artifacts[0]),
+			Compression: overridden.Deb.Compression,
+			Fields:      overridden.Deb.Fields,
+			Predepends:  overridden.Deb.Predepends,
+			Scripts: nfpm.DebScripts{
+				Rules:     overridden.Deb.Scripts.Rules,
+				Templates: overridden.Deb.Scripts.Templates,
+				Config:    overridden.Deb.Scripts.Config,
 			},
-			Deb: nfpm.Deb{
-				ArchVariant: debArchVariant(artifacts[0]),
-				Compression: overridden.Deb.Compression,
-				Fields:      overridden.Deb.Fields,
-				Predepends:  overridden.Deb.Predepends,
-				Scripts: nfpm.DebScripts{
-					Rules:     overridden.Deb.Scripts.Rules,
-					Templates: overridden.Deb.Scripts.Templates,
-					Config:    overridden.Deb.Scripts.Config,
-				},
-				Triggers: nfpm.DebTriggers{
-					Interest:        overridden.Deb.Triggers.Interest,
-					InterestAwait:   overridden.Deb.Triggers.InterestAwait,
-					InterestNoAwait: overridden.Deb.Triggers.InterestNoAwait,
-					Activate:        overridden.Deb.Triggers.Activate,
-					ActivateAwait:   overridden.Deb.Triggers.ActivateAwait,
-					ActivateNoAwait: overridden.Deb.Triggers.ActivateNoAwait,
-				},
-				Breaks: overridden.Deb.Breaks,
-				Signature: nfpm.DebSignature{
-					PackageSignature: nfpm.PackageSignature{
-						KeyFile:       debKeyFile,
-						KeyPassphrase: getPassphraseFromEnv(ctx, "DEB", fpm.ID),
-						// TODO: Method, Type, KeyID
-					},
-					Type: overridden.Deb.Signature.Type,
-				},
+			Triggers: nfpm.DebTriggers{
+				Interest:        overridden.Deb.Triggers.Interest,
+				InterestAwait:   overridden.Deb.Triggers.InterestAwait,
+				InterestNoAwait: overridden.Deb.Triggers.InterestNoAwait,
+				Activate:        overridden.Deb.Triggers.Activate,
+				ActivateAwait:   overridden.Deb.Triggers.ActivateAwait,
+				ActivateNoAwait: overridden.Deb.Triggers.ActivateNoAwait,
 			},
-			RPM: nfpm.RPM{
-				Summary:     overridden.RPM.Summary,
-				Group:       overridden.RPM.Group,
-				Compression: overridden.RPM.Compression,
-				Prefixes:    overridden.RPM.Prefixes,
-				Packager:    overridden.RPM.Packager,
-				BuildHost:   overridden.RPM.BuildHost,
-				Signature: nfpm.RPMSignature{
-					PackageSignature: nfpm.PackageSignature{
-						KeyFile:       rpmKeyFile,
-						KeyPassphrase: getPassphraseFromEnv(ctx, "RPM", fpm.ID),
-						// TODO: KeyID
-					},
+			Breaks: overridden.Deb.Breaks,
+			Signature: nfpm.DebSignature{
+				PackageSignature: nfpm.PackageSignature{
+					KeyFile:       debKeyFile,
+					KeyPassphrase: getPassphraseFromEnv(ctx, "DEB", fpm.ID),
+					// TODO: Method, Type, KeyID
 				},
-				Scripts: nfpm.RPMScripts{
-					PreTrans:  overridden.RPM.Scripts.PreTrans,
-					PostTrans: overridden.RPM.Scripts.PostTrans,
+				Type: overridden.Deb.Signature.Type,
+			},
+		},
+		RPM: nfpm.RPM{
+			Summary:     overridden.RPM.Summary,
+			Group:       overridden.RPM.Group,
+			Compression: overridden.RPM.Compression,
+			Prefixes:    overridden.RPM.Prefixes,
+			Packager:    overridden.RPM.Packager,
+			BuildHost:   overridden.RPM.BuildHost,
+			Signature: nfpm.RPMSignature{
+				PackageSignature: nfpm.PackageSignature{
+					KeyFile:       rpmKeyFile,
+					KeyPassphrase: getPassphraseFromEnv(ctx, "RPM", fpm.ID),
+					// TODO: KeyID
 				},
 			},
-			APK: nfpm.APK{
-				Signature: nfpm.APKSignature{
-					PackageSignature: nfpm.PackageSignature{
-						KeyFile:       apkKeyFile,
-						KeyPassphrase: getPassphraseFromEnv(ctx, "APK", fpm.ID),
-					},
-					KeyName: apkKeyName,
-				},
-				Scripts: nfpm.APKScripts{
-					PreUpgrade:  overridden.APK.Scripts.PreUpgrade,
-					PostUpgrade: overridden.APK.Scripts.PostUpgrade,
-				},
+			Scripts: nfpm.RPMScripts{
+				PreTrans:  overridden.RPM.Scripts.PreTrans,
+				PostTrans: overridden.RPM.Scripts.PostTrans,
 			},
-			ArchLinux: nfpm.ArchLinux{
-				Pkgbase:  overridden.ArchLinux.Pkgbase,
-				Packager: overridden.ArchLinux.Packager,
-				Scripts: nfpm.ArchLinuxScripts{
-					PreUpgrade:  overridden.ArchLinux.Scripts.PreUpgrade,
-					PostUpgrade: overridden.ArchLinux.Scripts.PostUpgrade,
+		},
+		APK: nfpm.APK{
+			Signature: nfpm.APKSignature{
+				PackageSignature: nfpm.PackageSignature{
+					KeyFile:       apkKeyFile,
+					KeyPassphrase: getPassphraseFromEnv(ctx, "APK", fpm.ID),
 				},
+				KeyName: apkKeyName,
 			},
-			IPK: nfpm.IPK{
-				ABIVersion:    overridden.IPK.ABIVersion,
-				AutoInstalled: overridden.IPK.AutoInstalled,
-				Alternatives:  overridden.IPK.ToNFPAlts(),
-				Essential:     overridden.IPK.Essential,
-				Predepends:    overridden.IPK.Predepends,
-				Tags:          overridden.IPK.Tags,
-				Fields:        overridden.IPK.Fields,
+			Scripts: nfpm.APKScripts{
+				PreUpgrade:  overridden.APK.Scripts.PreUpgrade,
+				PostUpgrade: overridden.APK.Scripts.PostUpgrade,
 			},
-			MSIX: nfpm.MSIX{
-				Arch:      overridden.MSIX.Arch,
-				Publisher: overridden.MSIX.Publisher,
-				Identity: nfpm.MSIXIdentity{
-					ResourceID: overridden.MSIX.Identity.ResourceID,
-				},
-				Properties: nfpm.MSIXProperties{
-					DisplayName:          overridden.MSIX.Properties.DisplayName,
-					PublisherDisplayName: overridden.MSIX.Properties.PublisherDisplayName,
-					Logo:                 overridden.MSIX.Properties.Logo,
-				},
-				Applications: msixApplications(overridden.MSIX.Applications),
-				Dependencies: nfpm.MSIXDependencies{
-					TargetDeviceFamilies: msixTargetDeviceFamilies(overridden.MSIX.Dependencies.TargetDeviceFamilies),
-				},
-				Capabilities: nfpm.MSIXCapabilities{
-					Capabilities:       overridden.MSIX.Capabilities.Capabilities,
-					DeviceCapabilities: overridden.MSIX.Capabilities.DeviceCapabilities,
-					Restricted:         overridden.MSIX.Capabilities.Restricted,
-				},
-				Signature: nfpm.MSIXSignature{
-					PFXFile:       msixPFXFile,
-					KeyPassphrase: getPassphraseFromEnv(ctx, "MSIX", fpm.ID),
-				},
+		},
+		ArchLinux: nfpm.ArchLinux{
+			Pkgbase:  overridden.ArchLinux.Pkgbase,
+			Packager: overridden.ArchLinux.Packager,
+			Scripts: nfpm.ArchLinuxScripts{
+				PreUpgrade:  overridden.ArchLinux.Scripts.PreUpgrade,
+				PostUpgrade: overridden.ArchLinux.Scripts.PostUpgrade,
+			},
+		},
+		IPK: nfpm.IPK{
+			ABIVersion:    overridden.IPK.ABIVersion,
+			AutoInstalled: overridden.IPK.AutoInstalled,
+			Alternatives:  overridden.IPK.ToNFPAlts(),
+			Essential:     overridden.IPK.Essential,
+			Predepends:    overridden.IPK.Predepends,
+			Tags:          overridden.IPK.Tags,
+			Fields:        overridden.IPK.Fields,
+		},
+		MSIX: nfpm.MSIX{
+			Arch:      overridden.MSIX.Arch,
+			Publisher: overridden.MSIX.Publisher,
+			Identity: nfpm.MSIXIdentity{
+				ResourceID: overridden.MSIX.Identity.ResourceID,
+			},
+			Properties: nfpm.MSIXProperties{
+				DisplayName:          overridden.MSIX.Properties.DisplayName,
+				PublisherDisplayName: overridden.MSIX.Properties.PublisherDisplayName,
+				Logo:                 overridden.MSIX.Properties.Logo,
+			},
+			Applications: msixApplications(overridden.MSIX.Applications),
+			Dependencies: nfpm.MSIXDependencies{
+				TargetDeviceFamilies: msixTargetDeviceFamilies(overridden.MSIX.Dependencies.TargetDeviceFamilies),
+			},
+			Capabilities: nfpm.MSIXCapabilities{
+				Capabilities:       overridden.MSIX.Capabilities.Capabilities,
+				DeviceCapabilities: overridden.MSIX.Capabilities.DeviceCapabilities,
+				Restricted:         overridden.MSIX.Capabilities.Restricted,
+			},
+			Signature: nfpm.MSIXSignature{
+				PFXFile:       msixPFXFile,
+				KeyPassphrase: getPassphraseFromEnv(ctx, "MSIX", fpm.ID),
 			},
 		},
 	}

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -47,10 +47,8 @@ func TestRunPipeError(t *testing.T) {
 		Dist: t.TempDir(),
 		NFPMs: []config.NFPM{
 			{
-				Formats: []string{"deb"},
-				NFPMOverridables: config.NFPMOverridables{
-					FileNameTemplate: "{{.ConventionalFileName}}",
-				},
+				Formats:          []string{"deb"},
+				FileNameTemplate: "{{.ConventionalFileName}}",
 			},
 		},
 	})
@@ -74,13 +72,11 @@ func TestRunPipeInvalidFormat(t *testing.T) {
 		ProjectName: "nope",
 		NFPMs: []config.NFPM{
 			{
-				Bindir:  "/usr/bin",
-				Formats: []string{"nope"},
-				Builds:  []string{"foo"},
-				NFPMOverridables: config.NFPMOverridables{
-					PackageName:      "foo",
-					FileNameTemplate: defaultNameTemplate,
-				},
+				Bindir:           "/usr/bin",
+				Formats:          []string{"nope"},
+				Builds:           []string{"foo"},
+				PackageName:      "foo",
+				FileNameTemplate: defaultNameTemplate,
 			},
 		},
 	}, testctx.WithVersion("1.2.3"), testctx.WithCurrentTag("v1.2.3"))
@@ -152,68 +148,66 @@ func TestRunPipe(t *testing.T) {
 					CArchive: libPrefix + "/c-archives",
 					CShared:  libPrefix + "/c-shareds",
 				},
-				NFPMOverridables: config.NFPMOverridables{
-					FileNameTemplate: defaultNameTemplate + "-{{ .Release }}-{{ .Epoch }}",
-					PackageName:      "foo",
-					Dependencies:     []string{"make"},
-					Recommends:       []string{"svn"},
-					Suggests:         []string{"bzr"},
-					Replaces:         []string{"fish"},
-					Conflicts:        []string{"git"},
-					Provides:         []string{"ash"},
-					Release:          "10",
-					Epoch:            "20",
-					Scripts: config.NFPMScripts{
-						PreInstall:  "./testdata/pre_install{{.Env.EXT}}",
-						PostInstall: "./testdata/post_install{{.Env.EXT}}",
-						PreRemove:   "./testdata/pre_remove{{.Env.EXT}}",
-						PostRemove:  "./testdata/post_remove{{.Env.EXT}}",
+				FileNameTemplate: defaultNameTemplate + "-{{ .Release }}-{{ .Epoch }}",
+				PackageName:      "foo",
+				Dependencies:     []string{"make"},
+				Recommends:       []string{"svn"},
+				Suggests:         []string{"bzr"},
+				Replaces:         []string{"fish"},
+				Conflicts:        []string{"git"},
+				Provides:         []string{"ash"},
+				Release:          "10",
+				Epoch:            "20",
+				Scripts: config.NFPMScripts{
+					PreInstall:  "./testdata/pre_install{{.Env.EXT}}",
+					PostInstall: "./testdata/post_install{{.Env.EXT}}",
+					PreRemove:   "./testdata/pre_remove{{.Env.EXT}}",
+					PostRemove:  "./testdata/post_remove{{.Env.EXT}}",
+				},
+				Contents: []config.NFPMContent{
+					{
+						Destination: "/var/log/foobar",
+						Type:        "dir",
+						FileInfo:    fileInfo,
 					},
-					Contents: []config.NFPMContent{
-						{
-							Destination: "/var/log/foobar",
-							Type:        "dir",
-							FileInfo:    fileInfo,
-						},
-						{
-							Source:      "./testdata/testfile.txt",
-							Destination: "/usr/share/testfile.txt",
-							FileInfo:    fileInfo,
-						},
-						{
-							Source:      "./testdata/testfile.txt",
-							Destination: "/etc/nope.conf",
-							Type:        "config",
-							FileInfo:    fileInfo,
-						},
-						{
-							Destination: "/etc/mydir",
-							Type:        "dir",
-							FileInfo:    fileInfo,
-						},
-						{
-							Source:      "./testdata/testfile.txt",
-							Destination: "/etc/nope-rpm.conf",
-							FileInfo:    fileInfo,
-							Type:        "config",
-							Packager:    "rpm",
-						},
-						{
-							Source:      "/etc/nope.conf",
-							Destination: "/etc/nope2.conf",
-							FileInfo:    fileInfo,
-							Type:        "symlink",
-						},
-						{
-							Source:      "./testdata/testfile-{{ .Arch }}{{.Amd64}}{{.Arm}}{{.Mips}}.txt",
-							Destination: "/etc/nope3_{{ .ProjectName }}.conf",
-							FileInfo:    fileInfo,
-						},
-						{
-							Source:      "./testdata/folder",
-							Destination: "/etc/folder",
-							FileInfo:    fileInfo,
-						},
+					{
+						Source:      "./testdata/testfile.txt",
+						Destination: "/usr/share/testfile.txt",
+						FileInfo:    fileInfo,
+					},
+					{
+						Source:      "./testdata/testfile.txt",
+						Destination: "/etc/nope.conf",
+						Type:        "config",
+						FileInfo:    fileInfo,
+					},
+					{
+						Destination: "/etc/mydir",
+						Type:        "dir",
+						FileInfo:    fileInfo,
+					},
+					{
+						Source:      "./testdata/testfile.txt",
+						Destination: "/etc/nope-rpm.conf",
+						FileInfo:    fileInfo,
+						Type:        "config",
+						Packager:    "rpm",
+					},
+					{
+						Source:      "/etc/nope.conf",
+						Destination: "/etc/nope2.conf",
+						FileInfo:    fileInfo,
+						Type:        "symlink",
+					},
+					{
+						Source:      "./testdata/testfile-{{ .Arch }}{{.Amd64}}{{.Arm}}{{.Mips}}.txt",
+						Destination: "/etc/nope3_{{ .ProjectName }}.conf",
+						FileInfo:    fileInfo,
+					},
+					{
+						Source:      "./testdata/folder",
+						Destination: "/etc/folder",
+						FileInfo:    fileInfo,
 					},
 				},
 			},
@@ -601,15 +595,13 @@ func doTestRunPipeConventionalNameTemplate(t *testing.T, snapshot bool) {
 				Vendor:      "asdf",
 				Homepage:    "https://goreleaser.com/",
 				Bindir:      "/usr/bin",
-				NFPMOverridables: config.NFPMOverridables{
-					FileNameTemplate: `
+				FileNameTemplate: `
 						{{- trimsuffix .ConventionalFileName .ConventionalExtension -}}
 						{{- if and (eq .Arm "6") (eq .ConventionalExtension ".deb") }}6{{ end -}}
 						{{- if not (eq .Amd64 "v1")}}{{ .Amd64 }}{{ end -}}
 						{{- .ConventionalExtension -}}
 					`,
-					PackageName: "foo{{ if .IsSnapshot }}-snapshot{{ end }}",
-				},
+				PackageName: "foo{{ if .IsSnapshot }}-snapshot{{ end }}",
 			},
 		},
 	}, testctx.WithVersion("1.0.0"), testctx.WithCurrentTag("v1.0.0"))
@@ -922,13 +914,11 @@ func TestRunPipeInvalidContentsSourceTemplate(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		NFPMs: []config.NFPM{
 			{
-				NFPMOverridables: config.NFPMOverridables{
-					PackageName: "foo",
-					Contents: []config.NFPMContent{
-						{
-							Source:      "{{.asdsd}",
-							Destination: "testfile",
-						},
+				PackageName: "foo",
+				Contents: []config.NFPMContent{
+					{
+						Source:      "{{.asdsd}",
+						Destination: "testfile",
 					},
 				},
 				Formats: []string{"deb"},
@@ -955,15 +945,13 @@ func TestRunPipeInvalidContentMTimeReportsCorrectValue(t *testing.T) {
 			{
 				// top-level MTime is empty, so the bug would show an empty
 				// value in the error instead of the actual invalid value.
-				NFPMOverridables: config.NFPMOverridables{
-					PackageName: "foo",
-					Contents: []config.NFPMContent{
-						{
-							Source:      "./testdata/testfile.txt",
-							Destination: "/usr/share/testfile.txt",
-							FileInfo: config.FileInfo{
-								MTime: "not-a-date",
-							},
+				PackageName: "foo",
+				Contents: []config.NFPMContent{
+					{
+						Source:      "./testdata/testfile.txt",
+						Destination: "/usr/share/testfile.txt",
+						FileInfo: config.FileInfo{
+							MTime: "not-a-date",
 						},
 					},
 				},
@@ -1020,15 +1008,13 @@ func TestCreateFileDoesntExist(t *testing.T) {
 		ProjectName: "asd",
 		NFPMs: []config.NFPM{
 			{
-				Formats: []string{"deb", "rpm", "ipk"},
-				Builds:  []string{"default"},
-				NFPMOverridables: config.NFPMOverridables{
-					PackageName: "foo",
-					Contents: []config.NFPMContent{
-						{
-							Source:      "testdata/testfile.txt",
-							Destination: "/var/lib/test/testfile.txt",
-						},
+				Formats:     []string{"deb", "rpm", "ipk"},
+				Builds:      []string{"default"},
+				PackageName: "foo",
+				Contents: []config.NFPMContent{
+					{
+						Source:      "testdata/testfile.txt",
+						Destination: "/var/lib/test/testfile.txt",
 					},
 				},
 			},
@@ -1095,11 +1081,9 @@ func TestDefaultSet(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		NFPMs: []config.NFPM{
 			{
-				Builds: []string{"foo"},
-				Bindir: "/bin",
-				NFPMOverridables: config.NFPMOverridables{
-					FileNameTemplate: "foo",
-				},
+				Builds:           []string{"foo"},
+				Bindir:           "/bin",
+				FileNameTemplate: "foo",
 			},
 		},
 	})
@@ -1115,10 +1099,8 @@ func TestOverrides(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		NFPMs: []config.NFPM{
 			{
-				Bindir: "/bin",
-				NFPMOverridables: config.NFPMOverridables{
-					FileNameTemplate: "foo",
-				},
+				Bindir:           "/bin",
+				FileNameTemplate: "foo",
 				Overrides: map[string]config.NFPMOverridables{
 					"deb": {
 						FileNameTemplate: "bar",
@@ -1153,22 +1135,20 @@ func TestDebSpecificConfig(t *testing.T) {
 			Dist:        dist,
 			NFPMs: []config.NFPM{
 				{
-					ID:         "someid",
-					Builds:     []string{"default"},
-					Formats:    []string{"deb"},
-					Maintainer: "foo",
-					NFPMOverridables: config.NFPMOverridables{
-						PackageName: "foo",
-						Contents: []config.NFPMContent{
-							{
-								Source:      "testdata/testfile.txt",
-								Destination: "/usr/share/testfile.txt",
-							},
+					ID:          "someid",
+					Builds:      []string{"default"},
+					Formats:     []string{"deb"},
+					Maintainer:  "foo",
+					PackageName: "foo",
+					Contents: []config.NFPMContent{
+						{
+							Source:      "testdata/testfile.txt",
+							Destination: "/usr/share/testfile.txt",
 						},
-						Deb: config.NFPMDeb{
-							Signature: config.NFPMDebSignature{
-								KeyFile: "./testdata/privkey.gpg",
-							},
+					},
+					Deb: config.NFPMDeb{
+						Signature: config.NFPMDebSignature{
+							KeyFile: "./testdata/privkey.gpg",
 						},
 					},
 				},
@@ -1287,21 +1267,19 @@ func TestRPMSpecificConfig(t *testing.T) {
 		Dist:        dist,
 		NFPMs: []config.NFPM{
 			{
-				ID:      "someid",
-				Builds:  []string{"default"},
-				Formats: []string{"rpm"},
-				NFPMOverridables: config.NFPMOverridables{
-					PackageName: "foo",
-					Contents: []config.NFPMContent{
-						{
-							Source:      "testdata/testfile.txt",
-							Destination: "/usr/share/testfile.txt",
-						},
+				ID:          "someid",
+				Builds:      []string{"default"},
+				Formats:     []string{"rpm"},
+				PackageName: "foo",
+				Contents: []config.NFPMContent{
+					{
+						Source:      "testdata/testfile.txt",
+						Destination: "/usr/share/testfile.txt",
 					},
-					RPM: config.NFPMRPM{
-						Signature: config.NFPMRPMSignature{
-							KeyFile: "./testdata/privkey.gpg",
-						},
+				},
+				RPM: config.NFPMRPM{
+					Signature: config.NFPMRPMSignature{
+						KeyFile: "./testdata/privkey.gpg",
 					},
 				},
 			},
@@ -1360,16 +1338,14 @@ func TestRPMSpecificScriptsConfig(t *testing.T) {
 		Dist:        dist,
 		NFPMs: []config.NFPM{
 			{
-				ID:      "someid",
-				Builds:  []string{"default"},
-				Formats: []string{"rpm"},
-				NFPMOverridables: config.NFPMOverridables{
-					PackageName: "foo",
-					RPM: config.NFPMRPM{
-						Scripts: config.NFPMRPMScripts{
-							PreTrans:  "/does/not/exist_pretrans.sh",
-							PostTrans: "/does/not/exist_posttrans.sh",
-						},
+				ID:          "someid",
+				Builds:      []string{"default"},
+				Formats:     []string{"rpm"},
+				PackageName: "foo",
+				RPM: config.NFPMRPM{
+					Scripts: config.NFPMRPMScripts{
+						PreTrans:  "/does/not/exist_pretrans.sh",
+						PostTrans: "/does/not/exist_posttrans.sh",
 					},
 				},
 			},
@@ -1422,22 +1398,20 @@ func TestAPKSpecificConfig(t *testing.T) {
 		Dist:        dist,
 		NFPMs: []config.NFPM{
 			{
-				ID:         "someid",
-				Maintainer: "me@me",
-				Builds:     []string{"default"},
-				Formats:    []string{"apk"},
-				NFPMOverridables: config.NFPMOverridables{
-					PackageName: "foo",
-					Contents: []config.NFPMContent{
-						{
-							Source:      "testdata/testfile.txt",
-							Destination: "/usr/share/testfile.txt",
-						},
+				ID:          "someid",
+				Maintainer:  "me@me",
+				Builds:      []string{"default"},
+				Formats:     []string{"apk"},
+				PackageName: "foo",
+				Contents: []config.NFPMContent{
+					{
+						Source:      "testdata/testfile.txt",
+						Destination: "/usr/share/testfile.txt",
 					},
-					APK: config.NFPMAPK{
-						Signature: config.NFPMAPKSignature{
-							KeyFile: "./testdata/rsa.priv",
-						},
+				},
+				APK: config.NFPMAPK{
+					Signature: config.NFPMAPKSignature{
+						KeyFile: "./testdata/rsa.priv",
 					},
 				},
 			},
@@ -1500,21 +1474,19 @@ func TestAPKSpecificScriptsConfig(t *testing.T) {
 		Dist:        dist,
 		NFPMs: []config.NFPM{
 			{
-				ID:         "someid",
-				Maintainer: "me@me",
-				Builds:     []string{"default"},
-				Formats:    []string{"apk"},
-				NFPMOverridables: config.NFPMOverridables{
-					PackageName: "foo",
-					Contents: []config.NFPMContent{
-						{
-							Source:      "testdata/testfile.txt",
-							Destination: "/usr/share/testfile.txt",
-						},
+				ID:          "someid",
+				Maintainer:  "me@me",
+				Builds:      []string{"default"},
+				Formats:     []string{"apk"},
+				PackageName: "foo",
+				Contents: []config.NFPMContent{
+					{
+						Source:      "testdata/testfile.txt",
+						Destination: "/usr/share/testfile.txt",
 					},
-					APK: config.NFPMAPK{
-						Scripts: scripts,
-					},
+				},
+				APK: config.NFPMAPK{
+					Scripts: scripts,
 				},
 			},
 		},
@@ -1618,15 +1590,13 @@ func TestOverridesVersionFields(t *testing.T) {
 				ID:         "someid",
 				Maintainer: "me",
 				Formats:    []string{"deb", "rpm"},
-				NFPMOverridables: config.NFPMOverridables{
-					FileNameTemplate: "{{ .PackageName }}_e{{ .Epoch }}_r{{ .Release }}_" +
-						"{{ trimsuffix .ConventionalFileName .ConventionalExtension }}",
-					PackageName:     "mybin",
-					Epoch:           "1",
-					Release:         "1",
-					Prerelease:      "alpha1",
-					VersionMetadata: "top",
-				},
+				FileNameTemplate: "{{ .PackageName }}_e{{ .Epoch }}_r{{ .Release }}_" +
+					"{{ trimsuffix .ConventionalFileName .ConventionalExtension }}",
+				PackageName:     "mybin",
+				Epoch:           "1",
+				Release:         "1",
+				Prerelease:      "alpha1",
+				VersionMetadata: "top",
 				Overrides: map[string]config.NFPMOverridables{
 					"rpm": {
 						PackageName:     "mybin-rpm",
@@ -1681,34 +1651,32 @@ func TestIPKSpecificConfig(t *testing.T) {
 		Dist:        dist,
 		NFPMs: []config.NFPM{
 			{
-				ID:         "someid",
-				Maintainer: "me@me",
-				Builds:     []string{"default"},
-				Formats:    []string{"ipk"},
-				NFPMOverridables: config.NFPMOverridables{
-					PackageName: "foo",
-					Contents: []config.NFPMContent{
+				ID:          "someid",
+				Maintainer:  "me@me",
+				Builds:      []string{"default"},
+				Formats:     []string{"ipk"},
+				PackageName: "foo",
+				Contents: []config.NFPMContent{
+					{
+						Source:      "testdata/testfile.txt",
+						Destination: "/usr/share/testfile.txt",
+					},
+				},
+				IPK: config.NFPMIPK{
+					ABIVersion: "1.0",
+					Alternatives: []config.NFPMIPKAlternative{
 						{
-							Source:      "testdata/testfile.txt",
-							Destination: "/usr/share/testfile.txt",
+							Priority: 100,
+							Target:   "/usr/bin/mybin",
+							LinkName: "/usr/bin/myaltbin",
 						},
 					},
-					IPK: config.NFPMIPK{
-						ABIVersion: "1.0",
-						Alternatives: []config.NFPMIPKAlternative{
-							{
-								Priority: 100,
-								Target:   "/usr/bin/mybin",
-								LinkName: "/usr/bin/myaltbin",
-							},
-						},
-						AutoInstalled: true,
-						Essential:     true,
-						Predepends:    []string{"libc"},
-						Tags:          []string{"foo", "bar"},
-						Fields: map[string]string{
-							"CustomField": "customValue",
-						},
+					AutoInstalled: true,
+					Essential:     true,
+					Predepends:    []string{"libc"},
+					Tags:          []string{"foo", "bar"},
+					Fields: map[string]string{
+						"CustomField": "customValue",
 					},
 				},
 			},
@@ -1768,48 +1736,46 @@ func TestMeta(t *testing.T) {
 		Dist:        dist,
 		NFPMs: []config.NFPM{
 			{
-				ID:          "someid",
-				Bindir:      "/usr/bin",
-				Builds:      []string{"default"},
-				Formats:     []string{"deb", "rpm"},
-				Section:     "somesection",
-				Priority:    "standard",
-				Description: "Some description",
-				License:     "MIT",
-				Maintainer:  "me@me",
-				Vendor:      "asdf",
-				Homepage:    "https://goreleaser.github.io",
-				Meta:        true,
-				NFPMOverridables: config.NFPMOverridables{
-					FileNameTemplate: defaultNameTemplate + "-{{ .Release }}-{{ .Epoch }}",
-					PackageName:      "foo",
-					Dependencies:     []string{"make"},
-					Recommends:       []string{"svn"},
-					Suggests:         []string{"bzr"},
-					Replaces:         []string{"fish"},
-					Conflicts:        []string{"git"},
-					Release:          "10",
-					Epoch:            "20",
-					Contents: []config.NFPMContent{
-						{
-							Source:      "testdata/testfile.txt",
-							Destination: "/usr/share/testfile.txt",
-						},
-						{
-							Source:      "./testdata/testfile.txt",
-							Destination: "/etc/nope.conf",
-							Type:        "config",
-						},
-						{
-							Source:      "./testdata/testfile.txt",
-							Destination: "/etc/nope-rpm.conf",
-							Type:        "config",
-							Packager:    "rpm",
-						},
-						{
-							Destination: "/var/log/foobar",
-							Type:        "dir",
-						},
+				ID:               "someid",
+				Bindir:           "/usr/bin",
+				Builds:           []string{"default"},
+				Formats:          []string{"deb", "rpm"},
+				Section:          "somesection",
+				Priority:         "standard",
+				Description:      "Some description",
+				License:          "MIT",
+				Maintainer:       "me@me",
+				Vendor:           "asdf",
+				Homepage:         "https://goreleaser.github.io",
+				Meta:             true,
+				FileNameTemplate: defaultNameTemplate + "-{{ .Release }}-{{ .Epoch }}",
+				PackageName:      "foo",
+				Dependencies:     []string{"make"},
+				Recommends:       []string{"svn"},
+				Suggests:         []string{"bzr"},
+				Replaces:         []string{"fish"},
+				Conflicts:        []string{"git"},
+				Release:          "10",
+				Epoch:            "20",
+				Contents: []config.NFPMContent{
+					{
+						Source:      "testdata/testfile.txt",
+						Destination: "/usr/share/testfile.txt",
+					},
+					{
+						Source:      "./testdata/testfile.txt",
+						Destination: "/etc/nope.conf",
+						Type:        "config",
+					},
+					{
+						Source:      "./testdata/testfile.txt",
+						Destination: "/etc/nope-rpm.conf",
+						Type:        "config",
+						Packager:    "rpm",
+					},
+					{
+						Destination: "/var/log/foobar",
+						Type:        "dir",
 					},
 				},
 			},
@@ -1869,17 +1835,15 @@ func TestMetaNoBinaries(t *testing.T) {
 				Vendor:      "asdf",
 				Homepage:    "https://goreleaser.github.io",
 				Meta:        true,
-				NFPMOverridables: config.NFPMOverridables{
-					PackageName: "foo",
-					Contents: []config.NFPMContent{
-						{
-							Source:      "testdata/testfile.txt",
-							Destination: "/usr/share/testfile.txt",
-						},
-						{
-							Destination: "/var/log/foobar",
-							Type:        "dir",
-						},
+				PackageName: "foo",
+				Contents: []config.NFPMContent{
+					{
+						Source:      "testdata/testfile.txt",
+						Destination: "/usr/share/testfile.txt",
+					},
+					{
+						Destination: "/var/log/foobar",
+						Type:        "dir",
 					},
 				},
 			},
@@ -1915,32 +1879,30 @@ func TestSkipSign(t *testing.T) {
 		Dist:        dist,
 		NFPMs: []config.NFPM{
 			{
-				ID:      "someid",
-				Builds:  []string{"default"},
-				Formats: []string{"deb", "rpm", "apk"},
-				NFPMOverridables: config.NFPMOverridables{
-					PackageName:      "foo",
-					FileNameTemplate: defaultNameTemplate,
-					Contents: []config.NFPMContent{
-						{
-							Source:      "testdata/testfile.txt",
-							Destination: "/usr/share/testfile.txt",
-						},
+				ID:               "someid",
+				Builds:           []string{"default"},
+				Formats:          []string{"deb", "rpm", "apk"},
+				PackageName:      "foo",
+				FileNameTemplate: defaultNameTemplate,
+				Contents: []config.NFPMContent{
+					{
+						Source:      "testdata/testfile.txt",
+						Destination: "/usr/share/testfile.txt",
 					},
-					Deb: config.NFPMDeb{
-						Signature: config.NFPMDebSignature{
-							KeyFile: "/does/not/exist.gpg",
-						},
+				},
+				Deb: config.NFPMDeb{
+					Signature: config.NFPMDebSignature{
+						KeyFile: "/does/not/exist.gpg",
 					},
-					RPM: config.NFPMRPM{
-						Signature: config.NFPMRPMSignature{
-							KeyFile: "/does/not/exist.gpg",
-						},
+				},
+				RPM: config.NFPMRPM{
+					Signature: config.NFPMRPMSignature{
+						KeyFile: "/does/not/exist.gpg",
 					},
-					APK: config.NFPMAPK{
-						Signature: config.NFPMAPKSignature{
-							KeyFile: "/does/not/exist.gpg",
-						},
+				},
+				APK: config.NFPMAPK{
+					Signature: config.NFPMAPKSignature{
+						KeyFile: "/does/not/exist.gpg",
 					},
 				},
 			},
@@ -2005,9 +1967,7 @@ func TestBinDirTemplating(t *testing.T) {
 				Maintainer:  "{{ .Env.MAINTAINER }}",
 				Vendor:      "asdf",
 				Homepage:    "https://goreleaser.com/{{ .Env.PRO }}",
-				NFPMOverridables: config.NFPMOverridables{
-					PackageName: "foo",
-				},
+				PackageName: "foo",
 			},
 		},
 	}, testctx.WithVersion("1.0.0"), testctx.WithCurrentTag("v1.0.0"))
@@ -2069,13 +2029,11 @@ func TestTemplateExt(t *testing.T) {
 		Dist: t.TempDir(),
 		NFPMs: []config.NFPM{
 			{
-				NFPMOverridables: config.NFPMOverridables{
-					FileNameTemplate: "a_{{ .ConventionalExtension }}_b",
-					PackageName:      "foo",
-				},
-				Meta:       true,
-				Maintainer: "foo@bar",
-				Formats:    []string{"deb", "rpm", "termux.deb", "apk", "archlinux"},
+				FileNameTemplate: "a_{{ .ConventionalExtension }}_b",
+				PackageName:      "foo",
+				Meta:             true,
+				Maintainer:       "foo@bar",
+				Formats:          []string{"deb", "rpm", "termux.deb", "apk", "archlinux"},
 			},
 		},
 	})
@@ -2109,13 +2067,11 @@ func TestTermuxArch(t *testing.T) {
 		Dist:        dist,
 		NFPMs: []config.NFPM{
 			{
-				ID:         "someid",
-				Maintainer: "me@me",
-				IDs:        []string{"default"},
-				Formats:    []string{"deb", "termux.deb"},
-				NFPMOverridables: config.NFPMOverridables{
-					PackageName: "foo",
-				},
+				ID:          "someid",
+				Maintainer:  "me@me",
+				IDs:         []string{"default"},
+				Formats:     []string{"deb", "termux.deb"},
+				PackageName: "foo",
 			},
 		},
 	})
@@ -2207,13 +2163,11 @@ func TestDebArchVariant(t *testing.T) {
 		Dist:        dist,
 		NFPMs: []config.NFPM{
 			{
-				ID:         "someid",
-				Maintainer: "me@me",
-				IDs:        []string{"default"},
-				Formats:    []string{"deb"},
-				NFPMOverridables: config.NFPMOverridables{
-					PackageName: "foo",
-				},
+				ID:          "someid",
+				Maintainer:  "me@me",
+				IDs:         []string{"default"},
+				Formats:     []string{"deb"},
+				PackageName: "foo",
 			},
 		},
 	}, testctx.WithVersion("1.0.0"))
@@ -2272,21 +2226,19 @@ func TestRunPipeMSIX(t *testing.T) {
 		Env:         []string{"PUBLISHER=CN=Me"},
 		NFPMs: []config.NFPM{
 			{
-				ID:      "someid",
-				Bindir:  "/usr/bin",
-				IDs:     []string{"foo"},
-				Formats: []string{"msix"},
-				NFPMOverridables: config.NFPMOverridables{
-					PackageName:      "mybin",
-					FileNameTemplate: "{{.ConventionalFileName}}",
-					MSIX: config.NFPMMSIX{
-						Publisher: "{{ .Env.PUBLISHER }}",
-						Properties: config.NFPMMSIXProperties{
-							Logo: logoPath,
-						},
-						Applications: []config.NFPMMSIXApplication{
-							{ID: "App", Executable: "mybin.exe"},
-						},
+				ID:               "someid",
+				Bindir:           "/usr/bin",
+				IDs:              []string{"foo"},
+				Formats:          []string{"msix"},
+				PackageName:      "mybin",
+				FileNameTemplate: "{{.ConventionalFileName}}",
+				MSIX: config.NFPMMSIX{
+					Publisher: "{{ .Env.PUBLISHER }}",
+					Properties: config.NFPMMSIXProperties{
+						Logo: logoPath,
+					},
+					Applications: []config.NFPMMSIXApplication{
+						{ID: "App", Executable: "mybin.exe"},
 					},
 				},
 			},
@@ -2335,22 +2287,20 @@ func TestRunPipeMSIXMixedFormats(t *testing.T) {
 		Dist:        dist,
 		NFPMs: []config.NFPM{
 			{
-				ID:         "someid",
-				Bindir:     "/usr/bin",
-				IDs:        []string{"foo"},
-				Formats:    []string{"deb", "msix"},
-				Maintainer: "me@me",
-				NFPMOverridables: config.NFPMOverridables{
-					PackageName:      "mybin",
-					FileNameTemplate: "{{.ConventionalFileName}}",
-					MSIX: config.NFPMMSIX{
-						Publisher: "CN=Me",
-						Properties: config.NFPMMSIXProperties{
-							Logo: logoPath,
-						},
-						Applications: []config.NFPMMSIXApplication{
-							{ID: "App", Executable: "mybin.exe"},
-						},
+				ID:               "someid",
+				Bindir:           "/usr/bin",
+				IDs:              []string{"foo"},
+				Formats:          []string{"deb", "msix"},
+				Maintainer:       "me@me",
+				PackageName:      "mybin",
+				FileNameTemplate: "{{.ConventionalFileName}}",
+				MSIX: config.NFPMMSIX{
+					Publisher: "CN=Me",
+					Properties: config.NFPMMSIXProperties{
+						Logo: logoPath,
+					},
+					Applications: []config.NFPMMSIXApplication{
+						{ID: "App", Executable: "mybin.exe"},
 					},
 				},
 			},

--- a/internal/pipe/srpm/srpm.go
+++ b/internal/pipe/srpm/srpm.go
@@ -185,18 +185,16 @@ func (Pipe) Run(ctx *context.Context) error {
 		Vendor:      srpm.Vendor,
 		Homepage:    srpm.URL,
 		License:     srpm.License,
-		Overridables: nfpm.Overridables{
-			Contents: contents,
-			RPM: nfpm.RPM{
-				Group:       srpm.Group,
-				Summary:     srpm.Summary,
-				Compression: srpm.Compression,
-				Packager:    srpm.Packager,
-				Signature: nfpm.RPMSignature{
-					PackageSignature: nfpm.PackageSignature{
-						KeyFile:       srpm.Signature.KeyFile,
-						KeyPassphrase: ctx.Env["SRPM_PASSPHRASE"],
-					},
+		Contents:    contents,
+		RPM: nfpm.RPM{
+			Group:       srpm.Group,
+			Summary:     srpm.Summary,
+			Compression: srpm.Compression,
+			Packager:    srpm.Packager,
+			Signature: nfpm.RPMSignature{
+				PackageSignature: nfpm.PackageSignature{
+					KeyFile:       srpm.Signature.KeyFile,
+					KeyPassphrase: ctx.Env["SRPM_PASSPHRASE"],
 				},
 			},
 		},

--- a/internal/pipe/webhook/webhook_test.go
+++ b/internal/pipe/webhook/webhook_test.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/internal/testlib"
 	"github.com/goreleaser/goreleaser/v2/pkg/config"

--- a/internal/skips/skips.go
+++ b/internal/skips/skips.go
@@ -44,12 +44,12 @@ const (
 func String(ctx *context.Context) string {
 	keys := slices.Sorted(maps.Keys(ctx.Skips))
 	str := strings.Join(keys, ", ")
-	if idx := strings.LastIndex(str, ","); idx > -1 {
+	if before, after, found := strings.CutLast(str, ","); found {
 		comma := ""
 		if len(keys) > 2 {
 			comma = ","
 		}
-		str = str[:idx] + comma + " and" + str[idx+1:]
+		str = before + comma + " and" + after
 	}
 	return str
 }

--- a/www/content/customization/ci/azurepipelines.md
+++ b/www/content/customization/ci/azurepipelines.md
@@ -74,7 +74,7 @@ trigger:
       - refs/tags/*
 
 variables:
-  GO_VERSION: "1.26"
+  GO_VERSION: "1.27"
 
 pool:
   vmImage: ubuntu-latest

--- a/www/content/customization/ci/codefresh.md
+++ b/www/content/customization/ci/codefresh.md
@@ -26,7 +26,7 @@ steps:
   BuildMyApp:
     title: Compiling go code
     stage: build
-    image: 'golang:1.26'
+    image: 'golang:1.27'
     commands:
       - go build
   ReleaseMyApp:

--- a/www/content/customization/ci/drone.md
+++ b/www/content/customization/ci/drone.md
@@ -98,12 +98,12 @@ pipeline:
     tags: true
 
   test:
-    image: golang:1.26
+    image: golang:1.27
     commands:
       - go test ./... -race
 
   release:
-    image: golang:1.26
+    image: golang:1.27
     secrets: [github_token]
     commands:
       curl -sfL https://goreleaser.com/static/run | bash

--- a/www/content/customization/ci/rwx.md
+++ b/www/content/customization/ci/rwx.md
@@ -33,7 +33,7 @@ tasks:
   - key: go
     call: golang/install 1.2.0
     with:
-      go-version: "1.26"
+      go-version: "1.27"
 
   - key: goreleaser
     run: |

--- a/www/content/customization/ci/semaphore.md
+++ b/www/content/customization/ci/semaphore.md
@@ -20,7 +20,7 @@ blocks:
       prologue:
         commands:
           # set go version
-          - sem-version go 1.26
+          - sem-version go 1.27
           - "export GOPATH=~/go"
           - "export PATH=/home/semaphore/go/bin:$PATH"
           - checkout
@@ -58,7 +58,7 @@ blocks:
         - name: goreleaser
       prologue:
         commands:
-          - sem-version go 1.26
+          - sem-version go 1.27
           - "export GOPATH=~/go"
           - "export PATH=/home/semaphore/go/bin:$PATH"
           - checkout

--- a/www/content/getting-started/install/oss.md
+++ b/www/content/getting-started/install/oss.md
@@ -184,7 +184,7 @@ apk add --allow-untrusted goreleaser*.apk
 go install github.com/goreleaser/goreleaser/v2@latest
 ```
 
-Requires Go 1.26.
+Requires Go 1.27.
 
 ## Bash Script
 

--- a/www/content/resources/contributing.md
+++ b/www/content/resources/contributing.md
@@ -13,7 +13,7 @@ By participating in this project, you agree to abide our
 Prerequisites:
 
 - [Task](https://taskfile.dev/installation)
-- [Go 1.26+](https://go.dev/doc/install)
+- [Go 1.27+](https://go.dev/doc/install)
 
 Other things you might need to run some of the tests (they should get
 automatically skipped if a needed tool isn't present):

--- a/www/go.mod
+++ b/www/go.mod
@@ -1,5 +1,5 @@
 module github.com/goreleaser/goreleaser/hugo-docs
 
-go 1.26.1
+go 1.27.0
 
 require github.com/imfing/hextra v0.12.3 // indirect


### PR DESCRIPTION
Updates the project to Go 1.27, and adopts a few things from the release.

## What

Version bumps:

- `go.mod` and `www/go.mod` to `1.27.0`
- `Dockerfile` base image to `golang:1.27.0-alpine` (with digest)
- `CONTRIBUTING.md` and the CI/install docs pages
- `.golangci.yaml`: `run.go` was still pinned to `1.24`, now `1.27`

Adopted from Go 1.27:

- the new stdlib [`uuid`](https://pkg.go.dev/uuid) package replaces
  `github.com/google/uuid`, dropping it as a direct dependency
- `strings.CutLast` replaces `strings.LastIndex` index arithmetic in the Rust
  target parser and in `skips.String`
- `errors.AsType` in the Bluesky pipe
- `embedlit`: struct literal keys may now be any valid field selector, so
  embedded literals such as `config.BuildDetails{...}` and `nfpm.Overridables{...}`
  can be flattened. This accounts for most of the diff, and is almost entirely
  in tests.

One real incompatibility surfaced, fixed in its own commit:

- **ko**: `ko.main` is optional, and `buildBuildOptions` passed it straight to
  `packages.Load`. Go 1.27 rejects an empty package pattern, so any ko build
  without an explicit `main` failed with `go: invalid package: ""`. Go 1.26 and
  earlier resolved it to the current directory. It now defaults to `.`, with a
  regression test that needs no Docker.

## Why

Keep the toolchain current, and take the small wins the release offers. Dropping
`github.com/google/uuid` removes a direct dependency for free.

## Notes

- `go fix` also proposes stripping `omitempty` from struct-typed JSON tags
  (`encoding/json/v2` semantics). That was **not** applied, since it would change
  the generated JSON schema.
- `www/static/schema.json` regenerates byte-identical.
- The `ruleguard` job fails on `main` too (`ruleguard: internal error: package
  "cmp" without types`). It is unrelated to this branch.
