### PR TITLE
test(dockers/v2): cover debug helpers

### DIFF
--- a/internal/pipe/docker/v2/debug_test.go
+++ b/internal/pipe/docker/v2/debug_test.go
@@ -1,0 +1,66 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsFileNotFoundError(t *testing.T) {
+	tests := []struct {
+		name     string
+		out      string
+		expected bool
+	}{
+		{
+			name:     "empty output",
+			out:      "",
+			expected: false,
+		},
+		{
+			name:     "unrelated error",
+			out:      "ERROR: failed to solve: no such image",
+			expected: false,
+		},
+		{
+			name:     "copy directive",
+			out:      "ERROR: failed to solve: >>> COPY ./bin /usr/bin",
+			expected: true,
+		},
+		{
+			name:     "add directive",
+			out:      "ERROR: failed to solve: >>> ADD ./config /etc",
+			expected: true,
+		},
+		{
+			name:     "copy without marker",
+			out:      "COPY ./bin /usr/bin",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, isFileNotFoundError(tt.out))
+		})
+	}
+}
+
+func TestFileNotFoundDetails(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "sub"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sub", "nested.txt"), []byte("x"), 0o644))
+
+	result := fileNotFoundDetails(dir)
+	require.Contains(t, result, "not available in the build context")
+	require.Contains(t, result, "main.go")
+}
+
+func TestFileNotFoundDetails_InvalidDir(t *testing.T) {
+	result := fileNotFoundDetails(filepath.Join(t.TempDir(), "does-not-exist"))
+	require.Contains(t, result, "not available in the build context")
+	require.NotContains(t, result, "\n")
+}


### PR DESCRIPTION
<!-- If applied, this commit will... -->

Add test coverage for the docker v2 debug helpers.

<!-- Why is this change being made? -->

- `isFileNotFoundError`, `fileNotFoundDetails`, and `buildTree` had no test coverage. This adds table-driven tests for all three, matching the style in `heuristics_test.go`.

- Package coverage goes from **76.2%** to **79.9%**.

- **Note on `buildTree` (91.7%):** the uncovered branch is the error return from the recursive call, which needs a nested directory that fails `os.ReadDir`. That isn't reproducible on Windows — `os.Chmod` only toggles the read-only bit, so I left it rather than adding a platform-specific test.