### PR TITLE
fix(gitlab): compare CI job tokens in constant time

### DIFF
--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"cmp"
+	"crypto/subtle"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -732,7 +733,7 @@ func checkUseJobToken(ctx context.Context, token string) bool {
 		// We may be creating a new client with a non-CI_JOB_TOKEN, for
 		// things like Homebrew publishing. We can't use the
 		// CI_JOB_TOKEN there
-		return token == ciToken
+		return subtle.ConstantTimeCompare([]byte(token), []byte(ciToken)) == 1
 	}
 	return false
 }


### PR DESCRIPTION
## What & why

`checkUseJobToken` in `internal/client/gitlab.go` compared the user-supplied token against `CI_JOB_TOKEN` with plain string equality:

```go
return token == ciToken
```

Go's string comparison short-circuits on the first differing byte, so comparison time leaks information about how many leading bytes match. In CI environments where goreleaser runs on shared or multi-tenant infrastructure, this is a (hard-to-exploit but real) timing side channel involving two secrets — the configured API token and the GitLab CI job token.

This PR swaps it for a constant-time comparison:

```diff
-import "crypto/tls"
+import "crypto/subtle"
+import "crypto/tls"
```

```diff
-		return token == ciToken
+		return subtle.ConstantTimeCompare([]byte(token), []byte(ciToken)) == 1
```

Behavior is unchanged except for timing: `subtle.ConstantTimeCompare` returns 0 when the lengths differ and 1 only on an exact match, which matches the previous semantics (`token == ciToken`) exactly.

## How this was found

We're building [deslop](https://stopthatslop.com), an open-source rule engine for AI coding agents. While benchmarking one of our AST-based security detectors (which flags non-constant-time comparisons where at least one operand originates from a credential source — env vars, config tokens, etc.) across ~500k LOC of popular Go projects (caddy, restic, lazygit, fzf, chi, viper, task, goreleaser), goreleaser produced **exactly one hit** — this line.

## Notes for reviewers

- Only 2 hunks: one import, one line changed.
- The empty-`ciToken` early return above means we never compare against an empty secret; length-leak via `ConstantTimeCompare`'s fast path on mismatched lengths isn't a concern here since `ciToken` length is fixed per environment.
- Happy to add a unit test if desired.

DCO sign-off included as required by the project.
