### PR TITLE
fix(aursources): clarify error and document source.enabled requirement

### DIFF
--- a/internal/pipe/aursources/aursources.go
+++ b/internal/pipe/aursources/aursources.go
@@ -30,7 +30,7 @@ const (
 	defaultCommitMsg = "Update to {{ .Tag }}"
 )
 
-var ErrNoArchivesFound = errors.New("no linux archives found")
+var ErrNoArchivesFound = errors.New("no source archives found: make sure to enable source.enabled")
 
 // Pipe for arch linux's AUR pkgbuild.
 type Pipe struct{}

--- a/www/content/customization/publish/aursources.md
+++ b/www/content/customization/publish/aursources.md
@@ -13,6 +13,10 @@ a `PKGBUILD` to an _Arch User Repository_ based on sources.
 > Before going further on this, make sure to read
 > [AUR's Submission Guidelines](https://wiki.archlinux.org/title/AUR_submission_guidelines).
 
+> [!NOTE]
+> `aur_sources` requires a [source archive][sourcearchive] to be configured.
+> Make sure to enable `source.enabled: true` in your configuration.
+
 This page describes the available options.
 
 ```yaml {filename=".goreleaser.yaml"}
@@ -199,3 +203,5 @@ aur_sources:
 > [!NOTE]
 > For more info about what each field does, please refer to
 > [Arch's PKGBUILD reference](https://wiki.archlinux.org/title/PKGBUILD).
+
+[sourcearchive]: /customization/package/source/


### PR DESCRIPTION
Closes #6815.

`aur_sources` filters for `artifact.UploadableSourceArchive` like `srpm` does, but the error said `no linux archives found`, which doesn't point at the actual cause. The docs page didn't mention the requirement either, while `srpm.md` does.

- error now mentions `source.enabled`
- added a note to the docs, mirroring the one in `srpm.md`

Happy to change the wording or drop the docs part if you'd rather handle it differently.