### PR TITLE
ci: speed up the test jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,15 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
+          # setup-go keys its cache on the hash of these files only, and saves
+          # it just once per key. license-check and golangci-lint resolve the
+          # same key and always finish first, so this job kept restoring a
+          # build cache without the -race/-coverpkg objects and recompiled
+          # everything (~2.5min). Taskfile.yml holds the test flags, so hashing
+          # it too gives this job a key of its own that it can populate.
+          cache-dependency-path: |
+            go.sum
+            Taskfile.yml
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "25"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,10 +47,23 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         include:
+          # -count=1 turns the go test cache off. CI never gets a hit from it:
+          # every run is a new commit, and on ubuntu -coverpkg=./... makes each
+          # test binary depend on every package, so all 124 are invalidated
+          # (measured: 0 of 124 cached, every run). The cost is still paid,
+          # though. With the cache on, go passes -test.testlogfile to every
+          # test binary and then hashes every file each test touched to build
+          # the key, and this suite opens a lot of files: internal/pipe/archive
+          # alone logs 1887 operations. File metadata calls cost far more on
+          # windows, so it suffered most: measured on one runner back to back,
+          # identical flags apart from -count=1, 331s with the cache on and
+          # 129s without.
+          - os: ubuntu-latest
+            test-args: TEST_OPTIONS=-count=1
           # the race detector is OS-independent and coverage is only uploaded
           # from ubuntu, so skip both on windows to speed up the slowest job.
           - os: windows-latest
-            test-args: RACE=false COVER=false
+            test-args: RACE=false COVER=false TEST_OPTIONS=-count=1
     runs-on: ${{ matrix.os }}
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,24 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+      - name: use-fast-disk
+        # D: is the runner's local SSD, and GitHub already puts the workspace
+        # and RUNNER_TEMP there. The Go caches and %TMP% still default to C:,
+        # the network-attached OS disk, so every build artifact and all 472
+        # t.TempDir() trees the suite creates land on the slow disk. This must
+        # run before setup-go, which reads `go env GOCACHE`/`GOMODCACHE` to
+        # decide which directories to cache.
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path D:\tmp, D:\gocache, D:\gomodcache | Out-Null
+          @(
+            "GOTMPDIR=D:\tmp"
+            "TMP=D:\tmp"
+            "TEMP=D:\tmp"
+            "GOCACHE=D:\gocache"
+            "GOMODCACHE=D:\gomodcache"
+          ) | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - uses: go-task/setup-task@a00fbb05ce67b35648be3c78cbc9fd85354c757e # v2.2.0
         with:
           version: 3.x

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -1613,7 +1613,8 @@ func TestToProxiedImportPath(t *testing.T) {
 }
 
 func TestCheckBuildElipsisWithProxiedSubpathMain(t *testing.T) {
-	folder := testlib.Mktmp(t)
+	t.Parallel()
+	folder := t.TempDir()
 	writeGoMod(t, folder, "github.com/foo/bar")
 	writeGoodMain(t, filepath.Join(folder, "cmd", "a"))
 	writeGoodMain(t, filepath.Join(folder, "cmd", "b"))
@@ -1646,7 +1647,8 @@ func TestCheckBuildElipsisWithProxiedSubpathMain(t *testing.T) {
 }
 
 func TestCheckBuildElipsisWithExplicitIDError(t *testing.T) {
-	folder := testlib.Mktmp(t)
+	t.Parallel()
+	folder := t.TempDir()
 	writeGoMod(t, folder, "github.com/foo/bar")
 	writeGoodMain(t, filepath.Join(folder, "cmd", "a"))
 	writeGoodMain(t, filepath.Join(folder, "cmd", "b"))
@@ -1668,7 +1670,8 @@ func TestCheckBuildElipsisWithExplicitIDError(t *testing.T) {
 }
 
 func TestCheckBuildElipsisWithExplicitBinaryError(t *testing.T) {
-	folder := testlib.Mktmp(t)
+	t.Parallel()
+	folder := t.TempDir()
 	writeGoMod(t, folder, "github.com/foo/bar")
 	writeGoodMain(t, filepath.Join(folder, "cmd", "a"))
 	writeGoodMain(t, filepath.Join(folder, "cmd", "b"))
@@ -1691,7 +1694,8 @@ func TestCheckBuildElipsisWithExplicitBinaryError(t *testing.T) {
 }
 
 func TestCheckBuildElipsisSingleMain(t *testing.T) {
-	folder := testlib.Mktmp(t)
+	t.Parallel()
+	folder := t.TempDir()
 	writeGoMod(t, folder, "github.com/foo/bar")
 	writeGoodMain(t, filepath.Join(folder, "cmd", "a"))
 
@@ -1717,7 +1721,8 @@ func TestCheckBuildElipsisSingleMain(t *testing.T) {
 }
 
 func TestCheckBuildElipsisSingleMainWithExplicitBinary(t *testing.T) {
-	folder := testlib.Mktmp(t)
+	t.Parallel()
+	folder := t.TempDir()
 	writeGoMod(t, folder, "github.com/foo/bar")
 	writeGoodMain(t, filepath.Join(folder, "cmd", "a"))
 

--- a/internal/pipe/archive/archive_test.go
+++ b/internal/pipe/archive/archive_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/goreleaser/goreleaser/v2/internal/testlib"
 	"github.com/goreleaser/goreleaser/v2/pkg/archive"
 	"github.com/goreleaser/goreleaser/v2/pkg/config"
+	"github.com/goreleaser/goreleaser/v2/pkg/context"
 	"github.com/stretchr/testify/require"
 )
 
@@ -286,79 +287,84 @@ func TestRunPipe(t *testing.T) {
 }
 
 func TestRunPipeDifferentBinaryCount(t *testing.T) {
-	folder := testlib.Mktmp(t)
-	dist := filepath.Join(folder, "dist")
-	require.NoError(t, os.Mkdir(dist, 0o755))
-	for _, arch := range []string{"darwinamd64", "linuxamd64"} {
-		createFakeBinary(t, dist, arch, "bin/mybin")
-	}
-	createFakeBinary(t, dist, "darwinamd64", "bin/foobar")
-	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
-		Dist:        dist,
-		ProjectName: "foobar",
-		Archives: []config.Archive{
-			{
-				ID:           "myid",
-				Formats:      []string{"tar.gz"},
-				Builds:       []string{"default", "foobar"},
-				NameTemplate: defaultNameTemplate,
+	t.Parallel()
+	// Pipe.Run adds artifacts to the context and writes archives into Dist, so
+	// each subtest needs its own context and its own dist directory.
+	setup := func(t *testing.T, allowDifferentBinaryCount bool) *context.Context {
+		t.Helper()
+		dist := filepath.Join(t.TempDir(), "dist")
+		require.NoError(t, os.Mkdir(dist, 0o755))
+		for _, arch := range []string{"darwinamd64", "linuxamd64"} {
+			createFakeBinary(t, dist, arch, "bin/mybin")
+		}
+		createFakeBinary(t, dist, "darwinamd64", "bin/foobar")
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			Dist:        dist,
+			ProjectName: "foobar",
+			Archives: []config.Archive{
+				{
+					ID:                        "myid",
+					Formats:                   []string{"tar.gz"},
+					Builds:                    []string{"default", "foobar"},
+					NameTemplate:              defaultNameTemplate,
+					AllowDifferentBinaryCount: allowDifferentBinaryCount,
+				},
 			},
-		},
-	})
+		})
 
-	darwinBuild := &artifact.Artifact{
-		Goos:   "darwin",
-		Goarch: "amd64",
-		Name:   "bin/mybin",
-		Path:   filepath.Join(dist, "darwinamd64", "bin", "mybin"),
-		Type:   artifact.Binary,
-		Extra: map[string]any{
-			artifact.ExtraBinary: "bin/mybin",
-			artifact.ExtraID:     "default",
-		},
+		ctx.Artifacts.Add(&artifact.Artifact{
+			Goos:   "darwin",
+			Goarch: "amd64",
+			Name:   "bin/mybin",
+			Path:   filepath.Join(dist, "darwinamd64", "bin", "mybin"),
+			Type:   artifact.Binary,
+			Extra: map[string]any{
+				artifact.ExtraBinary: "bin/mybin",
+				artifact.ExtraID:     "default",
+			},
+		})
+		ctx.Artifacts.Add(&artifact.Artifact{
+			Goos:   "darwin",
+			Goarch: "amd64",
+			Name:   "bin/foobar",
+			Path:   filepath.Join(dist, "darwinamd64", "bin", "foobar"),
+			Type:   artifact.Binary,
+			Extra: map[string]any{
+				artifact.ExtraBinary: "bin/foobar",
+				artifact.ExtraID:     "foobar",
+			},
+		})
+		ctx.Artifacts.Add(&artifact.Artifact{
+			Goos:   "linux",
+			Goarch: "amd64",
+			Name:   "bin/mybin",
+			Path:   filepath.Join(dist, "linuxamd64", "bin", "mybin"),
+			Type:   artifact.Binary,
+			Extra: map[string]any{
+				artifact.ExtraBinary: "bin/mybin",
+				artifact.ExtraID:     "default",
+			},
+		})
+		ctx.Version = "0.0.1"
+		ctx.Git.CurrentTag = "v0.0.1"
+		return ctx
 	}
-	darwinBuild2 := &artifact.Artifact{
-		Goos:   "darwin",
-		Goarch: "amd64",
-		Name:   "bin/foobar",
-		Path:   filepath.Join(dist, "darwinamd64", "bin", "foobar"),
-		Type:   artifact.Binary,
-		Extra: map[string]any{
-			artifact.ExtraBinary: "bin/foobar",
-			artifact.ExtraID:     "foobar",
-		},
-	}
-	linuxArmBuild := &artifact.Artifact{
-		Goos:   "linux",
-		Goarch: "amd64",
-		Name:   "bin/mybin",
-		Path:   filepath.Join(dist, "linuxamd64", "bin", "mybin"),
-		Type:   artifact.Binary,
-		Extra: map[string]any{
-			artifact.ExtraBinary: "bin/mybin",
-			artifact.ExtraID:     "default",
-		},
-	}
-
-	ctx.Artifacts.Add(darwinBuild)
-	ctx.Artifacts.Add(darwinBuild2)
-	ctx.Artifacts.Add(linuxArmBuild)
-	ctx.Version = "0.0.1"
-	ctx.Git.CurrentTag = "v0.0.1"
 
 	t.Run("check enabled", func(t *testing.T) {
-		ctx.Config.Archives[0].AllowDifferentBinaryCount = false
-		require.EqualError(t, Pipe{}.Run(ctx), "invalid archive: 0: "+ErrArchiveDifferentBinaryCount.Error())
+		t.Parallel()
+		err := Pipe{}.Run(setup(t, false))
+		require.EqualError(t, err, "invalid archive: 0: "+ErrArchiveDifferentBinaryCount.Error())
 	})
 
 	t.Run("check disabled", func(t *testing.T) {
-		ctx.Config.Archives[0].AllowDifferentBinaryCount = true
-		require.NoError(t, Pipe{}.Run(ctx))
+		t.Parallel()
+		require.NoError(t, Pipe{}.Run(setup(t, true)))
 	})
 }
 
 func TestRunPipeNoBinaries(t *testing.T) {
-	folder := testlib.Mktmp(t)
+	t.Parallel()
+	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
@@ -424,7 +430,8 @@ func tarInfo(t *testing.T, path, name string) *tar.Header {
 }
 
 func TestRunPipeBinary(t *testing.T) {
-	folder := testlib.Mktmp(t)
+	t.Parallel()
+	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "darwinamd64"), 0o755))
@@ -561,7 +568,8 @@ func TestRunPipeDistRemoved(t *testing.T) {
 }
 
 func TestRunPipeInvalidGlob(t *testing.T) {
-	folder := testlib.Mktmp(t)
+	t.Parallel()
+	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "darwinamd64"), 0o755))
@@ -646,7 +654,8 @@ func TestRunPipeNameTemplateWithSpace(t *testing.T) {
 }
 
 func TestRunPipeInvalidNameTemplate(t *testing.T) {
-	folder := testlib.Mktmp(t)
+	t.Parallel()
+	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "darwinamd64"), 0o755))
@@ -681,7 +690,8 @@ func TestRunPipeInvalidNameTemplate(t *testing.T) {
 }
 
 func TestRunPipeInvalidFilesNameTemplate(t *testing.T) {
-	folder := testlib.Mktmp(t)
+	t.Parallel()
+	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "darwinamd64"), 0o755))
@@ -719,7 +729,8 @@ func TestRunPipeInvalidFilesNameTemplate(t *testing.T) {
 }
 
 func TestRunPipeInvalidWrapInDirectoryTemplate(t *testing.T) {
-	folder := testlib.Mktmp(t)
+	t.Parallel()
+	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
 	require.NoError(t, os.Mkdir(filepath.Join(dist, "darwinamd64"), 0o755))
@@ -1286,7 +1297,8 @@ func TestSkip(t *testing.T) {
 }
 
 func TestFormatOverrideWithNoFormatOrNoGoos(t *testing.T) {
-	folder := testlib.Mktmp(t)
+	t.Parallel()
+	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
 	createFakeBinary(t, dist, "windowsamd64", "mybin.exe")

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -1232,7 +1232,7 @@ func TestRunEmptyTokenType(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	testlib.Mktmp(t)
+	t.Parallel()
 	repo := config.RepoRef{
 		Owner:  "owner",
 		Name:   "name",

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -88,7 +88,8 @@ func TestPipeDescription(t *testing.T) {
 }
 
 func TestBuild(t *testing.T) {
-	folder := testlib.Mktmp(t)
+	t.Parallel()
+	folder := t.TempDir()
 	config := config.Project{
 		Dist: folder,
 		Builds: []config.Build{
@@ -113,7 +114,8 @@ func TestBuild(t *testing.T) {
 }
 
 func TestRunPipe(t *testing.T) {
-	folder := testlib.Mktmp(t)
+	t.Parallel()
+	folder := t.TempDir()
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Dist: folder,
 		Builds: []config.Build{
@@ -177,7 +179,8 @@ func TestRunFullPipe(t *testing.T) {
 }
 
 func TestRunFullPipeFail(t *testing.T) {
-	folder := testlib.Mktmp(t)
+	t.Parallel()
+	folder := t.TempDir()
 	pre := filepath.Join(folder, "pre")
 	post := filepath.Join(folder, "post")
 	config := config.Project{
@@ -207,20 +210,27 @@ func TestRunFullPipeFail(t *testing.T) {
 }
 
 func TestRunPipeFailingHooks(t *testing.T) {
-	folder := testlib.Mktmp(t)
-	cfg := config.Project{
-		Dist: folder,
-		Builds: []config.Build{
-			{
-				Builder: "fake",
-				Binary:  "hooks",
-				Hooks:   config.BuildHookConfig{},
-				Targets: []string{"linux_amd64"},
+	t.Parallel()
+	// config.Project.Builds is a slice, so the copy WrapWithCfg makes still
+	// shares its backing array. Each subtest needs a config of its own before
+	// it can set hooks in parallel.
+	newCfg := func(t *testing.T) config.Project {
+		t.Helper()
+		return config.Project{
+			Dist: t.TempDir(),
+			Builds: []config.Build{
+				{
+					Builder: "fake",
+					Binary:  "hooks",
+					Hooks:   config.BuildHookConfig{},
+					Targets: []string{"linux_amd64"},
+				},
 			},
-		},
+		}
 	}
 	t.Run("pre-hook", func(t *testing.T) {
-		ctx := testctx.WrapWithCfg(t.Context(), cfg, testctx.WithCurrentTag("2.4.5"))
+		t.Parallel()
+		ctx := testctx.WrapWithCfg(t.Context(), newCfg(t), testctx.WithCurrentTag("2.4.5"))
 		ctx.Config.Builds[0].Hooks.Pre = []config.Hook{{Cmd: "exit 1"}}
 		ctx.Config.Builds[0].Hooks.Post = []config.Hook{{Cmd: testlib.Echo("post")}}
 
@@ -229,7 +239,8 @@ func TestRunPipeFailingHooks(t *testing.T) {
 		require.ErrorContains(t, err, "pre hook failed")
 	})
 	t.Run("post-hook", func(t *testing.T) {
-		ctx := testctx.WrapWithCfg(t.Context(), cfg, testctx.WithCurrentTag("2.4.5"))
+		t.Parallel()
+		ctx := testctx.WrapWithCfg(t.Context(), newCfg(t), testctx.WithCurrentTag("2.4.5"))
 		ctx.Config.Builds[0].Hooks.Pre = []config.Hook{{Cmd: testlib.Echo("pre")}}
 		ctx.Config.Builds[0].Hooks.Post = []config.Hook{{Cmd: "exit 1"}}
 		err := Pipe{}.Run(ctx)
@@ -238,8 +249,9 @@ func TestRunPipeFailingHooks(t *testing.T) {
 	})
 
 	t.Run("post-hook-skip", func(t *testing.T) {
+		t.Parallel()
 		ctx := testctx.WrapWithCfg(t.Context(),
-			cfg,
+			newCfg(t),
 			testctx.WithCurrentTag("2.4.5"),
 			testctx.Skip(skips.PostBuildHooks))
 
@@ -249,8 +261,9 @@ func TestRunPipeFailingHooks(t *testing.T) {
 	})
 
 	t.Run("pre-hook-skip", func(t *testing.T) {
+		t.Parallel()
 		ctx := testctx.WrapWithCfg(t.Context(),
-			cfg,
+			newCfg(t),
 			testctx.WithCurrentTag("2.4.5"),
 			testctx.Skip(skips.PreBuildHooks))
 
@@ -266,7 +279,8 @@ func TestDefaultNoBuilds(t *testing.T) {
 }
 
 func TestDefaultFail(t *testing.T) {
-	folder := testlib.Mktmp(t)
+	t.Parallel()
+	folder := t.TempDir()
 	config := config.Project{
 		Dist: folder,
 		Builds: []config.Build{
@@ -410,7 +424,8 @@ func TestDefaultPartialBuilds(t *testing.T) {
 }
 
 func TestSkipBuild(t *testing.T) {
-	folder := testlib.Mktmp(t)
+	t.Parallel()
+	folder := t.TempDir()
 	config := config.Project{
 		Dist: folder,
 		Builds: []config.Build{
@@ -425,7 +440,8 @@ func TestSkipBuild(t *testing.T) {
 }
 
 func TestSkipBuildTmpl(t *testing.T) {
-	folder := testlib.Mktmp(t)
+	t.Parallel()
+	folder := t.TempDir()
 	config := config.Project{
 		Dist: folder,
 		Env:  []string{"FOO=bar"},
@@ -615,7 +631,8 @@ func TestPipeOnBuild_invalidBinaryTpl(t *testing.T) {
 }
 
 func TestBuildOptionsForTarget(t *testing.T) {
-	tmpDir := testlib.Mktmp(t)
+	t.Parallel()
+	tmpDir := t.TempDir()
 
 	testCases := []struct {
 		name         string
@@ -727,6 +744,7 @@ func TestBuildOptionsForTarget(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 				Dist:   tmpDir,
 				Builds: []config.Build{tc.build},
@@ -747,7 +765,8 @@ func TestBuildOptionsForTarget(t *testing.T) {
 
 func TestRunHookFailWithLogs(t *testing.T) {
 	testlib.SkipIfWindows(t, "subshells don't work in windows")
-	folder := testlib.Mktmp(t)
+	t.Parallel()
+	folder := t.TempDir()
 	config := config.Project{
 		Dist: folder,
 		Builds: []config.Build{

--- a/internal/pipe/cask/cask_test.go
+++ b/internal/pipe/cask/cask_test.go
@@ -1176,7 +1176,7 @@ func TestRunEmptyTokenType(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	testlib.Mktmp(t)
+	t.Parallel()
 	repo := config.RepoRef{
 		Owner:  "owner",
 		Name:   "name",

--- a/internal/pipe/chocolatey/chocolatey_test.go
+++ b/internal/pipe/chocolatey/chocolatey_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/goreleaser/goreleaser/v2/internal/golden"
 	"github.com/goreleaser/goreleaser/v2/internal/skips"
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
-	"github.com/goreleaser/goreleaser/v2/internal/testlib"
 	"github.com/goreleaser/goreleaser/v2/pkg/config"
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
 	"github.com/stretchr/testify/require"
@@ -51,7 +50,7 @@ func TestSkip(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	testlib.Mktmp(t)
+	t.Parallel()
 
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "myproject",

--- a/internal/pipe/effectiveconfig/config_test.go
+++ b/internal/pipe/effectiveconfig/config_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
-	"github.com/goreleaser/goreleaser/v2/internal/testlib"
 	"github.com/goreleaser/goreleaser/v2/pkg/config"
 	"github.com/stretchr/testify/require"
 )
@@ -16,7 +15,8 @@ func TestPipeDescription(t *testing.T) {
 }
 
 func TestRun(t *testing.T) {
-	folder := testlib.Mktmp(t)
+	t.Parallel()
+	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{

--- a/internal/pipe/gomod/gomod_test.go
+++ b/internal/pipe/gomod/gomod_test.go
@@ -107,7 +107,8 @@ func TestCustomEnv(t *testing.T) {
 }
 
 func TestRunCustomDir(t *testing.T) {
-	dir := testlib.Mktmp(t)
+	t.Parallel()
+	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "src"), 0o755))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(dir, "src/main.go"),

--- a/internal/pipe/krew/krew_test.go
+++ b/internal/pipe/krew/krew_test.go
@@ -963,7 +963,7 @@ func TestRunMultipleBinaries(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	testlib.Mktmp(t)
+	t.Parallel()
 
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "myproject",

--- a/internal/pipe/project/project_test.go
+++ b/internal/pipe/project/project_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestCustomProjectName(t *testing.T) {
-	_ = testlib.Mktmp(t)
+	t.Parallel()
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		ProjectName: "foo",
 		Release: config.Release{

--- a/internal/pipe/sbom/sbom_test.go
+++ b/internal/pipe/sbom/sbom_test.go
@@ -278,6 +278,7 @@ func TestDisable(t *testing.T) {
 }
 
 func TestSBOMCatalogArtifacts(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		desc           string
 		ctx            *context.Context
@@ -501,6 +502,7 @@ func TestSBOMCatalogArtifacts(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			testSBOMCataloging(
 				t,
 				test.ctx,
@@ -560,7 +562,8 @@ func testSBOMCataloging(
 ) {
 	tb.Helper()
 
-	// resolve fakesyft path before Mktmp changes the working directory
+	// the pipe runs the command with its working directory set to dist, so the
+	// tool path has to be absolute.
 	fakesyft := "./testdata/fakesyft"
 	if testlib.IsWindows() {
 		fakesyft += ".bat"
@@ -568,7 +571,7 @@ func testSBOMCataloging(
 	fakesyft, err := filepath.Abs(fakesyft)
 	require.NoError(tb, err)
 
-	tmpdir := testlib.Mktmp(tb)
+	tmpdir := tb.TempDir()
 
 	ctx.Config.Dist = tmpdir
 	ctx.Version = "1.2.2"

--- a/internal/pipe/scoop/scoop_test.go
+++ b/internal/pipe/scoop/scoop_test.go
@@ -25,7 +25,7 @@ func TestDescription(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
-	testlib.Mktmp(t)
+	t.Parallel()
 
 	ctx := testctx.WrapWithCfg(t.Context(),
 		config.Project{

--- a/internal/testlib/git.go
+++ b/internal/testlib/git.go
@@ -14,12 +14,11 @@ import (
 // GitInit inits a new git project.
 func GitInit(tb testing.TB) {
 	tb.Helper()
-	out, err := fakeGit("init")
+	// a single `init -b main` instead of init + checkout + branch -D: process
+	// creation is expensive on Windows, and this helper runs ~70 times.
+	out, err := fakeGit("init", "-b", "main")
 	require.NoError(tb, err)
 	require.Contains(tb, out, "Initialized empty Git repository")
-	require.NoError(tb, err)
-	GitCheckoutBranch(tb, "main")
-	_, _ = fakeGit("branch", "-D", "master")
 }
 
 // GitRemoteAdd adds the given url as remote.


### PR DESCRIPTION
<!-- If applied, this commit will... -->

Roughly halve both `test` jobs, and stop the merge queue from waiting on the
Windows leg.

| job | before | after |
| --- | --- | --- |
| `test (windows-latest)` | 10–13.5m | **~5.5m** |
| `test (ubuntu-latest)` | ~11m | **~6.3m** |

Four changes, in order of how much they bought:

**1. Disable the go test cache in CI (`-count=1`).** This was the whole Windows
problem, and it was not the tests. When the cache is on, go passes
`-test.testlogfile` to every test binary and then hashes every file each test
opened to build the key. This suite opens a great many files —
`internal/pipe/archive` alone logs 1887 operations — and file metadata calls
cost far more on Windows. CI never gets a hit from that cache anyway: every run
is a new commit, and on ubuntu `-coverpkg=./...` makes each test binary depend
on every package, so all 124 are invalidated. Measured 0 of 124 cached, every
run. Measured on one runner back to back, identical flags apart from
`-count=1`: **331s with the cache on, 129s without**, with per-package test
times unchanged.

**2. Give the test job its own go build cache.** `setup-go` keys its cache on a
dependency file hash and saves it only once per key. `license-check` and
`golangci-lint` resolved the *same* key and always finished first, so the test
job kept restoring a build cache with no `-race`/`-coverpkg` objects and
recompiled everything. Hashing `Taskfile.yml` alongside `go.sum` gives this job
a key of its own. Measured: `task build` 67–97s → **5s**, `task test` 311–382s →
**165–201s**.

**3. Create the test git repo in one process.** `testlib.GitInit` ran three git
processes (`init`, `checkout -b main`, `branch -D master`); `git init -b main`
does it in one. Process creation costs 28–45ms more on Windows than on Linux,
measured, and this helper runs 70 times: 1660 git spawns across the affected
packages become 1474.

**4. Stop changing the working directory where it is not needed.**
`testlib.Mktmp` chdirs, and `t.Chdir` is incompatible with `t.Parallel()`, which
made all 161 call sites serial. 130 of them genuinely need the working
directory; the other 31 only wanted a scratch dir and now use `t.TempDir()`.
Two tests that shared config, artifacts and a dist directory between subtests
now build their own per subtest, so those subtests run in parallel too.

<!-- Why is this change being made? -->

The Windows `test` job was the merge-queue critical path at 10–13.5m, and its
duration was bimodal (258–490s) which made every change hard to judge. It is now
the *faster* of the two jobs.

Two things worth flagging honestly:

- The Windows local-SSD commit (`GOCACHE`/`GOMODCACHE`/`TMP` on `D:`) showed
  **no measurable improvement** across five samples. It is kept because the
  defaults are plainly wrong for this job, not because a speedup was measured.
  `D:` is not a separate physical disk on `windows-2025`.
- `-count=1` on ubuntu is likewise **not** a measured win: the cost there is
  about 3% on a cheap-metadata filesystem, well under the run-to-run noise. It
  is included because ubuntu provably never gets a cache hit, so the machinery
  is pure cost.

Measurements are against the full historical distribution of each step, not
single runs.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

- Go's cacheable-flag allowlist and the `-test.testlogfile` injection:
  [`src/cmd/go/internal/test/test.go`](https://github.com/golang/go/blob/go1.25.0/src/cmd/go/internal/test/test.go)
- `setup-go` cache key derivation:
  [`src/cache-restore.ts`](https://github.com/actions/setup-go/blob/main/src/cache-restore.ts)

Note: `ruleguard / scan` fails on this PR, but it fails on every `main` run too
(`internal error: package "cmp" without types`). It is unpinned upstream
(`go install ...@latest` with `go-version: stable`) and broke when Go 1.27
became stable. Unrelated to this change.

AI disclosure: I used an AI coding assistant to investigate the CI timings, make
these changes, and run the measurements above.
