### PR TITLE
feat(nix): drop the nix-hash dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,10 +120,6 @@ jobs:
         run: |
           flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
           flatpak install -y --user --noninteractive flathub org.freedesktop.Platform/x86_64/24.08 org.freedesktop.Sdk/x86_64/24.08 org.freedesktop.Platform/aarch64/24.08 org.freedesktop.Sdk/aarch64/24.08
-      - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
-        if: matrix.os == 'ubuntu-latest'
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: setup-nix-formatters
         # `nix profile add nixpkgs#...` resolves and builds from nixpkgs, which
         # took 18s. Both projects publish static linux binaries, so fetching

--- a/.github/workflows/nightly-oss.yml
+++ b/.github/workflows/nightly-oss.yml
@@ -59,9 +59,6 @@ jobs:
       - uses: crazy-max/ghaction-upx@c83f378efc804f828e988debb88ed6116feb2368 # v4.0.0
         with:
           install-only: true
-      - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: dockerhub-login
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,9 +125,6 @@ jobs:
       - uses: crazy-max/ghaction-upx@c83f378efc804f828e988debb88ed6116feb2368 # v4.0.0
         with:
           install-only: true
-      - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: dockerhub-login
         if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0

--- a/internal/pipe/nix/nix.go
+++ b/internal/pipe/nix/nix.go
@@ -5,8 +5,10 @@ import (
 	"bufio"
 	"bytes"
 	"cmp"
+	"crypto/sha256"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"os"
 	"os/exec"
@@ -64,7 +66,7 @@ type Pipe struct {
 
 func (Pipe) String() string                           { return "nixpkgs" }
 func (Pipe) ContinueOnError() bool                    { return true }
-func (Pipe) Dependencies(_ *context.Context) []string { return []string{nixHashBin} }
+func (Pipe) Dependencies(_ *context.Context) []string { return nil }
 
 func (p Pipe) Skip(ctx *context.Context) bool {
 	return skips.Any(ctx, skips.Nix) || len(ctx.Config.Nix) == 0
@@ -94,9 +96,6 @@ func (Pipe) Default(ctx *context.Context) error {
 }
 
 func (p Pipe) Run(ctx *context.Context) error {
-	if !p.hasher.Available() {
-		return pipe.Skipf("%s is not available", nixHashBin)
-	}
 	cli, err := client.NewReleaseClient(ctx)
 	if err != nil {
 		return err
@@ -599,33 +598,45 @@ func depNames(deps []config.NixDependency) []string {
 
 type fileHasher interface {
 	Hash(ctx stdctx.Context, name string) (string, error)
-	Available() bool
 }
 
-const nixHashBin = "nix-hash"
+// nixBase32Alphabet is nix's own base32 alphabet: it drops e, o, u and t.
+const nixBase32Alphabet = "0123456789abcdfghijklmnpqrsvwxyz"
 
-var realHasher fileHasher = nixHasher{bin: nixHashBin}
-
-type nixHasher struct{ bin string }
-
-func (p nixHasher) Available() bool {
-	_, err := exec.LookPath(p.bin)
-	return err == nil
-}
-
-func (p nixHasher) Hash(ctx stdctx.Context, name string) (string, error) {
-	// $ nix-hash --type sha256 --flat --base32 <(echo test)
-	out, err := exec.CommandContext(
-		ctx,
-		p.bin,
-		"--type", "sha256",
-		"--flat",
-		"--base32",
-		name,
-	).Output()
-	outStr := strings.TrimSpace(string(out))
-	if err != nil {
-		return "", fmt.Errorf("could not hash file: %s: %w: %s", name, err, outStr)
+// nixBase32 renders a hash the way nix does, reading the bit groups from the
+// end backwards. See printHash32 in nix's libutil/hash.cc.
+func nixBase32(h []byte) string {
+	n := (len(h)*8-1)/5 + 1
+	out := make([]byte, n)
+	for k := range n {
+		b := (n - 1 - k) * 5
+		i, j := b/8, b%8
+		c := h[i] >> j
+		if i+1 < len(h) {
+			c |= h[i+1] << (8 - j)
+		}
+		out[k] = nixBase32Alphabet[c&0x1f]
 	}
-	return outStr, nil
+	return string(out)
+}
+
+var realHasher fileHasher = goHasher{}
+
+// goHasher reproduces `nix-hash --type sha256 --flat --base32`, which is
+// simply the sha256 of the file rendered in nix's base32. Doing it here means
+// users do not need nix installed to publish a nix package, and saves a
+// process per artifact.
+type goHasher struct{}
+
+func (goHasher) Hash(_ stdctx.Context, name string) (string, error) {
+	f, err := os.Open(name)
+	if err != nil {
+		return "", fmt.Errorf("could not hash file: %s: %w", name, err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("could not hash file: %s: %w", name, err)
+	}
+	return nixBase32(h.Sum(nil)), nil
 }

--- a/internal/pipe/nix/nix.go
+++ b/internal/pipe/nix/nix.go
@@ -18,8 +18,6 @@ import (
 	"strings"
 	"text/template"
 
-	stdctx "context"
-
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/client"
@@ -323,7 +321,7 @@ func preparePkg(
 
 	platforms := map[string]bool{}
 	for _, art := range archives {
-		sha, err := hasher.Hash(ctx, art.Path)
+		sha, err := hasher.Hash(art.Path)
 		if err != nil {
 			return "", err
 		}
@@ -596,7 +594,7 @@ func depNames(deps []config.NixDependency) []string {
 }
 
 type fileHasher interface {
-	Hash(ctx stdctx.Context, name string) (string, error)
+	Hash(name string) (string, error)
 }
 
 // nixBase32Alphabet is nix's own base32 alphabet: it drops e, o, u and t.
@@ -622,12 +620,11 @@ func nixBase32(h []byte) string {
 var realHasher fileHasher = goHasher{}
 
 // goHasher reproduces `nix-hash --type sha256 --flat --base32`, which is
-// simply the sha256 of the file rendered in nix's base32. Doing it here means
-// users do not need nix installed to publish a nix package, and saves a
-// process per artifact.
+// simply the sha256 of the file rendered in nix's base32, so that users do not
+// need nix installed to publish a nix package.
 type goHasher struct{}
 
-func (goHasher) Hash(_ stdctx.Context, name string) (string, error) {
+func (goHasher) Hash(name string) (string, error) {
 	f, err := os.Open(name)
 	if err != nil {
 		return "", fmt.Errorf("could not hash file: %s: %w", name, err)

--- a/internal/pipe/nix/nix.go
+++ b/internal/pipe/nix/nix.go
@@ -64,9 +64,8 @@ type Pipe struct {
 	hasher fileHasher
 }
 
-func (Pipe) String() string                           { return "nixpkgs" }
-func (Pipe) ContinueOnError() bool                    { return true }
-func (Pipe) Dependencies(_ *context.Context) []string { return nil }
+func (Pipe) String() string        { return "nixpkgs" }
+func (Pipe) ContinueOnError() bool { return true }
 
 func (p Pipe) Skip(ctx *context.Context) bool {
 	return skips.Any(ctx, skips.Nix) || len(ctx.Config.Nix) == 0

--- a/internal/pipe/nix/nix_test.go
+++ b/internal/pipe/nix/nix_test.go
@@ -60,6 +60,14 @@ func TestHasher(t *testing.T) {
 		require.Equal(t, zeroHash, nixBase32(make([]byte, sha256.Size)))
 	})
 
+	// the vectors above only emit 27 of the 32 characters; with this one, a
+	// typo anywhere in the alphabet fails the test.
+	t.Run("full alphabet", func(t *testing.T) {
+		// printf goreleaser > f && nix-hash --type sha256 --flat --base32 f
+		sum := sha256.Sum256([]byte("goreleaser"))
+		require.Equal(t, "19a48kbsv6pr8x1bnbbs61f80wilnc2dcgahb70xbmb73pr0s7sk", nixBase32(sum[:]))
+	})
+
 	t.Run("missing file", func(t *testing.T) {
 		_, err := realHasher.Hash(t.Context(), "./testdata/does-not-exist.bin")
 		require.Error(t, err)
@@ -675,10 +683,6 @@ func TestErrNoArchivesFound(t *testing.T) {
 		goamd64: "v1",
 		ids:     []string{"foo", "bar"},
 	}, "no archives found matching goos=[darwin linux] goarch=[amd64 arm arm64 386] goarm=[6 7] goamd64=v1 ids=[foo bar]")
-}
-
-func TestDependencies(t *testing.T) {
-	require.Empty(t, Pipe{}.Dependencies(nil))
 }
 
 func TestBinInstallFormats(t *testing.T) {

--- a/internal/pipe/nix/nix_test.go
+++ b/internal/pipe/nix/nix_test.go
@@ -1,7 +1,6 @@
 package nix
 
 import (
-	stdctx "context"
 	"crypto/sha256"
 	"html/template"
 	"maps"
@@ -45,15 +44,11 @@ func TestSkip(t *testing.T) {
 }
 
 func TestHasher(t *testing.T) {
-	// produced by `nix-hash --type sha256 --flat --base32 testdata/file.bin`.
-	// It pins the encoding: nix's base32 is a fixed format, so this value can
-	// only change if our implementation breaks.
-	const reference = "1n7yy95h81rziah4ppi64kr6fphwxjiq8cl70fpfrqvr0ml1xbcl"
-
 	t.Run("reference vector", func(t *testing.T) {
-		sha, err := realHasher.Hash(t.Context(), "./testdata/file.bin")
+		// produced by `nix-hash --type sha256 --flat --base32 testdata/file.bin`.
+		sha, err := realHasher.Hash("./testdata/file.bin")
 		require.NoError(t, err)
-		require.Equal(t, reference, sha)
+		require.Equal(t, "1n7yy95h81rziah4ppi64kr6fphwxjiq8cl70fpfrqvr0ml1xbcl", sha)
 	})
 
 	t.Run("all zeroes", func(t *testing.T) {
@@ -69,7 +64,7 @@ func TestHasher(t *testing.T) {
 	})
 
 	t.Run("missing file", func(t *testing.T) {
-		_, err := realHasher.Hash(t.Context(), "./testdata/does-not-exist.bin")
+		_, err := realHasher.Hash("./testdata/does-not-exist.bin")
 		require.Error(t, err)
 	})
 }
@@ -756,7 +751,7 @@ func linuxDep(s string) config.NixDependency {
 
 type fakeHasher map[string]string
 
-func (m fakeHasher) Hash(_ stdctx.Context, path string) (string, error) {
+func (m fakeHasher) Hash(path string) (string, error) {
 	return m[filepath.Base(path)], nil
 }
 
@@ -764,7 +759,7 @@ const zeroHash = "0000000000000000000000000000000000000000000000000000"
 
 type alwaysZeroHasher struct{}
 
-func (alwaysZeroHasher) Hash(stdctx.Context, string) (string, error) { return zeroHash, nil }
+func (alwaysZeroHasher) Hash(string) (string, error) { return zeroHash, nil }
 
 func TestDynamicallyLinked(t *testing.T) {
 	folder := t.TempDir()

--- a/internal/pipe/nix/nix_test.go
+++ b/internal/pipe/nix/nix_test.go
@@ -2,11 +2,10 @@ package nix
 
 import (
 	stdctx "context"
-	"errors"
+	"crypto/sha256"
 	"html/template"
 	"maps"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -39,39 +38,31 @@ func TestSkip(t *testing.T) {
 		}, testctx.Skip(skips.Nix))))
 	})
 	t.Run("nix-all-good", func(t *testing.T) {
-		testlib.CheckPath(t, "nix-hash")
-		testlib.SkipIfWindows(t, "nix doesn't work on windows")
 		require.False(t, New().Skip(testctx.WrapWithCfg(t.Context(), config.Project{
 			Nix: []config.Nix{{}},
 		})))
 	})
 }
 
-const fakeNixHashBin = "fake-nix-hash"
-
 func TestHasher(t *testing.T) {
-	t.Run("hash", func(t *testing.T) {
-		t.Run("fake-nix-hash", func(t *testing.T) {
-			_, err := nixHasher{fakeNixHashBin}.Hash(t.Context(), "any")
-			require.ErrorIs(t, err, exec.ErrNotFound)
-		})
-		t.Run("valid", func(t *testing.T) {
-			testlib.CheckPath(t, "nix-hash")
-			testlib.SkipIfWindows(t, "nix doesn't work on windows")
-			sha, err := realHasher.Hash(t.Context(), "./testdata/file.bin")
-			require.NoError(t, err)
-			require.Equal(t, "1n7yy95h81rziah4ppi64kr6fphwxjiq8cl70fpfrqvr0ml1xbcl", sha)
-		})
+	// produced by `nix-hash --type sha256 --flat --base32 testdata/file.bin`.
+	// It pins the encoding: nix's base32 is a fixed format, so this value can
+	// only change if our implementation breaks.
+	const reference = "1n7yy95h81rziah4ppi64kr6fphwxjiq8cl70fpfrqvr0ml1xbcl"
+
+	t.Run("reference vector", func(t *testing.T) {
+		sha, err := realHasher.Hash(t.Context(), "./testdata/file.bin")
+		require.NoError(t, err)
+		require.Equal(t, reference, sha)
 	})
-	t.Run("available", func(t *testing.T) {
-		t.Run("no-nix-hash", func(t *testing.T) {
-			require.False(t, nixHasher{fakeNixHashBin}.Available())
-		})
-		t.Run("valid", func(t *testing.T) {
-			testlib.CheckPath(t, "nix-hash")
-			testlib.SkipIfWindows(t, "nix doesn't work on windows")
-			require.True(t, realHasher.Available())
-		})
+
+	t.Run("all zeroes", func(t *testing.T) {
+		require.Equal(t, zeroHash, nixBase32(make([]byte, sha256.Size)))
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		_, err := realHasher.Hash(t.Context(), "./testdata/does-not-exist.bin")
+		require.Error(t, err)
 	})
 }
 
@@ -620,18 +611,6 @@ func TestRunPipe(t *testing.T) {
 	}
 }
 
-func TestRunSkipNoNix(t *testing.T) {
-	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
-		Nix: []config.Nix{
-			{},
-		},
-	})
-	p := Pipe{}
-	p.hasher = unavailableHasher{}
-	require.NoError(t, p.Default(ctx))
-	testlib.AssertSkipped(t, p.Run(ctx))
-}
-
 func TestRunPipeSomeSkipped(t *testing.T) {
 	folder := t.TempDir()
 	ctx := testctx.WrapWithCfg(
@@ -699,7 +678,7 @@ func TestErrNoArchivesFound(t *testing.T) {
 }
 
 func TestDependencies(t *testing.T) {
-	require.Equal(t, []string{"nix-hash"}, Pipe{}.Dependencies(nil))
+	require.Empty(t, Pipe{}.Dependencies(nil))
 }
 
 func TestBinInstallFormats(t *testing.T) {
@@ -771,26 +750,17 @@ func linuxDep(s string) config.NixDependency {
 	}
 }
 
-type unavailableHasher struct{}
-
-func (m unavailableHasher) Hash(stdctx.Context, string) (string, error) {
-	return "", errors.New("unavailable hasher")
-}
-func (m unavailableHasher) Available() bool { return false }
-
 type fakeHasher map[string]string
 
 func (m fakeHasher) Hash(_ stdctx.Context, path string) (string, error) {
 	return m[filepath.Base(path)], nil
 }
-func (m fakeHasher) Available() bool { return true }
 
 const zeroHash = "0000000000000000000000000000000000000000000000000000"
 
 type alwaysZeroHasher struct{}
 
 func (alwaysZeroHasher) Hash(stdctx.Context, string) (string, error) { return zeroHash, nil }
-func (alwaysZeroHasher) Available() bool                             { return true }
 
 func TestDynamicallyLinked(t *testing.T) {
 	folder := t.TempDir()

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -10,7 +10,6 @@ import (
 	dockerv2 "github.com/goreleaser/goreleaser/v2/internal/pipe/docker/v2"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/flatpak"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/makeself"
-	"github.com/goreleaser/goreleaser/v2/internal/pipe/nix"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/sbom"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/sign"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe/snapcraft"
@@ -59,7 +58,6 @@ var DependencyCheckers = []DependencyChecker{
 	docker.ManifestPipe{},
 	dockerv2.Base{},
 	chocolatey.Pipe{},
-	nix.New(),
 	flatpak.Pipe{},
 	makeself.Pipe{},
 	upx.Pipe{},

--- a/www/content/customization/publish/nix.md
+++ b/www/content/customization/publish/nix.md
@@ -134,8 +134,13 @@ nix:
 
 ### `nix-hash`
 
-The `nix-hash` binary must be available in the `$PATH` for the
-publishing to work.
+{{< g_version "v2.19-unreleased" >}}
+
+GoReleaser now hashes the artifacts itself, so `nix-hash` no longer needs to be
+in the `$PATH`. Nothing in this pipe requires Nix to be installed any more.
+
+On earlier versions, the `nix-hash` binary had to be available in the `$PATH`,
+and the pipe was skipped when it was missing.
 
 [iss4034]: https://github.com/goreleaser/goreleaser/issues/4034
 


### PR DESCRIPTION
<!-- If applied, this commit will... -->

Remove GoReleaser's dependency on Nix being installed.

`nix-hash --type sha256 --flat --base32` is simply the sha256 of the file
rendered in Nix's own base32 alphabet, so GoReleaser now does it directly
instead of shelling out.

<!-- Why is this change being made? -->

Users had to have Nix installed to publish a Nix package: the pipe listed
`nix-hash` as a dependency and skipped the whole thing when it was missing,
which is a surprising failure mode for a package manager you may not otherwise
use.

**How it is verified.** The repository already contained a reference vector:
`internal/pipe/nix/testdata/file.bin` with the expected
`1n7yy95h81rziah4ppi64kr6fphwxjiq8cl70fpfrqvr0ml1xbcl`, produced by `nix-hash`
itself. The new implementation reproduces it exactly, and the all-zeroes vector
matches the `zeroHash` constant already used by the tests.

A third vector, the sha256 of `goreleaser`, was added because those two only
ever emit 27 of the 32 characters in the alphabet: with `2` and `3` exchanged
in `nixBase32Alphabet` both of them still passed. With the third one, a typo
anywhere in the alphabet fails the test.

I did try a differential test that shelled out to real `nix-hash` and compared,
but `testlib.CheckPath` does not skip on CI — `InPath` returns true there on
purpose so a missing tool fails loudly rather than skipping silently — so that
test cannot survive removing Nix from CI. The reference vectors cover it.

`TestRunSkipNoNix` covered the skip that no longer exists, so it goes too. The
pipe no longer declares any dependency, so it is also removed from
`healthcheck.DependencyCheckers`.

**CI.** With hashing done in Go, nothing in CI needs Nix any more, so the
installation is gone from `build.yml`, `release.yml` and `nightly-oss.yml`. The
two formatters the tests exercise are fetched as pinned release binaries by
#6828, which landed first.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

Docs updated at `www/content/customization/publish/nix.md`, marked
`v2.19-unreleased`.

AI disclosure: I used an AI coding assistant to implement and verify this
change against the existing reference vector.