### PR TITLE
ci: drop the ruleguard job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,6 @@ jobs:
       - run: task licenses:check
   semgrep:
     uses: caarlos0/meta/.github/workflows/semgrep.yml@c7f17af352dac91fa6c785d06ebac8547f1abdd3 # v0.1.0
-  ruleguard:
-    uses: caarlos0/meta/.github/workflows/ruleguard.yml@c7f17af352dac91fa6c785d06ebac8547f1abdd3 # v0.1.0
-    with:
-      args: "-disable largeloopcopy"
   test:
     strategy:
       fail-fast: true


### PR DESCRIPTION
Remove the `ruleguard` job from the build workflow.

`quasilyte/go-ruleguard` looks abandoned: the last push was 2025-09-25.

No other job has `needs: ruleguard`, and `.golangci.yaml` does not use
ruleguard either (`gocritic` runs, but the `ruleguard` check is not enabled).

Note: if `ruleguard` is a required status check in the branch protection rules,
it must also be removed there.

https://github.com/quasilyte/go-ruleguard
