### PR TITLE
perf: skip needless docker probes; make the ko registry test hermetic

### DIFF
--- a/internal/pipe/docker/v2/docker.go
+++ b/internal/pipe/docker/v2/docker.go
@@ -124,6 +124,13 @@ func (Base) Default(ctx *context.Context) error {
 
 // Run implements pipeline.Piper.
 func (p Snapshot) Run(ctx *context.Context) error {
+	enabled, err := anyEnabled(ctx)
+	if err != nil {
+		return err
+	}
+	if !enabled {
+		return pipe.Skip("configuration is disabled")
+	}
 	checkBuildxDriver(ctx)
 	log.Warn("snapshot build: will not push any images")
 
@@ -160,6 +167,13 @@ func (p Snapshot) Run(ctx *context.Context) error {
 
 // Publish implements publish.Publisher.
 func (p Publish) Publish(ctx *context.Context) error {
+	enabled, err := anyEnabled(ctx)
+	if err != nil {
+		return err
+	}
+	if !enabled {
+		return pipe.Skip("configuration is disabled")
+	}
 	checkBuildxDriver(ctx)
 	g := semerrgroup.NewSkipAware(semerrgroup.New(ctx.Parallelism))
 	for _, d := range ctx.Config.DockersV2 {
@@ -171,7 +185,7 @@ func (p Publish) Publish(ctx *context.Context) error {
 			return buildImage(ctx, d, extraArgs...)
 		})
 	}
-	err := g.Wait()
+	err = g.Wait()
 	// reports whatever was actually pushed, even if another configuration was
 	// skipped or failed.
 	for _, img := range ctx.Artifacts.Filter(artifact.ByType(artifact.DockerImageV2)).List() {
@@ -721,6 +735,23 @@ func isDriverValid(driver string) bool {
 
 // testForceNoDaemon is a test-only flag to simulate daemon unavailability.
 var testForceNoDaemon = false
+
+// anyEnabled reports whether at least one configuration is enabled. Probing
+// docker costs two subprocesses, so there is no point paying for them when
+// every configuration is disabled.
+func anyEnabled(ctx *context.Context) (bool, error) {
+	tpl := tmpl.New(ctx)
+	for _, d := range ctx.Config.DockersV2 {
+		disable, err := tpl.Bool(d.Disable)
+		if err != nil {
+			return false, err
+		}
+		if !disable {
+			return true, nil
+		}
+	}
+	return false, nil
+}
 
 // isDockerDaemonAvailable checks if the docker daemon is accessible.
 func isDockerDaemonAvailable(ctx stdctx.Context) bool {

--- a/internal/pipe/ko/ko_test.go
+++ b/internal/pipe/ko/ko_test.go
@@ -585,7 +585,7 @@ func TestKoValidateMainPathIssue4382(t *testing.T) {
 			{
 				ID:         "default",
 				Build:      "foo",
-				Repository: "fakerepo",
+				Repository: "fakerepo.invalid",
 			},
 		},
 	})
@@ -603,7 +603,7 @@ func TestKoValidateMainPathIssue4382(t *testing.T) {
 			{
 				ID:         "default",
 				Build:      "foo",
-				Repository: "fakerepo",
+				Repository: "fakerepo.invalid",
 			},
 		},
 	})
@@ -665,7 +665,7 @@ func TestPublishPipeError(t *testing.T) {
 					ID:         "default",
 					Build:      "foo",
 					WorkingDir: "./testdata/app/",
-					Repository: "fakerepo:8080/",
+					Repository: "fakerepo.invalid:8080/",
 					Tags:       []string{"latest", "{{.Tag}}"},
 				},
 			},
@@ -779,7 +779,7 @@ func TestPublishPipeError(t *testing.T) {
 		ctx := makeCtx()
 		require.NoError(t, Pipe{}.Default(ctx))
 		err := Pipe{}.Publish(ctx)
-		require.ErrorContains(t, err, `Get "https://fakerepo:8080/v2/": dial tcp:`)
+		require.ErrorContains(t, err, `Get "https://fakerepo.invalid:8080/v2/": dial tcp:`)
 	})
 }
 

--- a/internal/pipe/snapcraft/snapcraft_test.go
+++ b/internal/pipe/snapcraft/snapcraft_test.go
@@ -143,7 +143,8 @@ func TestRunPipe(t *testing.T) {
 
 func TestBadTemplate(t *testing.T) {
 	testlib.SkipIfWindows(t, "snap doesn't work in windows")
-	testlib.CheckPath(t, "snapcraft")
+	// fails before packing.
+	fakeSnapcraft(t)
 	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
@@ -177,7 +178,8 @@ func TestBadTemplate(t *testing.T) {
 
 func TestRunPipeInvalidNameTemplate(t *testing.T) {
 	testlib.SkipIfWindows(t, "snap doesn't work in windows")
-	testlib.CheckPath(t, "snapcraft")
+	// fails before packing.
+	fakeSnapcraft(t)
 	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
@@ -201,7 +203,8 @@ func TestRunPipeInvalidNameTemplate(t *testing.T) {
 
 func TestRunPipeWithName(t *testing.T) {
 	testlib.SkipIfWindows(t, "snap doesn't work in windows")
-	testlib.CheckPath(t, "snapcraft")
+	// metadata-only, see TestRunPipeMetadata.
+	fakeSnapcraft(t)
 	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
@@ -237,7 +240,9 @@ func TestRunPipeWithName(t *testing.T) {
 
 func TestRunPipeMetadata(t *testing.T) {
 	testlib.SkipIfWindows(t, "snap doesn't work in windows")
-	testlib.CheckPath(t, "snapcraft")
+	// only the metadata goreleaser generates is asserted here, and the pipe
+	// does not check the packed file, so a real snapcraft is not needed.
+	fakeSnapcraft(t)
 	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
@@ -449,7 +454,9 @@ func TestNoSnapcraftInPath(t *testing.T) {
 
 func TestRunNoArguments(t *testing.T) {
 	testlib.SkipIfWindows(t, "snap doesn't work in windows")
-	testlib.CheckPath(t, "snapcraft")
+	// only the metadata goreleaser generates is asserted here, and the pipe
+	// does not check the packed file, so a real snapcraft is not needed.
+	fakeSnapcraft(t)
 	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
@@ -485,7 +492,9 @@ func TestRunNoArguments(t *testing.T) {
 
 func TestCompleter(t *testing.T) {
 	testlib.SkipIfWindows(t, "snap doesn't work in windows")
-	testlib.CheckPath(t, "snapcraft")
+	// only the metadata goreleaser generates is asserted here, and the pipe
+	// does not check the packed file, so a real snapcraft is not needed.
+	fakeSnapcraft(t)
 	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
@@ -524,7 +533,9 @@ func TestCompleter(t *testing.T) {
 
 func TestCommand(t *testing.T) {
 	testlib.SkipIfWindows(t, "snap doesn't work in windows")
-	testlib.CheckPath(t, "snapcraft")
+	// only the metadata goreleaser generates is asserted here, and the pipe
+	// does not check the packed file, so a real snapcraft is not needed.
+	fakeSnapcraft(t)
 	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))
@@ -561,7 +572,8 @@ func TestCommand(t *testing.T) {
 
 func TestExtraFile(t *testing.T) {
 	testlib.SkipIfWindows(t, "snap doesn't work in windows")
-	testlib.CheckPath(t, "snapcraft")
+	// only the prime/ contents goreleaser writes are asserted.
+	fakeSnapcraft(t)
 	folder := t.TempDir()
 	dist := filepath.Join(folder, "dist")
 	require.NoError(t, os.Mkdir(dist, 0o755))


### PR DESCRIPTION
<!-- If applied, this commit will... -->

Two findings from the `go test -json` timings captured on CI.

**`dockers_v2` probed docker even when every configuration was disabled**

`Snapshot.Run` and `Publish.Publish` ran `docker buildx inspect` and `docker
info` *before* evaluating each configuration's `disable` template. A fully
disabled configuration therefore paid two subprocesses and logged a misleading
`no docker daemon available` warning. They now evaluate `disable` first and
skip.

This is a small production win too: users with `disable: true` no longer shell
out to docker at all.

`TestDisable/disabled` went from **4.6s to 0.00s** on the windows runner, where
probing a docker that is not installed is slow.

**The ko test pointed at a single-label host name**

`fakerepo` is not guaranteed to fail to resolve: a wildcard search domain would
resolve it and quietly change what the test exercises. It also makes the
resolver walk the search domains first, which is why the subtest costs 4.6s on
CI.

`.invalid` never resolves (RFC 2606) and contains a dot, so it is tried as-is
first.

<!-- Why is this change being made? -->

Continuing the pass over the slowest tests. For the record, the ones above these
in the list are genuinely toolchain-bound and I left them alone: zig, rust,
node, poetry and golang `TestBuild` run real compilers, `snapcraft.TestRunPipe`
really runs `snapcraft pack`, and the `docker`/`sign` tests really build and
sign images.

One I looked at and deliberately did not change: `docker.TestBuildCommand`
appears to cost 4.6s on windows, but that is the one-time
`dockerSupportsProvenanceFlags` probe (`sync.OnceValue` running
`docker build --help`) being attributed to whichever subtest happens to run
first. Production needs that probe.

I also measured the zig/rust builder tests, which are the two slowest overall.
They force a per-test `ZIG_GLOBAL_CACHE_DIR`, so every run recompiles zig's
stdlib. Sharing that cache is worth about **41%** on the zig test locally
(10.5s -> 6.2s), but the isolation is deliberate: the comment records that a
shared cache got corrupted when the zig and rust packages built in parallel
(#6754). That deserves its own PR with repeated-run validation, not a drive-by.

AI disclosure: I used an AI coding assistant to analyse the CI timings and make
these changes.

**Update: snapcraft**

Seven snapcraft tests required a real snapcraft install without needing one.
Five only read the `prime/meta/snap.yaml` that goreleaser itself writes, one
only reads files goreleaser copies into `prime/`, and two fail before packing.
The pipe hands `prime/` to `snapcraft pack` and records the resulting path
without checking the file, so the existing no-op fake satisfies them all. They
cost 3.3-3.9s each on CI and now cost about 0.1s, and they run on machines
without snapcraft where they used to skip. `TestRunPipe` still packs for real.
