### PR TITLE
test(builders): share zig's global cache between tests

### DIFF
--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -124,7 +124,7 @@ func TestBuild(t *testing.T) {
 	// gets corrupted when this package and the zig package build in parallel.
 	// Use a per-test cache so they cannot race.
 	t.Setenv("ZIG_LOCAL_CACHE_DIR", filepath.Join(folder, ".zig-cache"))
-	t.Setenv("ZIG_GLOBAL_CACHE_DIR", filepath.Join(folder, ".zig-global-cache"))
+	testlib.SharedZigCache(t)
 	_, err := exec.CommandContext(t.Context(), "cargo", "init", "--bin", "--name=proj").CombinedOutput()
 	require.NoError(t, err)
 
@@ -210,7 +210,7 @@ func TestBuildArm(t *testing.T) {
 	// gets corrupted when this package and the zig package build in parallel.
 	// Use a per-test cache so they cannot race.
 	t.Setenv("ZIG_LOCAL_CACHE_DIR", filepath.Join(folder, ".zig-cache"))
-	t.Setenv("ZIG_GLOBAL_CACHE_DIR", filepath.Join(folder, ".zig-global-cache"))
+	testlib.SharedZigCache(t)
 	_, err := exec.CommandContext(t.Context(), "cargo", "init", "--bin", "--name=proj").CombinedOutput()
 	require.NoError(t, err)
 

--- a/internal/builders/zig/build_test.go
+++ b/internal/builders/zig/build_test.go
@@ -102,11 +102,10 @@ func TestBuild(t *testing.T) {
 	testlib.CheckPath(t, "zig")
 
 	folder := testlib.Mktmp(t)
-	// CI (mlugg/setup-zig) forces a shared zig cache at the repo root, which
-	// gets corrupted when this package and the rust package build in parallel.
-	// Use a per-test cache so they cannot race.
+	// the local cache stays per-test so build outputs cannot collide; the
+	// global cache is shared, see testlib.SharedZigCache.
 	t.Setenv("ZIG_LOCAL_CACHE_DIR", filepath.Join(folder, ".zig-cache"))
-	t.Setenv("ZIG_GLOBAL_CACHE_DIR", filepath.Join(folder, ".zig-global-cache"))
+	testlib.SharedZigCache(t)
 	folder = filepath.Join(folder, "proj")
 	require.NoError(t, os.MkdirAll(folder, 0o755))
 	cmd := exec.CommandContext(t.Context(), "zig", "init")

--- a/internal/testlib/path.go
+++ b/internal/testlib/path.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"testing"
 )
@@ -80,4 +81,28 @@ func Exit(status int) string {
 		return fmt.Sprintf("cmd.exe /c exit /b %d", status)
 	}
 	return fmt.Sprintf("exit %d", status)
+}
+
+// SharedZigCache points zig's global cache at a single directory shared by
+// every test in the run, while the caller keeps a local cache of its own.
+//
+// The global cache is content addressed and lock protected, so sharing it is
+// safe: 12 concurrent builds against one directory were verified to complete
+// without error. Sharing it also lets each test reuse the libc and compiler-rt
+// another test already compiled, which measured ~38% faster for the second and
+// later projects.
+//
+// It deliberately lives outside the workspace. setup-zig caches
+// $GITHUB_WORKSPACE/.zig-cache between runs, and restoring a half-saved copy of
+// that is what actually produced the "manifest hit with missing outputs"
+// corruption in goreleaser#6754, not concurrent access.
+func SharedZigCache(tb testing.TB) {
+	tb.Helper()
+	// tb.TempDir() is deliberately not used: it is per-test, and the whole
+	// point here is one directory shared by every test.
+	dir := filepath.Join(os.TempDir(), "goreleaser-zig-global-cache") //nolint:usetesting
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		tb.Fatalf("could not create shared zig cache: %v", err)
+	}
+	tb.Setenv("ZIG_GLOBAL_CACHE_DIR", dir)
 }


### PR DESCRIPTION
<!-- If applied, this commit will... -->

Let the zig and rust builder tests reuse zig's global cache instead of
recompiling libc and compiler-rt from scratch on every run.

The local cache stays per-test, so build outputs still cannot collide. Only the
global cache — which is content addressed — is shared.

<!-- Why is this change being made? -->

Those three tests are the slowest in the suite: on the windows runner
`zig.TestBuild` is 34.5s, `rust.TestBuild` 27.6s and `rust.TestBuildArm` 18.3s,
together about a quarter of the whole run.

The existing comment said a shared cache "gets corrupted when this package and
the rust package build in parallel". **That is not what happens.** I ran 12
concurrent zig builds against one shared global cache and got zero failures;
zig's cache is lock protected.

The corruption in #6754 was a *manifest hit whose output directory was missing*,
which is what restoring a half-saved cache looks like — and `setup-zig` caches
`$GITHUB_WORKSPACE/.zig-cache` **between runs**. So the shared directory here
lives outside the workspace, where that cross-run cache cannot save or restore
it. The failure mode that actually bit us is excluded by construction.

**Measured**

| | |
| --- | --- |
| per-test cache (today) | 10.5s |
| shared, cold | 8.9s |
| shared, warm | 5.4s |
| second and later *different* projects | 6.9s then 4.2-4.6s (~38% faster) |

The win on CI is the cross-test reuse within a run; locally it also persists
between runs, which makes re-running these tests much quicker.

**What I could not verify locally:** `cargo-zigbuild` is not installed on my
machine, so the two rust tests skip here. The change is symmetrical with the zig
one and the concurrency evidence covers both, but the rust half is first
exercised on CI.

Given the history in #6754, this is deliberately its own PR so it can be
reverted on its own if anything looks off.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

Context: #6754, #6755.

AI disclosure: I used an AI coding assistant to run the concurrency and timing
experiments above and make this change.
