### PR TITLE
chore: measure per-test times in CI (do not merge)

### DIFF
--- a/.ci-logs/run.log
+++ b/.ci-logs/run.log
@@ -1,0 +1,7191 @@
+license-check	UNKNOWN STEP	﻿2026-08-30T05:02:49.9191292Z Current runner version: '2.336.0'
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9261285Z ##[group]Runner Image Provisioner
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9262922Z Hosted Compute Agent
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9263880Z Version: 20260819.586
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9264991Z Commit: 3cc4a88dfa507ef76119ad1bb3eccc6378bb2b76
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9266071Z Build Date: 2026-08-18T23:20:18Z
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9267213Z Worker ID: {ff067a5a-2559-46b9-83d9-50842bef9685}
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9268425Z Azure Region: eastus2
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9269354Z ##[endgroup]
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9271777Z ##[group]Operating System
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9272755Z Ubuntu
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9273705Z 24.04.4
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9274499Z LTS
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9275749Z ##[endgroup]
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9276764Z ##[group]Runner Image
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9277702Z Image: ubuntu-24.04
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9278673Z Version: 20260823.283.1
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9280882Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260823.283/images/ubuntu/Ubuntu2404-Readme.md
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9283480Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260823.283
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9285041Z ##[endgroup]
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9286875Z ##[group]GITHUB_TOKEN Permissions
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9289865Z Contents: read
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9291239Z Metadata: read
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9292112Z ##[endgroup]
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9295695Z Secret source: Actions
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9297500Z Prepare workflow directory
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9753434Z Prepare all required actions
+license-check	UNKNOWN STEP	2026-08-30T05:02:49.9821035Z Getting action download info
+license-check	UNKNOWN STEP	2026-08-30T05:02:50.2308777Z Download action repository 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1' (SHA:3d3c42e5aac5ba805825da76410c181273ba90b1)
+license-check	UNKNOWN STEP	2026-08-30T05:02:50.3497787Z Download action repository 'actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e' (SHA:b7ad1dad31e06c5925ef5d2fc7ad053ef454303e)
+license-check	UNKNOWN STEP	2026-08-30T05:02:50.5749352Z Download action repository 'go-task/setup-task@a00fbb05ce67b35648be3c78cbc9fd85354c757e' (SHA:a00fbb05ce67b35648be3c78cbc9fd85354c757e)
+license-check	UNKNOWN STEP	2026-08-30T05:02:50.8639660Z Complete job name: license-check
+license-check	UNKNOWN STEP	2026-08-30T05:02:50.9562390Z ##[group]Run actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+license-check	UNKNOWN STEP	2026-08-30T05:02:50.9564439Z with:
+license-check	UNKNOWN STEP	2026-08-30T05:02:50.9565257Z   repository: goreleaser/goreleaser
+license-check	UNKNOWN STEP	2026-08-30T05:02:50.9574495Z   token: ***
+license-check	UNKNOWN STEP	2026-08-30T05:02:50.9575287Z   ssh-strict: true
+license-check	UNKNOWN STEP	2026-08-30T05:02:50.9576083Z   ssh-user: git
+license-check	UNKNOWN STEP	2026-08-30T05:02:50.9576879Z   persist-credentials: true
+license-check	UNKNOWN STEP	2026-08-30T05:02:50.9577788Z   clean: true
+license-check	UNKNOWN STEP	2026-08-30T05:02:50.9578595Z   sparse-checkout-cone-mode: true
+license-check	UNKNOWN STEP	2026-08-30T05:02:50.9579560Z   fetch-depth: 1
+license-check	UNKNOWN STEP	2026-08-30T05:02:50.9580352Z   fetch-tags: false
+license-check	UNKNOWN STEP	2026-08-30T05:02:50.9581456Z   show-progress: true
+license-check	UNKNOWN STEP	2026-08-30T05:02:50.9582286Z   lfs: false
+license-check	UNKNOWN STEP	2026-08-30T05:02:50.9583040Z   submodules: false
+license-check	UNKNOWN STEP	2026-08-30T05:02:50.9583872Z   set-safe-directory: true
+license-check	UNKNOWN STEP	2026-08-30T05:02:50.9584810Z   allow-unsafe-pr-checkout: false
+license-check	UNKNOWN STEP	2026-08-30T05:02:50.9586034Z ##[endgroup]
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0602872Z Syncing repository: goreleaser/goreleaser
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0605613Z ##[group]Getting Git version info
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0606944Z Working directory is '/home/runner/work/goreleaser/goreleaser'
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0609416Z [command]/usr/bin/git version
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0625363Z git version 2.55.0
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0645470Z ##[endgroup]
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0657208Z Temporarily overriding HOME='/home/runner/work/_temp/808594dd-e433-4b4f-802c-641acb33dc8d' before making global git config changes
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0661663Z Adding repository directory to the temporary git global config as a safe directory
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0665137Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/goreleaser/goreleaser
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0709083Z Deleting the contents of '/home/runner/work/goreleaser/goreleaser'
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0713031Z ##[group]Determining repository object format
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0715652Z ##[endgroup]
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0717673Z ##[group]Initializing the repository
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0720216Z [command]/usr/bin/git init /home/runner/work/goreleaser/goreleaser
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0800564Z hint: Using 'master' as the name for the initial branch. This default branch name
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0803399Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0806366Z hint: to use in all of your new repositories, which will suppress this warning,
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0808971Z hint: call:
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0810240Z hint:
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0811923Z hint: 	git config --global init.defaultBranch <name>
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0814010Z hint:
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0815925Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0818873Z hint: 'development'. The just-created branch can be renamed via this command:
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0821735Z hint:
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0822870Z hint: 	git branch -m <name>
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0824003Z hint:
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0825460Z hint: Disable this message with "git config set advice.defaultBranchName false"
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0827863Z Initialized empty Git repository in /home/runner/work/goreleaser/goreleaser/.git/
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0833074Z [command]/usr/bin/git remote add origin https://github.com/goreleaser/goreleaser
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0861471Z ##[endgroup]
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0863479Z ##[group]Disabling automatic garbage collection
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0865041Z [command]/usr/bin/git config --local gc.auto 0
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0894975Z ##[endgroup]
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0896522Z ##[group]Setting up auth
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0897596Z Removing SSH command configuration
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0899728Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.0932474Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.1243362Z Removing HTTP extra header
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.1247984Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.1280554Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.1511395Z Removing includeIf entries pointing to credentials config files
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.1513268Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.1543942Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.1777220Z [command]/usr/bin/git config --file /home/runner/work/_temp/git-credentials-b3fd9116-e4f2-4801-b844-122938580c67.config http.https://github.com/.extraheader AUTHORIZATION: basic ***
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.1814212Z [command]/usr/bin/git config --local includeIf.gitdir:/home/runner/work/goreleaser/goreleaser/.git.path /home/runner/work/_temp/git-credentials-b3fd9116-e4f2-4801-b844-122938580c67.config
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.1845214Z [command]/usr/bin/git config --local includeIf.gitdir:/home/runner/work/goreleaser/goreleaser/.git/worktrees/*.path /home/runner/work/_temp/git-credentials-b3fd9116-e4f2-4801-b844-122938580c67.config
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.1878592Z [command]/usr/bin/git config --local includeIf.gitdir:/github/workspace/.git.path /github/runner_temp/git-credentials-b3fd9116-e4f2-4801-b844-122938580c67.config
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.1910511Z [command]/usr/bin/git config --local includeIf.gitdir:/github/workspace/.git/worktrees/*.path /github/runner_temp/git-credentials-b3fd9116-e4f2-4801-b844-122938580c67.config
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.1939268Z ##[endgroup]
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.1940577Z ##[group]Fetching the repository
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.1945882Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +36e43dd08f724956b188af2f6f3bcfd5efd355ec:refs/remotes/origin/main
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.6426028Z From https://github.com/goreleaser/goreleaser
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.6428082Z  * [new ref]         36e43dd08f724956b188af2f6f3bcfd5efd355ec -> origin/main
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.6436827Z [command]/usr/bin/git branch --list --remote origin/main
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.6463560Z   origin/main
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.6471751Z [command]/usr/bin/git rev-parse refs/remotes/origin/main
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.6494714Z 36e43dd08f724956b188af2f6f3bcfd5efd355ec
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.6499753Z ##[endgroup]
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.6501321Z ##[group]Determining the checkout info
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.6502915Z ##[endgroup]
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.6504216Z [command]/usr/bin/git sparse-checkout disable
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.6549623Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.6578441Z ##[group]Checking out the ref
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.6581555Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.7356670Z Switched to a new branch 'main'
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.7364873Z branch 'main' set up to track 'origin/main'.
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.7370889Z ##[endgroup]
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.7423708Z [command]/usr/bin/git log -1 --format=%H
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.7452716Z 36e43dd08f724956b188af2f6f3bcfd5efd355ec
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.7731112Z ##[group]Run actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.7731785Z with:
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.7732189Z   go-version: stable
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.7732600Z   check-latest: false
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.7735570Z   token: ***
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.7735956Z   cache: true
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.7736356Z ##[endgroup]
+license-check	UNKNOWN STEP	2026-08-30T05:02:51.8916531Z Setup go version spec stable
+license-check	UNKNOWN STEP	2026-08-30T05:02:52.2114530Z stable version resolved as 1.27.0
+license-check	UNKNOWN STEP	2026-08-30T05:02:52.2119911Z Attempting to download 1.27.0...
+license-check	UNKNOWN STEP	2026-08-30T05:02:52.2120624Z matching 1.27.0...
+license-check	UNKNOWN STEP	2026-08-30T05:02:52.2142956Z Acquiring 1.27.0 from https://github.com/actions/go-versions/releases/download/1.27.0-32325163857/go-1.27.0-linux-x64.tar.gz
+license-check	UNKNOWN STEP	2026-08-30T05:02:52.7042720Z Extracting Go...
+license-check	UNKNOWN STEP	2026-08-30T05:02:52.7152111Z [command]/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/d62c3ba9-7858-4ebf-90cb-2b58a19c2e80 -f /home/runner/work/_temp/713ee170-2720-46c5-8c10-61e9c1bb37ec
+license-check	UNKNOWN STEP	2026-08-30T05:02:54.5882128Z Successfully extracted go to /home/runner/work/_temp/d62c3ba9-7858-4ebf-90cb-2b58a19c2e80
+license-check	UNKNOWN STEP	2026-08-30T05:02:54.5882771Z Adding to the cache ...
+license-check	UNKNOWN STEP	2026-08-30T05:02:59.5171532Z Successfully cached go to /opt/hostedtoolcache/go/1.27.0/x64
+license-check	UNKNOWN STEP	2026-08-30T05:02:59.5172666Z Added go to the path
+license-check	UNKNOWN STEP	2026-08-30T05:02:59.5175105Z Successfully set up Go version stable
+license-check	UNKNOWN STEP	2026-08-30T05:02:59.5374158Z [command]/opt/hostedtoolcache/go/1.27.0/x64/bin/go env GOMODCACHE
+license-check	UNKNOWN STEP	2026-08-30T05:02:59.5406775Z [command]/opt/hostedtoolcache/go/1.27.0/x64/bin/go env GOCACHE
+license-check	UNKNOWN STEP	2026-08-30T05:02:59.5440122Z /home/runner/go/pkg/mod
+license-check	UNKNOWN STEP	2026-08-30T05:02:59.5458552Z /home/runner/.cache/go-build
+license-check	UNKNOWN STEP	2026-08-30T05:02:59.6141200Z Cache hit for: setup-go-Linux-x64-ubuntu24-go-1.27.0-70e369aef7f72b34eefef141b1a07e9f033a9c196f8b3d4332b8dc129da604b6
+license-check	UNKNOWN STEP	2026-08-30T05:03:00.6855251Z Received 268435456 of 625837011 (42.9%), 250.0 MBs/sec
+license-check	UNKNOWN STEP	2026-08-30T05:03:01.6862802Z Received 536870912 of 625837011 (85.8%), 252.5 MBs/sec
+license-check	UNKNOWN STEP	2026-08-30T05:03:01.9487010Z Received 625837011 of 625837011 (100.0%), 261.2 MBs/sec
+license-check	UNKNOWN STEP	2026-08-30T05:03:01.9487715Z Cache Size: ~597 MB (625837011 B)
+license-check	UNKNOWN STEP	2026-08-30T05:03:01.9538551Z [command]/usr/bin/tar -xf /home/runner/work/_temp/b33fed8e-91e4-4cd3-a065-4b9de6190757/cache.tzst -P -C /home/runner/work/goreleaser/goreleaser --use-compress-program unzstd
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2361116Z Cache restored successfully
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2675310Z Cache restored from key: setup-go-Linux-x64-ubuntu24-go-1.27.0-70e369aef7f72b34eefef141b1a07e9f033a9c196f8b3d4332b8dc129da604b6
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2701707Z go version go1.27.0 linux/amd64
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2702201Z 
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2702679Z ##[group]go env
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2830269Z AR='ar'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2830547Z CC='gcc'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2831310Z CGO_CFLAGS='-O2 -g'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2831568Z CGO_CPPFLAGS=''
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2831810Z CGO_CXXFLAGS='-O2 -g'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2832085Z CGO_ENABLED='1'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2832320Z CGO_FFLAGS='-O2 -g'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2832568Z CGO_LDFLAGS='-O2 -g'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2832805Z CXX='g++'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2833028Z GCCGO='gccgo'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2833272Z GO111MODULE=''
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2833539Z GOAMD64='v1'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2834413Z GOARCH='amd64'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2834756Z GOAUTH='netrc'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2835134Z GOBIN='/home/runner/go/bin'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2835438Z GOCACHE='/home/runner/.cache/go-build'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2835829Z GOCACHEPROG=''
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2836051Z GODEBUG=''
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2836354Z GOENV='/home/runner/.config/go/env'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2836650Z GOEXE=''
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2836861Z GOEXPERIMENT=''
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2837087Z GOFIPS140='off'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2837295Z GOFLAGS=''
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2837963Z GOGCCFLAGS='-fPIC -m64 -pthread -Wl,--no-gc-sections -fmessage-length=0 -ffile-prefix-map=/tmp/go-build4258000736=/tmp/go-build -gno-record-gcc-switches'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2838632Z GOHOSTARCH='amd64'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2838861Z GOHOSTOS='linux'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2839080Z GOINSECURE=''
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2839588Z GOMOD='/home/runner/work/goreleaser/goreleaser/go.mod'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2839965Z GOMODCACHE='/home/runner/go/pkg/mod'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2840246Z GONOPROXY=''
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2840460Z GONOSUMDB=''
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2840841Z GOOS='linux'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2841160Z GOPACKAGESDRIVER=''
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2841407Z GOPATH='/home/runner/go'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2841992Z GOPRIVATE=''
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2842491Z GOPROXY='https://proxy.golang.org,direct'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2843042Z GOROOT='/opt/hostedtoolcache/go/1.27.0/x64'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2843547Z GOSUMDB='sum.golang.org'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2844046Z GOTELEMETRY='local'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2844404Z GOTELEMETRYDIR='/home/runner/.config/go/telemetry'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2844739Z GOTMPDIR=''
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2844953Z GOTOOLCHAIN='local'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2845283Z GOTOOLDIR='/opt/hostedtoolcache/go/1.27.0/x64/pkg/tool/linux_amd64'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2845644Z GOVCS=''
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2845860Z GOVERSION='go1.27.0'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2846094Z GOWORK=''
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2846319Z PKG_CONFIG='pkg-config'
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2846484Z 
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.2846939Z ##[endgroup]
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.3154352Z ##[group]Run go-task/setup-task@a00fbb05ce67b35648be3c78cbc9fd85354c757e
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.3154767Z with:
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.3154983Z   version: 3.x
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.3157798Z   repo-token: ***
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.3158045Z   max-retries: 3
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.3158268Z env:
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.3158495Z   GOTOOLCHAIN: local
+license-check	UNKNOWN STEP	2026-08-30T05:03:08.3158736Z ##[endgroup]
+license-check	UNKNOWN STEP	2026-08-30T05:03:11.1868640Z [command]/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/28aec762-7b7f-4234-a1c7-7354e114b33b -f /home/runner/work/_temp/1462185c-61ab-4590-b695-630c25a80ef8
+license-check	UNKNOWN STEP	2026-08-30T05:03:11.5709686Z Successfully setup Task version v3.53.1
+license-check	UNKNOWN STEP	2026-08-30T05:03:11.5843340Z ##[group]Run task licenses:check
+license-check	UNKNOWN STEP	2026-08-30T05:03:11.5843750Z ^[[36;1mtask licenses:check^[[0m
+license-check	UNKNOWN STEP	2026-08-30T05:03:11.5887175Z shell: /usr/bin/bash -e {0}
+license-check	UNKNOWN STEP	2026-08-30T05:03:11.5887451Z env:
+license-check	UNKNOWN STEP	2026-08-30T05:03:11.5887660Z   GOTOOLCHAIN: local
+license-check	UNKNOWN STEP	2026-08-30T05:03:11.5887892Z ##[endgroup]
+license-check	UNKNOWN STEP	2026-08-30T05:03:11.6461771Z ^[[32mtask: [licenses:check] go run github.com/google/go-licenses/v2@latest check \
+license-check	UNKNOWN STEP	2026-08-30T05:03:11.6462462Z   --allowed_licenses=MIT,Apache-2.0,BSD-3-Clause,BSD-2-Clause,ISC,MPL-2.0 \
+license-check	UNKNOWN STEP	2026-08-30T05:03:11.6462937Z   --ignore github.com/in-toto \
+license-check	UNKNOWN STEP	2026-08-30T05:03:11.6463311Z   --ignore github.com/multiformats/go-base36 \
+license-check	UNKNOWN STEP	2026-08-30T05:03:11.6463679Z   --ignore github.com/ipfs/bbloom \
+license-check	UNKNOWN STEP	2026-08-30T05:03:11.6464208Z   --ignore github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer \
+license-check	UNKNOWN STEP	2026-08-30T05:03:11.6464670Z   ./...
+license-check	UNKNOWN STEP	2026-08-30T05:03:11.6465153Z 
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7386126Z ^[[0mW0830 05:03:12.738278    2361 library.go:141] "golang.org/x/sys/unix" contains non-Go code that can't be inspected for further dependencies:
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7387056Z /home/runner/go/pkg/mod/golang.org/x/sys@v0.47.0/unix/asm_linux_amd64.s
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7387952Z W0830 05:03:12.738359    2361 library.go:141] "golang.org/x/crypto/blake2b" contains non-Go code that can't be inspected for further dependencies:
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7388694Z /home/runner/go/pkg/mod/golang.org/x/crypto@v0.55.0/blake2b/blake2bAVX2_amd64.s
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7389428Z /home/runner/go/pkg/mod/golang.org/x/crypto@v0.55.0/blake2b/blake2b_amd64.s
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7390152Z W0830 05:03:12.738365    2361 library.go:141] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7391096Z /home/runner/go/pkg/mod/golang.org/x/sys@v0.47.0/cpu/cpu_gc_x86.s
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7392034Z W0830 05:03:12.738370    2361 library.go:141] "golang.org/x/crypto/blake2s" contains non-Go code that can't be inspected for further dependencies:
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7393225Z /home/runner/go/pkg/mod/golang.org/x/crypto@v0.55.0/blake2s/blake2s_amd64.s
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7394451Z W0830 05:03:12.738377    2361 library.go:141] "lukechampine.com/blake3/guts" contains non-Go code that can't be inspected for further dependencies:
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7395627Z /home/runner/go/pkg/mod/lukechampine.com/blake3@v1.4.1/guts/compress_amd64.s
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7396865Z W0830 05:03:12.738381    2361 library.go:141] "github.com/klauspost/cpuid/v2" contains non-Go code that can't be inspected for further dependencies:
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7398029Z /home/runner/go/pkg/mod/github.com/klauspost/cpuid/v2@v2.3.0/cpuid_amd64.s
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7399275Z W0830 05:03:12.738483    2361 library.go:141] "github.com/cloudflare/circl/dh/x25519" contains non-Go code that can't be inspected for further dependencies:
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7400504Z /home/runner/go/pkg/mod/github.com/cloudflare/circl@v1.6.3/dh/x25519/curve_amd64.h
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7401649Z /home/runner/go/pkg/mod/github.com/cloudflare/circl@v1.6.3/dh/x25519/curve_amd64.s
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7402946Z W0830 05:03:12.738493    2361 library.go:141] "github.com/cloudflare/circl/math/fp25519" contains non-Go code that can't be inspected for further dependencies:
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7404249Z /home/runner/go/pkg/mod/github.com/cloudflare/circl@v1.6.3/math/fp25519/fp_amd64.h
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7404809Z /home/runner/go/pkg/mod/github.com/cloudflare/circl@v1.6.3/math/fp25519/fp_amd64.s
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7405997Z W0830 05:03:12.738502    2361 library.go:141] "github.com/cloudflare/circl/dh/x448" contains non-Go code that can't be inspected for further dependencies:
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7407205Z /home/runner/go/pkg/mod/github.com/cloudflare/circl@v1.6.3/dh/x448/curve_amd64.h
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7408075Z /home/runner/go/pkg/mod/github.com/cloudflare/circl@v1.6.3/dh/x448/curve_amd64.s
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7409941Z W0830 05:03:12.738511    2361 library.go:141] "github.com/cloudflare/circl/math/fp448" contains non-Go code that can't be inspected for further dependencies:
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7411513Z /home/runner/go/pkg/mod/github.com/cloudflare/circl@v1.6.3/math/fp448/fp_amd64.h
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7412437Z /home/runner/go/pkg/mod/github.com/cloudflare/circl@v1.6.3/math/fp448/fp_amd64.s
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7413716Z W0830 05:03:12.738547    2361 library.go:141] "golang.org/x/crypto/argon2" contains non-Go code that can't be inspected for further dependencies:
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7414908Z /home/runner/go/pkg/mod/golang.org/x/crypto@v0.55.0/argon2/blamka_amd64.s
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7416099Z W0830 05:03:12.738583    2361 library.go:141] "github.com/pjbgf/sha1cd" contains non-Go code that can't be inspected for further dependencies:
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7417254Z /home/runner/go/pkg/mod/github.com/pjbgf/sha1cd@v0.6.0/sha1cdblock_amd64.s
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7418573Z W0830 05:03:12.738721    2361 library.go:141] "golang.org/x/crypto/internal/poly1305" contains non-Go code that can't be inspected for further dependencies:
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7420250Z /home/runner/go/pkg/mod/golang.org/x/crypto@v0.55.0/internal/poly1305/sum_amd64.s
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7421789Z W0830 05:03:12.738889    2361 library.go:141] "github.com/klauspost/compress/zstd" contains non-Go code that can't be inspected for further dependencies:
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7422900Z /home/runner/go/pkg/mod/github.com/klauspost/compress@v1.19.2/zstd/fse_decoder_amd64.s
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7423502Z /home/runner/go/pkg/mod/github.com/klauspost/compress@v1.19.2/zstd/matchlen_amd64.s
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7424066Z /home/runner/go/pkg/mod/github.com/klauspost/compress@v1.19.2/zstd/seqdec_amd64.s
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7424855Z W0830 05:03:12.738902    2361 library.go:141] "github.com/klauspost/compress/huff0" contains non-Go code that can't be inspected for further dependencies:
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7425616Z /home/runner/go/pkg/mod/github.com/klauspost/compress@v1.19.2/huff0/decompress_amd64.s
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7426475Z W0830 05:03:12.738909    2361 library.go:141] "github.com/klauspost/compress/internal/cpuinfo" contains non-Go code that can't be inspected for further dependencies:
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7427328Z /home/runner/go/pkg/mod/github.com/klauspost/compress@v1.19.2/internal/cpuinfo/cpuinfo_amd64.s
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7428196Z W0830 05:03:12.738916    2361 library.go:141] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7429057Z /home/runner/go/pkg/mod/github.com/klauspost/compress@v1.19.2/zstd/internal/xxhash/xxhash_amd64.s
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7429837Z W0830 05:03:12.739143    2361 library.go:141] "github.com/cespare/xxhash/v2" contains non-Go code that can't be inspected for further dependencies:
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7430524Z /home/runner/go/pkg/mod/github.com/cespare/xxhash/v2@v2.3.0/xxhash_amd64.s
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7431535Z W0830 05:03:12.739769    2361 library.go:141] "golang.org/x/crypto/chacha20poly1305" contains non-Go code that can't be inspected for further dependencies:
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7432338Z /home/runner/go/pkg/mod/golang.org/x/crypto@v0.55.0/chacha20poly1305/chacha20poly1305_amd64.s
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7433200Z W0830 05:03:12.740110    2361 library.go:141] "github.com/envoyproxy/protoc-gen-validate/validate" contains non-Go code that can't be inspected for further dependencies:
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7434041Z /home/runner/go/pkg/mod/github.com/envoyproxy/protoc-gen-validate@v1.3.3/validate/validate.h
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7434847Z W0830 05:03:12.741345    2361 library.go:141] "golang.org/x/crypto/salsa20/salsa" contains non-Go code that can't be inspected for further dependencies:
+license-check	UNKNOWN STEP	2026-08-30T05:03:12.7435580Z /home/runner/go/pkg/mod/golang.org/x/crypto@v0.55.0/salsa20/salsa/salsa20_amd64.s
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.6035883Z Post job cleanup.
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.7199292Z [command]/opt/hostedtoolcache/go/1.27.0/x64/bin/go env GOMODCACHE
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.7238653Z [command]/opt/hostedtoolcache/go/1.27.0/x64/bin/go env GOCACHE
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.7266732Z /home/runner/go/pkg/mod
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.7285628Z /home/runner/.cache/go-build
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.7291798Z Cache hit occurred on the primary key setup-go-Linux-x64-ubuntu24-go-1.27.0-70e369aef7f72b34eefef141b1a07e9f033a9c196f8b3d4332b8dc129da604b6, not saving cache.
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.7425861Z Post job cleanup.
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.8222881Z [command]/usr/bin/git version
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.8298689Z git version 2.55.0
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.8331426Z Temporarily overriding HOME='/home/runner/work/_temp/533532eb-68df-4c1f-8bc9-74f6d8552c91' before making global git config changes
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.8332652Z Adding repository directory to the temporary git global config as a safe directory
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.8336534Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/goreleaser/goreleaser
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.8390375Z Removing SSH command configuration
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.8391430Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.8409093Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.8644626Z Removing HTTP extra header
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.8649487Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.8683205Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.8912252Z Removing includeIf entries pointing to credentials config files
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.8918496Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.8946623Z includeif.gitdir:/home/runner/work/goreleaser/goreleaser/.git.path
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.8947408Z includeif.gitdir:/home/runner/work/goreleaser/goreleaser/.git/worktrees/*.path
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.8947913Z includeif.gitdir:/github/workspace/.git.path
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.8948297Z includeif.gitdir:/github/workspace/.git/worktrees/*.path
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.8956039Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/home/runner/work/goreleaser/goreleaser/.git.path
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.8979804Z /home/runner/work/_temp/git-credentials-b3fd9116-e4f2-4801-b844-122938580c67.config
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.8993296Z [command]/usr/bin/git config --local --unset includeif.gitdir:/home/runner/work/goreleaser/goreleaser/.git.path \/home\/runner\/work\/_temp\/git\-credentials\-b3fd9116\-e4f2\-4801\-b844\-122938580c67\.config
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.9031305Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/home/runner/work/goreleaser/goreleaser/.git/worktrees/*.path
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.9056258Z /home/runner/work/_temp/git-credentials-b3fd9116-e4f2-4801-b844-122938580c67.config
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.9066635Z [command]/usr/bin/git config --local --unset includeif.gitdir:/home/runner/work/goreleaser/goreleaser/.git/worktrees/*.path \/home\/runner\/work\/_temp\/git\-credentials\-b3fd9116\-e4f2\-4801\-b844\-122938580c67\.config
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.9111885Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/github/workspace/.git.path
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.9135048Z /github/runner_temp/git-credentials-b3fd9116-e4f2-4801-b844-122938580c67.config
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.9143719Z [command]/usr/bin/git config --local --unset includeif.gitdir:/github/workspace/.git.path \/github\/runner_temp\/git\-credentials\-b3fd9116\-e4f2\-4801\-b844\-122938580c67\.config
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.9178053Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/github/workspace/.git/worktrees/*.path
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.9201742Z /github/runner_temp/git-credentials-b3fd9116-e4f2-4801-b844-122938580c67.config
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.9211420Z [command]/usr/bin/git config --local --unset includeif.gitdir:/github/workspace/.git/worktrees/*.path \/github\/runner_temp\/git\-credentials\-b3fd9116\-e4f2\-4801\-b844\-122938580c67\.config
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.9248945Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.9502456Z Removing credentials config '/home/runner/work/_temp/git-credentials-b3fd9116-e4f2-4801-b844-122938580c67.config'
+license-check	UNKNOWN STEP	2026-08-30T05:03:14.9675116Z Cleaning up orphan processes
+check	UNKNOWN STEP	﻿2026-08-30T05:02:50.8183432Z Current runner version: '2.336.0'
+check	UNKNOWN STEP	2026-08-30T05:02:50.8251079Z ##[group]Runner Image Provisioner
+check	UNKNOWN STEP	2026-08-30T05:02:50.8252484Z Hosted Compute Agent
+check	UNKNOWN STEP	2026-08-30T05:02:50.8253389Z Version: 20260819.586
+check	UNKNOWN STEP	2026-08-30T05:02:50.8254414Z Commit: 3cc4a88dfa507ef76119ad1bb3eccc6378bb2b76
+check	UNKNOWN STEP	2026-08-30T05:02:50.8255589Z Build Date: 2026-08-18T23:20:18Z
+check	UNKNOWN STEP	2026-08-30T05:02:50.8256649Z Worker ID: {4533784f-40ce-4968-9aa5-0f5d8045b246}
+check	UNKNOWN STEP	2026-08-30T05:02:50.8257872Z Azure Region: centralus
+check	UNKNOWN STEP	2026-08-30T05:02:50.8258766Z ##[endgroup]
+check	UNKNOWN STEP	2026-08-30T05:02:50.8261273Z ##[group]Operating System
+check	UNKNOWN STEP	2026-08-30T05:02:50.8262272Z Ubuntu
+check	UNKNOWN STEP	2026-08-30T05:02:50.8263058Z 24.04.4
+check	UNKNOWN STEP	2026-08-30T05:02:50.8264171Z LTS
+check	UNKNOWN STEP	2026-08-30T05:02:50.8264982Z ##[endgroup]
+check	UNKNOWN STEP	2026-08-30T05:02:50.8266084Z ##[group]Runner Image
+check	UNKNOWN STEP	2026-08-30T05:02:50.8267026Z Image: ubuntu-24.04
+check	UNKNOWN STEP	2026-08-30T05:02:50.8268420Z Version: 20260823.283.1
+check	UNKNOWN STEP	2026-08-30T05:02:50.8270748Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260823.283/images/ubuntu/Ubuntu2404-Readme.md
+check	UNKNOWN STEP	2026-08-30T05:02:50.8273504Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260823.283
+check	UNKNOWN STEP	2026-08-30T05:02:50.8275168Z ##[endgroup]
+check	UNKNOWN STEP	2026-08-30T05:02:50.8277037Z ##[group]GITHUB_TOKEN Permissions
+check	UNKNOWN STEP	2026-08-30T05:02:50.8280232Z Contents: read
+check	UNKNOWN STEP	2026-08-30T05:02:50.8281242Z Metadata: read
+check	UNKNOWN STEP	2026-08-30T05:02:50.8282129Z ##[endgroup]
+check	UNKNOWN STEP	2026-08-30T05:02:50.8285414Z Secret source: Actions
+check	UNKNOWN STEP	2026-08-30T05:02:50.8287444Z Prepare workflow directory
+check	UNKNOWN STEP	2026-08-30T05:02:50.8652419Z Prepare all required actions
+check	UNKNOWN STEP	2026-08-30T05:02:50.8719507Z Getting action download info
+check	UNKNOWN STEP	2026-08-30T05:02:51.1086709Z Download action repository 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1' (SHA:3d3c42e5aac5ba805825da76410c181273ba90b1)
+check	UNKNOWN STEP	2026-08-30T05:02:51.2475118Z Download action repository 'goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94' (SHA:f06c13b6b1a9625abc9e6e439d9c05a8f2190e94)
+check	UNKNOWN STEP	2026-08-30T05:02:51.6230771Z Complete job name: check
+check	UNKNOWN STEP	2026-08-30T05:02:51.7009368Z ##[group]Run actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+check	UNKNOWN STEP	2026-08-30T05:02:51.7010641Z with:
+check	UNKNOWN STEP	2026-08-30T05:02:51.7011083Z   fetch-depth: 0
+check	UNKNOWN STEP	2026-08-30T05:02:51.7011564Z   repository: goreleaser/goreleaser
+check	UNKNOWN STEP	2026-08-30T05:02:51.7015580Z   token: ***
+check	UNKNOWN STEP	2026-08-30T05:02:51.7016028Z   ssh-strict: true
+check	UNKNOWN STEP	2026-08-30T05:02:51.7016480Z   ssh-user: git
+check	UNKNOWN STEP	2026-08-30T05:02:51.7016943Z   persist-credentials: true
+check	UNKNOWN STEP	2026-08-30T05:02:51.7017438Z   clean: true
+check	UNKNOWN STEP	2026-08-30T05:02:51.7018016Z   sparse-checkout-cone-mode: true
+check	UNKNOWN STEP	2026-08-30T05:02:51.7018554Z   fetch-tags: false
+check	UNKNOWN STEP	2026-08-30T05:02:51.7019013Z   show-progress: true
+check	UNKNOWN STEP	2026-08-30T05:02:51.7019470Z   lfs: false
+check	UNKNOWN STEP	2026-08-30T05:02:51.7020015Z   submodules: false
+check	UNKNOWN STEP	2026-08-30T05:02:51.7020486Z   set-safe-directory: true
+check	UNKNOWN STEP	2026-08-30T05:02:51.7020997Z   allow-unsafe-pr-checkout: false
+check	UNKNOWN STEP	2026-08-30T05:02:51.7021725Z ##[endgroup]
+check	UNKNOWN STEP	2026-08-30T05:02:51.8008257Z Syncing repository: goreleaser/goreleaser
+check	UNKNOWN STEP	2026-08-30T05:02:51.8010326Z ##[group]Getting Git version info
+check	UNKNOWN STEP	2026-08-30T05:02:51.8011098Z Working directory is '/home/runner/work/goreleaser/goreleaser'
+check	UNKNOWN STEP	2026-08-30T05:02:51.8012185Z [command]/usr/bin/git version
+check	UNKNOWN STEP	2026-08-30T05:02:51.8054758Z git version 2.55.0
+check	UNKNOWN STEP	2026-08-30T05:02:51.8073658Z ##[endgroup]
+check	UNKNOWN STEP	2026-08-30T05:02:51.8085186Z Temporarily overriding HOME='/home/runner/work/_temp/59d75c89-fbfe-4b0c-ac76-045ae452ef0e' before making global git config changes
+check	UNKNOWN STEP	2026-08-30T05:02:51.8087425Z Adding repository directory to the temporary git global config as a safe directory
+check	UNKNOWN STEP	2026-08-30T05:02:51.8090621Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/goreleaser/goreleaser
+check	UNKNOWN STEP	2026-08-30T05:02:51.8133628Z Deleting the contents of '/home/runner/work/goreleaser/goreleaser'
+check	UNKNOWN STEP	2026-08-30T05:02:51.8137156Z ##[group]Determining repository object format
+check	UNKNOWN STEP	2026-08-30T05:02:51.8138835Z ##[endgroup]
+check	UNKNOWN STEP	2026-08-30T05:02:51.8140280Z ##[group]Initializing the repository
+check	UNKNOWN STEP	2026-08-30T05:02:51.8143890Z [command]/usr/bin/git init /home/runner/work/goreleaser/goreleaser
+check	UNKNOWN STEP	2026-08-30T05:02:51.8220683Z hint: Using 'master' as the name for the initial branch. This default branch name
+check	UNKNOWN STEP	2026-08-30T05:02:51.8222761Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+check	UNKNOWN STEP	2026-08-30T05:02:51.8224380Z hint: to use in all of your new repositories, which will suppress this warning,
+check	UNKNOWN STEP	2026-08-30T05:02:51.8225974Z hint: call:
+check	UNKNOWN STEP	2026-08-30T05:02:51.8226963Z hint:
+check	UNKNOWN STEP	2026-08-30T05:02:51.8228103Z hint: 	git config --global init.defaultBranch <name>
+check	UNKNOWN STEP	2026-08-30T05:02:51.8229425Z hint:
+check	UNKNOWN STEP	2026-08-30T05:02:51.8230875Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+check	UNKNOWN STEP	2026-08-30T05:02:51.8232638Z hint: 'development'. The just-created branch can be renamed via this command:
+check	UNKNOWN STEP	2026-08-30T05:02:51.8234268Z hint:
+check	UNKNOWN STEP	2026-08-30T05:02:51.8235237Z hint: 	git branch -m <name>
+check	UNKNOWN STEP	2026-08-30T05:02:51.8236266Z hint:
+check	UNKNOWN STEP	2026-08-30T05:02:51.8237503Z hint: Disable this message with "git config set advice.defaultBranchName false"
+check	UNKNOWN STEP	2026-08-30T05:02:51.8239540Z Initialized empty Git repository in /home/runner/work/goreleaser/goreleaser/.git/
+check	UNKNOWN STEP	2026-08-30T05:02:51.8242810Z [command]/usr/bin/git remote add origin https://github.com/goreleaser/goreleaser
+check	UNKNOWN STEP	2026-08-30T05:02:51.8279697Z ##[endgroup]
+check	UNKNOWN STEP	2026-08-30T05:02:51.8281165Z ##[group]Disabling automatic garbage collection
+check	UNKNOWN STEP	2026-08-30T05:02:51.8283266Z [command]/usr/bin/git config --local gc.auto 0
+check	UNKNOWN STEP	2026-08-30T05:02:51.8316109Z ##[endgroup]
+check	UNKNOWN STEP	2026-08-30T05:02:51.8317490Z ##[group]Setting up auth
+check	UNKNOWN STEP	2026-08-30T05:02:51.8318496Z Removing SSH command configuration
+check	UNKNOWN STEP	2026-08-30T05:02:51.8323477Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+check	UNKNOWN STEP	2026-08-30T05:02:51.8360711Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+check	UNKNOWN STEP	2026-08-30T05:02:51.8711274Z Removing HTTP extra header
+check	UNKNOWN STEP	2026-08-30T05:02:51.8715490Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+check	UNKNOWN STEP	2026-08-30T05:02:51.8751078Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+check	UNKNOWN STEP	2026-08-30T05:02:51.8995529Z Removing includeIf entries pointing to credentials config files
+check	UNKNOWN STEP	2026-08-30T05:02:51.9000971Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+check	UNKNOWN STEP	2026-08-30T05:02:51.9041531Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+check	UNKNOWN STEP	2026-08-30T05:02:51.9278187Z [command]/usr/bin/git config --file /home/runner/work/_temp/git-credentials-54b9e991-6819-4be3-9526-abc4b46ae277.config http.https://github.com/.extraheader AUTHORIZATION: basic ***
+check	UNKNOWN STEP	2026-08-30T05:02:51.9315325Z [command]/usr/bin/git config --local includeIf.gitdir:/home/runner/work/goreleaser/goreleaser/.git.path /home/runner/work/_temp/git-credentials-54b9e991-6819-4be3-9526-abc4b46ae277.config
+check	UNKNOWN STEP	2026-08-30T05:02:51.9345300Z [command]/usr/bin/git config --local includeIf.gitdir:/home/runner/work/goreleaser/goreleaser/.git/worktrees/*.path /home/runner/work/_temp/git-credentials-54b9e991-6819-4be3-9526-abc4b46ae277.config
+check	UNKNOWN STEP	2026-08-30T05:02:51.9378496Z [command]/usr/bin/git config --local includeIf.gitdir:/github/workspace/.git.path /github/runner_temp/git-credentials-54b9e991-6819-4be3-9526-abc4b46ae277.config
+check	UNKNOWN STEP	2026-08-30T05:02:51.9408470Z [command]/usr/bin/git config --local includeIf.gitdir:/github/workspace/.git/worktrees/*.path /github/runner_temp/git-credentials-54b9e991-6819-4be3-9526-abc4b46ae277.config
+check	UNKNOWN STEP	2026-08-30T05:02:51.9437883Z ##[endgroup]
+check	UNKNOWN STEP	2026-08-30T05:02:51.9438658Z ##[group]Fetching the repository
+check	UNKNOWN STEP	2026-08-30T05:02:51.9444365Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
+check	UNKNOWN STEP	2026-08-30T05:02:54.3189682Z From https://github.com/goreleaser/goreleaser
+check	UNKNOWN STEP	2026-08-30T05:02:54.3191824Z  * [new branch]        artifacts-vars           -> origin/artifacts-vars
+check	UNKNOWN STEP	2026-08-30T05:02:54.3193906Z  * [new branch]        ci                       -> origin/ci
+check	UNKNOWN STEP	2026-08-30T05:02:54.3196127Z  * [new branch]        copilot/fix-argo-cd-secondary-rate-limit -> origin/copilot/fix-argo-cd-secondary-rate-limit
+check	UNKNOWN STEP	2026-08-30T05:02:54.3211513Z  * [new branch]        copilot/fix-test         -> origin/copilot/fix-test
+check	UNKNOWN STEP	2026-08-30T05:02:54.3222031Z  * [new branch]        fix-termux-package-architecture -> origin/fix-termux-package-architecture
+check	UNKNOWN STEP	2026-08-30T05:02:54.3223553Z  * [new branch]        fix/winget-arm64-duplicate-check -> origin/fix/winget-arm64-duplicate-check
+check	UNKNOWN STEP	2026-08-30T05:02:54.3224735Z  * [new branch]        goarm-fix                -> origin/goarm-fix
+check	UNKNOWN STEP	2026-08-30T05:02:54.3225653Z  * [new branch]        goreleaser-bugs2         -> origin/goreleaser-bugs2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3226707Z  * [new branch]        goreleaser-install-script -> origin/goreleaser-install-script
+check	UNKNOWN STEP	2026-08-30T05:02:54.3227728Z  * [new branch]        main                     -> origin/main
+check	UNKNOWN STEP	2026-08-30T05:02:54.3228743Z  * [new branch]        nix                      -> origin/nix
+check	UNKNOWN STEP	2026-08-30T05:02:54.3230036Z  * [new branch]        nodejs-sea2              -> origin/nodejs-sea2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3231462Z  * [new branch]        nodejs-wip               -> origin/nodejs-wip
+check	UNKNOWN STEP	2026-08-30T05:02:54.3232637Z  * [new branch]        patch-1                  -> origin/patch-1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3233870Z  * [new branch]        quill-update             -> origin/quill-update
+check	UNKNOWN STEP	2026-08-30T05:02:54.3235031Z  * [new branch]        release-token            -> origin/release-token
+check	UNKNOWN STEP	2026-08-30T05:02:54.3236164Z  * [new branch]        zig-cache                -> origin/zig-cache
+check	UNKNOWN STEP	2026-08-30T05:02:54.3237183Z  * [new tag]           nightly                  -> nightly
+check	UNKNOWN STEP	2026-08-30T05:02:54.3238095Z  * [new tag]           v0.0.1                   -> v0.0.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3238983Z  * [new tag]           v0.0.2                   -> v0.0.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3240348Z  * [new tag]           v0.0.3                   -> v0.0.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3241652Z  * [new tag]           v0.0.4                   -> v0.0.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3242993Z  * [new tag]           v0.0.5                   -> v0.0.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3244194Z  * [new tag]           v0.0.6                   -> v0.0.6
+check	UNKNOWN STEP	2026-08-30T05:02:54.3245399Z  * [new tag]           v0.0.7                   -> v0.0.7
+check	UNKNOWN STEP	2026-08-30T05:02:54.3246624Z  * [new tag]           v0.0.8                   -> v0.0.8
+check	UNKNOWN STEP	2026-08-30T05:02:54.3247820Z  * [new tag]           v0.0.9                   -> v0.0.9
+check	UNKNOWN STEP	2026-08-30T05:02:54.3250172Z  * [new tag]           v0.1.0                   -> v0.1.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3251973Z  * [new tag]           v0.1.1                   -> v0.1.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3253351Z  * [new tag]           v0.1.2                   -> v0.1.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3254612Z  * [new tag]           v0.1.3                   -> v0.1.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3255790Z  * [new tag]           v0.1.4                   -> v0.1.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3256697Z  * [new tag]           v0.1.5                   -> v0.1.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3257456Z  * [new tag]           v0.1.6                   -> v0.1.6
+check	UNKNOWN STEP	2026-08-30T05:02:54.3258213Z  * [new tag]           v0.1.7                   -> v0.1.7
+check	UNKNOWN STEP	2026-08-30T05:02:54.3259368Z  * [new tag]           v0.1.8                   -> v0.1.8
+check	UNKNOWN STEP	2026-08-30T05:02:54.3260667Z  * [new tag]           v0.1.9                   -> v0.1.9
+check	UNKNOWN STEP	2026-08-30T05:02:54.3261588Z  * [new tag]           v0.10.0                  -> v0.10.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3262357Z  * [new tag]           v0.100.0                 -> v0.100.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3263141Z  * [new tag]           v0.101.0                 -> v0.101.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3263907Z  * [new tag]           v0.102.0                 -> v0.102.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3264670Z  * [new tag]           v0.103.0                 -> v0.103.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3265427Z  * [new tag]           v0.103.1                 -> v0.103.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3266195Z  * [new tag]           v0.104.0                 -> v0.104.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3267181Z  * [new tag]           v0.104.1                 -> v0.104.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3267932Z  * [new tag]           v0.104.2                 -> v0.104.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3268689Z  * [new tag]           v0.104.3                 -> v0.104.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3269444Z  * [new tag]           v0.105.0                 -> v0.105.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3270629Z  * [new tag]           v0.106.0                 -> v0.106.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3271544Z  * [new tag]           v0.107.0                 -> v0.107.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3272289Z  * [new tag]           v0.108.0                 -> v0.108.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3273016Z  * [new tag]           v0.109.0                 -> v0.109.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3273754Z  * [new tag]           v0.11.0                  -> v0.11.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3274477Z  * [new tag]           v0.11.1                  -> v0.11.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3275610Z  * [new tag]           v0.110.0                 -> v0.110.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3276407Z  * [new tag]           v0.111.0                 -> v0.111.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3277142Z  * [new tag]           v0.112.0                 -> v0.112.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3277865Z  * [new tag]           v0.112.1                 -> v0.112.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3278587Z  * [new tag]           v0.112.2                 -> v0.112.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3279296Z  * [new tag]           v0.113.0                 -> v0.113.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3280404Z  * [new tag]           v0.113.1                 -> v0.113.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3281142Z  * [new tag]           v0.114.0                 -> v0.114.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3281861Z  * [new tag]           v0.114.1                 -> v0.114.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3282600Z  * [new tag]           v0.115.0                 -> v0.115.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3283373Z  * [new tag]           v0.116.0                 -> v0.116.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3284134Z  * [new tag]           v0.117.0                 -> v0.117.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3285031Z  * [new tag]           v0.117.1                 -> v0.117.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3285771Z  * [new tag]           v0.117.2                 -> v0.117.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3286507Z  * [new tag]           v0.118.0                 -> v0.118.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3287237Z  * [new tag]           v0.118.1                 -> v0.118.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3287956Z  * [new tag]           v0.118.2                 -> v0.118.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3288694Z  * [new tag]           v0.119.0                 -> v0.119.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3289422Z  * [new tag]           v0.12.0                  -> v0.12.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3290534Z  * [new tag]           v0.12.1                  -> v0.12.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3291268Z  * [new tag]           v0.12.2                  -> v0.12.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3291980Z  * [new tag]           v0.12.3                  -> v0.12.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3292699Z  * [new tag]           v0.120.0                 -> v0.120.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3293424Z  * [new tag]           v0.120.1                 -> v0.120.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3294214Z  * [new tag]           v0.120.2                 -> v0.120.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3294945Z  * [new tag]           v0.120.3                 -> v0.120.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3295657Z  * [new tag]           v0.120.4                 -> v0.120.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3296375Z  * [new tag]           v0.120.5                 -> v0.120.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3297106Z  * [new tag]           v0.120.6                 -> v0.120.6
+check	UNKNOWN STEP	2026-08-30T05:02:54.3297817Z  * [new tag]           v0.120.7                 -> v0.120.7
+check	UNKNOWN STEP	2026-08-30T05:02:54.3298539Z  * [new tag]           v0.120.8                 -> v0.120.8
+check	UNKNOWN STEP	2026-08-30T05:02:54.3299247Z  * [new tag]           v0.121.0                 -> v0.121.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3300216Z  * [new tag]           v0.122.0                 -> v0.122.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3300936Z  * [new tag]           v0.123.0                 -> v0.123.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3301646Z  * [new tag]           v0.123.1                 -> v0.123.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3302375Z  * [new tag]           v0.123.2                 -> v0.123.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3303078Z  * [new tag]           v0.123.3                 -> v0.123.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3303931Z  * [new tag]           v0.124.0                 -> v0.124.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3304691Z  * [new tag]           v0.124.1                 -> v0.124.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3305412Z  * [new tag]           v0.125.0                 -> v0.125.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3306116Z  * [new tag]           v0.126.0                 -> v0.126.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3306827Z  * [new tag]           v0.127.0                 -> v0.127.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3307536Z  * [new tag]           v0.128.0                 -> v0.128.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3308240Z  * [new tag]           v0.129.0                 -> v0.129.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3308961Z  * [new tag]           v0.13.0                  -> v0.13.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3309673Z  * [new tag]           v0.13.1                  -> v0.13.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3310569Z  * [new tag]           v0.13.2                  -> v0.13.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3311402Z  * [new tag]           v0.13.3                  -> v0.13.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3312188Z  * [new tag]           v0.13.4                  -> v0.13.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3312943Z  * [new tag]           v0.13.5                  -> v0.13.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3313690Z  * [new tag]           v0.13.6                  -> v0.13.6
+check	UNKNOWN STEP	2026-08-30T05:02:54.3314406Z  * [new tag]           v0.130.0                 -> v0.130.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3315127Z  * [new tag]           v0.130.1                 -> v0.130.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3315839Z  * [new tag]           v0.130.2                 -> v0.130.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3322735Z  * [new tag]           v0.131.0                 -> v0.131.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3323557Z  * [new tag]           v0.131.1                 -> v0.131.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3324337Z  * [new tag]           v0.132.0                 -> v0.132.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3325083Z  * [new tag]           v0.132.1                 -> v0.132.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3325990Z  * [new tag]           v0.133.0                 -> v0.133.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3326747Z  * [new tag]           v0.134.0                 -> v0.134.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3327493Z  * [new tag]           v0.135.0                 -> v0.135.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3328231Z  * [new tag]           v0.136.0                 -> v0.136.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3328967Z  * [new tag]           v0.137.0                 -> v0.137.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3329694Z  * [new tag]           v0.138.0                 -> v0.138.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3330621Z  * [new tag]           v0.139.0                 -> v0.139.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3331374Z  * [new tag]           v0.14.0                  -> v0.14.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3332117Z  * [new tag]           v0.140.0                 -> v0.140.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3332850Z  * [new tag]           v0.140.1                 -> v0.140.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3333574Z  * [new tag]           v0.141.0                 -> v0.141.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3334304Z  * [new tag]           v0.142.0                 -> v0.142.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3335033Z  * [new tag]           v0.143.0                 -> v0.143.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3335770Z  * [new tag]           v0.144.0                 -> v0.144.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3336510Z  * [new tag]           v0.144.1                 -> v0.144.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3337252Z  * [new tag]           v0.145.0                 -> v0.145.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3337984Z  * [new tag]           v0.146.0                 -> v0.146.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3338721Z  * [new tag]           v0.147.0                 -> v0.147.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3339446Z  * [new tag]           v0.147.1                 -> v0.147.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3340371Z  * [new tag]           v0.147.2                 -> v0.147.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3341109Z  * [new tag]           v0.148.0                 -> v0.148.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3341897Z  * [new tag]           v0.149.0                 -> v0.149.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3342682Z  * [new tag]           v0.15.0                  -> v0.15.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3343464Z  * [new tag]           v0.15.1                  -> v0.15.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3344259Z  * [new tag]           v0.150.0                 -> v0.150.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3345228Z  * [new tag]           v0.150.1                 -> v0.150.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3346039Z  * [new tag]           v0.151.0                 -> v0.151.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3346838Z  * [new tag]           v0.151.1                 -> v0.151.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3347632Z  * [new tag]           v0.151.2                 -> v0.151.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3348429Z  * [new tag]           v0.152.0                 -> v0.152.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3349229Z  * [new tag]           v0.153.0                 -> v0.153.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3350276Z  * [new tag]           v0.154.0                 -> v0.154.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3351083Z  * [new tag]           v0.155.0                 -> v0.155.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3352101Z  * [new tag]           v0.155.1                 -> v0.155.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3353256Z  * [new tag]           v0.155.2                 -> v0.155.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3354471Z  * [new tag]           v0.156.0                 -> v0.156.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3355718Z  * [new tag]           v0.156.1                 -> v0.156.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3356944Z  * [new tag]           v0.156.2                 -> v0.156.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3358258Z  * [new tag]           v0.157.0                 -> v0.157.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3359508Z  * [new tag]           v0.158.0                 -> v0.158.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3360967Z  * [new tag]           v0.159.0                 -> v0.159.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3362217Z  * [new tag]           v0.16.0                  -> v0.16.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3363422Z  * [new tag]           v0.16.1                  -> v0.16.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3364619Z  * [new tag]           v0.160.0                 -> v0.160.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3365807Z  * [new tag]           v0.161.0                 -> v0.161.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3366993Z  * [new tag]           v0.161.1                 -> v0.161.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3368170Z  * [new tag]           v0.162.0                 -> v0.162.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3369020Z  * [new tag]           v0.162.1                 -> v0.162.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3370138Z  * [new tag]           v0.163.0                 -> v0.163.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3371487Z  * [new tag]           v0.163.1                 -> v0.163.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3372683Z  * [new tag]           v0.164.0                 -> v0.164.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3373821Z  * [new tag]           v0.165.0                 -> v0.165.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3375041Z  * [new tag]           v0.166.0                 -> v0.166.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3376247Z  * [new tag]           v0.166.1                 -> v0.166.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3377471Z  * [new tag]           v0.166.2                 -> v0.166.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3378691Z  * [new tag]           v0.167.0                 -> v0.167.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3380094Z  * [new tag]           v0.168.0                 -> v0.168.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3381446Z  * [new tag]           v0.168.1                 -> v0.168.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3382666Z  * [new tag]           v0.168.2                 -> v0.168.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3383892Z  * [new tag]           v0.169.0                 -> v0.169.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3385108Z  * [new tag]           v0.17.0                  -> v0.17.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3386295Z  * [new tag]           v0.17.1                  -> v0.17.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3387506Z  * [new tag]           v0.17.2                  -> v0.17.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3388701Z  * [new tag]           v0.17.3                  -> v0.17.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3390106Z  * [new tag]           v0.17.4                  -> v0.17.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3391329Z  * [new tag]           v0.17.5                  -> v0.17.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3392538Z  * [new tag]           v0.17.6                  -> v0.17.6
+check	UNKNOWN STEP	2026-08-30T05:02:54.3393764Z  * [new tag]           v0.170.0                 -> v0.170.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3394980Z  * [new tag]           v0.171.0                 -> v0.171.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3395835Z  * [new tag]           v0.172.0                 -> v0.172.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3396678Z  * [new tag]           v0.172.1                 -> v0.172.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3397900Z  * [new tag]           v0.173.0                 -> v0.173.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3398736Z  * [new tag]           v0.173.1                 -> v0.173.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3399657Z  * [new tag]           v0.173.2                 -> v0.173.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3400750Z  * [new tag]           v0.174.0                 -> v0.174.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3401577Z  * [new tag]           v0.174.1                 -> v0.174.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3402398Z  * [new tag]           v0.174.2                 -> v0.174.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3403216Z  * [new tag]           v0.175.0                 -> v0.175.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3404185Z  * [new tag]           v0.176.0                 -> v0.176.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3405244Z  * [new tag]           v0.177.0                 -> v0.177.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3406093Z  * [new tag]           v0.178.0                 -> v0.178.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3406925Z  * [new tag]           v0.179.0                 -> v0.179.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3407750Z  * [new tag]           v0.18.0                  -> v0.18.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3408564Z  * [new tag]           v0.18.1                  -> v0.18.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3409408Z  * [new tag]           v0.180.0                 -> v0.180.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3410638Z  * [new tag]           v0.180.1                 -> v0.180.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3411610Z  * [new tag]           v0.180.2                 -> v0.180.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3412939Z  * [new tag]           v0.180.3                 -> v0.180.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3414162Z  * [new tag]           v0.181.0                 -> v0.181.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3415347Z  * [new tag]           v0.181.1                 -> v0.181.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3416611Z  * [new tag]           v0.182.0                 -> v0.182.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3417851Z  * [new tag]           v0.182.1                 -> v0.182.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3419339Z  * [new tag]           v0.183.0                 -> v0.183.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3420803Z  * [new tag]           v0.184.0                 -> v0.184.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3422221Z  * [new tag]           v0.19.0                  -> v0.19.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3423660Z  * [new tag]           v0.2.0                   -> v0.2.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3424916Z  * [new tag]           v0.2.1                   -> v0.2.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3426129Z  * [new tag]           v0.2.2                   -> v0.2.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3427318Z  * [new tag]           v0.2.3                   -> v0.2.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3428516Z  * [new tag]           v0.2.4                   -> v0.2.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3429708Z  * [new tag]           v0.2.5                   -> v0.2.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3434105Z  * [new tag]           v0.2.6                   -> v0.2.6
+check	UNKNOWN STEP	2026-08-30T05:02:54.3434966Z  * [new tag]           v0.2.7                   -> v0.2.7
+check	UNKNOWN STEP	2026-08-30T05:02:54.3435769Z  * [new tag]           v0.2.8                   -> v0.2.8
+check	UNKNOWN STEP	2026-08-30T05:02:54.3436577Z  * [new tag]           v0.2.9                   -> v0.2.9
+check	UNKNOWN STEP	2026-08-30T05:02:54.3437774Z  * [new tag]           v0.20.0                  -> v0.20.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3438721Z  * [new tag]           v0.20.1                  -> v0.20.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3519163Z  * [new tag]           v0.20.2                  -> v0.20.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3521067Z  * [new tag]           v0.20.3                  -> v0.20.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3522187Z  * [new tag]           v0.20.4                  -> v0.20.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3523306Z  * [new tag]           v0.21.0                  -> v0.21.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3524312Z  * [new tag]           v0.21.1                  -> v0.21.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3525344Z  * [new tag]           v0.21.2                  -> v0.21.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3526337Z  * [new tag]           v0.21.3                  -> v0.21.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3527415Z  * [new tag]           v0.21.4                  -> v0.21.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3528429Z  * [new tag]           v0.21.5                  -> v0.21.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3529424Z  * [new tag]           v0.22.0                  -> v0.22.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3530929Z  * [new tag]           v0.22.1                  -> v0.22.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3531879Z  * [new tag]           v0.22.2                  -> v0.22.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3532831Z  * [new tag]           v0.23.0                  -> v0.23.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3533883Z  * [new tag]           v0.23.1                  -> v0.23.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3534984Z  * [new tag]           v0.24.0                  -> v0.24.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3536045Z  * [new tag]           v0.25.0                  -> v0.25.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3537073Z  * [new tag]           v0.26.0                  -> v0.26.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3538083Z  * [new tag]           v0.26.1                  -> v0.26.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3539101Z  * [new tag]           v0.27.0                  -> v0.27.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3540468Z  * [new tag]           v0.27.1                  -> v0.27.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3541469Z  * [new tag]           v0.27.2                  -> v0.27.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3542469Z  * [new tag]           v0.27.3                  -> v0.27.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3543492Z  * [new tag]           v0.27.4                  -> v0.27.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3544515Z  * [new tag]           v0.27.5                  -> v0.27.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3545581Z  * [new tag]           v0.28.0                  -> v0.28.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3546744Z  * [new tag]           v0.28.1                  -> v0.28.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3547855Z  * [new tag]           v0.28.2                  -> v0.28.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3548941Z  * [new tag]           v0.28.3                  -> v0.28.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3550229Z  * [new tag]           v0.28.4                  -> v0.28.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3551325Z  * [new tag]           v0.28.5                  -> v0.28.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3552407Z  * [new tag]           v0.28.6                  -> v0.28.6
+check	UNKNOWN STEP	2026-08-30T05:02:54.3553464Z  * [new tag]           v0.28.7                  -> v0.28.7
+check	UNKNOWN STEP	2026-08-30T05:02:54.3554696Z  * [new tag]           v0.28.8                  -> v0.28.8
+check	UNKNOWN STEP	2026-08-30T05:02:54.3555772Z  * [new tag]           v0.28.9                  -> v0.28.9
+check	UNKNOWN STEP	2026-08-30T05:02:54.3556854Z  * [new tag]           v0.3.0                   -> v0.3.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3557953Z  * [new tag]           v0.3.1                   -> v0.3.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3559021Z  * [new tag]           v0.3.2                   -> v0.3.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3560182Z  * [new tag]           v0.3.4                   -> v0.3.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3561224Z  * [new tag]           v0.3.5                   -> v0.3.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3562265Z  * [new tag]           v0.3.6                   -> v0.3.6
+check	UNKNOWN STEP	2026-08-30T05:02:54.3563317Z  * [new tag]           v0.30.0                  -> v0.30.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3564370Z  * [new tag]           v0.30.1                  -> v0.30.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3565419Z  * [new tag]           v0.30.2                  -> v0.30.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3566453Z  * [new tag]           v0.30.3                  -> v0.30.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3567490Z  * [new tag]           v0.30.4                  -> v0.30.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3568515Z  * [new tag]           v0.30.5                  -> v0.30.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3569532Z  * [new tag]           v0.31.0                  -> v0.31.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3570676Z  * [new tag]           v0.31.1                  -> v0.31.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3571699Z  * [new tag]           v0.32.0                  -> v0.32.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3572709Z  * [new tag]           v0.32.1                  -> v0.32.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3573731Z  * [new tag]           v0.32.2                  -> v0.32.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3574766Z  * [new tag]           v0.33.0                  -> v0.33.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3575806Z  * [new tag]           v0.33.1                  -> v0.33.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3576825Z  * [new tag]           v0.33.2                  -> v0.33.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3577858Z  * [new tag]           v0.34.0                  -> v0.34.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3578881Z  * [new tag]           v0.34.1                  -> v0.34.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3580177Z  * [new tag]           v0.34.2                  -> v0.34.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3581361Z  * [new tag]           v0.34.3                  -> v0.34.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3582395Z  * [new tag]           v0.34.4                  -> v0.34.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3583413Z  * [new tag]           v0.34.5                  -> v0.34.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3584427Z  * [new tag]           v0.35.0                  -> v0.35.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3585432Z  * [new tag]           v0.35.1                  -> v0.35.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3586439Z  * [new tag]           v0.35.2                  -> v0.35.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3587458Z  * [new tag]           v0.35.3                  -> v0.35.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3588455Z  * [new tag]           v0.35.4                  -> v0.35.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3589450Z  * [new tag]           v0.35.5                  -> v0.35.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3590628Z  * [new tag]           v0.35.6                  -> v0.35.6
+check	UNKNOWN STEP	2026-08-30T05:02:54.3591626Z  * [new tag]           v0.35.7                  -> v0.35.7
+check	UNKNOWN STEP	2026-08-30T05:02:54.3592655Z  * [new tag]           v0.36.0                  -> v0.36.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3593675Z  * [new tag]           v0.36.1                  -> v0.36.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3594664Z  * [new tag]           v0.37.0                  -> v0.37.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3595656Z  * [new tag]           v0.37.1                  -> v0.37.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3596642Z  * [new tag]           v0.37.10                 -> v0.37.10
+check	UNKNOWN STEP	2026-08-30T05:02:54.3597657Z  * [new tag]           v0.37.2                  -> v0.37.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3598656Z  * [new tag]           v0.37.3                  -> v0.37.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3599639Z  * [new tag]           v0.37.4                  -> v0.37.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3600726Z  * [new tag]           v0.37.5                  -> v0.37.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3601707Z  * [new tag]           v0.37.6                  -> v0.37.6
+check	UNKNOWN STEP	2026-08-30T05:02:54.3602689Z  * [new tag]           v0.37.7                  -> v0.37.7
+check	UNKNOWN STEP	2026-08-30T05:02:54.3603817Z  * [new tag]           v0.37.8                  -> v0.37.8
+check	UNKNOWN STEP	2026-08-30T05:02:54.3604811Z  * [new tag]           v0.37.9                  -> v0.37.9
+check	UNKNOWN STEP	2026-08-30T05:02:54.3605805Z  * [new tag]           v0.38.0                  -> v0.38.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3606778Z  * [new tag]           v0.39.0                  -> v0.39.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3607757Z  * [new tag]           v0.4.0                   -> v0.4.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3608734Z  * [new tag]           v0.4.1                   -> v0.4.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3609720Z  * [new tag]           v0.4.2                   -> v0.4.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3610827Z  * [new tag]           v0.4.3                   -> v0.4.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3611809Z  * [new tag]           v0.4.4                   -> v0.4.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3612783Z  * [new tag]           v0.4.5                   -> v0.4.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3613740Z  * [new tag]           v0.40.0                  -> v0.40.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3614721Z  * [new tag]           v0.40.1                  -> v0.40.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3615680Z  * [new tag]           v0.40.2                  -> v0.40.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3616645Z  * [new tag]           v0.40.3                  -> v0.40.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3617597Z  * [new tag]           v0.40.4                  -> v0.40.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3618556Z  * [new tag]           v0.40.5                  -> v0.40.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3619515Z  * [new tag]           v0.40.6                  -> v0.40.6
+check	UNKNOWN STEP	2026-08-30T05:02:54.3620702Z  * [new tag]           v0.41.0                  -> v0.41.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3621665Z  * [new tag]           v0.41.1                  -> v0.41.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3622621Z  * [new tag]           v0.42.0                  -> v0.42.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3623569Z  * [new tag]           v0.42.1                  -> v0.42.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3624525Z  * [new tag]           v0.42.2                  -> v0.42.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3625480Z  * [new tag]           v0.43.0                  -> v0.43.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3626433Z  * [new tag]           v0.44.0                  -> v0.44.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3627582Z  * [new tag]           v0.44.1                  -> v0.44.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3628564Z  * [new tag]           v0.44.2                  -> v0.44.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3629516Z  * [new tag]           v0.45.0                  -> v0.45.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3630685Z  * [new tag]           v0.45.1                  -> v0.45.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3631652Z  * [new tag]           v0.45.2                  -> v0.45.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3632613Z  * [new tag]           v0.45.3                  -> v0.45.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3633564Z  * [new tag]           v0.45.4                  -> v0.45.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3634512Z  * [new tag]           v0.45.5                  -> v0.45.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3635443Z  * [new tag]           v0.46.0                  -> v0.46.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3636391Z  * [new tag]           v0.46.1                  -> v0.46.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3637363Z  * [new tag]           v0.46.2                  -> v0.46.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3638327Z  * [new tag]           v0.46.3                  -> v0.46.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3639293Z  * [new tag]           v0.46.4                  -> v0.46.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3640585Z  * [new tag]           v0.47.0                  -> v0.47.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3641554Z  * [new tag]           v0.47.1                  -> v0.47.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3642513Z  * [new tag]           v0.48.0                  -> v0.48.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3643467Z  * [new tag]           v0.49.0                  -> v0.49.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3644431Z  * [new tag]           v0.49.1                  -> v0.49.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3645403Z  * [new tag]           v0.49.2                  -> v0.49.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3646360Z  * [new tag]           v0.49.3                  -> v0.49.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3647325Z  * [new tag]           v0.5.0                   -> v0.5.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3648290Z  * [new tag]           v0.5.1                   -> v0.5.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3649443Z  * [new tag]           v0.5.2                   -> v0.5.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3650516Z  * [new tag]           v0.5.3                   -> v0.5.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3651484Z  * [new tag]           v0.5.4                   -> v0.5.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3652443Z  * [new tag]           v0.5.5                   -> v0.5.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3653380Z  * [new tag]           v0.5.6                   -> v0.5.6
+check	UNKNOWN STEP	2026-08-30T05:02:54.3654314Z  * [new tag]           v0.5.7                   -> v0.5.7
+check	UNKNOWN STEP	2026-08-30T05:02:54.3655254Z  * [new tag]           v0.5.8                   -> v0.5.8
+check	UNKNOWN STEP	2026-08-30T05:02:54.3656195Z  * [new tag]           v0.5.9                   -> v0.5.9
+check	UNKNOWN STEP	2026-08-30T05:02:54.3657139Z  * [new tag]           v0.50.0                  -> v0.50.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3658153Z  * [new tag]           v0.50.1                  -> v0.50.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3659101Z  * [new tag]           v0.51.0                  -> v0.51.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3660279Z  * [new tag]           v0.52.0                  -> v0.52.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3661231Z  * [new tag]           v0.52.1                  -> v0.52.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3662185Z  * [new tag]           v0.52.2                  -> v0.52.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3663128Z  * [new tag]           v0.52.3                  -> v0.52.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3664083Z  * [new tag]           v0.53.0                  -> v0.53.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3665021Z  * [new tag]           v0.54.0                  -> v0.54.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3665956Z  * [new tag]           v0.54.1                  -> v0.54.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3666887Z  * [new tag]           v0.54.2                  -> v0.54.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3667820Z  * [new tag]           v0.54.3                  -> v0.54.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3668767Z  * [new tag]           v0.55.0                  -> v0.55.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3669710Z  * [new tag]           v0.55.1                  -> v0.55.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3670840Z  * [new tag]           v0.56.0                  -> v0.56.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3671781Z  * [new tag]           v0.57.0                  -> v0.57.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3672736Z  * [new tag]           v0.57.1                  -> v0.57.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3673825Z  * [new tag]           v0.57.2                  -> v0.57.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3674771Z  * [new tag]           v0.58.0                  -> v0.58.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3675720Z  * [new tag]           v0.58.1                  -> v0.58.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3676661Z  * [new tag]           v0.58.2                  -> v0.58.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3677590Z  * [new tag]           v0.58.3                  -> v0.58.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3678520Z  * [new tag]           v0.59.0                  -> v0.59.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3679463Z  * [new tag]           v0.59.1                  -> v0.59.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3680524Z  * [new tag]           v0.6.0                   -> v0.6.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3681470Z  * [new tag]           v0.6.1                   -> v0.6.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3682417Z  * [new tag]           v0.6.2                   -> v0.6.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3683359Z  * [new tag]           v0.60.0                  -> v0.60.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3684291Z  * [new tag]           v0.61.0                  -> v0.61.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3685242Z  * [new tag]           v0.61.1                  -> v0.61.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3686174Z  * [new tag]           v0.61.2                  -> v0.61.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3687091Z  * [new tag]           v0.61.3                  -> v0.61.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3688005Z  * [new tag]           v0.62.0                  -> v0.62.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3688932Z  * [new tag]           v0.62.1                  -> v0.62.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3689981Z  * [new tag]           v0.62.2                  -> v0.62.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3690916Z  * [new tag]           v0.62.3                  -> v0.62.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3691838Z  * [new tag]           v0.62.4                  -> v0.62.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3692776Z  * [new tag]           v0.62.5                  -> v0.62.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3693695Z  * [new tag]           v0.62.6                  -> v0.62.6
+check	UNKNOWN STEP	2026-08-30T05:02:54.3694750Z  * [new tag]           v0.63.0                  -> v0.63.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3695701Z  * [new tag]           v0.63.1                  -> v0.63.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3696646Z  * [new tag]           v0.64.0                  -> v0.64.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3697572Z  * [new tag]           v0.65.0                  -> v0.65.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3698511Z  * [new tag]           v0.66.0                  -> v0.66.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3699446Z  * [new tag]           v0.66.1                  -> v0.66.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3700620Z  * [new tag]           v0.67.0                  -> v0.67.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3701564Z  * [new tag]           v0.68.0                  -> v0.68.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3702498Z  * [new tag]           v0.69.0                  -> v0.69.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3703431Z  * [new tag]           v0.7.0                   -> v0.7.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3704367Z  * [new tag]           v0.7.1                   -> v0.7.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3705303Z  * [new tag]           v0.7.2                   -> v0.7.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3706246Z  * [new tag]           v0.7.3                   -> v0.7.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3707167Z  * [new tag]           v0.7.4                   -> v0.7.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3708091Z  * [new tag]           v0.7.5                   -> v0.7.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3709020Z  * [new tag]           v0.7.6                   -> v0.7.6
+check	UNKNOWN STEP	2026-08-30T05:02:54.3710139Z  * [new tag]           v0.7.7                   -> v0.7.7
+check	UNKNOWN STEP	2026-08-30T05:02:54.3711092Z  * [new tag]           v0.7.8                   -> v0.7.8
+check	UNKNOWN STEP	2026-08-30T05:02:54.3712027Z  * [new tag]           v0.7.9                   -> v0.7.9
+check	UNKNOWN STEP	2026-08-30T05:02:54.3712968Z  * [new tag]           v0.70.0                  -> v0.70.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3713904Z  * [new tag]           v0.71.0                  -> v0.71.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3714845Z  * [new tag]           v0.71.1                  -> v0.71.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3715786Z  * [new tag]           v0.72.0                  -> v0.72.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3716740Z  * [new tag]           v0.73.0                  -> v0.73.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3717692Z  * [new tag]           v0.73.1                  -> v0.73.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3718784Z  * [new tag]           v0.73.2                  -> v0.73.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3719720Z  * [new tag]           v0.74.0                  -> v0.74.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3720777Z  * [new tag]           v0.75.0                  -> v0.75.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3721729Z  * [new tag]           v0.76.0                  -> v0.76.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3722686Z  * [new tag]           v0.76.1                  -> v0.76.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3723649Z  * [new tag]           v0.77.0                  -> v0.77.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3724598Z  * [new tag]           v0.77.1                  -> v0.77.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3725532Z  * [new tag]           v0.77.2                  -> v0.77.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3726476Z  * [new tag]           v0.78.0                  -> v0.78.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3727417Z  * [new tag]           v0.79.0                  -> v0.79.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3728373Z  * [new tag]           v0.79.1                  -> v0.79.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3729315Z  * [new tag]           v0.79.2                  -> v0.79.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3730357Z  * [new tag]           v0.8.0                   -> v0.8.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3731288Z  * [new tag]           v0.8.1                   -> v0.8.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3732233Z  * [new tag]           v0.8.2                   -> v0.8.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3733168Z  * [new tag]           v0.8.3                   -> v0.8.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3734092Z  * [new tag]           v0.8.4                   -> v0.8.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3735011Z  * [new tag]           v0.8.5                   -> v0.8.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3735937Z  * [new tag]           v0.8.6                   -> v0.8.6
+check	UNKNOWN STEP	2026-08-30T05:02:54.3736858Z  * [new tag]           v0.8.7                   -> v0.8.7
+check	UNKNOWN STEP	2026-08-30T05:02:54.3737784Z  * [new tag]           v0.8.8                   -> v0.8.8
+check	UNKNOWN STEP	2026-08-30T05:02:54.3738720Z  * [new tag]           v0.8.9                   -> v0.8.9
+check	UNKNOWN STEP	2026-08-30T05:02:54.3739912Z  * [new tag]           v0.80.0                  -> v0.80.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3740977Z  * [new tag]           v0.80.1                  -> v0.80.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3741919Z  * [new tag]           v0.80.2                  -> v0.80.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3742865Z  * [new tag]           v0.81.0                  -> v0.81.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3743817Z  * [new tag]           v0.81.1                  -> v0.81.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3744748Z  * [new tag]           v0.82.0                  -> v0.82.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3745690Z  * [new tag]           v0.82.1                  -> v0.82.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3746632Z  * [new tag]           v0.82.2                  -> v0.82.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3747565Z  * [new tag]           v0.83.0                  -> v0.83.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3748507Z  * [new tag]           v0.83.1                  -> v0.83.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3749474Z  * [new tag]           v0.83.2                  -> v0.83.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3750604Z  * [new tag]           v0.83.3                  -> v0.83.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3751541Z  * [new tag]           v0.84.0                  -> v0.84.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3752478Z  * [new tag]           v0.85.0                  -> v0.85.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3753406Z  * [new tag]           v0.85.1                  -> v0.85.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3754341Z  * [new tag]           v0.85.2                  -> v0.85.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3755277Z  * [new tag]           v0.85.3                  -> v0.85.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3756218Z  * [new tag]           v0.86.0                  -> v0.86.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3757140Z  * [new tag]           v0.86.1                  -> v0.86.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3758110Z  * [new tag]           v0.87.0                  -> v0.87.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3759037Z  * [new tag]           v0.88.0                  -> v0.88.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3760064Z  * [new tag]           v0.89.0                  -> v0.89.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3761021Z  * [new tag]           v0.9.0                   -> v0.9.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3761959Z  * [new tag]           v0.9.1                   -> v0.9.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3763041Z  * [new tag]           v0.9.2                   -> v0.9.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3763965Z  * [new tag]           v0.9.3                   -> v0.9.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3764895Z  * [new tag]           v0.9.4                   -> v0.9.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3765829Z  * [new tag]           v0.9.5                   -> v0.9.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3766757Z  * [new tag]           v0.9.6                   -> v0.9.6
+check	UNKNOWN STEP	2026-08-30T05:02:54.3767681Z  * [new tag]           v0.9.7                   -> v0.9.7
+check	UNKNOWN STEP	2026-08-30T05:02:54.3768603Z  * [new tag]           v0.9.8                   -> v0.9.8
+check	UNKNOWN STEP	2026-08-30T05:02:54.3769531Z  * [new tag]           v0.90.0                  -> v0.90.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3770577Z  * [new tag]           v0.91.0                  -> v0.91.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3771517Z  * [new tag]           v0.91.1                  -> v0.91.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3772439Z  * [new tag]           v0.91.2                  -> v0.91.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3773372Z  * [new tag]           v0.92.0                  -> v0.92.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3774305Z  * [new tag]           v0.92.1                  -> v0.92.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3775234Z  * [new tag]           v0.93.0                  -> v0.93.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3776160Z  * [new tag]           v0.93.1                  -> v0.93.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3777077Z  * [new tag]           v0.93.2                  -> v0.93.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3778005Z  * [new tag]           v0.94.0                  -> v0.94.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3778932Z  * [new tag]           v0.95.0                  -> v0.95.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3779962Z  * [new tag]           v0.95.1                  -> v0.95.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3781026Z  * [new tag]           v0.95.2                  -> v0.95.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3781980Z  * [new tag]           v0.96.0                  -> v0.96.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3782900Z  * [new tag]           v0.97.0                  -> v0.97.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3783952Z  * [new tag]           v0.98.0                  -> v0.98.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3784865Z  * [new tag]           v0.99.0                  -> v0.99.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3785799Z  * [new tag]           v1.0.0                   -> v1.0.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3786743Z  * [new tag]           v1.1.0                   -> v1.1.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3787662Z  * [new tag]           v1.10.0                  -> v1.10.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3788585Z  * [new tag]           v1.10.1                  -> v1.10.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3789531Z  * [new tag]           v1.10.2                  -> v1.10.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3790697Z  * [new tag]           v1.10.3                  -> v1.10.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3791635Z  * [new tag]           v1.11.0                  -> v1.11.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3792577Z  * [new tag]           v1.11.1                  -> v1.11.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3793510Z  * [new tag]           v1.11.2                  -> v1.11.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3794440Z  * [new tag]           v1.11.3                  -> v1.11.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3795366Z  * [new tag]           v1.11.4                  -> v1.11.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3796292Z  * [new tag]           v1.11.5                  -> v1.11.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3797219Z  * [new tag]           v1.12.0                  -> v1.12.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3798143Z  * [new tag]           v1.12.1                  -> v1.12.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3799063Z  * [new tag]           v1.12.2                  -> v1.12.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3800089Z  * [new tag]           v1.12.3                  -> v1.12.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3801029Z  * [new tag]           v1.13.0                  -> v1.13.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3801974Z  * [new tag]           v1.13.1                  -> v1.13.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3802907Z  * [new tag]           v1.14.0                  -> v1.14.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3803821Z  * [new tag]           v1.14.1                  -> v1.14.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3804735Z  * [new tag]           v1.15.0                  -> v1.15.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3805651Z  * [new tag]           v1.15.1                  -> v1.15.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3806568Z  * [new tag]           v1.15.2                  -> v1.15.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3807653Z  * [new tag]           v1.16.0                  -> v1.16.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3808576Z  * [new tag]           v1.16.1                  -> v1.16.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3809503Z  * [new tag]           v1.16.2                  -> v1.16.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3810530Z  * [new tag]           v1.17.0                  -> v1.17.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3811437Z  * [new tag]           v1.17.1                  -> v1.17.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3812354Z  * [new tag]           v1.17.2                  -> v1.17.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3813278Z  * [new tag]           v1.18.0                  -> v1.18.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3814187Z  * [new tag]           v1.18.1                  -> v1.18.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3815092Z  * [new tag]           v1.18.2                  -> v1.18.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3816003Z  * [new tag]           v1.19.0                  -> v1.19.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3816917Z  * [new tag]           v1.19.1                  -> v1.19.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3817871Z  * [new tag]           v1.19.2                  -> v1.19.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3818781Z  * [new tag]           v1.2.0                   -> v1.2.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3819682Z  * [new tag]           v1.2.1                   -> v1.2.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3820814Z  * [new tag]           v1.2.2                   -> v1.2.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3821725Z  * [new tag]           v1.2.3                   -> v1.2.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3822632Z  * [new tag]           v1.2.4                   -> v1.2.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3823558Z  * [new tag]           v1.2.5                   -> v1.2.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3824467Z  * [new tag]           v1.20.0                  -> v1.20.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3825377Z  * [new tag]           v1.21.0                  -> v1.21.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3826280Z  * [new tag]           v1.21.1                  -> v1.21.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3827186Z  * [new tag]           v1.21.2                  -> v1.21.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3828233Z  * [new tag]           v1.22.0                  -> v1.22.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3829163Z  * [new tag]           v1.22.1                  -> v1.22.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3830298Z  * [new tag]           v1.23.0                  -> v1.23.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3831213Z  * [new tag]           v1.24.0                  -> v1.24.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3832109Z  * [new tag]           v1.25.0                  -> v1.25.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3833024Z  * [new tag]           v1.25.1                  -> v1.25.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3833935Z  * [new tag]           v1.26.0                  -> v1.26.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3834842Z  * [new tag]           v1.26.1                  -> v1.26.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3835774Z  * [new tag]           v1.26.2                  -> v1.26.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3836674Z  * [new tag]           v1.3.0                   -> v1.3.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3837560Z  * [new tag]           v1.3.1                   -> v1.3.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3838448Z  * [new tag]           v1.4.0                   -> v1.4.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3839345Z  * [new tag]           v1.4.1                   -> v1.4.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3840359Z  * [new tag]           v1.5.0                   -> v1.5.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3841253Z  * [new tag]           v1.6.0                   -> v1.6.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3842152Z  * [new tag]           v1.6.1                   -> v1.6.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3843045Z  * [new tag]           v1.6.2                   -> v1.6.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3843933Z  * [new tag]           v1.6.3                   -> v1.6.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3844825Z  * [new tag]           v1.7.0                   -> v1.7.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3845722Z  * [new tag]           v1.8.0                   -> v1.8.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3846611Z  * [new tag]           v1.8.1                   -> v1.8.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3847498Z  * [new tag]           v1.8.2                   -> v1.8.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3848389Z  * [new tag]           v1.8.3                   -> v1.8.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3849282Z  * [new tag]           v1.9.0                   -> v1.9.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3850298Z  * [new tag]           v1.9.1                   -> v1.9.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3851357Z  * [new tag]           v1.9.2                   -> v1.9.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3852263Z  * [new tag]           v2.0.0                   -> v2.0.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3853167Z  * [new tag]           v2.0.1                   -> v2.0.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3854065Z  * [new tag]           v2.1.0                   -> v2.1.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3854965Z  * [new tag]           v2.10.0                  -> v2.10.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3855880Z  * [new tag]           v2.10.1                  -> v2.10.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3856783Z  * [new tag]           v2.10.2                  -> v2.10.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3857714Z  * [new tag]           v2.11.0                  -> v2.11.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3858625Z  * [new tag]           v2.11.1                  -> v2.11.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3859518Z  * [new tag]           v2.11.2                  -> v2.11.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3860667Z  * [new tag]           v2.12.0                  -> v2.12.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3861607Z  * [new tag]           v2.12.1                  -> v2.12.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3862527Z  * [new tag]           v2.12.2                  -> v2.12.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3863438Z  * [new tag]           v2.12.3                  -> v2.12.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3864332Z  * [new tag]           v2.12.4                  -> v2.12.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3865220Z  * [new tag]           v2.12.5                  -> v2.12.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3866123Z  * [new tag]           v2.12.6                  -> v2.12.6
+check	UNKNOWN STEP	2026-08-30T05:02:54.3867007Z  * [new tag]           v2.12.7                  -> v2.12.7
+check	UNKNOWN STEP	2026-08-30T05:02:54.3867911Z  * [new tag]           v2.13.0                  -> v2.13.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3868797Z  * [new tag]           v2.13.1                  -> v2.13.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3869690Z  * [new tag]           v2.13.2                  -> v2.13.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3870775Z  * [new tag]           v2.13.3                  -> v2.13.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3871814Z  * [new tag]           v2.14.0                  -> v2.14.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3872721Z  * [new tag]           v2.14.1                  -> v2.14.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3873618Z  * [new tag]           v2.14.2                  -> v2.14.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3874500Z  * [new tag]           v2.14.3                  -> v2.14.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3875384Z  * [new tag]           v2.15.0                  -> v2.15.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3876281Z  * [new tag]           v2.15.1                  -> v2.15.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3877165Z  * [new tag]           v2.15.2                  -> v2.15.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3878046Z  * [new tag]           v2.15.3                  -> v2.15.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3878936Z  * [new tag]           v2.15.4                  -> v2.15.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3879945Z  * [new tag]           v2.16.0                  -> v2.16.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3880858Z  * [new tag]           v2.17.0                  -> v2.17.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3881754Z  * [new tag]           v2.17.1                  -> v2.17.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3882649Z  * [new tag]           v2.18.0                  -> v2.18.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3883679Z  * [new tag]           v2.18.0-52825890-nightly -> v2.18.0-52825890-nightly
+check	UNKNOWN STEP	2026-08-30T05:02:54.3884860Z  * [new tag]           v2.18.0-97002309-nightly -> v2.18.0-97002309-nightly
+check	UNKNOWN STEP	2026-08-30T05:02:54.3886044Z  * [new tag]           v2.18.0-a38ac317-nightly -> v2.18.0-a38ac317-nightly
+check	UNKNOWN STEP	2026-08-30T05:02:54.3887267Z  * [new tag]           v2.18.0-cd616d2c-nightly -> v2.18.0-cd616d2c-nightly
+check	UNKNOWN STEP	2026-08-30T05:02:54.3888489Z  * [new tag]           v2.19.0-315a4fdf-nightly -> v2.19.0-315a4fdf-nightly
+check	UNKNOWN STEP	2026-08-30T05:02:54.3889700Z  * [new tag]           v2.19.0-8afe0bba-nightly -> v2.19.0-8afe0bba-nightly
+check	UNKNOWN STEP	2026-08-30T05:02:54.3890887Z  * [new tag]           v2.2.0                   -> v2.2.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3891793Z  * [new tag]           v2.3.0                   -> v2.3.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3892684Z  * [new tag]           v2.3.1                   -> v2.3.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3893585Z  * [new tag]           v2.3.2                   -> v2.3.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3894639Z  * [new tag]           v2.4.0                   -> v2.4.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3895534Z  * [new tag]           v2.4.1                   -> v2.4.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3896433Z  * [new tag]           v2.4.2                   -> v2.4.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3897338Z  * [new tag]           v2.4.3                   -> v2.4.3
+check	UNKNOWN STEP	2026-08-30T05:02:54.3898235Z  * [new tag]           v2.4.4                   -> v2.4.4
+check	UNKNOWN STEP	2026-08-30T05:02:54.3899113Z  * [new tag]           v2.4.5                   -> v2.4.5
+check	UNKNOWN STEP	2026-08-30T05:02:54.3900171Z  * [new tag]           v2.4.6                   -> v2.4.6
+check	UNKNOWN STEP	2026-08-30T05:02:54.3901120Z  * [new tag]           v2.4.7                   -> v2.4.7
+check	UNKNOWN STEP	2026-08-30T05:02:54.3902006Z  * [new tag]           v2.4.8                   -> v2.4.8
+check	UNKNOWN STEP	2026-08-30T05:02:54.3902877Z  * [new tag]           v2.5.0                   -> v2.5.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3903743Z  * [new tag]           v2.5.1                   -> v2.5.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3904608Z  * [new tag]           v2.6.0                   -> v2.6.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3905474Z  * [new tag]           v2.6.1                   -> v2.6.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3906337Z  * [new tag]           v2.7.0                   -> v2.7.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3907194Z  * [new tag]           v2.8.0                   -> v2.8.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3908062Z  * [new tag]           v2.8.1                   -> v2.8.1
+check	UNKNOWN STEP	2026-08-30T05:02:54.3908939Z  * [new tag]           v2.8.2                   -> v2.8.2
+check	UNKNOWN STEP	2026-08-30T05:02:54.3909904Z  * [new tag]           v2.9.0                   -> v2.9.0
+check	UNKNOWN STEP	2026-08-30T05:02:54.3912059Z [command]/usr/bin/git branch --list --remote origin/main
+check	UNKNOWN STEP	2026-08-30T05:02:54.3913093Z   origin/main
+check	UNKNOWN STEP	2026-08-30T05:02:54.3914496Z [command]/usr/bin/git rev-parse refs/remotes/origin/main
+check	UNKNOWN STEP	2026-08-30T05:02:54.3915441Z 36e43dd08f724956b188af2f6f3bcfd5efd355ec
+check	UNKNOWN STEP	2026-08-30T05:02:54.3917269Z ##[endgroup]
+check	UNKNOWN STEP	2026-08-30T05:02:54.3918145Z ##[group]Determining the checkout info
+check	UNKNOWN STEP	2026-08-30T05:02:54.3919198Z ##[endgroup]
+check	UNKNOWN STEP	2026-08-30T05:02:54.3920022Z [command]/usr/bin/git sparse-checkout disable
+check	UNKNOWN STEP	2026-08-30T05:02:54.3921963Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+check	UNKNOWN STEP	2026-08-30T05:02:54.3924160Z ##[group]Checking out the ref
+check	UNKNOWN STEP	2026-08-30T05:02:54.3925271Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+check	UNKNOWN STEP	2026-08-30T05:02:54.4338883Z Switched to a new branch 'main'
+check	UNKNOWN STEP	2026-08-30T05:02:54.4343727Z branch 'main' set up to track 'origin/main'.
+check	UNKNOWN STEP	2026-08-30T05:02:54.4352873Z ##[endgroup]
+check	UNKNOWN STEP	2026-08-30T05:02:54.4403182Z [command]/usr/bin/git log -1 --format=%H
+check	UNKNOWN STEP	2026-08-30T05:02:54.4430454Z 36e43dd08f724956b188af2f6f3bcfd5efd355ec
+check	UNKNOWN STEP	2026-08-30T05:02:54.4700959Z ##[group]Run goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94
+check	UNKNOWN STEP	2026-08-30T05:02:54.4702179Z with:
+check	UNKNOWN STEP	2026-08-30T05:02:54.4702665Z   distribution: goreleaser-pro
+check	UNKNOWN STEP	2026-08-30T05:02:54.4703303Z   version: ~> 2
+check	UNKNOWN STEP	2026-08-30T05:02:54.4703781Z   args: check
+check	UNKNOWN STEP	2026-08-30T05:02:54.4704248Z   workdir: .
+check	UNKNOWN STEP	2026-08-30T05:02:54.4704722Z   install-only: false
+check	UNKNOWN STEP	2026-08-30T05:02:54.4705246Z env:
+check	UNKNOWN STEP	2026-08-30T05:02:54.4705977Z   GORELEASER_KEY: ***
+check	UNKNOWN STEP	2026-08-30T05:02:54.4706507Z ##[endgroup]
+check	UNKNOWN STEP	2026-08-30T05:02:54.8774197Z Downloading https://github.com/goreleaser/goreleaser-pro/releases/download/v2.18.0/goreleaser-pro_Linux_x86_64.tar.gz
+check	UNKNOWN STEP	2026-08-30T05:02:55.4241694Z Downloading https://github.com/goreleaser/goreleaser-pro/releases/download/v2.18.0/checksums.txt
+check	UNKNOWN STEP	2026-08-30T05:02:55.7091839Z Checksum verified for goreleaser-pro_Linux_x86_64.tar.gz
+check	UNKNOWN STEP	2026-08-30T05:02:55.7114386Z cosign not found in PATH, skipping signature verification
+check	UNKNOWN STEP	2026-08-30T05:02:55.7115273Z Extracting GoReleaser
+check	UNKNOWN STEP	2026-08-30T05:02:55.7217199Z [command]/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/7cdff03c-8f04-4297-8fe6-4c1ccfffd09f -f /home/runner/work/_temp/fba49fb6-65a6-4524-8129-222650c2c755
+check	UNKNOWN STEP	2026-08-30T05:02:56.3367726Z GoReleaser ~> 2 installed successfully
+check	UNKNOWN STEP	2026-08-30T05:02:56.3440148Z [command]/opt/hostedtoolcache/goreleaser-action/2.18.0/x64/goreleaser check
+check	UNKNOWN STEP	2026-08-30T05:02:56.4659332Z ^[[1;94m  •^[[m by using this software you agree with its EULA, available at https://goreleaser.com/eula
+check	UNKNOWN STEP	2026-08-30T05:02:56.4660711Z ^[[1;94m  •^[[m running goreleaser v2.18.0
+check	UNKNOWN STEP	2026-08-30T05:02:56.4679952Z ^[[1;94m  •^[[m ^[[1mchecking^[[m                                  ^[[1;94mpath^[[m=.goreleaser.yaml
+check	UNKNOWN STEP	2026-08-30T05:03:01.1293095Z ^[[1;94m  •^[[m ^[[1m1 configuration file(s) validated^[[m
+check	UNKNOWN STEP	2026-08-30T05:03:01.1293753Z ^[[1;94m  •^[[m thanks for using GoReleaser Pro!
+check	UNKNOWN STEP	2026-08-30T05:03:01.1764895Z Post job cleanup.
+check	UNKNOWN STEP	2026-08-30T05:03:01.2600995Z [command]/usr/bin/git version
+check	UNKNOWN STEP	2026-08-30T05:03:01.2637021Z git version 2.55.0
+check	UNKNOWN STEP	2026-08-30T05:03:01.2676952Z Temporarily overriding HOME='/home/runner/work/_temp/f06a53bc-e12d-4cfc-8375-d5509880a0ae' before making global git config changes
+check	UNKNOWN STEP	2026-08-30T05:03:01.2678458Z Adding repository directory to the temporary git global config as a safe directory
+check	UNKNOWN STEP	2026-08-30T05:03:01.2682854Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/goreleaser/goreleaser
+check	UNKNOWN STEP	2026-08-30T05:03:01.2715131Z Removing SSH command configuration
+check	UNKNOWN STEP	2026-08-30T05:03:01.2722095Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+check	UNKNOWN STEP	2026-08-30T05:03:01.2757295Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+check	UNKNOWN STEP	2026-08-30T05:03:01.2991664Z Removing HTTP extra header
+check	UNKNOWN STEP	2026-08-30T05:03:01.2997834Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+check	UNKNOWN STEP	2026-08-30T05:03:01.3032815Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+check	UNKNOWN STEP	2026-08-30T05:03:01.3264007Z Removing includeIf entries pointing to credentials config files
+check	UNKNOWN STEP	2026-08-30T05:03:01.3269368Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+check	UNKNOWN STEP	2026-08-30T05:03:01.3297064Z includeif.gitdir:/home/runner/work/goreleaser/goreleaser/.git.path
+check	UNKNOWN STEP	2026-08-30T05:03:01.3297905Z includeif.gitdir:/home/runner/work/goreleaser/goreleaser/.git/worktrees/*.path
+check	UNKNOWN STEP	2026-08-30T05:03:01.3298411Z includeif.gitdir:/github/workspace/.git.path
+check	UNKNOWN STEP	2026-08-30T05:03:01.3298858Z includeif.gitdir:/github/workspace/.git/worktrees/*.path
+check	UNKNOWN STEP	2026-08-30T05:03:01.3305930Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/home/runner/work/goreleaser/goreleaser/.git.path
+check	UNKNOWN STEP	2026-08-30T05:03:01.3329310Z /home/runner/work/_temp/git-credentials-54b9e991-6819-4be3-9526-abc4b46ae277.config
+check	UNKNOWN STEP	2026-08-30T05:03:01.3338898Z [command]/usr/bin/git config --local --unset includeif.gitdir:/home/runner/work/goreleaser/goreleaser/.git.path \/home\/runner\/work\/_temp\/git\-credentials\-54b9e991\-6819\-4be3\-9526\-abc4b46ae277\.config
+check	UNKNOWN STEP	2026-08-30T05:03:01.3372767Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/home/runner/work/goreleaser/goreleaser/.git/worktrees/*.path
+check	UNKNOWN STEP	2026-08-30T05:03:01.3395381Z /home/runner/work/_temp/git-credentials-54b9e991-6819-4be3-9526-abc4b46ae277.config
+check	UNKNOWN STEP	2026-08-30T05:03:01.3405930Z [command]/usr/bin/git config --local --unset includeif.gitdir:/home/runner/work/goreleaser/goreleaser/.git/worktrees/*.path \/home\/runner\/work\/_temp\/git\-credentials\-54b9e991\-6819\-4be3\-9526\-abc4b46ae277\.config
+check	UNKNOWN STEP	2026-08-30T05:03:01.3440886Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/github/workspace/.git.path
+check	UNKNOWN STEP	2026-08-30T05:03:01.3463479Z /github/runner_temp/git-credentials-54b9e991-6819-4be3-9526-abc4b46ae277.config
+check	UNKNOWN STEP	2026-08-30T05:03:01.3470721Z [command]/usr/bin/git config --local --unset includeif.gitdir:/github/workspace/.git.path \/github\/runner_temp\/git\-credentials\-54b9e991\-6819\-4be3\-9526\-abc4b46ae277\.config
+check	UNKNOWN STEP	2026-08-30T05:03:01.3501718Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/github/workspace/.git/worktrees/*.path
+check	UNKNOWN STEP	2026-08-30T05:03:01.3522849Z /github/runner_temp/git-credentials-54b9e991-6819-4be3-9526-abc4b46ae277.config
+check	UNKNOWN STEP	2026-08-30T05:03:01.3530307Z [command]/usr/bin/git config --local --unset includeif.gitdir:/github/workspace/.git/worktrees/*.path \/github\/runner_temp\/git\-credentials\-54b9e991\-6819\-4be3\-9526\-abc4b46ae277\.config
+check	UNKNOWN STEP	2026-08-30T05:03:01.3563869Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+check	UNKNOWN STEP	2026-08-30T05:03:01.3790656Z Removing credentials config '/home/runner/work/_temp/git-credentials-54b9e991-6819-4be3-9526-abc4b46ae277.config'
+check	UNKNOWN STEP	2026-08-30T05:03:01.3938481Z Cleaning up orphan processes
+test (ubuntu-latest)	UNKNOWN STEP	﻿2026-08-30T05:02:50.1982582Z Current runner version: '2.336.0'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2051519Z ##[group]Runner Image Provisioner
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2052885Z Hosted Compute Agent
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2054133Z Version: 20260819.586
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2055356Z Commit: 3cc4a88dfa507ef76119ad1bb3eccc6378bb2b76
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2056635Z Build Date: 2026-08-18T23:20:18Z
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2057895Z Worker ID: {53877c74-a954-4faa-bfc2-e8290eb82be7}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2059094Z Azure Region: eastus
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2060249Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2062452Z ##[group]Operating System
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2063504Z Ubuntu
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2064825Z 24.04.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2065695Z LTS
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2066692Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2067633Z ##[group]Runner Image
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2068567Z Image: ubuntu-24.04
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2069636Z Version: 20260823.283.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2071800Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260823.283/images/ubuntu/Ubuntu2404-Readme.md
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2074853Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260823.283
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2076642Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2078515Z ##[group]GITHUB_TOKEN Permissions
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2081652Z Contents: read
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2082611Z Metadata: read
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2083898Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2087463Z Secret source: Actions
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2089662Z Prepare workflow directory
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2654823Z Prepare all required actions
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.2726158Z Getting action download info
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.5749247Z Download action repository 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1' (SHA:3d3c42e5aac5ba805825da76410c181273ba90b1)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.7121108Z Download action repository 'go-task/setup-task@a00fbb05ce67b35648be3c78cbc9fd85354c757e' (SHA:a00fbb05ce67b35648be3c78cbc9fd85354c757e)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:50.8545376Z Download action repository 'docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8' (SHA:96fe6ef7f33517b61c61be40b68a1882f3264fb8)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:51.0298119Z Download action repository 'docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e' (SHA:37fe631027851001ddb9b187196cc803df7f5f0e)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:51.2175541Z Download action repository 'crazy-max/ghaction-upx@c83f378efc804f828e988debb88ed6116feb2368' (SHA:c83f378efc804f828e988debb88ed6116feb2368)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:51.3297279Z Download action repository 'actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9' (SHA:55cc8345863c7cc4c66a329aec7e433d2d1c52a9)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:51.4403734Z Download action repository 'cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24' (SHA:13d8dd58da0234aa297dedd986986ccb8e7f3e24)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:51.5204248Z Download action repository 'actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e' (SHA:b7ad1dad31e06c5925ef5d2fc7ad053ef454303e)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:51.6777735Z Download action repository 'actions/setup-node@820762786026740c76f36085b0efc47a31fe5020' (SHA:820762786026740c76f36085b0efc47a31fe5020)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:51.7603979Z Download action repository 'mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29' (SHA:d1434d08867e3ee9daa34448df10607b98908d29)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:53.0060277Z Download action repository 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6' (SHA:0c5077e51419868618aeaa5fe8019c62421857d6)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:53.1298650Z Download action repository 'denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed' (SHA:22d081ff2d3a40755e97629de92e3bcbfa7cf2ed)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:53.2718689Z Download action repository 'cargo-bins/cargo-binstall@75b4bfae1b2c753a6806bbce6e6cb89b602de33c' (SHA:75b4bfae1b2c753a6806bbce6e6cb89b602de33c)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:53.4002530Z Download action repository 'astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d' (SHA:20cfd1bf945f4377ade1205e4dbc17946fc9a30d)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:53.5859706Z Download action repository 'sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6' (SHA:6f9f17788090df1f26f669e9d70d6ae9567deba6)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:53.6674969Z Download action repository 'anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610' (SHA:e22c389904149dbc22b58101806040fa8d37a610)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:53.7958239Z Download action repository 'codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f' (SHA:fb8b3582c8e4def4969c97caa2f19720cb33a72f)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.0730626Z Getting action download info
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.1361677Z Download action repository 'actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd' (SHA:ed597411d8f924073f98dfc5c65a23a2325f34cd)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.2885434Z Complete job name: test (ubuntu-latest)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.3562492Z ##[group]Run actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.3563207Z with:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.3563425Z   fetch-depth: 0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.3563927Z   repository: goreleaser/goreleaser
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.3566532Z   token: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.3566753Z   ssh-strict: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.3566964Z   ssh-user: git
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.3567204Z   persist-credentials: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.3567444Z   clean: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.3567678Z   sparse-checkout-cone-mode: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.3567971Z   fetch-tags: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.3568197Z   show-progress: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.3568411Z   lfs: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.3568606Z   submodules: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.3568821Z   set-safe-directory: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.3569072Z   allow-unsafe-pr-checkout: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.3569586Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.3569815Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.3570084Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4543076Z Syncing repository: goreleaser/goreleaser
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4545255Z ##[group]Getting Git version info
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4545952Z Working directory is '/home/runner/work/goreleaser/goreleaser'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4546987Z [command]/usr/bin/git version
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4647656Z git version 2.55.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4668345Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4678442Z Temporarily overriding HOME='/home/runner/work/_temp/1438ca69-8827-4562-91cf-e92955f17fb4' before making global git config changes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4679364Z Adding repository directory to the temporary git global config as a safe directory
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4683869Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/goreleaser/goreleaser
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4738414Z Deleting the contents of '/home/runner/work/goreleaser/goreleaser'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4741637Z ##[group]Determining repository object format
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4742982Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4743824Z ##[group]Initializing the repository
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4747514Z [command]/usr/bin/git init /home/runner/work/goreleaser/goreleaser
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4886272Z hint: Using 'master' as the name for the initial branch. This default branch name
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4887394Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4888098Z hint: to use in all of your new repositories, which will suppress this warning,
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4888651Z hint: call:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4888897Z hint:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4889242Z hint: 	git config --global init.defaultBranch <name>
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4889838Z hint:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4890520Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4891319Z hint: 'development'. The just-created branch can be renamed via this command:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4892184Z hint:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4892666Z hint: 	git branch -m <name>
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4893222Z hint:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4894361Z hint: Disable this message with "git config set advice.defaultBranchName false"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4895706Z Initialized empty Git repository in /home/runner/work/goreleaser/goreleaser/.git/
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4902276Z [command]/usr/bin/git remote add origin https://github.com/goreleaser/goreleaser
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4950014Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4950737Z ##[group]Disabling automatic garbage collection
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4954735Z [command]/usr/bin/git config --local gc.auto 0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4983484Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4984836Z ##[group]Setting up auth
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4985395Z Removing SSH command configuration
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.4990622Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.5021121Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.5459333Z Removing HTTP extra header
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.5465407Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.5511688Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.5736195Z Removing includeIf entries pointing to credentials config files
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.5741891Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.5775444Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.6012378Z [command]/usr/bin/git config --file /home/runner/work/_temp/git-credentials-d68c473e-b985-464a-82b1-61057d331eb9.config http.https://github.com/.extraheader AUTHORIZATION: basic ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.6050733Z [command]/usr/bin/git config --local includeIf.gitdir:/home/runner/work/goreleaser/goreleaser/.git.path /home/runner/work/_temp/git-credentials-d68c473e-b985-464a-82b1-61057d331eb9.config
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.6080885Z [command]/usr/bin/git config --local includeIf.gitdir:/home/runner/work/goreleaser/goreleaser/.git/worktrees/*.path /home/runner/work/_temp/git-credentials-d68c473e-b985-464a-82b1-61057d331eb9.config
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.6115309Z [command]/usr/bin/git config --local includeIf.gitdir:/github/workspace/.git.path /github/runner_temp/git-credentials-d68c473e-b985-464a-82b1-61057d331eb9.config
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.6144750Z [command]/usr/bin/git config --local includeIf.gitdir:/github/workspace/.git/worktrees/*.path /github/runner_temp/git-credentials-d68c473e-b985-464a-82b1-61057d331eb9.config
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.6169810Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.6170334Z ##[group]Fetching the repository
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:54.6176656Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5204259Z From https://github.com/goreleaser/goreleaser
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5206144Z  * [new branch]        artifacts-vars           -> origin/artifacts-vars
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5207063Z  * [new branch]        ci                       -> origin/ci
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5208302Z  * [new branch]        copilot/fix-argo-cd-secondary-rate-limit -> origin/copilot/fix-argo-cd-secondary-rate-limit
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5209679Z  * [new branch]        copilot/fix-test         -> origin/copilot/fix-test
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5210887Z  * [new branch]        fix-termux-package-architecture -> origin/fix-termux-package-architecture
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5212272Z  * [new branch]        fix/winget-arm64-duplicate-check -> origin/fix/winget-arm64-duplicate-check
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5213380Z  * [new branch]        goarm-fix                -> origin/goarm-fix
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5214588Z  * [new branch]        goreleaser-bugs2         -> origin/goreleaser-bugs2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5215736Z  * [new branch]        goreleaser-install-script -> origin/goreleaser-install-script
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5216804Z  * [new branch]        main                     -> origin/main
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5217468Z  * [new branch]        nix                      -> origin/nix
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5218146Z  * [new branch]        nodejs-sea2              -> origin/nodejs-sea2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5218875Z  * [new branch]        nodejs-wip               -> origin/nodejs-wip
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5220034Z  * [new branch]        patch-1                  -> origin/patch-1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5220755Z  * [new branch]        quill-update             -> origin/quill-update
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5221551Z  * [new branch]        release-token            -> origin/release-token
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5222265Z  * [new branch]        zig-cache                -> origin/zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5222683Z  * [new tag]           nightly                  -> nightly
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5223089Z  * [new tag]           v0.0.1                   -> v0.0.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5223891Z  * [new tag]           v0.0.2                   -> v0.0.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5224294Z  * [new tag]           v0.0.3                   -> v0.0.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5224629Z  * [new tag]           v0.0.4                   -> v0.0.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5224955Z  * [new tag]           v0.0.5                   -> v0.0.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5225548Z  * [new tag]           v0.0.6                   -> v0.0.6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5226142Z  * [new tag]           v0.0.7                   -> v0.0.7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5226731Z  * [new tag]           v0.0.8                   -> v0.0.8
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5227361Z  * [new tag]           v0.0.9                   -> v0.0.9
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5227955Z  * [new tag]           v0.1.0                   -> v0.1.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5228606Z  * [new tag]           v0.1.1                   -> v0.1.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5253836Z  * [new tag]           v0.1.2                   -> v0.1.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5254595Z  * [new tag]           v0.1.3                   -> v0.1.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5255314Z  * [new tag]           v0.1.4                   -> v0.1.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5255784Z  * [new tag]           v0.1.5                   -> v0.1.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5256157Z  * [new tag]           v0.1.6                   -> v0.1.6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5256506Z  * [new tag]           v0.1.7                   -> v0.1.7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5256841Z  * [new tag]           v0.1.8                   -> v0.1.8
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5257176Z  * [new tag]           v0.1.9                   -> v0.1.9
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5257505Z  * [new tag]           v0.10.0                  -> v0.10.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5257853Z  * [new tag]           v0.100.0                 -> v0.100.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5258200Z  * [new tag]           v0.101.0                 -> v0.101.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5258526Z  * [new tag]           v0.102.0                 -> v0.102.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5258851Z  * [new tag]           v0.103.0                 -> v0.103.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5259183Z  * [new tag]           v0.103.1                 -> v0.103.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5259507Z  * [new tag]           v0.104.0                 -> v0.104.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5259829Z  * [new tag]           v0.104.1                 -> v0.104.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5260172Z  * [new tag]           v0.104.2                 -> v0.104.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5260501Z  * [new tag]           v0.104.3                 -> v0.104.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5260838Z  * [new tag]           v0.105.0                 -> v0.105.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5261171Z  * [new tag]           v0.106.0                 -> v0.106.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5261494Z  * [new tag]           v0.107.0                 -> v0.107.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5261816Z  * [new tag]           v0.108.0                 -> v0.108.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5262141Z  * [new tag]           v0.109.0                 -> v0.109.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5262473Z  * [new tag]           v0.11.0                  -> v0.11.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5262806Z  * [new tag]           v0.11.1                  -> v0.11.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5263143Z  * [new tag]           v0.110.0                 -> v0.110.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5263471Z  * [new tag]           v0.111.0                 -> v0.111.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5264458Z  * [new tag]           v0.112.0                 -> v0.112.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5265063Z  * [new tag]           v0.112.1                 -> v0.112.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5265694Z  * [new tag]           v0.112.2                 -> v0.112.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5266612Z  * [new tag]           v0.113.0                 -> v0.113.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5267199Z  * [new tag]           v0.113.1                 -> v0.113.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5267817Z  * [new tag]           v0.114.0                 -> v0.114.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5268450Z  * [new tag]           v0.114.1                 -> v0.114.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5269043Z  * [new tag]           v0.115.0                 -> v0.115.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5269670Z  * [new tag]           v0.116.0                 -> v0.116.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5270521Z  * [new tag]           v0.117.0                 -> v0.117.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5271157Z  * [new tag]           v0.117.1                 -> v0.117.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5271799Z  * [new tag]           v0.117.2                 -> v0.117.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5272450Z  * [new tag]           v0.118.0                 -> v0.118.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5273084Z  * [new tag]           v0.118.1                 -> v0.118.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5274023Z  * [new tag]           v0.118.2                 -> v0.118.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5274688Z  * [new tag]           v0.119.0                 -> v0.119.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5275335Z  * [new tag]           v0.12.0                  -> v0.12.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5275965Z  * [new tag]           v0.12.1                  -> v0.12.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5276688Z  * [new tag]           v0.12.2                  -> v0.12.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5277292Z  * [new tag]           v0.12.3                  -> v0.12.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5277931Z  * [new tag]           v0.120.0                 -> v0.120.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5278396Z  * [new tag]           v0.120.1                 -> v0.120.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5278764Z  * [new tag]           v0.120.2                 -> v0.120.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5279146Z  * [new tag]           v0.120.3                 -> v0.120.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5279519Z  * [new tag]           v0.120.4                 -> v0.120.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5279877Z  * [new tag]           v0.120.5                 -> v0.120.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5280254Z  * [new tag]           v0.120.6                 -> v0.120.6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5280620Z  * [new tag]           v0.120.7                 -> v0.120.7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5280981Z  * [new tag]           v0.120.8                 -> v0.120.8
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5281354Z  * [new tag]           v0.121.0                 -> v0.121.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5281718Z  * [new tag]           v0.122.0                 -> v0.122.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5282081Z  * [new tag]           v0.123.0                 -> v0.123.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5282454Z  * [new tag]           v0.123.1                 -> v0.123.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5282819Z  * [new tag]           v0.123.2                 -> v0.123.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5283182Z  * [new tag]           v0.123.3                 -> v0.123.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5283851Z  * [new tag]           v0.124.0                 -> v0.124.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5284241Z  * [new tag]           v0.124.1                 -> v0.124.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5284609Z  * [new tag]           v0.125.0                 -> v0.125.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5284970Z  * [new tag]           v0.126.0                 -> v0.126.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5285327Z  * [new tag]           v0.127.0                 -> v0.127.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5285694Z  * [new tag]           v0.128.0                 -> v0.128.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5286052Z  * [new tag]           v0.129.0                 -> v0.129.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5286414Z  * [new tag]           v0.13.0                  -> v0.13.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5286793Z  * [new tag]           v0.13.1                  -> v0.13.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5287163Z  * [new tag]           v0.13.2                  -> v0.13.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5287522Z  * [new tag]           v0.13.3                  -> v0.13.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5287890Z  * [new tag]           v0.13.4                  -> v0.13.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5288249Z  * [new tag]           v0.13.5                  -> v0.13.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5288602Z  * [new tag]           v0.13.6                  -> v0.13.6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5289148Z  * [new tag]           v0.130.0                 -> v0.130.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5289513Z  * [new tag]           v0.130.1                 -> v0.130.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5289877Z  * [new tag]           v0.130.2                 -> v0.130.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5290248Z  * [new tag]           v0.131.0                 -> v0.131.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5290772Z  * [new tag]           v0.131.1                 -> v0.131.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5291141Z  * [new tag]           v0.132.0                 -> v0.132.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5291620Z  * [new tag]           v0.132.1                 -> v0.132.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5291994Z  * [new tag]           v0.133.0                 -> v0.133.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5292367Z  * [new tag]           v0.134.0                 -> v0.134.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5292730Z  * [new tag]           v0.135.0                 -> v0.135.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5293092Z  * [new tag]           v0.136.0                 -> v0.136.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5293459Z  * [new tag]           v0.137.0                 -> v0.137.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5293996Z  * [new tag]           v0.138.0                 -> v0.138.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5294374Z  * [new tag]           v0.139.0                 -> v0.139.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5294746Z  * [new tag]           v0.14.0                  -> v0.14.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5295114Z  * [new tag]           v0.140.0                 -> v0.140.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5295475Z  * [new tag]           v0.140.1                 -> v0.140.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5295834Z  * [new tag]           v0.141.0                 -> v0.141.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5296203Z  * [new tag]           v0.142.0                 -> v0.142.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5296573Z  * [new tag]           v0.143.0                 -> v0.143.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5296934Z  * [new tag]           v0.144.0                 -> v0.144.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5297299Z  * [new tag]           v0.144.1                 -> v0.144.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5297663Z  * [new tag]           v0.145.0                 -> v0.145.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5298028Z  * [new tag]           v0.146.0                 -> v0.146.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5298386Z  * [new tag]           v0.147.0                 -> v0.147.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5298754Z  * [new tag]           v0.147.1                 -> v0.147.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5299117Z  * [new tag]           v0.147.2                 -> v0.147.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5299482Z  * [new tag]           v0.148.0                 -> v0.148.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5299840Z  * [new tag]           v0.149.0                 -> v0.149.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5300212Z  * [new tag]           v0.15.0                  -> v0.15.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5300586Z  * [new tag]           v0.15.1                  -> v0.15.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5300954Z  * [new tag]           v0.150.0                 -> v0.150.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5301315Z  * [new tag]           v0.150.1                 -> v0.150.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5301672Z  * [new tag]           v0.151.0                 -> v0.151.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5302038Z  * [new tag]           v0.151.1                 -> v0.151.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5302398Z  * [new tag]           v0.151.2                 -> v0.151.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5302766Z  * [new tag]           v0.152.0                 -> v0.152.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5303130Z  * [new tag]           v0.153.0                 -> v0.153.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5303486Z  * [new tag]           v0.154.0                 -> v0.154.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5304033Z  * [new tag]           v0.155.0                 -> v0.155.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5304395Z  * [new tag]           v0.155.1                 -> v0.155.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5304759Z  * [new tag]           v0.155.2                 -> v0.155.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5305125Z  * [new tag]           v0.156.0                 -> v0.156.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5305489Z  * [new tag]           v0.156.1                 -> v0.156.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5305850Z  * [new tag]           v0.156.2                 -> v0.156.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5306214Z  * [new tag]           v0.157.0                 -> v0.157.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5306716Z  * [new tag]           v0.158.0                 -> v0.158.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5307083Z  * [new tag]           v0.159.0                 -> v0.159.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5307450Z  * [new tag]           v0.16.0                  -> v0.16.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5307819Z  * [new tag]           v0.16.1                  -> v0.16.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5308182Z  * [new tag]           v0.160.0                 -> v0.160.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5308547Z  * [new tag]           v0.161.0                 -> v0.161.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5309019Z  * [new tag]           v0.161.1                 -> v0.161.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5309397Z  * [new tag]           v0.162.0                 -> v0.162.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5309762Z  * [new tag]           v0.162.1                 -> v0.162.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5310120Z  * [new tag]           v0.163.0                 -> v0.163.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5310483Z  * [new tag]           v0.163.1                 -> v0.163.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5310856Z  * [new tag]           v0.164.0                 -> v0.164.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5311225Z  * [new tag]           v0.165.0                 -> v0.165.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5311582Z  * [new tag]           v0.166.0                 -> v0.166.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5311941Z  * [new tag]           v0.166.1                 -> v0.166.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5312298Z  * [new tag]           v0.166.2                 -> v0.166.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5312661Z  * [new tag]           v0.167.0                 -> v0.167.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5313025Z  * [new tag]           v0.168.0                 -> v0.168.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5313396Z  * [new tag]           v0.168.1                 -> v0.168.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5314019Z  * [new tag]           v0.168.2                 -> v0.168.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5314386Z  * [new tag]           v0.169.0                 -> v0.169.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5314747Z  * [new tag]           v0.17.0                  -> v0.17.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5315119Z  * [new tag]           v0.17.1                  -> v0.17.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5315503Z  * [new tag]           v0.17.2                  -> v0.17.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5315870Z  * [new tag]           v0.17.3                  -> v0.17.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5316231Z  * [new tag]           v0.17.4                  -> v0.17.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5316598Z  * [new tag]           v0.17.5                  -> v0.17.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5316975Z  * [new tag]           v0.17.6                  -> v0.17.6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5317349Z  * [new tag]           v0.170.0                 -> v0.170.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5317735Z  * [new tag]           v0.171.0                 -> v0.171.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5318342Z  * [new tag]           v0.172.0                 -> v0.172.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5319028Z  * [new tag]           v0.172.1                 -> v0.172.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5319609Z  * [new tag]           v0.173.0                 -> v0.173.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5320186Z  * [new tag]           v0.173.1                 -> v0.173.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5320896Z  * [new tag]           v0.173.2                 -> v0.173.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5321585Z  * [new tag]           v0.174.0                 -> v0.174.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5322322Z  * [new tag]           v0.174.1                 -> v0.174.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5322989Z  * [new tag]           v0.174.2                 -> v0.174.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5323876Z  * [new tag]           v0.175.0                 -> v0.175.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5324521Z  * [new tag]           v0.176.0                 -> v0.176.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5325139Z  * [new tag]           v0.177.0                 -> v0.177.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5325777Z  * [new tag]           v0.178.0                 -> v0.178.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5326380Z  * [new tag]           v0.179.0                 -> v0.179.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5326998Z  * [new tag]           v0.18.0                  -> v0.18.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5327660Z  * [new tag]           v0.18.1                  -> v0.18.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5328364Z  * [new tag]           v0.180.0                 -> v0.180.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5329357Z  * [new tag]           v0.180.1                 -> v0.180.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5329998Z  * [new tag]           v0.180.2                 -> v0.180.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5330641Z  * [new tag]           v0.180.3                 -> v0.180.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5331257Z  * [new tag]           v0.181.0                 -> v0.181.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5331859Z  * [new tag]           v0.181.1                 -> v0.181.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5332459Z  * [new tag]           v0.182.0                 -> v0.182.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5333253Z  * [new tag]           v0.182.1                 -> v0.182.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5334140Z  * [new tag]           v0.183.0                 -> v0.183.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5334761Z  * [new tag]           v0.184.0                 -> v0.184.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5335370Z  * [new tag]           v0.19.0                  -> v0.19.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5336031Z  * [new tag]           v0.2.0                   -> v0.2.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5336916Z  * [new tag]           v0.2.1                   -> v0.2.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5337313Z  * [new tag]           v0.2.2                   -> v0.2.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5337697Z  * [new tag]           v0.2.3                   -> v0.2.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5338050Z  * [new tag]           v0.2.4                   -> v0.2.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5338402Z  * [new tag]           v0.2.5                   -> v0.2.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5338760Z  * [new tag]           v0.2.6                   -> v0.2.6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5339116Z  * [new tag]           v0.2.7                   -> v0.2.7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5339474Z  * [new tag]           v0.2.8                   -> v0.2.8
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5339834Z  * [new tag]           v0.2.9                   -> v0.2.9
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5340194Z  * [new tag]           v0.20.0                  -> v0.20.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5340559Z  * [new tag]           v0.20.1                  -> v0.20.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5340921Z  * [new tag]           v0.20.2                  -> v0.20.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5341286Z  * [new tag]           v0.20.3                  -> v0.20.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5341643Z  * [new tag]           v0.20.4                  -> v0.20.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5342005Z  * [new tag]           v0.21.0                  -> v0.21.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5342367Z  * [new tag]           v0.21.1                  -> v0.21.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5342891Z  * [new tag]           v0.21.2                  -> v0.21.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5343721Z  * [new tag]           v0.21.3                  -> v0.21.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5344419Z  * [new tag]           v0.21.4                  -> v0.21.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5345038Z  * [new tag]           v0.21.5                  -> v0.21.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5345427Z  * [new tag]           v0.22.0                  -> v0.22.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5345798Z  * [new tag]           v0.22.1                  -> v0.22.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5346165Z  * [new tag]           v0.22.2                  -> v0.22.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5346522Z  * [new tag]           v0.23.0                  -> v0.23.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5346886Z  * [new tag]           v0.23.1                  -> v0.23.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5347246Z  * [new tag]           v0.24.0                  -> v0.24.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5347604Z  * [new tag]           v0.25.0                  -> v0.25.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5347961Z  * [new tag]           v0.26.0                  -> v0.26.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5348317Z  * [new tag]           v0.26.1                  -> v0.26.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5348674Z  * [new tag]           v0.27.0                  -> v0.27.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5349035Z  * [new tag]           v0.27.1                  -> v0.27.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5349392Z  * [new tag]           v0.27.2                  -> v0.27.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5349747Z  * [new tag]           v0.27.3                  -> v0.27.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5350106Z  * [new tag]           v0.27.4                  -> v0.27.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5350469Z  * [new tag]           v0.27.5                  -> v0.27.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5350824Z  * [new tag]           v0.28.0                  -> v0.28.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5351380Z  * [new tag]           v0.28.1                  -> v0.28.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5351930Z  * [new tag]           v0.28.2                  -> v0.28.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5352603Z  * [new tag]           v0.28.3                  -> v0.28.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5353138Z  * [new tag]           v0.28.4                  -> v0.28.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5353804Z  * [new tag]           v0.28.5                  -> v0.28.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5354519Z  * [new tag]           v0.28.6                  -> v0.28.6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5355511Z  * [new tag]           v0.28.7                  -> v0.28.7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5356267Z  * [new tag]           v0.28.8                  -> v0.28.8
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5356930Z  * [new tag]           v0.28.9                  -> v0.28.9
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5357567Z  * [new tag]           v0.3.0                   -> v0.3.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5358214Z  * [new tag]           v0.3.1                   -> v0.3.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5358903Z  * [new tag]           v0.3.2                   -> v0.3.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5359545Z  * [new tag]           v0.3.4                   -> v0.3.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5360163Z  * [new tag]           v0.3.5                   -> v0.3.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5360788Z  * [new tag]           v0.3.6                   -> v0.3.6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5361407Z  * [new tag]           v0.30.0                  -> v0.30.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5362027Z  * [new tag]           v0.30.1                  -> v0.30.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5362704Z  * [new tag]           v0.30.2                  -> v0.30.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5363399Z  * [new tag]           v0.30.3                  -> v0.30.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5364347Z  * [new tag]           v0.30.4                  -> v0.30.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5364979Z  * [new tag]           v0.30.5                  -> v0.30.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5365630Z  * [new tag]           v0.31.0                  -> v0.31.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5366278Z  * [new tag]           v0.31.1                  -> v0.31.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5366898Z  * [new tag]           v0.32.0                  -> v0.32.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5367497Z  * [new tag]           v0.32.1                  -> v0.32.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5368098Z  * [new tag]           v0.32.2                  -> v0.32.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5368696Z  * [new tag]           v0.33.0                  -> v0.33.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5369302Z  * [new tag]           v0.33.1                  -> v0.33.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5369914Z  * [new tag]           v0.33.2                  -> v0.33.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5370523Z  * [new tag]           v0.34.0                  -> v0.34.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5371398Z  * [new tag]           v0.34.1                  -> v0.34.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5371868Z  * [new tag]           v0.34.2                  -> v0.34.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5372250Z  * [new tag]           v0.34.3                  -> v0.34.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5372626Z  * [new tag]           v0.34.4                  -> v0.34.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5372998Z  * [new tag]           v0.34.5                  -> v0.34.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5373359Z  * [new tag]           v0.35.0                  -> v0.35.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5374042Z  * [new tag]           v0.35.1                  -> v0.35.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5374407Z  * [new tag]           v0.35.2                  -> v0.35.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5374770Z  * [new tag]           v0.35.3                  -> v0.35.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5375135Z  * [new tag]           v0.35.4                  -> v0.35.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5375493Z  * [new tag]           v0.35.5                  -> v0.35.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5375856Z  * [new tag]           v0.35.6                  -> v0.35.6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5376217Z  * [new tag]           v0.35.7                  -> v0.35.7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5376575Z  * [new tag]           v0.36.0                  -> v0.36.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5376943Z  * [new tag]           v0.36.1                  -> v0.36.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5377431Z  * [new tag]           v0.37.0                  -> v0.37.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5378284Z  * [new tag]           v0.37.1                  -> v0.37.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5378928Z  * [new tag]           v0.37.10                 -> v0.37.10
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5379598Z  * [new tag]           v0.37.2                  -> v0.37.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5380141Z  * [new tag]           v0.37.3                  -> v0.37.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5380511Z  * [new tag]           v0.37.4                  -> v0.37.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5380871Z  * [new tag]           v0.37.5                  -> v0.37.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5381228Z  * [new tag]           v0.37.6                  -> v0.37.6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5381747Z  * [new tag]           v0.37.7                  -> v0.37.7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5382115Z  * [new tag]           v0.37.8                  -> v0.37.8
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5382472Z  * [new tag]           v0.37.9                  -> v0.37.9
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5382831Z  * [new tag]           v0.38.0                  -> v0.38.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5383205Z  * [new tag]           v0.39.0                  -> v0.39.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5383826Z  * [new tag]           v0.4.0                   -> v0.4.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5384217Z  * [new tag]           v0.4.1                   -> v0.4.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5384575Z  * [new tag]           v0.4.2                   -> v0.4.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5384932Z  * [new tag]           v0.4.3                   -> v0.4.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5385295Z  * [new tag]           v0.4.4                   -> v0.4.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5385654Z  * [new tag]           v0.4.5                   -> v0.4.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5386021Z  * [new tag]           v0.40.0                  -> v0.40.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5386387Z  * [new tag]           v0.40.1                  -> v0.40.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5386753Z  * [new tag]           v0.40.2                  -> v0.40.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5387128Z  * [new tag]           v0.40.3                  -> v0.40.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5387490Z  * [new tag]           v0.40.4                  -> v0.40.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5387847Z  * [new tag]           v0.40.5                  -> v0.40.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5388205Z  * [new tag]           v0.40.6                  -> v0.40.6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5388560Z  * [new tag]           v0.41.0                  -> v0.41.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5388913Z  * [new tag]           v0.41.1                  -> v0.41.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5389274Z  * [new tag]           v0.42.0                  -> v0.42.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5389634Z  * [new tag]           v0.42.1                  -> v0.42.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5389995Z  * [new tag]           v0.42.2                  -> v0.42.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5390360Z  * [new tag]           v0.43.0                  -> v0.43.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5390717Z  * [new tag]           v0.44.0                  -> v0.44.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5391123Z  * [new tag]           v0.44.1                  -> v0.44.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5391593Z  * [new tag]           v0.44.2                  -> v0.44.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5391960Z  * [new tag]           v0.45.0                  -> v0.45.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5392322Z  * [new tag]           v0.45.1                  -> v0.45.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5392679Z  * [new tag]           v0.45.2                  -> v0.45.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5393040Z  * [new tag]           v0.45.3                  -> v0.45.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5393399Z  * [new tag]           v0.45.4                  -> v0.45.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5393989Z  * [new tag]           v0.45.5                  -> v0.45.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5394356Z  * [new tag]           v0.46.0                  -> v0.46.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5394789Z  * [new tag]           v0.46.1                  -> v0.46.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5395160Z  * [new tag]           v0.46.2                  -> v0.46.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5395520Z  * [new tag]           v0.46.3                  -> v0.46.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5395872Z  * [new tag]           v0.46.4                  -> v0.46.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5396226Z  * [new tag]           v0.47.0                  -> v0.47.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5396579Z  * [new tag]           v0.47.1                  -> v0.47.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5397195Z  * [new tag]           v0.48.0                  -> v0.48.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5397562Z  * [new tag]           v0.49.0                  -> v0.49.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5397917Z  * [new tag]           v0.49.1                  -> v0.49.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5398268Z  * [new tag]           v0.49.2                  -> v0.49.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5398623Z  * [new tag]           v0.49.3                  -> v0.49.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5398980Z  * [new tag]           v0.5.0                   -> v0.5.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5399450Z  * [new tag]           v0.5.1                   -> v0.5.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5399812Z  * [new tag]           v0.5.2                   -> v0.5.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5400166Z  * [new tag]           v0.5.3                   -> v0.5.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5400514Z  * [new tag]           v0.5.4                   -> v0.5.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5400863Z  * [new tag]           v0.5.5                   -> v0.5.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5401409Z  * [new tag]           v0.5.6                   -> v0.5.6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5401771Z  * [new tag]           v0.5.7                   -> v0.5.7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5402133Z  * [new tag]           v0.5.8                   -> v0.5.8
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5402490Z  * [new tag]           v0.5.9                   -> v0.5.9
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5402848Z  * [new tag]           v0.50.0                  -> v0.50.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5403214Z  * [new tag]           v0.50.1                  -> v0.50.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5403815Z  * [new tag]           v0.51.0                  -> v0.51.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5404339Z  * [new tag]           v0.52.0                  -> v0.52.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5404710Z  * [new tag]           v0.52.1                  -> v0.52.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5405065Z  * [new tag]           v0.52.2                  -> v0.52.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5405434Z  * [new tag]           v0.52.3                  -> v0.52.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5405920Z  * [new tag]           v0.53.0                  -> v0.53.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5406291Z  * [new tag]           v0.54.0                  -> v0.54.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5406933Z  * [new tag]           v0.54.1                  -> v0.54.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5407631Z  * [new tag]           v0.54.2                  -> v0.54.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5408305Z  * [new tag]           v0.54.3                  -> v0.54.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5408997Z  * [new tag]           v0.55.0                  -> v0.55.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5409688Z  * [new tag]           v0.55.1                  -> v0.55.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5410352Z  * [new tag]           v0.56.0                  -> v0.56.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5410988Z  * [new tag]           v0.57.0                  -> v0.57.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5411607Z  * [new tag]           v0.57.1                  -> v0.57.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5412224Z  * [new tag]           v0.57.2                  -> v0.57.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5412834Z  * [new tag]           v0.58.0                  -> v0.58.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5413449Z  * [new tag]           v0.58.1                  -> v0.58.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5414469Z  * [new tag]           v0.58.2                  -> v0.58.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5415164Z  * [new tag]           v0.58.3                  -> v0.58.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5415859Z  * [new tag]           v0.59.0                  -> v0.59.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5416505Z  * [new tag]           v0.59.1                  -> v0.59.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5417130Z  * [new tag]           v0.6.0                   -> v0.6.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5417760Z  * [new tag]           v0.6.1                   -> v0.6.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5418397Z  * [new tag]           v0.6.2                   -> v0.6.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5419027Z  * [new tag]           v0.60.0                  -> v0.60.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5419627Z  * [new tag]           v0.61.0                  -> v0.61.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5420223Z  * [new tag]           v0.61.1                  -> v0.61.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5420819Z  * [new tag]           v0.61.2                  -> v0.61.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5421660Z  * [new tag]           v0.61.3                  -> v0.61.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5422337Z  * [new tag]           v0.62.0                  -> v0.62.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5423171Z  * [new tag]           v0.62.1                  -> v0.62.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5423922Z  * [new tag]           v0.62.2                  -> v0.62.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5424309Z  * [new tag]           v0.62.3                  -> v0.62.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5424685Z  * [new tag]           v0.62.4                  -> v0.62.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5425066Z  * [new tag]           v0.62.5                  -> v0.62.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5425593Z  * [new tag]           v0.62.6                  -> v0.62.6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5425962Z  * [new tag]           v0.63.0                  -> v0.63.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5426322Z  * [new tag]           v0.63.1                  -> v0.63.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5426678Z  * [new tag]           v0.64.0                  -> v0.64.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5427041Z  * [new tag]           v0.65.0                  -> v0.65.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5427422Z  * [new tag]           v0.66.0                  -> v0.66.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5427796Z  * [new tag]           v0.66.1                  -> v0.66.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5428168Z  * [new tag]           v0.67.0                  -> v0.67.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5428528Z  * [new tag]           v0.68.0                  -> v0.68.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5428988Z  * [new tag]           v0.69.0                  -> v0.69.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5429591Z  * [new tag]           v0.7.0                   -> v0.7.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5430237Z  * [new tag]           v0.7.1                   -> v0.7.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5430915Z  * [new tag]           v0.7.2                   -> v0.7.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5431523Z  * [new tag]           v0.7.3                   -> v0.7.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5431900Z  * [new tag]           v0.7.4                   -> v0.7.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5432258Z  * [new tag]           v0.7.5                   -> v0.7.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5432612Z  * [new tag]           v0.7.6                   -> v0.7.6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5432995Z  * [new tag]           v0.7.7                   -> v0.7.7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5433357Z  * [new tag]           v0.7.8                   -> v0.7.8
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5433972Z  * [new tag]           v0.7.9                   -> v0.7.9
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5434349Z  * [new tag]           v0.70.0                  -> v0.70.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5434711Z  * [new tag]           v0.71.0                  -> v0.71.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5435077Z  * [new tag]           v0.71.1                  -> v0.71.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5435434Z  * [new tag]           v0.72.0                  -> v0.72.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5435792Z  * [new tag]           v0.73.0                  -> v0.73.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5436145Z  * [new tag]           v0.73.1                  -> v0.73.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5436504Z  * [new tag]           v0.73.2                  -> v0.73.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5436864Z  * [new tag]           v0.74.0                  -> v0.74.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5437231Z  * [new tag]           v0.75.0                  -> v0.75.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5437586Z  * [new tag]           v0.76.0                  -> v0.76.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5437950Z  * [new tag]           v0.76.1                  -> v0.76.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5438341Z  * [new tag]           v0.77.0                  -> v0.77.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5438707Z  * [new tag]           v0.77.1                  -> v0.77.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5439076Z  * [new tag]           v0.77.2                  -> v0.77.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5439439Z  * [new tag]           v0.78.0                  -> v0.78.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5439801Z  * [new tag]           v0.79.0                  -> v0.79.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5440157Z  * [new tag]           v0.79.1                  -> v0.79.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5440519Z  * [new tag]           v0.79.2                  -> v0.79.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5441023Z  * [new tag]           v0.8.0                   -> v0.8.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5441736Z  * [new tag]           v0.8.1                   -> v0.8.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5442709Z  * [new tag]           v0.8.2                   -> v0.8.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5443415Z  * [new tag]           v0.8.3                   -> v0.8.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5444381Z  * [new tag]           v0.8.4                   -> v0.8.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5445063Z  * [new tag]           v0.8.5                   -> v0.8.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5445734Z  * [new tag]           v0.8.6                   -> v0.8.6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5446363Z  * [new tag]           v0.8.7                   -> v0.8.7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5446979Z  * [new tag]           v0.8.8                   -> v0.8.8
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5447824Z  * [new tag]           v0.8.9                   -> v0.8.9
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5448460Z  * [new tag]           v0.80.0                  -> v0.80.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5449099Z  * [new tag]           v0.80.1                  -> v0.80.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5449793Z  * [new tag]           v0.80.2                  -> v0.80.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5450493Z  * [new tag]           v0.81.0                  -> v0.81.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5451181Z  * [new tag]           v0.81.1                  -> v0.81.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5451797Z  * [new tag]           v0.82.0                  -> v0.82.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5452433Z  * [new tag]           v0.82.1                  -> v0.82.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5453060Z  * [new tag]           v0.82.2                  -> v0.82.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5453960Z  * [new tag]           v0.83.0                  -> v0.83.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5454576Z  * [new tag]           v0.83.1                  -> v0.83.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5455210Z  * [new tag]           v0.83.2                  -> v0.83.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5455806Z  * [new tag]           v0.83.3                  -> v0.83.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5456414Z  * [new tag]           v0.84.0                  -> v0.84.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5457023Z  * [new tag]           v0.85.0                  -> v0.85.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5457662Z  * [new tag]           v0.85.1                  -> v0.85.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5458534Z  * [new tag]           v0.85.2                  -> v0.85.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5458944Z  * [new tag]           v0.85.3                  -> v0.85.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5459317Z  * [new tag]           v0.86.0                  -> v0.86.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5459685Z  * [new tag]           v0.86.1                  -> v0.86.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5460049Z  * [new tag]           v0.87.0                  -> v0.87.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5460421Z  * [new tag]           v0.88.0                  -> v0.88.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5460783Z  * [new tag]           v0.89.0                  -> v0.89.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5461149Z  * [new tag]           v0.9.0                   -> v0.9.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5461518Z  * [new tag]           v0.9.1                   -> v0.9.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5461883Z  * [new tag]           v0.9.2                   -> v0.9.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5462245Z  * [new tag]           v0.9.3                   -> v0.9.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5462604Z  * [new tag]           v0.9.4                   -> v0.9.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5462970Z  * [new tag]           v0.9.5                   -> v0.9.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5463344Z  * [new tag]           v0.9.6                   -> v0.9.6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5464009Z  * [new tag]           v0.9.7                   -> v0.9.7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5464624Z  * [new tag]           v0.9.8                   -> v0.9.8
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5465282Z  * [new tag]           v0.90.0                  -> v0.90.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5465949Z  * [new tag]           v0.91.0                  -> v0.91.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5466399Z  * [new tag]           v0.91.1                  -> v0.91.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5466777Z  * [new tag]           v0.91.2                  -> v0.91.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5467138Z  * [new tag]           v0.92.0                  -> v0.92.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5467510Z  * [new tag]           v0.92.1                  -> v0.92.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5467867Z  * [new tag]           v0.93.0                  -> v0.93.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5468221Z  * [new tag]           v0.93.1                  -> v0.93.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5468765Z  * [new tag]           v0.93.2                  -> v0.93.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5469122Z  * [new tag]           v0.94.0                  -> v0.94.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5469485Z  * [new tag]           v0.95.0                  -> v0.95.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5469837Z  * [new tag]           v0.95.1                  -> v0.95.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5470195Z  * [new tag]           v0.95.2                  -> v0.95.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5470548Z  * [new tag]           v0.96.0                  -> v0.96.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5471140Z  * [new tag]           v0.97.0                  -> v0.97.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5471500Z  * [new tag]           v0.98.0                  -> v0.98.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5471860Z  * [new tag]           v0.99.0                  -> v0.99.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5472218Z  * [new tag]           v1.0.0                   -> v1.0.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5472581Z  * [new tag]           v1.1.0                   -> v1.1.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5472949Z  * [new tag]           v1.10.0                  -> v1.10.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5473314Z  * [new tag]           v1.10.1                  -> v1.10.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5473934Z  * [new tag]           v1.10.2                  -> v1.10.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5474308Z  * [new tag]           v1.10.3                  -> v1.10.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5474668Z  * [new tag]           v1.11.0                  -> v1.11.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5475032Z  * [new tag]           v1.11.1                  -> v1.11.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5475427Z  * [new tag]           v1.11.2                  -> v1.11.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5475812Z  * [new tag]           v1.11.3                  -> v1.11.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5476187Z  * [new tag]           v1.11.4                  -> v1.11.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5476548Z  * [new tag]           v1.11.5                  -> v1.11.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5476906Z  * [new tag]           v1.12.0                  -> v1.12.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5477266Z  * [new tag]           v1.12.1                  -> v1.12.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5477632Z  * [new tag]           v1.12.2                  -> v1.12.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5478009Z  * [new tag]           v1.12.3                  -> v1.12.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5478459Z  * [new tag]           v1.13.0                  -> v1.13.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5478874Z  * [new tag]           v1.13.1                  -> v1.13.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5479237Z  * [new tag]           v1.14.0                  -> v1.14.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5479606Z  * [new tag]           v1.14.1                  -> v1.14.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5479963Z  * [new tag]           v1.15.0                  -> v1.15.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5480329Z  * [new tag]           v1.15.1                  -> v1.15.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5480696Z  * [new tag]           v1.15.2                  -> v1.15.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5481063Z  * [new tag]           v1.16.0                  -> v1.16.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5481423Z  * [new tag]           v1.16.1                  -> v1.16.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5481785Z  * [new tag]           v1.16.2                  -> v1.16.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5482153Z  * [new tag]           v1.17.0                  -> v1.17.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5482555Z  * [new tag]           v1.17.1                  -> v1.17.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5482986Z  * [new tag]           v1.17.2                  -> v1.17.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5483346Z  * [new tag]           v1.18.0                  -> v1.18.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5483917Z  * [new tag]           v1.18.1                  -> v1.18.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5484302Z  * [new tag]           v1.18.2                  -> v1.18.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5484669Z  * [new tag]           v1.19.0                  -> v1.19.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5485032Z  * [new tag]           v1.19.1                  -> v1.19.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5485387Z  * [new tag]           v1.19.2                  -> v1.19.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5485749Z  * [new tag]           v1.2.0                   -> v1.2.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5486108Z  * [new tag]           v1.2.1                   -> v1.2.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5486618Z  * [new tag]           v1.2.2                   -> v1.2.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5486981Z  * [new tag]           v1.2.3                   -> v1.2.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5487336Z  * [new tag]           v1.2.4                   -> v1.2.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5487693Z  * [new tag]           v1.2.5                   -> v1.2.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5488052Z  * [new tag]           v1.20.0                  -> v1.20.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5488410Z  * [new tag]           v1.21.0                  -> v1.21.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5488766Z  * [new tag]           v1.21.1                  -> v1.21.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5489237Z  * [new tag]           v1.21.2                  -> v1.21.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5489607Z  * [new tag]           v1.22.0                  -> v1.22.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5489962Z  * [new tag]           v1.22.1                  -> v1.22.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5490324Z  * [new tag]           v1.23.0                  -> v1.23.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5490686Z  * [new tag]           v1.24.0                  -> v1.24.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5491057Z  * [new tag]           v1.25.0                  -> v1.25.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5491418Z  * [new tag]           v1.25.1                  -> v1.25.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5491776Z  * [new tag]           v1.26.0                  -> v1.26.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5492136Z  * [new tag]           v1.26.1                  -> v1.26.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5492503Z  * [new tag]           v1.26.2                  -> v1.26.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5492867Z  * [new tag]           v1.3.0                   -> v1.3.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5493231Z  * [new tag]           v1.3.1                   -> v1.3.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5493853Z  * [new tag]           v1.4.0                   -> v1.4.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5494420Z  * [new tag]           v1.4.1                   -> v1.4.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5494870Z  * [new tag]           v1.5.0                   -> v1.5.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5495246Z  * [new tag]           v1.6.0                   -> v1.6.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5495607Z  * [new tag]           v1.6.1                   -> v1.6.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5495979Z  * [new tag]           v1.6.2                   -> v1.6.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5496337Z  * [new tag]           v1.6.3                   -> v1.6.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5496699Z  * [new tag]           v1.7.0                   -> v1.7.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5497059Z  * [new tag]           v1.8.0                   -> v1.8.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5497418Z  * [new tag]           v1.8.1                   -> v1.8.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5497817Z  * [new tag]           v1.8.2                   -> v1.8.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5498275Z  * [new tag]           v1.8.3                   -> v1.8.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5498639Z  * [new tag]           v1.9.0                   -> v1.9.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5498993Z  * [new tag]           v1.9.1                   -> v1.9.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5499348Z  * [new tag]           v1.9.2                   -> v1.9.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5499704Z  * [new tag]           v2.0.0                   -> v2.0.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5500063Z  * [new tag]           v2.0.1                   -> v2.0.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5500423Z  * [new tag]           v2.1.0                   -> v2.1.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5500783Z  * [new tag]           v2.10.0                  -> v2.10.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5501145Z  * [new tag]           v2.10.1                  -> v2.10.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5501504Z  * [new tag]           v2.10.2                  -> v2.10.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5501872Z  * [new tag]           v2.11.0                  -> v2.11.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5502224Z  * [new tag]           v2.11.1                  -> v2.11.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5502583Z  * [new tag]           v2.11.2                  -> v2.11.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5502947Z  * [new tag]           v2.12.0                  -> v2.12.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5503303Z  * [new tag]           v2.12.1                  -> v2.12.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5503905Z  * [new tag]           v2.12.2                  -> v2.12.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5504276Z  * [new tag]           v2.12.3                  -> v2.12.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5504797Z  * [new tag]           v2.12.4                  -> v2.12.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5505153Z  * [new tag]           v2.12.5                  -> v2.12.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5505508Z  * [new tag]           v2.12.6                  -> v2.12.6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5505862Z  * [new tag]           v2.12.7                  -> v2.12.7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5506217Z  * [new tag]           v2.13.0                  -> v2.13.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5506581Z  * [new tag]           v2.13.1                  -> v2.13.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5506940Z  * [new tag]           v2.13.2                  -> v2.13.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5507408Z  * [new tag]           v2.13.3                  -> v2.13.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5507769Z  * [new tag]           v2.14.0                  -> v2.14.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5508125Z  * [new tag]           v2.14.1                  -> v2.14.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5508492Z  * [new tag]           v2.14.2                  -> v2.14.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5508850Z  * [new tag]           v2.14.3                  -> v2.14.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5509212Z  * [new tag]           v2.15.0                  -> v2.15.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5509591Z  * [new tag]           v2.15.1                  -> v2.15.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5509963Z  * [new tag]           v2.15.2                  -> v2.15.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5510330Z  * [new tag]           v2.15.3                  -> v2.15.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5510695Z  * [new tag]           v2.15.4                  -> v2.15.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5511055Z  * [new tag]           v2.16.0                  -> v2.16.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5511422Z  * [new tag]           v2.17.0                  -> v2.17.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5511783Z  * [new tag]           v2.17.1                  -> v2.17.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5512142Z  * [new tag]           v2.18.0                  -> v2.18.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5512582Z  * [new tag]           v2.18.0-52825890-nightly -> v2.18.0-52825890-nightly
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5513114Z  * [new tag]           v2.18.0-97002309-nightly -> v2.18.0-97002309-nightly
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5513850Z  * [new tag]           v2.18.0-a38ac317-nightly -> v2.18.0-a38ac317-nightly
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5514358Z  * [new tag]           v2.18.0-cd616d2c-nightly -> v2.18.0-cd616d2c-nightly
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5514831Z  * [new tag]           v2.19.0-315a4fdf-nightly -> v2.19.0-315a4fdf-nightly
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5515296Z  * [new tag]           v2.19.0-8afe0bba-nightly -> v2.19.0-8afe0bba-nightly
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5515726Z  * [new tag]           v2.2.0                   -> v2.2.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5516093Z  * [new tag]           v2.3.0                   -> v2.3.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5516460Z  * [new tag]           v2.3.1                   -> v2.3.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5516820Z  * [new tag]           v2.3.2                   -> v2.3.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5517178Z  * [new tag]           v2.4.0                   -> v2.4.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5517539Z  * [new tag]           v2.4.1                   -> v2.4.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5517895Z  * [new tag]           v2.4.2                   -> v2.4.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5518260Z  * [new tag]           v2.4.3                   -> v2.4.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5518620Z  * [new tag]           v2.4.4                   -> v2.4.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5518979Z  * [new tag]           v2.4.5                   -> v2.4.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5519335Z  * [new tag]           v2.4.6                   -> v2.4.6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5519700Z  * [new tag]           v2.4.7                   -> v2.4.7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5520056Z  * [new tag]           v2.4.8                   -> v2.4.8
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5520412Z  * [new tag]           v2.5.0                   -> v2.5.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5520772Z  * [new tag]           v2.5.1                   -> v2.5.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5521132Z  * [new tag]           v2.6.0                   -> v2.6.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5521489Z  * [new tag]           v2.6.1                   -> v2.6.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5521851Z  * [new tag]           v2.7.0                   -> v2.7.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5522241Z  * [new tag]           v2.8.0                   -> v2.8.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5522741Z  * [new tag]           v2.8.1                   -> v2.8.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5523099Z  * [new tag]           v2.8.2                   -> v2.8.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5523454Z  * [new tag]           v2.9.0                   -> v2.9.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5524634Z [command]/usr/bin/git branch --list --remote origin/main
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5525028Z   origin/main
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5525645Z [command]/usr/bin/git rev-parse refs/remotes/origin/main
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5526015Z 36e43dd08f724956b188af2f6f3bcfd5efd355ec
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5526746Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5527310Z ##[group]Determining the checkout info
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5528058Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5528343Z [command]/usr/bin/git sparse-checkout disable
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5529099Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5529945Z ##[group]Checking out the ref
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.5530417Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.6287281Z Switched to a new branch 'main'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.6293021Z branch 'main' set up to track 'origin/main'.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.6303148Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.6347391Z [command]/usr/bin/git log -1 --format=%H
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.6371907Z 36e43dd08f724956b188af2f6f3bcfd5efd355ec
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.6610136Z ##[group]Run go-task/setup-task@a00fbb05ce67b35648be3c78cbc9fd85354c757e
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.6610571Z with:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.6610773Z   version: 3.x
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.6613440Z   repo-token: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.6613903Z   max-retries: 3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.6614119Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.6614325Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:56.6614594Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.3065138Z [command]/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/46f5beaf-f2d1-410c-ac35-5320b3d71a7c -f /home/runner/work/_temp/7263a165-3889-4ebd-91ba-65983f47e2b7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.6585800Z Successfully setup Task version v3.53.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.6744569Z ##[group]Run docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.6745027Z with:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.6745268Z   image: docker.io/tonistiigi/binfmt:latest
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.6745573Z   platforms: all
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.6745807Z   reset: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.6746029Z   cache-image: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.6746249Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.6746468Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.6746751Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.8141844Z ##[group]Docker info
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.8187190Z [command]/usr/bin/docker version
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9392033Z Client: Docker Engine - Community
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9392680Z  Version:           28.0.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9395378Z  API version:       1.48
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9395905Z  Go version:        go1.23.7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9396323Z  Git commit:        b8034c0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9396777Z  Built:             Tue Mar 25 15:07:16 2025
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9397342Z  OS/Arch:           linux/amd64
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9397756Z  Context:           default
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9398089Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9398283Z Server: Docker Engine - Community
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9398764Z  Engine:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9399101Z   Version:          28.0.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9399554Z   API version:      1.48 (minimum version 1.24)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9400069Z   Go version:       go1.23.7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9400484Z   Git commit:       6430e49
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9400899Z   Built:            Tue Mar 25 15:07:16 2025
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9401357Z   OS/Arch:          linux/amd64
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9401781Z   Experimental:     false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9402171Z  containerd:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9402492Z   Version:          v2.3.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9402805Z   GitCommit:        aad11006b869517fcd3009450b6f82da282e1a9b
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9403162Z  runc:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9403353Z   Version:          1.4.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9403880Z   GitCommit:        v1.4.3-0-gbb14dab
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9404450Z  docker-init:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9404677Z   Version:          0.19.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9404913Z   GitCommit:        de40ad0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9475358Z [command]/usr/bin/docker info
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3413724Z Client: Docker Engine - Community
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3414269Z  Version:    28.0.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3414664Z  Context:    default
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3415038Z  Debug Mode: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3415410Z  Plugins:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3415758Z   buildx: Docker Buildx (Docker Inc.)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3416177Z     Version:  v0.36.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3416677Z     Path:     /usr/libexec/docker/cli-plugins/docker-buildx
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3417278Z   compose: Docker Compose (Docker Inc.)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3417671Z     Version:  v2.38.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3418104Z     Path:     /usr/libexec/docker/cli-plugins/docker-compose
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3418370Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3418448Z Server:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3418633Z  Containers: 0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3418865Z   Running: 0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3419213Z   Paused: 0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3419400Z   Stopped: 0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3419585Z  Images: 6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3419770Z  Server Version: 28.0.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3419995Z  Storage Driver: overlay2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3420349Z   Backing Filesystem: extfs
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3420596Z   Supports d_type: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3420810Z   Using metacopy: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3421028Z   Native Overlay Diff: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3421287Z   userxattr: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3421594Z  Logging Driver: json-file
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3421819Z  Cgroup Driver: systemd
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3422034Z  Cgroup Version: 2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3422230Z  Plugins:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3422434Z   Volume: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3422795Z   Network: bridge host ipvlan macvlan null overlay
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3423203Z   Log: awslogs fluentd gcplogs gelf journald json-file local splunk syslog
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3423827Z  Swarm: inactive
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3424097Z  Runtimes: runc io.containerd.runc.v2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3424753Z  Default Runtime: runc
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3425133Z  Init Binary: docker-init
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3425445Z  containerd version: aad11006b869517fcd3009450b6f82da282e1a9b
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3425783Z  runc version: v1.4.3-0-gbb14dab
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3426048Z  init version: de40ad0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3426379Z  Security Options:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3426591Z   apparmor
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3426767Z   seccomp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3426952Z    Profile: builtin
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3427162Z   cgroupns
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3427491Z  Kernel Version: 6.17.0-1022-azure
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3427762Z  Operating System: Ubuntu 24.04.4 LTS
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3428019Z  OSType: linux
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3428224Z  Architecture: x86_64
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3428495Z  CPUs: 4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3428745Z  Total Memory: 15.62GiB
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3428965Z  Name: runnervmgx7h7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3429196Z  ID: a9bdcc8e-7fee-41a1-b6e5-bb51314b0287
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3429490Z  Docker Root Dir: /var/lib/docker
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3429868Z  Debug Mode: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3430091Z  Username: githubactions
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3430319Z  Experimental: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3430529Z  Insecure Registries:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3436610Z   ::1/128
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3436822Z   127.0.0.0/8
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3437041Z  Live Restore Enabled: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3437218Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3452367Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.3452793Z ##[group]Pulling binfmt Docker image
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.4088106Z Cache hit for: docker.io--tonistiigi--binfmt-latest-linux-x64
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.6448032Z Received 32265061 of 32265061 (100.0%), 162.8 MBs/sec
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.6448664Z Cache Size: ~31 MB (32265061 B)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.6559138Z [command]/usr/bin/tar -xf /home/runner/work/_temp/712ef05f-6727-4db8-bbbe-90c7e8480c00/cache.tzst -P -C /home/runner/work/goreleaser/goreleaser --use-compress-program unzstd
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.7910754Z Cache restored successfully
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.7927392Z Restored docker.io--tonistiigi--binfmt-latest-linux-x64 from GitHub Actions cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.8309485Z Cached to hosted tool cache /opt/hostedtoolcache/docker.io--tonistiigi--binfmt/latest/linux-x64
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.8311827Z Copying /opt/hostedtoolcache/docker.io--tonistiigi--binfmt/latest/linux-x64/image.tar to /home/runner/.docker/.cache/images/docker.io--tonistiigi--binfmt/latest/linux-x64/image.tar
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.8804953Z Image found from cache in /home/runner/.docker/.cache/images/docker.io--tonistiigi--binfmt/latest/linux-x64/image.tar
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:02.8829561Z [command]/usr/bin/docker load -i /home/runner/.docker/.cache/images/docker.io--tonistiigi--binfmt/latest/linux-x64/image.tar
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.0140669Z Loaded image: tonistiigi/binfmt:latest
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.0258596Z [command]/usr/bin/docker pull docker.io/tonistiigi/binfmt:latest
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.2516194Z latest: Pulling from tonistiigi/binfmt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.3329303Z Digest: sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.3334698Z Status: Image is up to date for tonistiigi/binfmt:latest
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.3342467Z docker.io/tonistiigi/binfmt:latest
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.3380166Z [command]/usr/bin/docker save -o /home/runner/work/_temp/docker-actions-toolkit-G7Mojq/749e64100d3fa0c09bdbc8a02e4fb9cb3ee64266f7f661c98371040689abacb3.tar docker.io/tonistiigi/binfmt:latest
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7104312Z Copying /home/runner/work/_temp/docker-actions-toolkit-G7Mojq/749e64100d3fa0c09bdbc8a02e4fb9cb3ee64266f7f661c98371040689abacb3.tar to /home/runner/.docker/.cache/images/docker.io--tonistiigi--binfmt/latest/linux-x64/image.tar
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7805662Z Image cached to /home/runner/.docker/.cache/images/docker.io--tonistiigi--binfmt/latest/linux-x64/image.tar
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7807663Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7808333Z ##[group]Image info
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7824083Z [command]/usr/bin/docker image inspect docker.io/tonistiigi/binfmt:latest
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8457435Z [
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8458041Z     {
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8459276Z         "Id": "sha256:15935d0512bf0a8e5afa1df990d971cf97a619ede08fa60f2d5966a62de6d6b7",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8460540Z         "RepoTags": [
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8461264Z             "tonistiigi/binfmt:latest"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8461756Z         ],
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8462096Z         "RepoDigests": [
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8462873Z             "tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8463929Z         ],
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8464261Z         "Parent": "",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8464692Z         "Comment": "buildkit.dockerfile.v0",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8465267Z         "Created": "2026-06-05T19:12:02.167333037Z",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8465655Z         "DockerVersion": "",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8465910Z         "Author": "",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8466129Z         "Config": {
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8466342Z             "Hostname": "",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8466576Z             "Domainname": "",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8466834Z             "User": "",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8467059Z             "AttachStdin": false,
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8467327Z             "AttachStdout": false,
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8467748Z             "AttachStderr": false,
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8468203Z             "Tty": false,
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8468598Z             "OpenStdin": false,
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8469056Z             "StdinOnce": false,
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8469482Z             "Env": [
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8470071Z                 "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8470741Z                 "QEMU_PRESERVE_ARGV0=1"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8471191Z             ],
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8471513Z             "Cmd": null,
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8471875Z             "Image": "",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8472245Z             "Volumes": {
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8472648Z                 "/tmp": {}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8473043Z             },
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8473397Z             "WorkingDir": "/",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8474446Z             "Entrypoint": [
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8474870Z                 "/usr/bin/binfmt"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8475288Z             ],
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8475639Z             "OnBuild": null,
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8476074Z             "Labels": null
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8476455Z         },
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8476813Z         "Architecture": "amd64",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8477238Z         "Os": "linux",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8477605Z         "Size": 85304497,
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8477999Z         "GraphDriver": {
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8478411Z             "Data": {
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8479295Z                 "LowerDir": "/var/lib/docker/overlay2/6903c7ade6873f50eea1dc420360d219062c19d3cc08e37ca134a996d658eb31/diff",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8480784Z                 "MergedDir": "/var/lib/docker/overlay2/8365962fbd7254da3ca1d39e521b213e3e99d177e58db2057fbedf292fc99620/merged",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8482372Z                 "UpperDir": "/var/lib/docker/overlay2/8365962fbd7254da3ca1d39e521b213e3e99d177e58db2057fbedf292fc99620/diff",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8484227Z                 "WorkDir": "/var/lib/docker/overlay2/8365962fbd7254da3ca1d39e521b213e3e99d177e58db2057fbedf292fc99620/work"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8485246Z             },
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8485646Z             "Name": "overlay2"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8486083Z         },
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8486438Z         "RootFS": {
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8486844Z             "Type": "layers",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8487296Z             "Layers": [
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8488000Z                 "sha256:c747b796d990a647df062f87e24f1ef5e4a90a312cd9c4ae8b7d09667d57befb",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8489056Z                 "sha256:6d831b0f477d9df7afe18e5a65c97e8084fef8fe10c2930b65f728ab68d0bb5b"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8489860Z             ]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8490228Z         },
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8490593Z         "Metadata": {
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8491049Z             "LastTagTime": "0001-01-01T00:00:00Z"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8491562Z         }
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8491906Z     }
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8492248Z ]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8493191Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8494110Z ##[group]Binfmt version
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8495122Z [command]/usr/bin/docker run --rm --privileged docker.io/tonistiigi/binfmt:latest --version
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.2787295Z binfmt/e29e7d7 qemu/v10.2.3 go/1.26.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.3515547Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.3516298Z ##[group]Installing QEMU static binaries
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.3533231Z [command]/usr/bin/docker run --rm --privileged docker.io/tonistiigi/binfmt:latest --install all
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.4852165Z installing: mips64le OK
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.4852709Z installing: mips64 OK
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.4853108Z installing: loong64 OK
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.4853482Z installing: arm64 OK
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.4854294Z installing: s390x OK
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.4854538Z installing: riscv64 OK
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.4854779Z installing: arm OK
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.4855029Z installing: ppc64le OK
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5058894Z {
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5059612Z   "supported": [
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5060087Z     "linux/amd64",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5060472Z     "linux/amd64/v2",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5060866Z     "linux/amd64/v3",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5061253Z     "linux/arm64",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5061619Z     "linux/riscv64",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5061981Z     "linux/ppc64le",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5062338Z     "linux/s390x",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5062703Z     "linux/386",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5063064Z     "linux/mips64le",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5063456Z     "linux/mips64",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5064746Z     "linux/loong64",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5065195Z     "linux/arm/v7",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5065616Z     "linux/arm/v6"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5066016Z   ],
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5066332Z   "emulators": [
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5066716Z     "llvm-16-runtime.binfmt",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5067197Z     "llvm-17-runtime.binfmt",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5067705Z     "llvm-18-runtime.binfmt",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5068201Z     "python3.12",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5068617Z     "qemu-aarch64",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5069370Z     "qemu-arm",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5069799Z     "qemu-loongarch64",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5070271Z     "qemu-mips64",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5070695Z     "qemu-mips64el",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5071158Z     "qemu-ppc64le",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5071586Z     "qemu-riscv64",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5072001Z     "qemu-s390x"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5072398Z   ]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5072729Z }
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5674293Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5674771Z ##[group]Extracting available platforms
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.7765606Z linux/amd64,linux/amd64/v2,linux/amd64/v3,linux/arm64,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/loong64,linux/arm/v7,linux/arm/v6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.7767046Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.7957992Z ##[group]Run docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.7958460Z with:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.7958681Z   driver-opts: network=host
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.7958944Z   driver: docker-container
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.7959198Z   use: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.7959524Z   keep-state: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.7959836Z   cache-binary: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.7960229Z   cleanup: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.7985090Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.7985464Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.7986023Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.9890024Z ##[group]Docker info
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:06.9915217Z [command]/usr/bin/docker version
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0119703Z Client: Docker Engine - Community
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0123423Z  Version:           28.0.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0124197Z  API version:       1.48
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0124692Z  Go version:        go1.23.7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0125212Z  Git commit:        b8034c0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0125809Z  Built:             Tue Mar 25 15:07:16 2025
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0126278Z  OS/Arch:           linux/amd64
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0126843Z  Context:           default
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0127324Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0127513Z Server: Docker Engine - Community
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0127968Z  Engine:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0128312Z   Version:          28.0.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0128763Z   API version:      1.48 (minimum version 1.24)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0129269Z   Go version:       go1.23.7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0129679Z   Git commit:       6430e49
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0130096Z   Built:            Tue Mar 25 15:07:16 2025
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0130582Z   OS/Arch:          linux/amd64
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0131006Z   Experimental:     false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0131359Z  containerd:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0131579Z   Version:          v2.3.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0131883Z   GitCommit:        aad11006b869517fcd3009450b6f82da282e1a9b
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0132209Z  runc:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0132410Z   Version:          1.4.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0132662Z   GitCommit:        v1.4.3-0-gbb14dab
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0132932Z  docker-init:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0133139Z   Version:          0.19.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0133372Z   GitCommit:        de40ad0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0210836Z [command]/usr/bin/docker info
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0785914Z Client: Docker Engine - Community
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0786838Z  Version:    28.0.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0787511Z  Context:    default
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0787948Z  Debug Mode: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0788326Z  Plugins:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0788720Z   buildx: Docker Buildx (Docker Inc.)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0789213Z     Version:  v0.36.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0789731Z     Path:     /usr/libexec/docker/cli-plugins/docker-buildx
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0790433Z   compose: Docker Compose (Docker Inc.)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0790941Z     Version:  v2.38.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0791463Z     Path:     /usr/libexec/docker/cli-plugins/docker-compose
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0791927Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0792066Z Server:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0792427Z  Containers: 0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0792798Z   Running: 0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0793158Z   Paused: 0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0794125Z   Stopped: 0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0794515Z  Images: 7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0794886Z  Server Version: 28.0.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0795327Z  Storage Driver: overlay2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0796317Z   Backing Filesystem: extfs
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0796782Z   Supports d_type: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0797213Z   Using metacopy: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0797650Z   Native Overlay Diff: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0798098Z   userxattr: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0798513Z  Logging Driver: json-file
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0799015Z  Cgroup Driver: systemd
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0799451Z  Cgroup Version: 2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0799848Z  Plugins:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0800197Z   Volume: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0800666Z   Network: bridge host ipvlan macvlan null overlay
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0801500Z   Log: awslogs fluentd gcplogs gelf journald json-file local splunk syslog
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0802214Z  Swarm: inactive
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0802964Z  Runtimes: io.containerd.runc.v2 runc
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0803780Z  Default Runtime: runc
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0804227Z  Init Binary: docker-init
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0804859Z  containerd version: aad11006b869517fcd3009450b6f82da282e1a9b
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0805533Z  runc version: v1.4.3-0-gbb14dab
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0806011Z  init version: de40ad0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0806423Z  Security Options:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0806818Z   apparmor
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0807144Z   seccomp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0807493Z    Profile: builtin
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0807887Z   cgroupns
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0808247Z  Kernel Version: 6.17.0-1022-azure
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0808747Z  Operating System: Ubuntu 24.04.4 LTS
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0809225Z  OSType: linux
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0809608Z  Architecture: x86_64
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0809990Z  CPUs: 4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0810334Z  Total Memory: 15.62GiB
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0810755Z  Name: runnervmgx7h7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0811212Z  ID: a9bdcc8e-7fee-41a1-b6e5-bb51314b0287
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0811743Z  Docker Root Dir: /var/lib/docker
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0812204Z  Debug Mode: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0812605Z  Username: githubactions
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0813023Z  Experimental: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0813425Z  Insecure Registries:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0814275Z   ::1/128
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0814602Z   127.0.0.0/8
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0814975Z  Live Restore Enabled: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0815275Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0815806Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.1655196Z ##[group]Buildx version
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.1684349Z [command]/usr/bin/docker buildx version
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.2138481Z github.com/docker/buildx v0.36.1 1d8dde89b8aba914e05e45366770736fea1fd690
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.2168261Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.2317020Z ##[group]Inspecting default docker context
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.2471563Z [
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.2471914Z   {
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.2472275Z     "Name": "default",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.2472708Z     "Metadata": {},
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.2473132Z     "Endpoints": {
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.2473769Z       "docker": {
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.2474197Z         "Host": "unix:///var/run/docker.sock",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.2474772Z         "SkipTLSVerify": false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.2475224Z       }
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.2475567Z     },
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.2475951Z     "TLSMaterial": {},
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.2476372Z     "Storage": {
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.2476793Z       "MetadataPath": "<IN MEMORY>",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.2477298Z       "TLSPath": "<IN MEMORY>"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.2477746Z     }
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.2478077Z   }
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.2478397Z ]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.2479089Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.2479797Z ##[group]Creating a new builder instance
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.3667350Z [command]/usr/bin/docker buildx create --name builder-87029ac1-86b4-4cd4-a8a7-496bf34c6438 --driver docker-container --driver-opt network=host --buildkitd-flags --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host --use
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.4327592Z builder-87029ac1-86b4-4cd4-a8a7-496bf34c6438
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.4360139Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.4361196Z ##[group]Booting builder
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.4397227Z [command]/usr/bin/docker buildx inspect --bootstrap --builder builder-87029ac1-86b4-4cd4-a8a7-496bf34c6438
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.4888128Z #1 [internal] booting buildkit
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:07.6394722Z #1 pulling image moby/buildkit:buildx-stable-1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.4385189Z #1 pulling image moby/buildkit:buildx-stable-1 1.9s done
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.5899397Z #1 creating container buildx_buildkit_builder-87029ac1-86b4-4cd4-a8a7-496bf34c64380
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7563571Z #1 creating container buildx_buildkit_builder-87029ac1-86b4-4cd4-a8a7-496bf34c64380 0.3s done
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7595907Z #1 DONE 2.3s
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7953139Z Name:          builder-87029ac1-86b4-4cd4-a8a7-496bf34c6438
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7953791Z Driver:        docker-container
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7954110Z Last Activity: 2026-08-30 05:03:07 +0000 UTC
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7954682Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7954772Z Nodes:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7955051Z Name:                  builder-87029ac1-86b4-4cd4-a8a7-496bf34c64380
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7955437Z Endpoint:              unix:///var/run/docker.sock
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7955769Z Driver Options:        network="host"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7956055Z Status:                running
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7956609Z BuildKit daemon flags: --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7957161Z BuildKit version:      v0.32.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7957918Z Platforms:             linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/mips64le, linux/mips64, linux/loong64, linux/arm/v7, linux/arm/v6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7958696Z Labels:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7958961Z  org.mobyproject.buildkit.worker.executor:         oci
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7959394Z  org.mobyproject.buildkit.worker.hostname:         runnervmgx7h7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7959877Z  org.mobyproject.buildkit.worker.network:          host
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7960295Z  org.mobyproject.buildkit.worker.oci.process-mode: sandbox
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7960721Z  org.mobyproject.buildkit.worker.selinux.enabled:  false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7961145Z  org.mobyproject.buildkit.worker.snapshotter:      overlayfs
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7961517Z GC Policy rule#0:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7961729Z  All:            false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7962078Z  Filters:        type==source.local type==exec.cachemount type==source.git.checkout
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7962489Z  Keep Duration:  48h0m0s
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7962726Z  Max Used Space: 488.3MiB
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7962952Z GC Policy rule#1:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7963157Z  All:            false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7963373Z  Keep Duration:  1440h0m0s
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7963884Z  Reserved Space: 9.313GiB
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7964287Z  Max Used Space: 93.13GiB
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7964682Z  Min Free Space: 27.01GiB
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7965065Z GC Policy rule#2:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7965424Z  All:            false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7965806Z  Reserved Space: 9.313GiB
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7966197Z  Max Used Space: 93.13GiB
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7966582Z  Min Free Space: 27.01GiB
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7966961Z GC Policy rule#3:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7967316Z  All:            true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7967692Z  Reserved Space: 9.313GiB
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.7968084Z  Max Used Space: 93.13GiB
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8004503Z  Min Free Space: 27.01GiB
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8005332Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8863349Z ##[group]Inspect builder
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8864082Z {
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8864401Z   "nodes": [
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8864752Z     {
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8865229Z       "name": "builder-87029ac1-86b4-4cd4-a8a7-496bf34c64380",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8865895Z       "endpoint": "unix:///var/run/docker.sock",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8866407Z       "driver-opts": [
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8866648Z         "network=host"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8867015Z       ],
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8867375Z       "status": "running",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8868115Z       "buildkitd-flags": "--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8869628Z       "buildkit": "v0.32.2",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8871004Z       "platforms": "linux/amd64,linux/amd64/v2,linux/amd64/v3,linux/arm64,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/loong64,linux/arm/v7,linux/arm/v6",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8872714Z       "features": {
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8873269Z         "Automatically load images to the Docker Engine image store": true,
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8874522Z         "Cache export": true,
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8874985Z         "Direct push": true,
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8875443Z         "Docker exporter": true,
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8875979Z         "Multi-platform build": true,
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8876521Z         "OCI exporter": true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8877901Z       },
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8878221Z       "labels": {
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8878747Z         "org.mobyproject.buildkit.worker.executor": "oci",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8879490Z         "org.mobyproject.buildkit.worker.hostname": "runnervmgx7h7",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8880285Z         "org.mobyproject.buildkit.worker.network": "host",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8881191Z         "org.mobyproject.buildkit.worker.oci.process-mode": "sandbox",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8884250Z         "org.mobyproject.buildkit.worker.selinux.enabled": "false",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8884933Z         "org.mobyproject.buildkit.worker.snapshotter": "overlayfs"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8885348Z       },
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8885565Z       "gcPolicy": [
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8885776Z         {
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8885989Z           "all": false,
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8886240Z           "filter": [
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8886603Z             "type==source.local type==exec.cachemount type==source.git.checkout"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8887031Z           ],
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8887276Z           "keepDuration": "48h0m0s",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8887575Z           "maxUsedSpace": "488.3MiB"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8887818Z         },
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8887997Z         {
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8888186Z           "all": false,
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8888440Z           "keepDuration": "1440h0m0s",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8888706Z           "reservedSpace": "9.313GiB",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8888982Z           "maxUsedSpace": "93.13GiB",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8889239Z           "minFreeSpace": "27.01GiB"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8889499Z         },
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8889706Z         {
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8889926Z           "all": false,
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8890208Z           "reservedSpace": "9.313GiB",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8890565Z           "maxUsedSpace": "93.13GiB",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8890906Z           "minFreeSpace": "27.01GiB"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8891185Z         },
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8891380Z         {
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8891587Z           "all": true,
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8891829Z           "reservedSpace": "9.313GiB",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8892108Z           "maxUsedSpace": "93.13GiB",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8892403Z           "minFreeSpace": "27.01GiB"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8892673Z         }
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8892869Z       ]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8893046Z     }
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8893249Z   ],
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8893789Z   "name": "builder-87029ac1-86b4-4cd4-a8a7-496bf34c6438",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8894383Z   "driver": "docker-container",
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8894693Z   "lastActivity": "2026-08-30T05:03:07.000Z"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8894990Z }
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8895413Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8896045Z ##[group]BuildKit version
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8896804Z builder-87029ac1-86b4-4cd4-a8a7-496bf34c64380: v0.32.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8897685Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.9015224Z ##[group]Run sudo snap install snapcraft --classic
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.9015699Z ^[[36;1msudo snap install snapcraft --classic^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.9054607Z shell: /usr/bin/bash -e {0}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.9054895Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.9055110Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:09.9055393Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:13.1430648Z 2026-08-30T05:03:13Z INFO Waiting for automatic snapd restart...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:14.2723471Z 2026-08-30T05:03:14Z INFO Waiting for automatic snapd restart...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:15.2999378Z 2026-08-30T05:03:15Z INFO Waiting for automatic snapd restart...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.3583881Z snapcraft 9.0.1 from Canonical** installed
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.3655479Z ##[group]Run crazy-max/ghaction-upx@c83f378efc804f828e988debb88ed6116feb2368
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.3655915Z with:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.3656118Z   install-only: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.3656339Z   version: latest
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.3656546Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.3656745Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.3657001Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.4825519Z UPX 5.2.0 found
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.4828145Z ##[group]Downloading https://github.com/upx/upx/releases/download/v5.2.0/upx-5.2.0-amd64_linux.tar.xz...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.6323153Z Downloaded to /home/runner/work/_temp/e32db169-eaab-4b56-9c9c-10f01ea1df9c
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.6412652Z [command]/usr/bin/tar x --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/b8bdef74-4931-436d-8fd5-f63894391c94 -f /home/runner/work/_temp/e32db169-eaab-4b56-9c9c-10f01ea1df9c
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.6787488Z Extracted to /home/runner/work/_temp/b8bdef74-4931-436d-8fd5-f63894391c94
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.6849096Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.6948839Z ##[group]Run sudo apt update -q
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.6949177Z ^[[36;1msudo apt update -q^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.6949539Z ^[[36;1msudo apt install -yq makeself flatpak flatpak-builder^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.6985636Z shell: /usr/bin/bash -e {0}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.6985920Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.6986133Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.6986408Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.7194852Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.7195278Z WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.7195713Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.8024822Z Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.8299893Z Get:6 https://packages.microsoft.com/repos/azure-cli noble InRelease [3564 B]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.8416546Z Get:7 https://dl.google.com/linux/chrome-stable/deb stable InRelease [2548 B]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.8420307Z Get:8 https://packages.microsoft.com/ubuntu/24.04/prod noble InRelease [3600 B]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.8445998Z Hit:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.8465184Z Get:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.8530083Z Get:4 http://azure.archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.8565088Z Get:5 http://azure.archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:27.9729887Z Get:9 https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages [1406 B]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:28.0016550Z Get:10 https://packages.microsoft.com/ubuntu/24.04/prod noble/main amd64 Packages [427 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:28.0075595Z Get:11 https://packages.microsoft.com/ubuntu/24.04/prod noble/main armhf Packages [12.5 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:28.0100020Z Get:12 https://packages.microsoft.com/ubuntu/24.04/prod noble/main arm64 Packages [381 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:28.1044538Z Get:13 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [1230 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:28.1124586Z Get:14 http://azure.archive.ubuntu.com/ubuntu noble-updates/main Translation-en [287 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:28.1149702Z Get:15 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Components [180 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:28.1169684Z Get:16 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages [1689 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:28.1258339Z Get:17 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe Translation-en [338 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:28.1285675Z Get:18 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 Components [388 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:28.1317516Z Get:19 http://azure.archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Packages [1486 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:28.1396244Z Get:20 http://azure.archive.ubuntu.com/ubuntu noble-updates/restricted Translation-en [339 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:28.1426813Z Get:21 http://azure.archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Components [940 B]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:28.1591606Z Get:22 http://azure.archive.ubuntu.com/ubuntu noble-backports/main amd64 Components [5744 B]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:28.2096894Z Get:23 http://azure.archive.ubuntu.com/ubuntu noble-backports/universe amd64 Components [12.6 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:28.2285093Z Get:24 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 Packages [972 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:28.2355166Z Get:25 http://azure.archive.ubuntu.com/ubuntu noble-security/main Translation-en [206 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:28.2368121Z Get:26 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 Components [46.4 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:28.2386176Z Get:27 http://azure.archive.ubuntu.com/ubuntu noble-security/universe amd64 Packages [1203 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:28.2481143Z Get:28 http://azure.archive.ubuntu.com/ubuntu noble-security/universe Translation-en [241 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:28.2505745Z Get:29 http://azure.archive.ubuntu.com/ubuntu noble-security/universe amd64 Components [76.3 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:28.2524462Z Get:30 http://azure.archive.ubuntu.com/ubuntu noble-security/restricted amd64 Packages [1392 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:28.2601436Z Get:31 http://azure.archive.ubuntu.com/ubuntu noble-security/restricted Translation-en [321 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:28.2638208Z Get:32 http://azure.archive.ubuntu.com/ubuntu noble-security/multiverse Translation-en [11.1 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:32.3740203Z Fetched 11.6 MB in 1s (8320 kB/s)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.1516557Z Reading package lists...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.3218818Z Building dependency tree...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.3225707Z Reading state information...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.3369464Z 38 packages can be upgraded. Run 'apt list --upgradable' to see them.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.3481872Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.3482396Z WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.3482946Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.3592075Z Reading package lists...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.5250449Z Building dependency tree...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.5258212Z Reading state information...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6678338Z The following additional packages will be installed:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6679214Z   appstream-compose bubblewrap desktop-file-utils elfutils ffmpeg
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6680007Z   gir1.2-flatpak-1.0 gsettings-desktop-schemas i965-va-driver
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6680889Z   intel-media-va-driver libaacs0 libappstream-compose0 libasm1t64 libass9
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6681824Z   libasyncns0 libavahi-glib1 libavc1394-0 libavcodec60 libavdevice60
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6682656Z   libavfilter9 libavformat60 libavutil58 libbdplus0 libblas3 libbluray2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6683946Z   libbs2b0 libcaca0 libcdio-cdda2t64 libcdio-paranoia2t64 libcdio19t64
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6684884Z   libchromaprint1 libcjson1 libcodec2-1.2 libdav1d7 libdc1394-25 libdecor-0-0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6685846Z   libdecor-0-plugin-1-gtk libflac12t64 libflatpak0 libflite1 libgme0 libgsm1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6686737Z   libhwy1t64 libiec61883-0 libigdgmm12 libjack-jackd2-0 libjxl0.7 liblapack3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6687670Z   liblilv-0-0 libmalcontent-0-0 libmbedcrypto7t64 libmp3lame0 libmpg123-0t64
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6688598Z   libmysofa1 libopenal-data libopenal1 libopenmpt0t64 libopus0 libostree-1-1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6689505Z   libpipewire-0.3-0t64 libpipewire-0.3-common libplacebo338 libpocketsphinx3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6690492Z   libpostproc57 libpulse0 librav1e0 libraw1394-11 librist4 librsvg2-2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6691353Z   librsvg2-common librubberband2 libsamplerate0 libsdl2-2.0-0 libserd-0-0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6692286Z   libshine3 libsndfile1 libsndio7.0 libsord-0-0 libsoxr0 libspa-0.2-modules
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6693176Z   libspeex1 libsphinxbase3t64 libsratom-0-0 libsrt1.5-gnutls libssh-gcrypt-4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6694219Z   libsvtav1enc1d1 libswresample4 libswscale7 libtheora0 libtwolame0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6694957Z   libudfread0 libunibreak5 libva-drm2 libva-x11-2 libva2 libvdpau1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6695728Z   libvidstab1.1 libvorbisenc2 libvpl2 libvpx9 libwebrtc-audio-processing1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6696510Z   libx264-164 libx265-199 libxcb-shape0 libxv1 libxvidcore4 libzimg2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6697704Z   libzix-0-0 libzvbi-common libzvbi0t64 mesa-va-drivers mesa-vdpau-drivers
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6698587Z   ocl-icd-libopencl1 optipng ostree pocketsphinx-en-us session-migration
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6699430Z   va-driver-all vdpau-driver-all xdg-dbus-proxy xdg-desktop-portal
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6700096Z   xdg-desktop-portal-gtk
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6700395Z Suggested packages:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6700769Z   ffmpeg-doc avahi-daemon malcontent-gui brz subversion i965-va-driver-shaders
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6701310Z   libcuda1 libnvcuvid1 libnvidia-encode1 libbluray-bdj jackd2 libportaudio2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6701825Z   opus-tools pipewire pulseaudio libraw1394-doc librsvg2-bin serdi sndiod
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6702307Z   sordi speex opencl-icd libvdpau-va-gl1 accountsservice evince
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.6702674Z   xdg-desktop-portal-gnome
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7848856Z The following NEW packages will be installed:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7849743Z   appstream-compose bubblewrap desktop-file-utils elfutils ffmpeg flatpak
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7851257Z   flatpak-builder gir1.2-flatpak-1.0 gsettings-desktop-schemas i965-va-driver
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7852300Z   intel-media-va-driver libaacs0 libappstream-compose0 libasm1t64 libass9
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7864524Z   libasyncns0 libavahi-glib1 libavc1394-0 libavcodec60 libavdevice60
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7874752Z   libavfilter9 libavformat60 libavutil58 libbdplus0 libblas3 libbluray2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7875701Z   libbs2b0 libcaca0 libcdio-cdda2t64 libcdio-paranoia2t64 libcdio19t64
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7876409Z   libchromaprint1 libcjson1 libcodec2-1.2 libdav1d7 libdc1394-25 libdecor-0-0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7877135Z   libdecor-0-plugin-1-gtk libflac12t64 libflatpak0 libflite1 libgme0 libgsm1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7877836Z   libhwy1t64 libiec61883-0 libigdgmm12 libjack-jackd2-0 libjxl0.7 liblapack3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7878523Z   liblilv-0-0 libmalcontent-0-0 libmbedcrypto7t64 libmp3lame0 libmpg123-0t64
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7879213Z   libmysofa1 libopenal-data libopenal1 libopenmpt0t64 libopus0 libostree-1-1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7879930Z   libpipewire-0.3-0t64 libpipewire-0.3-common libplacebo338 libpocketsphinx3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7880601Z   libpostproc57 libpulse0 librav1e0 libraw1394-11 librist4 librsvg2-2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7881246Z   librsvg2-common librubberband2 libsamplerate0 libsdl2-2.0-0 libserd-0-0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7881919Z   libshine3 libsndfile1 libsndio7.0 libsord-0-0 libsoxr0 libspa-0.2-modules
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7882601Z   libspeex1 libsphinxbase3t64 libsratom-0-0 libsrt1.5-gnutls libssh-gcrypt-4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7883219Z   libsvtav1enc1d1 libswresample4 libswscale7 libtheora0 libtwolame0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7884017Z   libudfread0 libunibreak5 libva-drm2 libva-x11-2 libva2 libvdpau1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7884628Z   libvidstab1.1 libvorbisenc2 libvpl2 libvpx9 libwebrtc-audio-processing1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7885227Z   libx264-164 libx265-199 libxcb-shape0 libxv1 libxvidcore4 libzimg2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7885762Z   libzix-0-0 libzvbi-common libzvbi0t64 makeself mesa-va-drivers
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7886356Z   mesa-vdpau-drivers ocl-icd-libopencl1 optipng ostree pocketsphinx-en-us
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7886954Z   session-migration va-driver-all vdpau-driver-all xdg-dbus-proxy
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.7887439Z   xdg-desktop-portal xdg-desktop-portal-gtk
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.8357210Z 0 upgraded, 124 newly installed, 0 to remove and 38 not upgraded.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.8939527Z Need to get 99.0 MB of archives.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.8940046Z After this operation, 246 MB of additional disk space will be used.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.8940771Z Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.9183844Z Get:2 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 librsvg2-2 amd64 2.58.0+dfsg-1build1 [2135 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.9446008Z Get:3 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libappstream-compose0 amd64 1.0.2-1build6 [84.3 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.9527092Z Get:4 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 appstream-compose amd64 1.0.2-1build6 [27.7 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.9609316Z Get:5 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 bubblewrap amd64 0.9.0-1ubuntu0.1 [50.2 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.9692920Z Get:6 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 desktop-file-utils amd64 0.27-2build1 [53.8 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.9776092Z Get:7 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libasm1t64 amd64 0.190-1.1ubuntu0.1 [17.5 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.9859962Z Get:8 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 elfutils amd64 0.190-1.1ubuntu0.1 [525 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:33.9969444Z Get:9 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 libva2 amd64 2.20.0-2ubuntu0.2 [66.4 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.0049550Z Get:10 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 libva-drm2 amd64 2.20.0-2ubuntu0.2 [7124 B]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.0126039Z Get:11 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 libva-x11-2 amd64 2.20.0-2ubuntu0.2 [12.0 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.0205953Z Get:12 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libvdpau1 amd64 1.5-2build1 [27.8 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.0287390Z Get:13 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libvpl2 amd64 2023.3.0-1build1 [99.8 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.0372103Z Get:14 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 ocl-icd-libopencl1 amd64 2.3.2-1build1 [38.5 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.0457981Z Get:15 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavutil58 amd64 7:6.1.1-3ubuntu5 [401 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.0562451Z Get:16 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libcodec2-1.2 amd64 1.2.0-2build1 [8998 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.1168881Z Get:17 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libdav1d7 amd64 1.4.1-1build1 [604 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.1283882Z Get:18 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libgsm1 amd64 1.0.22-1build1 [27.8 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.1363436Z Get:19 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libhwy1t64 amd64 1.0.7-8.1build1 [584 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.1920522Z Get:20 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 libjxl0.7 amd64 0.7.0-10.2ubuntu6.1 [1001 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.2064143Z Get:21 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libmp3lame0 amd64 3.100-6build1 [142 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.2149005Z Get:22 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libopus0 amd64 1.4-1build1 [208 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.2237762Z Get:23 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 librav1e0 amd64 0.7.1-2 [1022 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.2449595Z Get:24 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libshine3 amd64 3.1.1-2build1 [23.2 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.2532366Z Get:25 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libspeex1 amd64 1.2.1-2ubuntu2.24.04.1 [59.6 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.2616572Z Get:26 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsvtav1enc1d1 amd64 1.7.0+dfsg-2build1 [2425 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.3039536Z Get:27 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsoxr0 amd64 0.1.3-4build3 [80.0 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.3125365Z Get:28 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libswresample4 amd64 7:6.1.1-3ubuntu5 [63.8 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.3212251Z Get:29 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libtheora0 amd64 1.1.1+dfsg.1-16.1build3 [211 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.3323329Z Get:30 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libtwolame0 amd64 0.4.0-2build3 [52.3 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.3409195Z Get:31 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libvorbisenc2 amd64 1.3.7-1build3 [80.8 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.3493907Z Get:32 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libvpx9 amd64 1.14.0-1ubuntu2.3 [1143 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.3695153Z Get:33 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libx264-164 amd64 2:0.164.3108+git31e19f9-1 [604 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.3816587Z Get:34 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libx265-199 amd64 3.5-2build1 [1226 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.3974482Z Get:35 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libxvidcore4 amd64 2:1.3.7-1build1 [219 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.4060318Z Get:36 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzvbi-common all 0.2.42-2 [42.4 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.4138966Z Get:37 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzvbi0t64 amd64 0.2.42-2 [261 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.4228912Z Get:38 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavcodec60 amd64 7:6.1.1-3ubuntu5 [5851 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.5239988Z Get:39 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libraw1394-11 amd64 2.1.2-2build3 [26.2 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.5320981Z Get:40 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libavc1394-0 amd64 0.5.4-5build3 [15.4 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.5404074Z Get:41 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libunibreak5 amd64 5.1-2build1 [25.0 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.5484161Z Get:42 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libass9 amd64 1:0.17.1-2build1 [104 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.5566374Z Get:43 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libudfread0 amd64 1.1.2-1build1 [19.0 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.5640681Z Get:44 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libbluray2 amd64 1:1.3.4-1build1 [159 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.5724566Z Get:45 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libchromaprint1 amd64 1.5.1-5 [30.5 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.5801959Z Get:46 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libgme0 amd64 0.6.3-7build1 [134 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.5921438Z Get:47 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libmpg123-0t64 amd64 1.32.5-1ubuntu1.1 [169 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.6022489Z Get:48 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenmpt0t64 amd64 0.7.3-1.1build3 [647 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.6141867Z Get:49 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libcjson1 amd64 1.7.17-1 [24.8 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.6222388Z Get:50 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmbedcrypto7t64 amd64 2.28.8-1 [209 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.6314032Z Get:51 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 librist4 amd64 0.2.10+dfsg-2 [74.9 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.6394287Z Get:52 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsrt1.5-gnutls amd64 1.5.3-1build2 [316 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.6498007Z Get:53 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libssh-gcrypt-4 amd64 0.10.6-2ubuntu0.4 [225 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.6602490Z Get:54 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavformat60 amd64 7:6.1.1-3ubuntu5 [1153 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.6759720Z Get:55 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libbs2b0 amd64 3.1.0+dfsg-7build1 [10.6 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.6841390Z Get:56 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libflite1 amd64 2.2-6build3 [13.6 MB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.7814799Z Get:57 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libserd-0-0 amd64 0.32.2-1 [43.6 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.8316848Z Get:58 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzix-0-0 amd64 0.4.2-2build1 [23.6 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.8394440Z Get:59 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsord-0-0 amd64 0.16.16-2build1 [15.8 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.8471238Z Get:60 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsratom-0-0 amd64 0.6.16-1build1 [17.3 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.8550057Z Get:61 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 liblilv-0-0 amd64 0.24.22-1build1 [41.0 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.8633833Z Get:62 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmysofa1 amd64 1.3.2+dfsg-2ubuntu2 [1158 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.8797454Z Get:63 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libplacebo338 amd64 6.338.2-2build1 [2654 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.9103166Z Get:64 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libblas3 amd64 3.12.0-3build1.1 [238 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.9195028Z Get:65 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 liblapack3 amd64 3.12.0-3build1.1 [2646 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.9519570Z Get:66 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libasyncns0 amd64 0.8-6build4 [11.3 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.9599027Z Get:67 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libflac12t64 amd64 1.4.3+ds-2.1ubuntu2 [197 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.9688514Z Get:68 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libsndfile1 amd64 1.2.2-1ubuntu5.24.04.1 [209 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.9783185Z Get:69 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libpulse0 amd64 1:16.1+dfsg1-2ubuntu10.1 [292 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.9883937Z Get:70 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsphinxbase3t64 amd64 0.8+5prealpha+1-17build2 [126 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:34.9967047Z Get:71 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libpocketsphinx3 amd64 0.8.0+real5prealpha+1-15ubuntu5 [133 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.0057873Z Get:72 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libpostproc57 amd64 7:6.1.1-3ubuntu5 [49.9 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.0142469Z Get:73 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libsamplerate0 amd64 0.2.2-4build1 [1344 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.0307977Z Get:74 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 librubberband2 amd64 3.3.0+dfsg-2build1 [130 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.0395720Z Get:75 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libswscale7 amd64 7:6.1.1-3ubuntu5 [193 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.0929202Z Get:76 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libvidstab1.1 amd64 1.1.0-2build1 [38.5 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.1007935Z Get:77 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzimg2 amd64 3.0.5+ds1-1build1 [254 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.1103946Z Get:78 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavfilter9 amd64 7:6.1.1-3ubuntu5 [4235 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.1487945Z Get:79 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libcaca0 amd64 0.99.beta20-4ubuntu0.2 [209 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.1584198Z Get:80 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libcdio19t64 amd64 2.1.0-4.1ubuntu1.2 [62.4 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.1664409Z Get:81 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libcdio-cdda2t64 amd64 10.2+2.0.1-1.1build2 [16.5 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.1741473Z Get:82 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libcdio-paranoia2t64 amd64 10.2+2.0.1-1.1build2 [16.6 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.1817807Z Get:83 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libdc1394-25 amd64 2.2.6-4build1 [90.1 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.1899656Z Get:84 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libiec61883-0 amd64 1.2.0-6build1 [24.5 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.1986527Z Get:85 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libjack-jackd2-0 amd64 1.9.21~dfsg-3ubuntu3 [289 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.2095161Z Get:86 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenal-data all 1:1.23.1-4build1 [161 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.2195757Z Get:87 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsndio7.0 amd64 1.9.0-0.3build3 [29.6 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.2282951Z Get:88 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenal1 amd64 1:1.23.1-4build1 [540 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.2399636Z Get:89 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libdecor-0-0 amd64 0.2.2-1build2 [16.5 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.2477345Z Get:90 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libsdl2-2.0-0 amd64 2.30.0+dfsg-1ubuntu3.1 [686 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.2638196Z Get:91 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libxcb-shape0 amd64 1.15-1ubuntu2 [6100 B]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.2716309Z Get:92 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libxv1 amd64 2:1.0.11-1.1build1 [10.7 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.2794721Z Get:93 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavdevice60 amd64 7:6.1.1-3ubuntu5 [82.3 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.2885809Z Get:94 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 ffmpeg amd64 7:6.1.1-3ubuntu5 [1879 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.3604069Z Get:95 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 xdg-dbus-proxy amd64 0.1.5-1ubuntu0.2 [26.4 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.3684882Z Get:96 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libmalcontent-0-0 amd64 0.11.1-1ubuntu1.3 [22.3 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.3764240Z Get:97 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libavahi-glib1 amd64 0.8-13ubuntu6.2 [8186 B]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.3844821Z Get:98 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libostree-1-1 amd64 2024.5-1build2 [373 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.3960746Z Get:99 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 flatpak amd64 1.14.6-1ubuntu0.1 [1350 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.4179913Z Get:100 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 libflatpak0 amd64 1.14.6-1ubuntu0.1 [303 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.4291321Z Get:101 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 gir1.2-flatpak-1.0 amd64 1.14.6-1ubuntu0.1 [13.0 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.4370124Z Get:102 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 ostree amd64 2024.5-1build2 [181 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.4496049Z Get:103 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 flatpak-builder amd64 1.4.2-1build2 [163 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.4618651Z Get:104 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 session-migration amd64 0.3.9build1 [9034 B]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.4701167Z Get:105 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 gsettings-desktop-schemas all 46.1-0ubuntu1 [35.6 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.4782219Z Get:106 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 libigdgmm12 amd64 22.3.17+ds1-1ubuntu1 [145 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.4875222Z Get:107 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 intel-media-va-driver amd64 24.1.0+dfsg1-1ubuntu0.2 [3163 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.5240511Z Get:108 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libaacs0 amd64 0.11.1-2build1 [62.9 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.5352967Z Get:109 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libbdplus0 amd64 0.2.0-3build1 [52.2 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.5434625Z Get:110 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libdecor-0-plugin-1-gtk amd64 0.2.2-1build2 [22.2 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.5514938Z Get:111 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libwebrtc-audio-processing1 amd64 0.3.1-0ubuntu6 [290 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.5619323Z Get:112 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libspa-0.2-modules amd64 1.0.5-1ubuntu3.3 [628 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.5748036Z Get:113 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libpipewire-0.3-0t64 amd64 1.0.5-1ubuntu3.3 [252 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.5842964Z Get:114 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libpipewire-0.3-common all 1.0.5-1ubuntu3.3 [19.5 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.5924640Z Get:115 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 librsvg2-common amd64 2.58.0+dfsg-1build1 [11.8 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.6004357Z Get:116 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 makeself all 2.5.0-1 [24.2 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.6083382Z Get:117 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 mesa-va-drivers amd64 25.2.8-0ubuntu0.24.04.2 [6784 B]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.6162307Z Get:118 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 mesa-vdpau-drivers amd64 25.2.8-0ubuntu0.24.04.2 [23.2 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.6242442Z Get:119 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 optipng amd64 0.7.8+ds-1build2 [110 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.6771278Z Get:120 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 i965-va-driver amd64 2.4.1+dfsg1-1ubuntu0.2 [332 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.6874841Z Get:121 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 va-driver-all amd64 2.20.0-2ubuntu0.2 [5014 B]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.6951703Z Get:122 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 vdpau-driver-all amd64 1.5-2build1 [4414 B]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.7031578Z Get:123 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 xdg-desktop-portal amd64 1.18.4-1ubuntu2.24.04.2 [307 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.7130664Z Get:124 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 xdg-desktop-portal-gtk amd64 1.15.1-1build2 [80.3 kB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:35.7216397Z Get:125 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 pocketsphinx-en-us all 0.8.0+real5prealpha+1-15ubuntu5 [27.4 MB]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:36.2864839Z Fetched 99.0 MB in 2s (48.6 MB/s)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:36.3140441Z Selecting previously unselected package librsvg2-2:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:36.3547735Z (Reading database ... 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:36.3548306Z (Reading database ... 5%
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:36.3548747Z (Reading database ... 10%
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:36.3549188Z (Reading database ... 15%
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:36.3549750Z (Reading database ... 20%
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:36.3550150Z (Reading database ... 25%
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:36.3550548Z (Reading database ... 30%
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:36.3551106Z (Reading database ... 35%
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:36.3551411Z (Reading database ... 40%
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:36.3551734Z (Reading database ... 45%
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:36.3552654Z (Reading database ... 50%
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:36.3605215Z (Reading database ... 55%
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:36.4179237Z (Reading database ... 60%
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:36.6496104Z (Reading database ... 65%
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:36.8188707Z (Reading database ... 70%
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:37.0506281Z (Reading database ... 75%
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:37.2081414Z (Reading database ... 80%
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:37.4640283Z (Reading database ... 85%
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:37.6151459Z (Reading database ... 90%
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:37.8134543Z (Reading database ... 95%
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:37.8135180Z (Reading database ... 100%
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:37.8135936Z (Reading database ... 203385 files and directories currently installed.)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:37.8177286Z Preparing to unpack .../000-librsvg2-2_2.58.0+dfsg-1build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:37.8219103Z Unpacking librsvg2-2:amd64 (2.58.0+dfsg-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:37.8759058Z Selecting previously unselected package libappstream-compose0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:37.8888298Z Preparing to unpack .../001-libappstream-compose0_1.0.2-1build6_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:37.8902035Z Unpacking libappstream-compose0:amd64 (1.0.2-1build6) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:37.9128658Z Selecting previously unselected package appstream-compose.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:37.9255060Z Preparing to unpack .../002-appstream-compose_1.0.2-1build6_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:37.9266403Z Unpacking appstream-compose (1.0.2-1build6) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:37.9518155Z Selecting previously unselected package bubblewrap.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:37.9644041Z Preparing to unpack .../003-bubblewrap_0.9.0-1ubuntu0.1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:37.9658968Z Unpacking bubblewrap (0.9.0-1ubuntu0.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.0010228Z Selecting previously unselected package desktop-file-utils.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.0135655Z Preparing to unpack .../004-desktop-file-utils_0.27-2build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.0151267Z Unpacking desktop-file-utils (0.27-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.0538275Z Selecting previously unselected package libasm1t64:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.0663894Z Preparing to unpack .../005-libasm1t64_0.190-1.1ubuntu0.1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.0676778Z Unpacking libasm1t64:amd64 (0.190-1.1ubuntu0.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.0889838Z Selecting previously unselected package elfutils.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.1016042Z Preparing to unpack .../006-elfutils_0.190-1.1ubuntu0.1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.1026124Z Unpacking elfutils (0.190-1.1ubuntu0.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.1403079Z Selecting previously unselected package libva2:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.1527604Z Preparing to unpack .../007-libva2_2.20.0-2ubuntu0.2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.1543802Z Unpacking libva2:amd64 (2.20.0-2ubuntu0.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.1782115Z Selecting previously unselected package libva-drm2:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.1907498Z Preparing to unpack .../008-libva-drm2_2.20.0-2ubuntu0.2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.1918517Z Unpacking libva-drm2:amd64 (2.20.0-2ubuntu0.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.2148250Z Selecting previously unselected package libva-x11-2:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.2272848Z Preparing to unpack .../009-libva-x11-2_2.20.0-2ubuntu0.2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.2286302Z Unpacking libva-x11-2:amd64 (2.20.0-2ubuntu0.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.2525834Z Selecting previously unselected package libvdpau1:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.2650262Z Preparing to unpack .../010-libvdpau1_1.5-2build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.2660937Z Unpacking libvdpau1:amd64 (1.5-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.2892356Z Selecting previously unselected package libvpl2.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.3016811Z Preparing to unpack .../011-libvpl2_2023.3.0-1build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.3029106Z Unpacking libvpl2 (2023.3.0-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.3265231Z Selecting previously unselected package ocl-icd-libopencl1:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.3390189Z Preparing to unpack .../012-ocl-icd-libopencl1_2.3.2-1build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.3403362Z Unpacking ocl-icd-libopencl1:amd64 (2.3.2-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.3668530Z Selecting previously unselected package libavutil58:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.3792972Z Preparing to unpack .../013-libavutil58_7%3a6.1.1-3ubuntu5_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.3807200Z Unpacking libavutil58:amd64 (7:6.1.1-3ubuntu5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.4076916Z Selecting previously unselected package libcodec2-1.2:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.4201456Z Preparing to unpack .../014-libcodec2-1.2_1.2.0-2build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.4212501Z Unpacking libcodec2-1.2:amd64 (1.2.0-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.4961780Z Selecting previously unselected package libdav1d7:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.5087756Z Preparing to unpack .../015-libdav1d7_1.4.1-1build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.5096998Z Unpacking libdav1d7:amd64 (1.4.1-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.5394786Z Selecting previously unselected package libgsm1:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.5519842Z Preparing to unpack .../016-libgsm1_1.0.22-1build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.5554012Z Unpacking libgsm1:amd64 (1.0.22-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.5778022Z Selecting previously unselected package libhwy1t64:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.5902035Z Preparing to unpack .../017-libhwy1t64_1.0.7-8.1build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.5911870Z Unpacking libhwy1t64:amd64 (1.0.7-8.1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.6255509Z Selecting previously unselected package libjxl0.7:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.6381541Z Preparing to unpack .../018-libjxl0.7_0.7.0-10.2ubuntu6.1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.6392083Z Unpacking libjxl0.7:amd64 (0.7.0-10.2ubuntu6.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.6758942Z Selecting previously unselected package libmp3lame0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.6885407Z Preparing to unpack .../019-libmp3lame0_3.100-6build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.6900842Z Unpacking libmp3lame0:amd64 (3.100-6build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.7144014Z Selecting previously unselected package libopus0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.7270059Z Preparing to unpack .../020-libopus0_1.4-1build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.7283440Z Unpacking libopus0:amd64 (1.4-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.7525628Z Selecting previously unselected package librav1e0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.7651249Z Preparing to unpack .../021-librav1e0_0.7.1-2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.7661994Z Unpacking librav1e0:amd64 (0.7.1-2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.7997773Z Selecting previously unselected package libshine3:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.8123433Z Preparing to unpack .../022-libshine3_3.1.1-2build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.8133427Z Unpacking libshine3:amd64 (3.1.1-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.8365221Z Selecting previously unselected package libspeex1:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.8494037Z Preparing to unpack .../023-libspeex1_1.2.1-2ubuntu2.24.04.1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.8503893Z Unpacking libspeex1:amd64 (1.2.1-2ubuntu2.24.04.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.8756601Z Selecting previously unselected package libsvtav1enc1d1:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.8884098Z Preparing to unpack .../024-libsvtav1enc1d1_1.7.0+dfsg-2build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.8895907Z Unpacking libsvtav1enc1d1:amd64 (1.7.0+dfsg-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.9398927Z Selecting previously unselected package libsoxr0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.9527244Z Preparing to unpack .../025-libsoxr0_0.1.3-4build3_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.9541594Z Unpacking libsoxr0:amd64 (0.1.3-4build3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.9781912Z Selecting previously unselected package libswresample4:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.9908549Z Preparing to unpack .../026-libswresample4_7%3a6.1.1-3ubuntu5_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:38.9922148Z Unpacking libswresample4:amd64 (7:6.1.1-3ubuntu5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.0151217Z Selecting previously unselected package libtheora0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.0277362Z Preparing to unpack .../027-libtheora0_1.1.1+dfsg.1-16.1build3_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.0290478Z Unpacking libtheora0:amd64 (1.1.1+dfsg.1-16.1build3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.0535983Z Selecting previously unselected package libtwolame0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.0662236Z Preparing to unpack .../028-libtwolame0_0.4.0-2build3_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.0672422Z Unpacking libtwolame0:amd64 (0.4.0-2build3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.0889581Z Selecting previously unselected package libvorbisenc2:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.1015838Z Preparing to unpack .../029-libvorbisenc2_1.3.7-1build3_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.1025977Z Unpacking libvorbisenc2:amd64 (1.3.7-1build3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.1267652Z Selecting previously unselected package libvpx9:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.1393378Z Preparing to unpack .../030-libvpx9_1.14.0-1ubuntu2.3_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.1408039Z Unpacking libvpx9:amd64 (1.14.0-1ubuntu2.3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.1762022Z Selecting previously unselected package libx264-164:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.1887367Z Preparing to unpack .../031-libx264-164_2%3a0.164.3108+git31e19f9-1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.1901537Z Unpacking libx264-164:amd64 (2:0.164.3108+git31e19f9-1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.2247485Z Selecting previously unselected package libx265-199:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.2373389Z Preparing to unpack .../032-libx265-199_3.5-2build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.2387020Z Unpacking libx265-199:amd64 (3.5-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.3040364Z Selecting previously unselected package libxvidcore4:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.3167185Z Preparing to unpack .../033-libxvidcore4_2%3a1.3.7-1build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.3179731Z Unpacking libxvidcore4:amd64 (2:1.3.7-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.3411280Z Selecting previously unselected package libzvbi-common.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.3538721Z Preparing to unpack .../034-libzvbi-common_0.2.42-2_all.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.3550354Z Unpacking libzvbi-common (0.2.42-2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.4223304Z Selecting previously unselected package libzvbi0t64:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.4351899Z Preparing to unpack .../035-libzvbi0t64_0.2.42-2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.4364140Z Unpacking libzvbi0t64:amd64 (0.2.42-2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.4627462Z Selecting previously unselected package libavcodec60:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.4754965Z Preparing to unpack .../036-libavcodec60_7%3a6.1.1-3ubuntu5_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.4765836Z Unpacking libavcodec60:amd64 (7:6.1.1-3ubuntu5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.5649143Z Selecting previously unselected package libraw1394-11:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.5775025Z Preparing to unpack .../037-libraw1394-11_2.1.2-2build3_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.5786648Z Unpacking libraw1394-11:amd64 (2.1.2-2build3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.6040094Z Selecting previously unselected package libavc1394-0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.6167214Z Preparing to unpack .../038-libavc1394-0_0.5.4-5build3_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.6180866Z Unpacking libavc1394-0:amd64 (0.5.4-5build3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.6608367Z Selecting previously unselected package libunibreak5:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.6738111Z Preparing to unpack .../039-libunibreak5_5.1-2build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.6749424Z Unpacking libunibreak5:amd64 (5.1-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.7019796Z Selecting previously unselected package libass9:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.7147299Z Preparing to unpack .../040-libass9_1%3a0.17.1-2build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.7455713Z Unpacking libass9:amd64 (1:0.17.1-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.7880771Z Selecting previously unselected package libudfread0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.8006932Z Preparing to unpack .../041-libudfread0_1.1.2-1build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.8017722Z Unpacking libudfread0:amd64 (1.1.2-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.8408991Z Selecting previously unselected package libbluray2:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.8536632Z Preparing to unpack .../042-libbluray2_1%3a1.3.4-1build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.8554492Z Unpacking libbluray2:amd64 (1:1.3.4-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.8821289Z Selecting previously unselected package libchromaprint1:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.8950628Z Preparing to unpack .../043-libchromaprint1_1.5.1-5_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.8960000Z Unpacking libchromaprint1:amd64 (1.5.1-5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.9216918Z Selecting previously unselected package libgme0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.9342304Z Preparing to unpack .../044-libgme0_0.6.3-7build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.9353370Z Unpacking libgme0:amd64 (0.6.3-7build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.9617513Z Selecting previously unselected package libmpg123-0t64:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.9744422Z Preparing to unpack .../045-libmpg123-0t64_1.32.5-1ubuntu1.1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:39.9758022Z Unpacking libmpg123-0t64:amd64 (1.32.5-1ubuntu1.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.0066246Z Selecting previously unselected package libopenmpt0t64:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.0193772Z Preparing to unpack .../046-libopenmpt0t64_0.7.3-1.1build3_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.0208929Z Unpacking libopenmpt0t64:amd64 (0.7.3-1.1build3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.0503182Z Selecting previously unselected package libcjson1:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.0644060Z Preparing to unpack .../047-libcjson1_1.7.17-1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.0695572Z Unpacking libcjson1:amd64 (1.7.17-1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.0948402Z Selecting previously unselected package libmbedcrypto7t64:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.1075728Z Preparing to unpack .../048-libmbedcrypto7t64_2.28.8-1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.1085240Z Unpacking libmbedcrypto7t64:amd64 (2.28.8-1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.1322310Z Selecting previously unselected package librist4:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.1448834Z Preparing to unpack .../049-librist4_0.2.10+dfsg-2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.1458878Z Unpacking librist4:amd64 (0.2.10+dfsg-2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.1678390Z Selecting previously unselected package libsrt1.5-gnutls:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.1805626Z Preparing to unpack .../050-libsrt1.5-gnutls_1.5.3-1build2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.1829904Z Unpacking libsrt1.5-gnutls:amd64 (1.5.3-1build2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.2087247Z Selecting previously unselected package libssh-gcrypt-4:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.2212672Z Preparing to unpack .../051-libssh-gcrypt-4_0.10.6-2ubuntu0.4_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.2226708Z Unpacking libssh-gcrypt-4:amd64 (0.10.6-2ubuntu0.4) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.2476726Z Selecting previously unselected package libavformat60:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.2602106Z Preparing to unpack .../052-libavformat60_7%3a6.1.1-3ubuntu5_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.2614373Z Unpacking libavformat60:amd64 (7:6.1.1-3ubuntu5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.2963400Z Selecting previously unselected package libbs2b0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.3088879Z Preparing to unpack .../053-libbs2b0_3.1.0+dfsg-7build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.3100737Z Unpacking libbs2b0:amd64 (3.1.0+dfsg-7build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.3375749Z Selecting previously unselected package libflite1:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.3501980Z Preparing to unpack .../054-libflite1_2.2-6build3_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.3518900Z Unpacking libflite1:amd64 (2.2-6build3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.4670972Z Selecting previously unselected package libserd-0-0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.4797794Z Preparing to unpack .../055-libserd-0-0_0.32.2-1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.4811910Z Unpacking libserd-0-0:amd64 (0.32.2-1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.5047396Z Selecting previously unselected package libzix-0-0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.5174275Z Preparing to unpack .../056-libzix-0-0_0.4.2-2build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.5189042Z Unpacking libzix-0-0:amd64 (0.4.2-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.5433194Z Selecting previously unselected package libsord-0-0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.5559664Z Preparing to unpack .../057-libsord-0-0_0.16.16-2build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.5571059Z Unpacking libsord-0-0:amd64 (0.16.16-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.5793732Z Selecting previously unselected package libsratom-0-0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.5918940Z Preparing to unpack .../058-libsratom-0-0_0.6.16-1build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.5929790Z Unpacking libsratom-0-0:amd64 (0.6.16-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.6144619Z Selecting previously unselected package liblilv-0-0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.6270799Z Preparing to unpack .../059-liblilv-0-0_0.24.22-1build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.6283035Z Unpacking liblilv-0-0:amd64 (0.24.22-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.6532759Z Selecting previously unselected package libmysofa1:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.6659528Z Preparing to unpack .../060-libmysofa1_1.3.2+dfsg-2ubuntu2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.6669850Z Unpacking libmysofa1:amd64 (1.3.2+dfsg-2ubuntu2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.6942878Z Selecting previously unselected package libplacebo338:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.7068902Z Preparing to unpack .../061-libplacebo338_6.338.2-2build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.7082220Z Unpacking libplacebo338:amd64 (6.338.2-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.7647685Z Selecting previously unselected package libblas3:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.7773859Z Preparing to unpack .../062-libblas3_3.12.0-3build1.1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.7804492Z Unpacking libblas3:amd64 (3.12.0-3build1.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.8061614Z Selecting previously unselected package liblapack3:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.8188469Z Preparing to unpack .../063-liblapack3_3.12.0-3build1.1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.8221674Z Unpacking liblapack3:amd64 (3.12.0-3build1.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.8756174Z Selecting previously unselected package libasyncns0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.8884163Z Preparing to unpack .../064-libasyncns0_0.8-6build4_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.8895446Z Unpacking libasyncns0:amd64 (0.8-6build4) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.9112692Z Selecting previously unselected package libflac12t64:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.9240853Z Preparing to unpack .../065-libflac12t64_1.4.3+ds-2.1ubuntu2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.9250714Z Unpacking libflac12t64:amd64 (1.4.3+ds-2.1ubuntu2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.9481397Z Selecting previously unselected package libsndfile1:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.9607467Z Preparing to unpack .../066-libsndfile1_1.2.2-1ubuntu5.24.04.1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.9617435Z Unpacking libsndfile1:amd64 (1.2.2-1ubuntu5.24.04.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:40.9890122Z Selecting previously unselected package libpulse0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.0016396Z Preparing to unpack .../067-libpulse0_1%3a16.1+dfsg1-2ubuntu10.1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.0086048Z Unpacking libpulse0:amd64 (1:16.1+dfsg1-2ubuntu10.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.0349008Z Selecting previously unselected package libsphinxbase3t64:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.0477584Z Preparing to unpack .../068-libsphinxbase3t64_0.8+5prealpha+1-17build2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.0487122Z Unpacking libsphinxbase3t64:amd64 (0.8+5prealpha+1-17build2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.0715821Z Selecting previously unselected package libpocketsphinx3:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.0842206Z Preparing to unpack .../069-libpocketsphinx3_0.8.0+real5prealpha+1-15ubuntu5_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.0852079Z Unpacking libpocketsphinx3:amd64 (0.8.0+real5prealpha+1-15ubuntu5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.1090657Z Selecting previously unselected package libpostproc57:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.1216770Z Preparing to unpack .../070-libpostproc57_7%3a6.1.1-3ubuntu5_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.1225760Z Unpacking libpostproc57:amd64 (7:6.1.1-3ubuntu5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.1443925Z Selecting previously unselected package libsamplerate0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.1568858Z Preparing to unpack .../071-libsamplerate0_0.2.2-4build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.1579594Z Unpacking libsamplerate0:amd64 (0.2.2-4build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.1842673Z Selecting previously unselected package librubberband2:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.1969227Z Preparing to unpack .../072-librubberband2_3.3.0+dfsg-2build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.1979142Z Unpacking librubberband2:amd64 (3.3.0+dfsg-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.2232517Z Selecting previously unselected package libswscale7:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.2357385Z Preparing to unpack .../073-libswscale7_7%3a6.1.1-3ubuntu5_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.2368433Z Unpacking libswscale7:amd64 (7:6.1.1-3ubuntu5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.2603076Z Selecting previously unselected package libvidstab1.1:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.2729199Z Preparing to unpack .../074-libvidstab1.1_1.1.0-2build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.2738719Z Unpacking libvidstab1.1:amd64 (1.1.0-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.2946867Z Selecting previously unselected package libzimg2:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.3072237Z Preparing to unpack .../075-libzimg2_3.0.5+ds1-1build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.3080555Z Unpacking libzimg2:amd64 (3.0.5+ds1-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.3342553Z Selecting previously unselected package libavfilter9:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.3468440Z Preparing to unpack .../076-libavfilter9_7%3a6.1.1-3ubuntu5_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.3478988Z Unpacking libavfilter9:amd64 (7:6.1.1-3ubuntu5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.4191431Z Selecting previously unselected package libcaca0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.4320037Z Preparing to unpack .../077-libcaca0_0.99.beta20-4ubuntu0.2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.4330915Z Unpacking libcaca0:amd64 (0.99.beta20-4ubuntu0.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.4590305Z Selecting previously unselected package libcdio19t64:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.4715885Z Preparing to unpack .../078-libcdio19t64_2.1.0-4.1ubuntu1.2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.4726151Z Unpacking libcdio19t64:amd64 (2.1.0-4.1ubuntu1.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.4951540Z Selecting previously unselected package libcdio-cdda2t64:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.5077607Z Preparing to unpack .../079-libcdio-cdda2t64_10.2+2.0.1-1.1build2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.5087369Z Unpacking libcdio-cdda2t64:amd64 (10.2+2.0.1-1.1build2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.5295421Z Selecting previously unselected package libcdio-paranoia2t64:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.5422482Z Preparing to unpack .../080-libcdio-paranoia2t64_10.2+2.0.1-1.1build2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.5433120Z Unpacking libcdio-paranoia2t64:amd64 (10.2+2.0.1-1.1build2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.5641508Z Selecting previously unselected package libdc1394-25:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.5766978Z Preparing to unpack .../081-libdc1394-25_2.2.6-4build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.5776743Z Unpacking libdc1394-25:amd64 (2.2.6-4build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.5994371Z Selecting previously unselected package libiec61883-0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.6120369Z Preparing to unpack .../082-libiec61883-0_1.2.0-6build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.6130357Z Unpacking libiec61883-0:amd64 (1.2.0-6build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.6464595Z Selecting previously unselected package libjack-jackd2-0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.6592588Z Preparing to unpack .../083-libjack-jackd2-0_1.9.21~dfsg-3ubuntu3_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.6601604Z Unpacking libjack-jackd2-0:amd64 (1.9.21~dfsg-3ubuntu3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.6853445Z Selecting previously unselected package libopenal-data.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.6981546Z Preparing to unpack .../084-libopenal-data_1%3a1.23.1-4build1_all.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.6991291Z Unpacking libopenal-data (1:1.23.1-4build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.7232729Z Selecting previously unselected package libsndio7.0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.7359981Z Preparing to unpack .../085-libsndio7.0_1.9.0-0.3build3_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.7369221Z Unpacking libsndio7.0:amd64 (1.9.0-0.3build3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.7595071Z Selecting previously unselected package libopenal1:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.7722982Z Preparing to unpack .../086-libopenal1_1%3a1.23.1-4build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.7731835Z Unpacking libopenal1:amd64 (1:1.23.1-4build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.8010943Z Selecting previously unselected package libdecor-0-0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.8138456Z Preparing to unpack .../087-libdecor-0-0_0.2.2-1build2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.8147138Z Unpacking libdecor-0-0:amd64 (0.2.2-1build2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.8367508Z Selecting previously unselected package libsdl2-2.0-0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.8497560Z Preparing to unpack .../088-libsdl2-2.0-0_2.30.0+dfsg-1ubuntu3.1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.8512283Z Unpacking libsdl2-2.0-0:amd64 (2.30.0+dfsg-1ubuntu3.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.8821532Z Selecting previously unselected package libxcb-shape0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.8948752Z Preparing to unpack .../089-libxcb-shape0_1.15-1ubuntu2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.8962723Z Unpacking libxcb-shape0:amd64 (1.15-1ubuntu2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.9195996Z Selecting previously unselected package libxv1:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.9321580Z Preparing to unpack .../090-libxv1_2%3a1.0.11-1.1build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.9336278Z Unpacking libxv1:amd64 (2:1.0.11-1.1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.9572526Z Selecting previously unselected package libavdevice60:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.9700056Z Preparing to unpack .../091-libavdevice60_7%3a6.1.1-3ubuntu5_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.9714956Z Unpacking libavdevice60:amd64 (7:6.1.1-3ubuntu5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:41.9942240Z Selecting previously unselected package ffmpeg.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.0071426Z Preparing to unpack .../092-ffmpeg_7%3a6.1.1-3ubuntu5_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.0089616Z Unpacking ffmpeg (7:6.1.1-3ubuntu5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.0454871Z Selecting previously unselected package xdg-dbus-proxy.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.0581032Z Preparing to unpack .../093-xdg-dbus-proxy_0.1.5-1ubuntu0.2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.0590484Z Unpacking xdg-dbus-proxy (0.1.5-1ubuntu0.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.0813377Z Selecting previously unselected package libmalcontent-0-0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.0941702Z Preparing to unpack .../094-libmalcontent-0-0_0.11.1-1ubuntu1.3_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.0973225Z Unpacking libmalcontent-0-0:amd64 (0.11.1-1ubuntu1.3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.1184493Z Selecting previously unselected package libavahi-glib1:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.1311812Z Preparing to unpack .../095-libavahi-glib1_0.8-13ubuntu6.2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.1321081Z Unpacking libavahi-glib1:amd64 (0.8-13ubuntu6.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.1530699Z Selecting previously unselected package libostree-1-1:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.1656983Z Preparing to unpack .../096-libostree-1-1_2024.5-1build2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.1665655Z Unpacking libostree-1-1:amd64 (2024.5-1build2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.1931591Z Selecting previously unselected package flatpak.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.2059652Z Preparing to unpack .../097-flatpak_1.14.6-1ubuntu0.1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.2151971Z Unpacking flatpak (1.14.6-1ubuntu0.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.3361063Z Selecting previously unselected package libflatpak0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.3486704Z Preparing to unpack .../098-libflatpak0_1.14.6-1ubuntu0.1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.3498707Z Unpacking libflatpak0:amd64 (1.14.6-1ubuntu0.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.3726998Z Selecting previously unselected package gir1.2-flatpak-1.0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.3855288Z Preparing to unpack .../099-gir1.2-flatpak-1.0_1.14.6-1ubuntu0.1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.3863954Z Unpacking gir1.2-flatpak-1.0:amd64 (1.14.6-1ubuntu0.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.4071506Z Selecting previously unselected package ostree.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.4202158Z Preparing to unpack .../100-ostree_2024.5-1build2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.4211347Z Unpacking ostree (2024.5-1build2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.4506313Z Selecting previously unselected package flatpak-builder.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.4634693Z Preparing to unpack .../101-flatpak-builder_1.4.2-1build2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.4645691Z Unpacking flatpak-builder (1.4.2-1build2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.4898266Z Selecting previously unselected package session-migration.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.5024964Z Preparing to unpack .../102-session-migration_0.3.9build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.5032971Z Unpacking session-migration (0.3.9build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.5251595Z Selecting previously unselected package gsettings-desktop-schemas.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.5378215Z Preparing to unpack .../103-gsettings-desktop-schemas_46.1-0ubuntu1_all.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.5388778Z Unpacking gsettings-desktop-schemas (46.1-0ubuntu1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.5765696Z Selecting previously unselected package libigdgmm12:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.5891540Z Preparing to unpack .../104-libigdgmm12_22.3.17+ds1-1ubuntu1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.5901288Z Unpacking libigdgmm12:amd64 (22.3.17+ds1-1ubuntu1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.6152298Z Selecting previously unselected package intel-media-va-driver:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.6279886Z Preparing to unpack .../105-intel-media-va-driver_24.1.0+dfsg1-1ubuntu0.2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.6289854Z Unpacking intel-media-va-driver:amd64 (24.1.0+dfsg1-1ubuntu0.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.6949632Z Selecting previously unselected package libaacs0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.7077100Z Preparing to unpack .../106-libaacs0_0.11.1-2build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.7085976Z Unpacking libaacs0:amd64 (0.11.1-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.7308893Z Selecting previously unselected package libbdplus0:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.7435825Z Preparing to unpack .../107-libbdplus0_0.2.0-3build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.7445534Z Unpacking libbdplus0:amd64 (0.2.0-3build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.7680913Z Selecting previously unselected package libdecor-0-plugin-1-gtk:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.7807445Z Preparing to unpack .../108-libdecor-0-plugin-1-gtk_0.2.2-1build2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.7818799Z Unpacking libdecor-0-plugin-1-gtk:amd64 (0.2.2-1build2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.8034736Z Selecting previously unselected package libwebrtc-audio-processing1:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.8159890Z Preparing to unpack .../109-libwebrtc-audio-processing1_0.3.1-0ubuntu6_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.8169640Z Unpacking libwebrtc-audio-processing1:amd64 (0.3.1-0ubuntu6) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.8396155Z Selecting previously unselected package libspa-0.2-modules:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.8522132Z Preparing to unpack .../110-libspa-0.2-modules_1.0.5-1ubuntu3.3_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.8534553Z Unpacking libspa-0.2-modules:amd64 (1.0.5-1ubuntu3.3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.8855339Z Selecting previously unselected package libpipewire-0.3-0t64:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.8980549Z Preparing to unpack .../111-libpipewire-0.3-0t64_1.0.5-1ubuntu3.3_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.8989079Z Unpacking libpipewire-0.3-0t64:amd64 (1.0.5-1ubuntu3.3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.9220394Z Selecting previously unselected package libpipewire-0.3-common.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.9345568Z Preparing to unpack .../112-libpipewire-0.3-common_1.0.5-1ubuntu3.3_all.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.9355719Z Unpacking libpipewire-0.3-common (1.0.5-1ubuntu3.3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.9551860Z Selecting previously unselected package librsvg2-common:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.9678119Z Preparing to unpack .../113-librsvg2-common_2.58.0+dfsg-1build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.9705577Z Unpacking librsvg2-common:amd64 (2.58.0+dfsg-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:42.9923694Z Selecting previously unselected package makeself.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.0049073Z Preparing to unpack .../114-makeself_2.5.0-1_all.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.0058399Z Unpacking makeself (2.5.0-1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.0256053Z Selecting previously unselected package mesa-va-drivers:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.0380995Z Preparing to unpack .../115-mesa-va-drivers_25.2.8-0ubuntu0.24.04.2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.0389644Z Unpacking mesa-va-drivers:amd64 (25.2.8-0ubuntu0.24.04.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.0590182Z Selecting previously unselected package mesa-vdpau-drivers:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.0715835Z Preparing to unpack .../116-mesa-vdpau-drivers_25.2.8-0ubuntu0.24.04.2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.0724699Z Unpacking mesa-vdpau-drivers:amd64 (25.2.8-0ubuntu0.24.04.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.0966222Z Selecting previously unselected package optipng.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.1090834Z Preparing to unpack .../117-optipng_0.7.8+ds-1build2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.1098980Z Unpacking optipng (0.7.8+ds-1build2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.1311322Z Selecting previously unselected package i965-va-driver:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.1436295Z Preparing to unpack .../118-i965-va-driver_2.4.1+dfsg1-1ubuntu0.2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.1444958Z Unpacking i965-va-driver:amd64 (2.4.1+dfsg1-1ubuntu0.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.1698938Z Selecting previously unselected package va-driver-all:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.1824933Z Preparing to unpack .../119-va-driver-all_2.20.0-2ubuntu0.2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.1835247Z Unpacking va-driver-all:amd64 (2.20.0-2ubuntu0.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.2084948Z Selecting previously unselected package vdpau-driver-all:amd64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.2212618Z Preparing to unpack .../120-vdpau-driver-all_1.5-2build1_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.2225124Z Unpacking vdpau-driver-all:amd64 (1.5-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.2425475Z Selecting previously unselected package xdg-desktop-portal.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.2553923Z Preparing to unpack .../121-xdg-desktop-portal_1.18.4-1ubuntu2.24.04.2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.2565886Z Unpacking xdg-desktop-portal (1.18.4-1ubuntu2.24.04.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.2827283Z Selecting previously unselected package xdg-desktop-portal-gtk.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.2954643Z Preparing to unpack .../122-xdg-desktop-portal-gtk_1.15.1-1build2_amd64.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.2963442Z Unpacking xdg-desktop-portal-gtk (1.15.1-1build2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.3199516Z Selecting previously unselected package pocketsphinx-en-us.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.3327660Z Preparing to unpack .../123-pocketsphinx-en-us_0.8.0+real5prealpha+1-15ubuntu5_all.deb ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.3352796Z Unpacking pocketsphinx-en-us (0.8.0+real5prealpha+1-15ubuntu5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.5194529Z Setting up libgme0:amd64 (0.6.3-7build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.5221264Z Setting up libchromaprint1:amd64 (1.5.1-5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.5265978Z Setting up libssh-gcrypt-4:amd64 (0.10.6-2ubuntu0.4) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.5291736Z Setting up libpipewire-0.3-common (1.0.5-1ubuntu3.3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.5315787Z Setting up libhwy1t64:amd64 (1.0.7-8.1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.5339566Z Setting up bubblewrap (0.9.0-1ubuntu0.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.5385781Z Setting up libudfread0:amd64 (1.1.2-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.5410718Z Setting up session-migration (0.3.9build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.6661401Z Created symlink /etc/systemd/user/graphical-session-pre.target.wants/session-migration.service → /usr/lib/systemd/user/session-migration.service.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.6662509Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.6690469Z Setting up libraw1394-11:amd64 (2.1.2-2build3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.6716167Z Setting up desktop-file-utils (0.27-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.6951513Z Setting up libspeex1:amd64 (1.2.1-2ubuntu2.24.04.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.6975502Z Setting up libshine3:amd64 (3.1.1-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7003229Z Setting up libcaca0:amd64 (0.99.beta20-4ubuntu0.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7032049Z Setting up libvpl2 (2023.3.0-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7058674Z Setting up makeself (2.5.0-1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7086295Z Setting up libx264-164:amd64 (2:0.164.3108+git31e19f9-1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7112627Z Setting up libtwolame0:amd64 (0.4.0-2build3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7137731Z Setting up libmbedcrypto7t64:amd64 (2.28.8-1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7167012Z Setting up libgsm1:amd64 (1.0.22-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7194795Z Setting up libsoxr0:amd64 (0.1.3-4build3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7219577Z Setting up libzix-0-0:amd64 (0.4.2-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7245382Z Setting up libcodec2-1.2:amd64 (1.2.0-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7273780Z Setting up libmysofa1:amd64 (1.3.2+dfsg-2ubuntu2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7299381Z Setting up libxcb-shape0:amd64 (1.15-1ubuntu2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7335289Z Setting up libcdio19t64:amd64 (2.1.0-4.1ubuntu1.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7361911Z Setting up libwebrtc-audio-processing1:amd64 (0.3.1-0ubuntu6) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7388337Z Setting up libsvtav1enc1d1:amd64 (1.7.0+dfsg-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7411762Z Setting up libigdgmm12:amd64 (22.3.17+ds1-1ubuntu1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7436244Z Setting up libmpg123-0t64:amd64 (1.32.5-1ubuntu1.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7488497Z Setting up libcjson1:amd64 (1.7.17-1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7516363Z Setting up libxvidcore4:amd64 (2:1.3.7-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7543900Z Setting up librav1e0:amd64 (0.7.1-2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7571088Z Setting up libcdio-cdda2t64:amd64 (10.2+2.0.1-1.1build2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7594459Z Setting up librist4:amd64 (0.2.10+dfsg-2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7619613Z Setting up librsvg2-2:amd64 (2.58.0+dfsg-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7650072Z Setting up libblas3:amd64 (3.12.0-3build1.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7718409Z update-alternatives: using /usr/lib/x86_64-linux-gnu/blas/libblas.so.3 to provide /usr/lib/x86_64-linux-gnu/libblas.so.3 (libblas.so.3-x86_64-linux-gnu) in auto mode
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7738535Z Setting up libplacebo338:amd64 (6.338.2-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7763101Z Setting up libva2:amd64 (2.20.0-2ubuntu0.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7807738Z Setting up libspa-0.2-modules:amd64 (1.0.5-1ubuntu3.3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7835801Z Setting up optipng (0.7.8+ds-1build2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7862886Z Setting up libasm1t64:amd64 (0.190-1.1ubuntu0.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7892057Z Setting up libopus0:amd64 (1.4-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7915907Z Setting up libcdio-paranoia2t64:amd64 (10.2+2.0.1-1.1build2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7939636Z Setting up libdc1394-25:amd64 (2.2.6-4build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.7972795Z Setting up intel-media-va-driver:amd64 (24.1.0+dfsg1-1ubuntu0.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8001334Z Setting up libxv1:amd64 (2:1.0.11-1.1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8029308Z Setting up libunibreak5:amd64 (5.1-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8059172Z Setting up libaacs0:amd64 (0.11.1-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8086803Z Setting up libjxl0.7:amd64 (0.7.0-10.2ubuntu6.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8126259Z Setting up librsvg2-common:amd64 (2.58.0+dfsg-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8229331Z Setting up pocketsphinx-en-us (0.8.0+real5prealpha+1-15ubuntu5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8260676Z Setting up libx265-199:amd64 (3.5-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8292044Z Setting up libsndio7.0:amd64 (1.9.0-0.3build3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8324356Z Setting up xdg-dbus-proxy (0.1.5-1ubuntu0.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8347238Z Setting up libbdplus0:amd64 (0.2.0-3build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8373694Z Setting up libvidstab1.1:amd64 (1.1.0-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8404034Z Setting up libvpx9:amd64 (1.14.0-1ubuntu2.3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8429928Z Setting up libsrt1.5-gnutls:amd64 (1.5.3-1build2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8456445Z Setting up libflite1:amd64 (2.2-6build3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8483919Z Setting up libdav1d7:amd64 (1.4.1-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8517711Z Setting up libva-drm2:amd64 (2.20.0-2ubuntu0.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8548264Z Setting up ocl-icd-libopencl1:amd64 (2.3.2-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8576806Z Setting up libasyncns0:amd64 (0.8-6build4) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8624945Z Setting up libvdpau1:amd64 (1.5-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8670793Z Setting up libbs2b0:amd64 (3.1.0+dfsg-7build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8696281Z Setting up libtheora0:amd64 (1.1.1+dfsg.1-16.1build3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8723902Z Setting up libdecor-0-0:amd64 (0.2.2-1build2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8753153Z Setting up libzimg2:amd64 (3.0.5+ds1-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8781541Z Setting up libopenal-data (1:1.23.1-4build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8824516Z Setting up libavahi-glib1:amd64 (0.8-13ubuntu6.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8863651Z Setting up libflac12t64:amd64 (1.4.3+ds-2.1ubuntu2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8914521Z Setting up mesa-va-drivers:amd64 (25.2.8-0ubuntu0.24.04.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8943748Z Setting up libbluray2:amd64 (1:1.3.4-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.8981044Z Setting up libsamplerate0:amd64 (0.2.2-4build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.9029241Z Setting up libva-x11-2:amd64 (2.20.0-2ubuntu0.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.9067688Z Setting up libpipewire-0.3-0t64:amd64 (1.0.5-1ubuntu3.3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.9107230Z Setting up libdecor-0-plugin-1-gtk:amd64 (0.2.2-1build2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.9145161Z Setting up libopenmpt0t64:amd64 (0.7.3-1.1build3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.9182079Z Setting up libzvbi-common (0.2.42-2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.9210977Z Setting up libmp3lame0:amd64 (3.100-6build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.9286207Z Setting up i965-va-driver:amd64 (2.4.1+dfsg1-1ubuntu0.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.9327070Z Setting up libvorbisenc2:amd64 (1.3.7-1build3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.9371866Z Setting up libmalcontent-0-0:amd64 (0.11.1-1ubuntu1.3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.9643746Z Setting up libiec61883-0:amd64 (1.2.0-6build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.9671792Z Setting up libserd-0-0:amd64 (0.32.2-1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.9732096Z Setting up libappstream-compose0:amd64 (1.0.2-1build6) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.9759768Z Setting up libavc1394-0:amd64 (0.5.4-5build3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.9794461Z Setting up gsettings-desktop-schemas (46.1-0ubuntu1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.9822126Z Setting up mesa-vdpau-drivers:amd64 (25.2.8-0ubuntu0.24.04.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.9850946Z Setting up elfutils (0.190-1.1ubuntu0.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.9890658Z Setting up liblapack3:amd64 (3.12.0-3build1.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.9965570Z update-alternatives: using /usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3 to provide /usr/lib/x86_64-linux-gnu/liblapack.so.3 (liblapack.so.3-x86_64-linux-gnu) in auto mode
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:43.9986358Z Setting up xdg-desktop-portal (1.18.4-1ubuntu2.24.04.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.1054697Z Created symlink /etc/systemd/user/graphical-session-pre.target.wants/xdg-desktop-portal-rewrite-launchers.service → /usr/lib/systemd/user/xdg-desktop-portal-rewrite-launchers.service.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.1055962Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.1085911Z Setting up libzvbi0t64:amd64 (0.2.42-2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.1108816Z Setting up libostree-1-1:amd64 (2024.5-1build2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.1140762Z Setting up appstream-compose (1.0.2-1build6) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.1164274Z Setting up libavutil58:amd64 (7:6.1.1-3ubuntu5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.1188468Z Setting up libopenal1:amd64 (1:1.23.1-4build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.1215128Z Setting up ostree (2024.5-1build2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.1245027Z Setting up libass9:amd64 (1:0.17.1-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.1277426Z Setting up libswresample4:amd64 (7:6.1.1-3ubuntu5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.1315136Z Setting up va-driver-all:amd64 (2.20.0-2ubuntu0.2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.1339228Z Setting up flatpak (1.14.6-1ubuntu0.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.3428934Z Setting up libavcodec60:amd64 (7:6.1.1-3ubuntu5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.3452159Z Setting up librubberband2:amd64 (3.3.0+dfsg-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.3481306Z Setting up libflatpak0:amd64 (1.14.6-1ubuntu0.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.3509263Z Setting up libjack-jackd2-0:amd64 (1.9.21~dfsg-3ubuntu3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.3537186Z Setting up vdpau-driver-all:amd64 (1.5-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.3588084Z Setting up libsord-0-0:amd64 (0.16.16-2build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.3617705Z Setting up libpostproc57:amd64 (7:6.1.1-3ubuntu5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.3643394Z Setting up libsratom-0-0:amd64 (0.6.16-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.3671351Z Setting up libsndfile1:amd64 (1.2.2-1ubuntu5.24.04.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.3699953Z Setting up liblilv-0-0:amd64 (0.24.22-1build1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.3725659Z Setting up libswscale7:amd64 (7:6.1.1-3ubuntu5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.3754022Z Setting up libpulse0:amd64 (1:16.1+dfsg1-2ubuntu10.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.3835994Z Setting up libavformat60:amd64 (7:6.1.1-3ubuntu5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.3867088Z Setting up gir1.2-flatpak-1.0:amd64 (1.14.6-1ubuntu0.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.3900220Z Setting up libsphinxbase3t64:amd64 (0.8+5prealpha+1-17build2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.3926022Z Setting up libsdl2-2.0-0:amd64 (2.30.0+dfsg-1ubuntu3.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.3950534Z Setting up flatpak-builder (1.4.2-1build2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.3979597Z Setting up libpocketsphinx3:amd64 (0.8.0+real5prealpha+1-15ubuntu5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.4005139Z Setting up libavfilter9:amd64 (7:6.1.1-3ubuntu5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.4038912Z Setting up libavdevice60:amd64 (7:6.1.1-3ubuntu5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.4067429Z Setting up ffmpeg (7:6.1.1-3ubuntu5) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.4173245Z Processing triggers for libc-bin (2.39-0ubuntu8.8) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.4582386Z Processing triggers for man-db (2.12.0-4build2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.4605723Z Not building database; man-db/auto-update is not 'true'.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.4618209Z Processing triggers for libglib2.0-0t64:amd64 (2.80.0-6ubuntu3.8) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.4774733Z Processing triggers for dbus (1.14.10-4ubuntu4.1) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.4861090Z Processing triggers for libgdk-pixbuf-2.0-0:amd64 (2.42.10+dfsg-3ubuntu3.3) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:44.5444970Z Setting up xdg-desktop-portal-gtk (1.15.1-1build2) ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:45.1889309Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:45.1890015Z Running kernel seems to be up-to-date.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:45.1890419Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:45.1890601Z No services need to be restarted.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:45.1890902Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:45.1891086Z No containers need to be restarted.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:45.1891406Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:45.1891613Z No user sessions are running outdated binaries.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:45.1892001Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:45.1892348Z No VM guests are running outdated hypervisor (qemu) binaries on this host.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:46.2165500Z ##[group]Run actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:46.2165923Z with:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:46.2166148Z   path: ~/.local/share/flatpak
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:46.2166432Z   key: flatpak-Linux-freedesktop-24.08
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:46.2166738Z   enableCrossOsArchive: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:46.2167001Z   fail-on-cache-miss: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:46.2167262Z   lookup-only: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:46.2167485Z   save-always: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:46.2167701Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:46.2167903Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:46.2168164Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:46.3981071Z Cache hit for: flatpak-Linux-freedesktop-24.08
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:47.4629690Z Received 184549376 of 1563321856 (11.8%), 176.0 MBs/sec
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:48.4811733Z Received 402653184 of 1563321856 (25.8%), 190.2 MBs/sec
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:49.4844303Z Received 654311424 of 1563321856 (41.9%), 206.5 MBs/sec
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:50.4894980Z Received 880803840 of 1563321856 (56.3%), 208.9 MBs/sec
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:51.4856017Z Received 1077936128 of 1563321856 (69.0%), 204.7 MBs/sec
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:52.4877882Z Received 1342177280 of 1563321856 (85.9%), 212.4 MBs/sec
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:53.2450613Z Received 1563321856 of 1563321856 (100.0%), 219.8 MBs/sec
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:53.2452784Z Cache Size: ~1491 MB (1563321856 B)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:03:53.2562487Z [command]/usr/bin/tar -xf /home/runner/work/_temp/11e1b361-c27a-44d6-8b40-d4550ca7bda8/cache.tzst -P -C /home/runner/work/goreleaser/goreleaser --use-compress-program unzstd
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.3554412Z Cache restored successfully
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4296457Z Cache restored from key: flatpak-Linux-freedesktop-24.08
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4522211Z ##[group]Run cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4522695Z with:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4525708Z   github_access_token: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4525986Z   enable_kvm: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4526218Z   set_as_trusted_user: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4526460Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4526676Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4526944Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4588240Z ##[start-action display=Run ${GITHUB_ACTION_PATH}/install-nix.sh;id=__cachix_install-nix-action.__run]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4611201Z ##[group]Run ${GITHUB_ACTION_PATH}/install-nix.sh
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4611591Z ^[[36;1m${GITHUB_ACTION_PATH}/install-nix.sh^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4648848Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4649222Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4649448Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4649727Z   INPUT_EXTRA_NIX_CONFIG: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4652423Z   INPUT_GITHUB_ACCESS_TOKEN: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4652720Z   INPUT_INSTALL_OPTIONS: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4652981Z   INPUT_INSTALL_URL: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4653214Z   INPUT_NIX_PATH: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4653438Z   INPUT_ENABLE_KVM: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4653895Z   INPUT_SET_AS_TRUSTED_USER: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4656408Z   GITHUB_TOKEN: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4656634Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4746187Z ##[group]Enabling KVM support
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.4812239Z KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5152845Z Enabled KVM
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5153400Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5154248Z ##[group]Installing Nix
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5449733Z installer options: --no-channel-add --nix-extra-conf-file /tmp/tmp.0ILJ74BpPc/nix.conf --daemon --daemon-user-count 8
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5550969Z * Host releases.nixos.org:443 was resolved.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5551428Z * IPv6: 2a04:4e42:77::347
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5551742Z * IPv4: 146.75.29.91
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5552159Z *   Trying 146.75.29.91:443...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5596850Z * Connected to releases.nixos.org (146.75.29.91) port 443
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5611917Z * ALPN: curl offers h2,http/1.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5613931Z } [5 bytes data]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5614500Z * TLSv1.3 (OUT), TLS handshake, Client hello (1):
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5615195Z } [512 bytes data]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5793407Z *  CAfile: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5794165Z *  CApath: /etc/ssl/certs
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5794591Z { [5 bytes data]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5795030Z * TLSv1.3 (IN), TLS handshake, Server hello (2):
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5795579Z { [122 bytes data]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5796084Z * TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5796695Z { [19 bytes data]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5797142Z * TLSv1.3 (IN), TLS handshake, Certificate (11):
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5797665Z { [4080 bytes data]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5806416Z * TLSv1.3 (IN), TLS handshake, CERT verify (15):
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5807011Z { [264 bytes data]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5807477Z * TLSv1.3 (IN), TLS handshake, Finished (20):
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5808041Z { [36 bytes data]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5808553Z * TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5809128Z } [1 bytes data]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5812072Z * TLSv1.3 (OUT), TLS handshake, Finished (20):
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5812425Z } [36 bytes data]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5812805Z * SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256 / X25519 / RSASSA-PSS
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5813236Z * ALPN: server accepted h2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5813490Z * Server certificate:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5814049Z *  subject: CN=releases.nixos.org
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5814336Z *  start date: Jul 11 23:12:56 2026 GMT
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5814984Z *  expire date: Oct  9 23:12:55 2026 GMT
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5815405Z *  subjectAltName: host "releases.nixos.org" matched cert's "releases.nixos.org"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5815839Z *  issuer: C=US; O=Let's Encrypt; CN=YR2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5816345Z *  SSL certificate verify ok.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5816832Z *   Certificate level 0: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5817534Z *   Certificate level 1: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5818201Z *   Certificate level 2: Public key type RSA (4096/152 Bits/secBits), signed using sha256WithRSAEncryption
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5818861Z *   Certificate level 3: Public key type RSA (4096/152 Bits/secBits), signed using sha256WithRSAEncryption
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5819320Z { [5 bytes data]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5819592Z * TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5819916Z { [201 bytes data]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5820160Z * using HTTP/2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5820522Z * [HTTP/2] [1] OPENED stream for https://releases.nixos.org/nix/nix-2.35.2/install
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5820952Z * [HTTP/2] [1] [:method: GET]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5821213Z * [HTTP/2] [1] [:scheme: https]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5821514Z * [HTTP/2] [1] [:authority: releases.nixos.org]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5821859Z * [HTTP/2] [1] [:path: /nix/nix-2.35.2/install]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5822160Z * [HTTP/2] [1] [user-agent: curl/8.5.0]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5822449Z * [HTTP/2] [1] [accept: */*]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5822693Z } [5 bytes data]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5822931Z > GET /nix/nix-2.35.2/install HTTP/2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5823473Z > Host: releases.nixos.org
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5823971Z > User-Agent: curl/8.5.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5824226Z > Accept: */*
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5824430Z > 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5914751Z { [5 bytes data]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5919406Z < HTTP/2 200 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5919857Z < last-modified: Wed, 12 Aug 2026 22:06:45 GMT
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5920440Z < etag: "9f08ad80caddcb58f53e8551ff155b13"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5921032Z < x-amz-server-side-encryption: AES256
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5921520Z < content-type: text/plain
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5921912Z < server: AmazonS3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5922265Z < via: 1.1 varnish, 1.1 varnish
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5922701Z < access-control-allow-origin: *
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5923149Z < accept-ranges: bytes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5923801Z < date: Sun, 30 Aug 2026 05:04:10 GMT
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5924238Z < age: 34687
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5924688Z < x-served-by: cache-dub4323-DUB, cache-iad-kiad7000053-IAD
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5925261Z < x-cache: HIT, HIT
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5925605Z < x-cache-hits: 2, 3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5925974Z < content-length: 4499
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5926341Z < 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5926643Z { [4499 bytes data]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5927087Z * Connection #0 to host releases.nixos.org left intact
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.5996921Z downloading Nix 2.35.2 binary tarball for x86_64-linux from 'https://releases.nixos.org/nix/nix-2.35.2/nix-2.35.2-x86_64-linux.tar.xz' to '/tmp/nix-binary-tarball-unpack.HEnroetKbs'...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.6043941Z   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.6045085Z                                  Dload  Upload   Total   Spent    Left  Speed
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.6045619Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.7187854Z   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:10.7188565Z 100 25.8M  100 25.8M    0     0   226M      0 --:--:-- --:--:-- --:--:--  226M
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5371443Z Note: a multi-user installation is possible. See https://nix.dev/manual/nix/stable/installation/installing-binary.html#multi-user-installation
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5382138Z ^[[1;31mSwitching to the Multi-user Installer^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5485265Z ^[[32mWelcome to the Multi-User Nix Installation
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5495588Z ^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5496046Z This installation tool will set up your computer with the Nix package
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5497054Z manager. This will happen in a few stages:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5497428Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5497757Z 1. Make sure your computer doesn't already have Nix. If it does, I
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5498857Z    will show you instructions on how to clean up your old install.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5499378Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5499696Z 2. Show you what I am going to install and where. Then I will ask
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5500362Z    if you are ready to continue.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5500610Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5500988Z 3. Create the system users ^[[34m(uids [30001..30008])^[[0m and groups ^[[34m(gid 30000)^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5501533Z    that the Nix daemon uses to run builds. To create system users
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5501968Z    in a different range, exit and run this tool again with
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5502331Z    NIX_FIRST_BUILD_UID set.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5502516Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5502680Z 4. Perform the basic installation of the Nix files daemon.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5502961Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5503164Z 5. Configure your shell to import special Nix Profile files, so you
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5503836Z    can use Nix.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5504054Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5504161Z 6. Start the Nix daemon.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5504320Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5504790Z ^[[32m^[[4;32mWould you like to see a more detailed list of what I will do?
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5505298Z ^[[0mNo TTY, assuming you would say yes :)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5509963Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5510216Z I will:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5510391Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5510766Z  - make sure your computer doesn't already have Nix files
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5511597Z    (if it does, I will tell you how to clean them up.)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5512431Z  - create local users (see the list above for the users I'll make)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5513204Z  - create a local group (nixbld)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5513999Z  - install Nix in /nix
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5516947Z  - create a configuration file in /etc/nix
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5517663Z  - set up the "default profile" by creating some Nix-related files in
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5518334Z    /root
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5525530Z  - back up /etc/bash.bashrc to /etc/bash.bashrc.backup-before-nix
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5526337Z  - update /etc/bash.bashrc to include some Nix configuration
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5536822Z  - load and start a service (at /etc/systemd/system/nix-daemon.service
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5537425Z    and /etc/systemd/system/nix-daemon.socket) for nix-daemon
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5537908Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5539015Z ^[[32m^[[4;32mReady to continue?
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5539628Z ^[[0mNo TTY, assuming you would say yes :)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5557590Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5558068Z ^[[34m---- let's talk about sudo -----------------------------------------------------
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5568746Z ^[[0mThis script is going to call sudo a lot. Normally, it would show you
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5569315Z exactly what commands it is running and why. However, the script is
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5570006Z run in a headless fashion, like this:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5570364Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5570613Z   $ curl -L https://nixos.org/nix/install | sh
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5571015Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5571323Z or maybe in a CI pipeline. Because of that, I'm going to skip the
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5572019Z verbose output in the interest of brevity.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5572387Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5572557Z If you would like to
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5572984Z see the output, try like this:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5573277Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5573769Z   $ curl -L -o install-nix https://nixos.org/nix/install
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5574215Z   $ sh ./install-nix
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5574358Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5574370Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5574603Z ^[[32m~~> Checking for artifacts of previous installs
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5582099Z ^[[0mBefore I try to install, I'll check for signs Nix already is or has
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5582505Z been installed on this system.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5628744Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5629624Z ^[[34m---- Nix config report ---------------------------------------------------------
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5630942Z ^[[0m^[[1m        Temp Dir^[[0m:	/tmp/tmp.bHgrt5XOIL
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5631600Z ^[[1m        Nix Root^[[0m:	/nix
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5632145Z ^[[1m     Build Users^[[0m:	8
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5632875Z ^[[1m  Build Group ID^[[0m:	30000
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5633252Z ^[[1mBuild Group Name^[[0m:	nixbld
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5633448Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5633903Z ^[[4;34mbuild users:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5634237Z ^[[0m^[[1m    Username^[[0m:	UID
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5662933Z ^[[1m     nixbld1^[[0m:	30001
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5673393Z ^[[1m     nixbld2^[[0m:	30002
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5684528Z ^[[1m     nixbld3^[[0m:	30003
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5695345Z ^[[1m     nixbld4^[[0m:	30004
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5705462Z ^[[1m     nixbld5^[[0m:	30005
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5715901Z ^[[1m     nixbld6^[[0m:	30006
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5726324Z ^[[1m     nixbld7^[[0m:	30007
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5737006Z ^[[1m     nixbld8^[[0m:	30008
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5737366Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5737631Z ^[[32m^[[4;32mReady to continue?
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5738163Z ^[[0mNo TTY, assuming you would say yes :)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5738473Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.5738649Z ^[[32m~~> Setting up the build group nixbld
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.6101130Z ^[[0m^[[1m            Created^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.6126082Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.6126618Z ^[[32m~~> Setting up the build user nixbld1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.6275304Z useradd warning: nixbld1's uid 30001 is greater than SYS_UID_MAX 999
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.6382931Z ^[[0m^[[1m           Created^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.6388637Z ^[[1m            Hidden^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.6408468Z ^[[1m    Home Directory^[[0m:	/var/empty
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.6429076Z ^[[1m              Note^[[0m:	Nix build user 1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.6447718Z ^[[1m   Logins Disabled^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.6475634Z ^[[1m  Member of nixbld^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.6494283Z ^[[1m    PrimaryGroupID^[[0m:	30000
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.6505403Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.6505946Z ^[[32m~~> Setting up the build user nixbld2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.6645202Z useradd warning: nixbld2's uid 30002 is greater than SYS_UID_MAX 999
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.6747054Z ^[[0m^[[1m           Created^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.6753122Z ^[[1m            Hidden^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.6772301Z ^[[1m    Home Directory^[[0m:	/var/empty
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.6793152Z ^[[1m              Note^[[0m:	Nix build user 2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.6812097Z ^[[1m   Logins Disabled^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.6832683Z ^[[1m  Member of nixbld^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.6851737Z ^[[1m    PrimaryGroupID^[[0m:	30000
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.6863857Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.6864294Z ^[[32m~~> Setting up the build user nixbld3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7044342Z useradd warning: nixbld3's uid 30003 is greater than SYS_UID_MAX 999
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7144420Z ^[[0m^[[1m           Created^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7150417Z ^[[1m            Hidden^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7170380Z ^[[1m    Home Directory^[[0m:	/var/empty
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7193409Z ^[[1m              Note^[[0m:	Nix build user 3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7211560Z ^[[1m   Logins Disabled^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7231101Z ^[[1m  Member of nixbld^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7249683Z ^[[1m    PrimaryGroupID^[[0m:	30000
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7261461Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7261930Z ^[[32m~~> Setting up the build user nixbld4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7406382Z useradd warning: nixbld4's uid 30004 is greater than SYS_UID_MAX 999
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7508670Z ^[[0m^[[1m           Created^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7514370Z ^[[1m            Hidden^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7534093Z ^[[1m    Home Directory^[[0m:	/var/empty
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7554769Z ^[[1m              Note^[[0m:	Nix build user 4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7573137Z ^[[1m   Logins Disabled^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7592928Z ^[[1m  Member of nixbld^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7611562Z ^[[1m    PrimaryGroupID^[[0m:	30000
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7623056Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7624040Z ^[[32m~~> Setting up the build user nixbld5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7766679Z useradd warning: nixbld5's uid 30005 is greater than SYS_UID_MAX 999
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7856818Z ^[[0m^[[1m           Created^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7862504Z ^[[1m            Hidden^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7881863Z ^[[1m    Home Directory^[[0m:	/var/empty
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7903087Z ^[[1m              Note^[[0m:	Nix build user 5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7921638Z ^[[1m   Logins Disabled^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7941610Z ^[[1m  Member of nixbld^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7960099Z ^[[1m    PrimaryGroupID^[[0m:	30000
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7971703Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.7972062Z ^[[32m~~> Setting up the build user nixbld6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.8156838Z useradd warning: nixbld6's uid 30006 is greater than SYS_UID_MAX 999
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.8257506Z ^[[0m^[[1m           Created^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.8263208Z ^[[1m            Hidden^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.8282662Z ^[[1m    Home Directory^[[0m:	/var/empty
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.8303390Z ^[[1m              Note^[[0m:	Nix build user 6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.8321973Z ^[[1m   Logins Disabled^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.8342336Z ^[[1m  Member of nixbld^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.8360696Z ^[[1m    PrimaryGroupID^[[0m:	30000
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.8372410Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.8372863Z ^[[32m~~> Setting up the build user nixbld7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.8513461Z useradd warning: nixbld7's uid 30007 is greater than SYS_UID_MAX 999
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.8615302Z ^[[0m^[[1m           Created^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.8621046Z ^[[1m            Hidden^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.8640298Z ^[[1m    Home Directory^[[0m:	/var/empty
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.8662214Z ^[[1m              Note^[[0m:	Nix build user 7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.8680239Z ^[[1m   Logins Disabled^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.8700449Z ^[[1m  Member of nixbld^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.8718621Z ^[[1m    PrimaryGroupID^[[0m:	30000
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.8730000Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.8730675Z ^[[32m~~> Setting up the build user nixbld8
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.8895513Z useradd warning: nixbld8's uid 30008 is greater than SYS_UID_MAX 999
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9002896Z ^[[0m^[[1m           Created^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9008941Z ^[[1m            Hidden^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9028667Z ^[[1m    Home Directory^[[0m:	/var/empty
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9049896Z ^[[1m              Note^[[0m:	Nix build user 8
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9068336Z ^[[1m   Logins Disabled^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9089637Z ^[[1m  Member of nixbld^[[0m:	Yes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9108450Z ^[[1m    PrimaryGroupID^[[0m:	30000
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9108818Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9109284Z ^[[32m~~> Setting up the basic directory structure
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9217222Z ^[[0minstall: creating directory '/nix'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9217649Z install: creating directory '/nix/var'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9218009Z install: creating directory '/nix/var/log'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9218389Z install: creating directory '/nix/var/log/nix'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9218783Z install: creating directory '/nix/var/log/nix/drvs'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9219169Z install: creating directory '/nix/var/nix'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9219711Z install: creating directory '/nix/var/nix/db'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9220228Z install: creating directory '/nix/var/nix/gcroots'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9220703Z install: creating directory '/nix/var/nix/profiles'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9221182Z install: creating directory '/nix/var/nix/temproots'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9221646Z install: creating directory '/nix/var/nix/userpool'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9222110Z install: creating directory '/nix/var/nix/daemon-socket'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9222603Z install: creating directory '/nix/var/nix/gcroots/per-user'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9223108Z install: creating directory '/nix/var/nix/profiles/per-user'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9300578Z install: creating directory '/nix/store'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9382108Z install: creating directory '/etc/nix'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9392141Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:12.9392623Z ^[[32m~~> Installing Nix
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.1227646Z ^[[0m      Alright! We have our first nix at /nix/store/irfrbndi76zhkvqsfhmsn4a99iafck29-nix-2.35.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.1659252Z       Just finished getting the nix database ready.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.1662224Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.1663913Z ^[[32m~~> Setting up shell profiles: /etc/bashrc /etc/profile.d/nix.sh /etc/zshrc /etc/bash.bashrc /etc/zsh/zshrc
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.1833302Z ^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.1833906Z # Nix
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.1834916Z if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.1835545Z   . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.1836191Z fi
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.1836490Z # End Nix
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.1836616Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2005498Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2005777Z # Nix
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2006396Z if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2007478Z   . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2008134Z fi
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2008458Z # End Nix
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2008654Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2175962Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2176193Z # Nix
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2176602Z if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2177158Z   . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2177691Z fi
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2178209Z # End Nix
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2178418Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2339848Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2340175Z # Nix
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2340720Z if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2341776Z   . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2342417Z fi
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2342762Z # End Nix
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2342957Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2343249Z # System-wide .bashrc file for interactive bash(1) shells.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2343967Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2344323Z # To enable the settings / commands in this file for login shells as well,
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2345086Z # this file has to be sourced in /etc/profile.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2345466Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2345690Z # If not running interactively, don't do anything
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2346261Z [ -z "$PS1" ] && return
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2346519Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2346797Z # check the window size after each command and, if necessary,
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2347446Z # update the values of LINES and COLUMNS.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2347948Z shopt -s checkwinsize
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2348209Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2348591Z # set variable identifying the chroot you work in (used in the prompt below)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2349441Z if [ -z "${debian_chroot:-}" ] && [ -r /etc/debian_chroot ]; then
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2350078Z     debian_chroot=$(cat /etc/debian_chroot)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2350561Z fi
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2350757Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2351021Z # set a fancy prompt (non-color, overwrite the one in /etc/profile)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2351535Z # but only if not SUDOing and have SUDO_PS1 set; then assume smart user.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2351988Z if ! [ -n "${SUDO_USER}" -a -n "${SUDO_PS1}" ]; then
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2352356Z   PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2352686Z fi
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2352793Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2353083Z # Commented out, don't overwrite xterm -T "title" -n "icontitle" by default.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2354102Z # If this is an xterm set the title to user@host:dir
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2354667Z #case "$TERM" in
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2355046Z #xterm*|rxvt*)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2355759Z #    PROMPT_COMMAND='echo -ne "\033]0;${USER}@${HOSTNAME}: ${PWD}\007"'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2356400Z #    ;;
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2356585Z #*)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2356773Z #    ;;
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2356980Z #esac
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2357092Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2357227Z # enable bash completion in interactive shells
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2357551Z #if ! shopt -oq posix; then
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2357920Z #  if [ -f /usr/share/bash-completion/bash_completion ]; then
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2358302Z #    . /usr/share/bash-completion/bash_completion
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2358645Z #  elif [ -f /etc/bash_completion ]; then
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2358950Z #    . /etc/bash_completion
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2359416Z #  fi
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2359602Z #fi
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2359704Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2359783Z # sudo hint
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2360122Z if [ ! -e "$HOME/.sudo_as_admin_successful" ] && [ ! -e "$HOME/.hushlogin" ] ; then
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2360678Z     case " $(groups) " in *\ admin\ *|*\ sudo\ *)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2360999Z     if [ -x /usr/bin/sudo ]; then
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2361278Z 	cat <<-EOF
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2361588Z 	To run a command as administrator (user "root"), use "sudo <command>".
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2361971Z 	See "man sudo_root" for details.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2362220Z 	
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2362403Z 	EOF
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2362580Z     fi
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2362766Z     esac
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2362943Z fi
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2363048Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2363207Z # if the command-not-found package is installed, use it
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2364012Z if [ -x /usr/lib/command-not-found -o -x /usr/share/command-not-found/command-not-found ]; then
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2364502Z 	function command_not_found_handle {
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2364857Z 	        # check because c-n-f could've been removed in the meantime
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2365247Z                 if [ -x /usr/lib/command-not-found ]; then
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2365584Z 		   /usr/lib/command-not-found -- "$1"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2365861Z                    return $?
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2366392Z                 elif [ -x /usr/share/command-not-found/command-not-found ]; then
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2366834Z 		   /usr/share/command-not-found/command-not-found -- "$1"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2367302Z                    return $?
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2367704Z 		else
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2368071Z 		   printf "%s: command not found\n" "$1" >&2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2368588Z 		   return 127
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2368931Z 		fi
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2369266Z 	}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2369573Z fi
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2369762Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2370633Z ^[[32m~~> Setting up shell profiles for Fish with conf.d/nix.fish inside /etc/fish /usr/local/etc/fish /opt/homebrew/etc/fish /opt/local/etc/fish
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2581667Z ^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2582047Z ^[[32m~~> Setting up the default profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.2882729Z installing 'nix-2.35.2'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.3045439Z building '/nix/store/3v9waf1zcy52sd2xf30ndbwssp7d4sza-user-environment.drv'...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.3460265Z installing 'nix-manual-2.35.2-man'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.3618318Z building '/nix/store/87kv2ra7c0a549l86df0y18w8w3ir6qk-user-environment.drv'...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.4023352Z installing 'nss-cacert-3.123'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.4177039Z building '/nix/store/aq6vipp55pqkyy4i7v7sxjrfdibk3a8s-user-environment.drv'...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.4380432Z ^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.4380827Z ^[[32m~~> Setting up the nix-daemon systemd service
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.4750485Z Created symlink /etc/systemd/system/nix-daemon.service → /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.service.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.7749696Z Created symlink /etc/systemd/system/nix-daemon.socket → /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.socket.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:13.7751702Z Created symlink /etc/systemd/system/sockets.target.wants/nix-daemon.socket → /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.socket.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.4032018Z ^[[0m^[[32mAlright! We're done!
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.4057725Z ^[[0mTry it! Open a new terminal, and type:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.4058541Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.4058863Z   $ nix-shell -p nix-info --run "nix-info -m"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.4059334Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.4059902Z Thank you for using this installer. If you have any feedback or need
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.4060746Z help, don't hesitate:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.4061157Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.4061320Z You can open an issue at
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.4062030Z https://github.com/NixOS/nix/issues/new?labels=installer&template=installer.md
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.4062402Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.4062595Z Or get in touch with the community: https://nixos.org/community
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.4083261Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.4084344Z ^[[34m---- Reminders -----------------------------------------------------------------
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.4086043Z ^[[0m^[[34m[ 1 ]^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.4086655Z Nix won't work in active shell sessions until you restart them.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.4087142Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.4950031Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.4984387Z ##[end-action id=__cachix_install-nix-action.__run;outcome=success;conclusion=success;duration_ms=4039]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.5021100Z ##[group]Run mkdir -p "$HOME/.local/bin"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.5021495Z ^[[36;1mmkdir -p "$HOME/.local/bin"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.5021846Z ^[[36;1mcurl -fsSL -o "$HOME/.local/bin/alejandra" \^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.5022454Z ^[[36;1m  https://github.com/kamadorueda/alejandra/releases/download/4.0.0/alejandra-x86_64-unknown-linux-musl^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.5023078Z ^[[36;1mcurl -fsSL -o "$HOME/.local/bin/nixfmt" \^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.5023819Z ^[[36;1m  https://github.com/NixOS/nixfmt/releases/download/v1.4.0/nixfmt^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.5024759Z ^[[36;1mecho "a23b9d47cba945805c6169541046de890e94e07a5aa416c86dee15bca2da6216  $HOME/.local/bin/alejandra" | sha256sum -c -^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.5025657Z ^[[36;1mecho "62488394d5233283096466350487ed46470366f57db4bec824a87ecbacce960a  $HOME/.local/bin/nixfmt" | sha256sum -c -^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.5026325Z ^[[36;1mchmod +x "$HOME/.local/bin/alejandra" "$HOME/.local/bin/nixfmt"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.5026775Z ^[[36;1mecho "$HOME/.local/bin" >> "$GITHUB_PATH"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.5064523Z shell: /usr/bin/bash -e {0}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.5064799Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.5065017Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.5065322Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.5065700Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.5066168Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.5066503Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.8636395Z /home/runner/.local/bin/alejandra: OK
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.8685762Z /home/runner/.local/bin/nixfmt: OK
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.8762982Z ##[group]Run actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.8763391Z with:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.8763925Z   go-version-file: go.mod
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.8764233Z   cache-dependency-path: go.sum
+test (ubuntu-latest)	UNKNOWN STEP	Taskfile.yml
+test (ubuntu-latest)	UNKNOWN STEP	
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.8764560Z   check-latest: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.8767052Z   token: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.8767266Z   cache: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.8767464Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.8767677Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.8767960Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.8768330Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.8768775Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.8769092Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.9905072Z Setup go version spec 1.27.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:14.9922529Z Attempting to download 1.27.0...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:15.4094461Z matching 1.27.0...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:15.4098854Z Acquiring 1.27.0 from https://github.com/actions/go-versions/releases/download/1.27.0-32325163857/go-1.27.0-linux-x64.tar.gz
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:15.8928924Z Extracting Go...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:15.9049873Z [command]/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/7f8ea1a5-b7ed-4ea9-93bb-e14d0d3455db -f /home/runner/work/_temp/e270a6c3-f703-4dbd-ae57-553c27bb8893
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:17.5697135Z Successfully extracted go to /home/runner/work/_temp/7f8ea1a5-b7ed-4ea9-93bb-e14d0d3455db
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:17.5697809Z Adding to the cache ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:23.2296770Z Successfully cached go to /opt/hostedtoolcache/go/1.27.0/x64
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:23.2299130Z Added go to the path
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:23.2301184Z Successfully set up Go version 1.27.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:23.2511877Z [command]/opt/hostedtoolcache/go/1.27.0/x64/bin/go env GOMODCACHE
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:23.2546935Z [command]/opt/hostedtoolcache/go/1.27.0/x64/bin/go env GOCACHE
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:23.2575703Z /home/runner/go/pkg/mod
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:23.2595880Z /home/runner/.cache/go-build
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:23.3248589Z Cache hit for: setup-go-Linux-x64-ubuntu24-go-1.27.0-4effc5d79fd735aa8ad13170a172cf2e131e53a29f71095d44234c448ca04db9
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:24.3970922Z Received 243269632 of 1438124749 (16.9%), 231.1 MBs/sec
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:25.4004921Z Received 515899392 of 1438124749 (35.9%), 245.4 MBs/sec
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:26.4034296Z Received 788529152 of 1438124749 (54.8%), 249.9 MBs/sec
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:27.4020931Z Received 1073741824 of 1438124749 (74.7%), 255.4 MBs/sec
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:28.4093562Z Received 1342177280 of 1438124749 (93.3%), 255.1 MBs/sec
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6973338Z Received 1438124749 of 1438124749 (100.0%), 258.5 MBs/sec
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6974513Z Cache Size: ~1372 MB (1438124749 B)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:28.7104059Z [command]/usr/bin/tar -xf /home/runner/work/_temp/87a855c1-5e38-4be6-9f8a-b0b10691cb5b/cache.tzst -P -C /home/runner/work/goreleaser/goreleaser --use-compress-program unzstd
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:40.7478807Z Cache restored successfully
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:40.8562081Z Cache restored from key: setup-go-Linux-x64-ubuntu24-go-1.27.0-4effc5d79fd735aa8ad13170a172cf2e131e53a29f71095d44234c448ca04db9
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:40.8589405Z go version go1.27.0 linux/amd64
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:40.8589735Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:40.8590204Z ##[group]go env
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0016227Z AR='ar'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0025905Z CC='gcc'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0026315Z CGO_CFLAGS='-O2 -g'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0026739Z CGO_CPPFLAGS=''
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0027133Z CGO_CXXFLAGS='-O2 -g'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0027544Z CGO_ENABLED='1'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0027911Z CGO_FFLAGS='-O2 -g'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0028297Z CGO_LDFLAGS='-O2 -g'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0034422Z CXX='g++'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0034809Z GCCGO='gccgo'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0035202Z GO111MODULE=''
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0035552Z GOAMD64='v1'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0035895Z GOARCH='amd64'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0036318Z GOAUTH='netrc'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0036717Z GOBIN='/home/runner/go/bin'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0037230Z GOCACHE='/home/runner/.cache/go-build'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0038123Z GOCACHEPROG=''
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0038516Z GODEBUG=''
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0038907Z GOENV='/home/runner/.config/go/env'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0039388Z GOEXE=''
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0039762Z GOEXPERIMENT=''
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0040147Z GOFIPS140='off'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0040532Z GOFLAGS=''
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0041811Z GOGCCFLAGS='-fPIC -m64 -pthread -Wl,--no-gc-sections -fmessage-length=0 -ffile-prefix-map=/home/runner/work/_temp/go-build63041301=/tmp/go-build -gno-record-gcc-switches'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0043249Z GOHOSTARCH='amd64'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0044111Z GOHOSTOS='linux'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0044577Z GOINSECURE=''
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0045139Z GOMOD='/home/runner/work/goreleaser/goreleaser/go.mod'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0045588Z GOMODCACHE='/home/runner/go/pkg/mod'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0045905Z GONOPROXY=''
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0046136Z GONOSUMDB=''
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0046348Z GOOS='linux'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0046592Z GOPACKAGESDRIVER=''
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0046865Z GOPATH='/home/runner/go'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0047186Z GOPRIVATE=''
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0047543Z GOPROXY='https://proxy.golang.org,direct'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0047943Z GOROOT='/opt/hostedtoolcache/go/1.27.0/x64'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0048315Z GOSUMDB='sum.golang.org'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0048599Z GOTELEMETRY='local'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0048916Z GOTELEMETRYDIR='/home/runner/.config/go/telemetry'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0049347Z GOTMPDIR=''
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0049624Z GOTOOLCHAIN='local'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0050084Z GOTOOLDIR='/opt/hostedtoolcache/go/1.27.0/x64/pkg/tool/linux_amd64'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0050597Z GOVCS=''
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0050886Z GOVERSION='go1.27.0'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0051192Z GOWORK=''
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0051494Z PKG_CONFIG='pkg-config'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0051720Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0052187Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0510239Z ##[group]Run actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0510938Z with:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0511171Z   node-version: 25
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0511416Z   check-latest: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0514391Z   token: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0514647Z   package-manager-cache: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0514911Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0515128Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0515424Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0515816Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0516274Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0516606Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.0516842Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.4138311Z Attempting to download 25...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.8632471Z Not found in manifest. Falling back to download directly from Node
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:41.9085899Z Acquiring 25.9.0 - x64 from https://nodejs.org/dist/v25.9.0/node-v25.9.0-linux-x64.tar.gz
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:42.2309538Z Extracting ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:42.3113218Z [command]/usr/bin/tar xz --strip 1 --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/3844be2f-30e9-4880-8aee-779a29966692 -f /home/runner/work/_temp/8547b934-686d-4300-93c0-74383cc39db3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:43.6122144Z Adding to the cache ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:46.6989063Z Done
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:46.6992727Z ##[group]Environment details
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:46.9258392Z node: v25.9.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:46.9258907Z npm: 11.12.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:46.9259336Z yarn: 1.22.22
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:46.9260108Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:46.9461489Z Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:46.9462938Z ##[group]Run mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:46.9463325Z with:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:46.9463799Z   use-cache: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:46.9464095Z   cache-size-limit: 2048
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:46.9464353Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:46.9464584Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:46.9464884Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:46.9465267Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:46.9465734Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:46.9466075Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:46.9466305Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:47.3015999Z Using tool-cache: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:47.3017681Z Failed to read build.zig.zon (using latest): Error: ENOENT: no such file or directory, open 'build.zig.zon'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:47.9513937Z Fetching zig-x86_64-linux-0.16.0.tar.xz
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:48.0053633Z Cache hit for: setup-zig-tarball-zig-x86_64-linux-0.16.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:48.4012398Z Received 55481366 of 55481366 (100.0%), 146.2 MBs/sec
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:48.4015589Z Cache Size: ~53 MB (55481366 B)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:48.4087506Z [command]/usr/bin/tar -xf /home/runner/work/_temp/05fa9d05-2f4b-4d22-8df8-e1f5f5cf86a1/cache.tzst -P -C /home/runner/work/goreleaser/goreleaser --use-compress-program unzstd
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:48.4814561Z Cache restored successfully
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:48.4842557Z Fetch took 533 ms
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:48.4843206Z Extracting tarball zig-x86_64-linux-0.16.0.tar.xz
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:48.4921716Z [command]/usr/bin/tar xJ --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/76742cf4-c221-445d-b7a0-4427e72d0557 -f /home/runner/work/_temp/zig-x86_64-linux-0.16.0.tar.xz
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.2233842Z Extract took 3739 ms
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.2261468Z [command]/home/runner/work/_temp/76742cf4-c221-445d-b7a0-4427e72d0557/zig-x86_64-linux-0.16.0/zig version
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.2316125Z 0.16.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.2331071Z Resolved Zig version 0.16.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.2339206Z Attempting restore of Zig cache with prefix 'setup-zig-cache-v2-test-zig-x86_64-linux-0.16.0--'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.2798690Z Cache hit for restore-key: setup-zig-cache-v2-test-zig-x86_64-linux-0.16.0--33293313030-1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.5369026Z Received 33086915 of 33086915 (100.0%), 136.6 MBs/sec
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.5370347Z Cache Size: ~32 MB (33086915 B)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.5398096Z [command]/usr/bin/tar -xf /home/runner/work/_temp/e7843e26-c617-4cc1-a029-89c6d093ac9b/cache.tzst -P -C /home/runner/work/goreleaser/goreleaser --use-compress-program unzstd
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.7739898Z Cache restored successfully
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.7756998Z Cache hit (key 'setup-zig-cache-v2-test-zig-x86_64-linux-0.16.0--33293313030-1'): populating Zig cache directory at /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.7954397Z ##[group]Run oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.7954877Z with:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.7955106Z   no-cache: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.7957643Z   token: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.7957872Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.7958102Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.7958414Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.7958817Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.7959303Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.7959648Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.7960012Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.7960525Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:52.7960927Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:53.2240313Z Downloading a new version of Bun: https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-linux-x64.zip
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:53.4499042Z [command]/usr/bin/unzip -o -q /home/runner/work/_temp/d25cb3f5-0535-4de0-ba00-2e3148c7d324.zip
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:54.0613390Z [command]/home/runner/.bun/bin/bun --revision
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:54.0659028Z 1.4.0+34cbb9a40
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:54.0818236Z ##[group]Run denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:54.0818689Z with:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:54.0818916Z   deno-version: 2.x
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:54.0819162Z   deno-binary-name: deno
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:54.0819440Z   cache: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:54.0819659Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:54.0819885Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:54.0820195Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:54.0820635Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:54.0821114Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:54.0821456Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:54.0821819Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:54.0822350Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:54.0822757Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:54.3010108Z Going to install stable version 2.9.6.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:54.3021118Z Downloading Deno from https://github.com/denoland/deno/releases/download/v2.9.6/deno-x86_64-unknown-linux-gnu.zip.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:54.6179635Z [command]/usr/bin/unzip -o -q /home/runner/work/_temp/8cc73223-bc8b-4619-b72b-d12c187d7271
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.4481490Z Cached Deno to /opt/hostedtoolcache/deno/2.9.6/x64.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.5089925Z Installation complete.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.5599156Z ##[group]Run cargo-bins/cargo-binstall@75b4bfae1b2c753a6806bbce6e6cb89b602de33c
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.5599970Z with:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.5600326Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.5600706Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.5601241Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.5601936Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.5602741Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.5603358Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.5604226Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.5605157Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.5605881Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.5612960Z ##[start-action display=Install cargo-binstall;id=__cargo-bins_cargo-binstall.__run]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.5633454Z ##[group]Run set -eu
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.5634028Z ^[[36;1mset -eu^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.5634431Z ^[[36;1mbash "$GITHUB_ACTION_PATH/install-from-binstall-release.sh"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7019728Z shell: /usr/bin/sh -e {0}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7020033Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7020284Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7020618Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7021030Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7021531Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7021889Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7022281Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7022842Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7023261Z   BINSTALL_VERSION: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7023699Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7474505Z + set -o pipefail
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7476037Z + set -o pipefail
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7494634Z + case "${BINSTALL_VERSION:-}" in
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7495654Z ++ mktemp -d
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7497098Z + cd /home/runner/work/_temp/tmp.ElfuNXZDRz
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7499638Z + '[' -z '' ']'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7500947Z + base_url=https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7502087Z ++ uname -s
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7515920Z + os=Linux
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7516786Z + '[' Linux = Darwin ']'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7517532Z + '[' Linux = Linux ']'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7518187Z ++ uname -m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7555230Z + machine=x86_64
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7556343Z + '[' x86_64 = armv7l ']'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7557157Z + '[' x86_64 = riscv64 ']'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7558035Z + target=x86_64-unknown-linux-musl
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7558827Z + '[' x86_64 = armv7 ']'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7560373Z + url=https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7562623Z + do_curl https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7566040Z + curl --retry 10 -A 'Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/81.0' -L --proto =https --tlsv1.2 -sSf https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.7568062Z + tar -xvzf -
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.8438699Z cargo-binstall
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:55.9971435Z + ./cargo-binstall --self-install
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1024694Z + CARGO_HOME=/home/runner/.cargo
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1025578Z + case ":$PATH:" in
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1026371Z + '[' -n '' ']'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1036913Z ##[end-action id=__cargo-bins_cargo-binstall.__run;outcome=success;conclusion=success;duration_ms=542]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1040930Z ##[start-action display=Install cargo-binstall;id=__cargo-bins_cargo-binstall.__run_2]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1046462Z ##[end-action id=__cargo-bins_cargo-binstall.__run_2;outcome=skipped;conclusion=skipped;duration_ms=0]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1073237Z ##[group]Run rustup default stable
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1073953Z ^[[36;1mrustup default stable^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1074266Z ^[[36;1mcargo binstall cargo-zigbuild^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1114803Z shell: /usr/bin/bash -e {0}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1115097Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1115350Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1115663Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1116064Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1116548Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1116896Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1117267Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1117790Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1118192Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:56.6605221Z info: using existing install for stable-x86_64-unknown-linux-gnu
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:56.6656343Z info: default toolchain set to stable-x86_64-unknown-linux-gnu
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:56.6657103Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:57.3285918Z   stable-x86_64-unknown-linux-gnu unchanged - rustc 1.98.0 (88d9e12ae 2026-08-18)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:57.4833698Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:57.4833775Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:57.4835091Z  INFO the current QuickInstall statistics endpoint url="https://cargo-quickinstall-stats-server.fly.dev/record-install"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:57.4837065Z Opt in to telemetry? yes/[no]  INFO Settings saved path="/home/runner/.cargo/binstall.toml"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:57.4838642Z Binstall would like to collect install statistics for the QuickInstall project
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:57.4840559Z to help inform which packages should be included in its index in the future.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:57.4846018Z If you agree, please type 'yes'. If you disagree, telemetry will not be sent.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:57.4847452Z You can change this at any time by editing the binstall settings file.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:57.4941752Z  INFO resolve: Resolving package: 'cargo-zigbuild'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6203106Z  WARN The package cargo-zigbuild v0.23.3 (x86_64-unknown-linux-gnu) has been downloaded from github.com
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6205111Z  INFO This will install the following binaries:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6206230Z  INFO   - cargo-zigbuild => /home/runner/.cargo/bin/cargo-zigbuild
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6207834Z Do you wish to continue? [yes]/no  INFO Installing binaries...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6212103Z  INFO Done in 2.138452469s
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6308339Z ##[group]Run astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6308781Z with:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6309025Z   activate-environment: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6309317Z   no-project: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6309647Z   working-directory: /home/runner/work/goreleaser/goreleaser
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6312304Z   github-token: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6312554Z   enable-cache: auto
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6313175Z   cache-dependency-glob: **/*requirements*.txt
+test (ubuntu-latest)	UNKNOWN STEP	**/*requirements*.in
+test (ubuntu-latest)	UNKNOWN STEP	**/*constraints*.txt
+test (ubuntu-latest)	UNKNOWN STEP	**/*constraints*.in
+test (ubuntu-latest)	UNKNOWN STEP	**/pyproject.toml
+test (ubuntu-latest)	UNKNOWN STEP	**/uv.lock
+test (ubuntu-latest)	UNKNOWN STEP	**/*.py.lock
+test (ubuntu-latest)	UNKNOWN STEP	
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6314100Z   restore-cache: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6314360Z   save-cache: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6314598Z   prune-cache: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6314839Z   cache-python: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6315103Z   ignore-nothing-to-cache: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6315402Z   ignore-empty-workdir: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6315709Z   download-from-astral-mirror: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6316049Z   add-problem-matchers: true
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6316317Z   quiet: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6316559Z   resolution-strategy: highest
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6316832Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6317061Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6317363Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6317754Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6318217Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6318570Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6318927Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6319442Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6319834Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.8129253Z Trying to find version for uv in: /home/runner/work/goreleaser/goreleaser/uv.toml
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.8131255Z Could not find file: /home/runner/work/goreleaser/goreleaser/uv.toml
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.8132958Z Trying to find version for uv in: /home/runner/work/goreleaser/goreleaser/pyproject.toml
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.8134984Z Could not find file: /home/runner/work/goreleaser/goreleaser/pyproject.toml
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.8136708Z Could not determine uv version from uv.toml or pyproject.toml. Falling back to latest.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.8138971Z Fetching manifest data from https://raw.githubusercontent.com/astral-sh/versions/main/v1/uv.ndjson ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:04:59.8574984Z Downloading uv from "https://releases.astral.sh/github/uv/releases/download/0.12.7/uv-x86_64-unknown-linux-gnu.tar.gz" ...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:00.0067043Z [command]/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/87513cdc-7945-4783-b4e1-e627cfc34813 -f /home/runner/work/_temp/3392898b-8091-4372-8058-3e7202fdf419
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3895462Z Added /home/runner/.local/bin to the path
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3899739Z Added /opt/hostedtoolcache/uv/0.12.7/x86_64 to the path
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3901660Z Set UV_PYTHON_INSTALL_DIR to /home/runner/work/_temp/uv-python-dir
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3902942Z Added /home/runner/work/_temp/uv-python-dir to the path
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3987525Z Set UV_CACHE_DIR to /home/runner/work/_temp/setup-uv-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3988433Z Successfully installed uv version 0.12.7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:00.4671438Z Searching files using cache dependency glob: /home/runner/work/goreleaser/goreleaser/**/*requirements*.txt,/home/runner/work/goreleaser/goreleaser/**/*requirements*.in,/home/runner/work/goreleaser/goreleaser/**/*constraints*.txt,/home/runner/work/goreleaser/goreleaser/**/*constraints*.in,/home/runner/work/goreleaser/goreleaser/**/pyproject.toml,/home/runner/work/goreleaser/goreleaser/**/uv.lock,/home/runner/work/goreleaser/goreleaser/**/*.py.lock
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:00.6769749Z /home/runner/work/goreleaser/goreleaser/internal/builders/poetry/testdata/pyproject.toml
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:00.6806752Z /home/runner/work/goreleaser/goreleaser/internal/builders/uv/testdata/pyproject.toml
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:00.7740565Z /home/runner/work/goreleaser/goreleaser/internal/pyproject/testdata/pyproject.toml
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:00.8247770Z Found 3 files to hash.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:00.8322524Z Trying to restore cache from GitHub Actions cache with key: setup-uv-2-x86_64-unknown-linux-gnu-ubuntu-24.04-3.12.3-1472b101372efdfaea191c0f58d7baafced473780cbe79c2e88e1ffee5d9ceb3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:00.8839886Z Cache hit for: setup-uv-2-x86_64-unknown-linux-gnu-ubuntu-24.04-3.12.3-1472b101372efdfaea191c0f58d7baafced473780cbe79c2e88e1ffee5d9ceb3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:00.9334447Z Received 1219 of 1219 (100.0%), 0.1 MBs/sec
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:00.9335174Z Cache Size: ~0 MB (1219 B)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:00.9376655Z [command]/usr/bin/tar -xf /home/runner/work/_temp/47e88b04-142d-47b0-9a48-47bb436f11af/cache.tzst -P -C /home/runner/work/goreleaser/goreleaser --use-compress-program unzstd
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:00.9431933Z Cache restored successfully
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:00.9438471Z cache restored from GitHub Actions cache with key: setup-uv-2-x86_64-unknown-linux-gnu-ubuntu-24.04-3.12.3-1472b101372efdfaea191c0f58d7baafced473780cbe79c2e88e1ffee5d9ceb3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.0564711Z ##[group]Run uv tool install poetry
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.0565112Z ^[[36;1muv tool install poetry^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.0603908Z shell: /usr/bin/bash -e {0}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.0604210Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.0604449Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.0604771Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.0605186Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.0605675Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.0606024Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.0606394Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.0606948Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.0607451Z   UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.0607884Z   UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.0608220Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.2954801Z Resolved 46 packages in 218ms
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.3342250Z Downloading virtualenv (5.1MiB)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.3345387Z Downloading cryptography (4.5MiB)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.3357938Z Downloading dulwich (1.4MiB)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.3363707Z Downloading rapidfuzz (3.0MiB)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.5515289Z  Downloaded virtualenv
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.5717818Z  Downloaded rapidfuzz
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.5774541Z  Downloaded dulwich
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.5863036Z  Downloaded cryptography
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.5866725Z Prepared 46 packages in 289ms
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6125287Z Installed 46 packages in 25ms
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6125708Z  + anyio==4.14.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6126022Z  + backports-zstd==1.7.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6126335Z  + build==1.6.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6126617Z  + cachecontrol==0.14.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6126899Z  + certifi==2026.7.22
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6127421Z  + cffi==2.1.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6127989Z  + charset-normalizer==3.5.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6128522Z  + cleo==2.1.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6129049Z  + crashtest==0.4.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6129554Z  + cryptography==50.0.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6130059Z  + distlib==0.4.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6130545Z  + dulwich==1.2.14
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6131053Z  + fastjsonschema==2.22.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6131564Z  + filelock==3.32.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6132079Z  + findpython==0.8.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6132558Z  + h11==0.16.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6133049Z  + httpcore==1.0.9
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6133721Z  + httpx==0.28.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6135125Z  + idna==3.19
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6135483Z  + installer==1.0.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6135778Z  + jaraco-classes==3.4.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6136087Z  + jaraco-context==6.1.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6136392Z  + jaraco-functools==4.6.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6136704Z  + jeepney==0.9.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6136973Z  + keyring==25.7.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6137252Z  + more-itertools==11.1.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6137545Z  + msgpack==1.2.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6137808Z  + packaging==26.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6138102Z  + pbs-installer==2026.8.25
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6138407Z  + pkginfo==1.13
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6138699Z  + platformdirs==4.11.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6138979Z  + poetry==2.4.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6139250Z  + poetry-core==2.4.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6139529Z  + pycparser==3.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6139809Z  + pyproject-hooks==1.2.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6140115Z  + python-discovery==1.6.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6140416Z  + rapidfuzz==3.14.5
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6140689Z  + requests==2.34.2
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6140977Z  + requests-toolbelt==1.0.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6141290Z  + secretstorage==3.5.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6141806Z  + shellingham==1.5.4
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6142337Z  + tomlkit==0.15.1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6142917Z  + trove-classifiers==2026.6.1.19
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6143460Z  + typing-extensions==4.16.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6144102Z  + urllib3==2.7.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6144629Z  + virtualenv==21.7.7
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6153368Z Installed 1 executable: poetry
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6345541Z ##[group]Run sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6346038Z with:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6346288Z   cosign-release: v3.0.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6346577Z   install-dir: $HOME/.cosign
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6346856Z   use-sudo: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6347095Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6347329Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6347645Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6348071Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6348544Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6348896Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6349271Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6349797Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6350291Z   UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6350738Z   UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6351076Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6356832Z ##[start-action display=Run #!/bin/bash;id=__sigstore_cosign-installer.__run]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6371161Z ##[group]Run #!/bin/bash
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6371887Z ^[[36;1m#!/bin/bash^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6372242Z ^[[36;1m# Substitute environment variables in install-dir input^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6372701Z ^[[36;1minstall_dir=$(envsubst <<<"${input_install_dir}")^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6373259Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6373495Z ^[[36;1m# cosign install script^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6374006Z ^[[36;1mshopt -s expand_aliases^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6374310Z ^[[36;1mif [ -z "$NO_COLOR" ]; then^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6374680Z ^[[36;1m  alias log_info="echo -e \"\033[1;32mINFO\033[0m:\""^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6375145Z ^[[36;1m  alias log_error="echo -e \"\033[1;31mERROR\033[0m:\""^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6375511Z ^[[36;1melse^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6375779Z ^[[36;1m  alias log_info="echo \"INFO:\""^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6376124Z ^[[36;1m  alias log_error="echo \"ERROR:\""^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6376438Z ^[[36;1mfi^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6376664Z ^[[36;1mset -e^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6376903Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6377131Z ^[[36;1mCURL_RETRIES=3^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6377391Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6377661Z ^[[36;1m# This function helps compare versions.^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6378065Z ^[[36;1m# Returns 0 if version1 >= version2, 1 otherwise.^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6378473Z ^[[36;1m# Usage: is_version_ge "3.0.0" "$version_num"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6378820Z ^[[36;1mis_version_ge() {^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6379177Z ^[[36;1m    [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" == "$1" ]^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6379550Z ^[[36;1m}^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6379766Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6380086Z ^[[36;1m# Check for unsupported old versions (anything below v2.0.0)^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6380548Z ^[[36;1mif [[ "${input_cosign_release}" != "main" ]]; then^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6380974Z ^[[36;1m  # Extract version without 'v' prefix for comparison^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6381377Z ^[[36;1m  version_num="${input_cosign_release}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6381723Z ^[[36;1m  version_num="${version_num#v}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6382021Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6382286Z ^[[36;1m  # Check if version is less than v2.0.0^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6382661Z ^[[36;1m  if ! is_version_ge "2.0.0" "$version_num"; then^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6383124Z ^[[36;1m    log_error "cosign versions below v2.0.0 are no longer supported."^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6383957Z ^[[36;1m    log_error "Requested version: ${input_cosign_release}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6384477Z ^[[36;1m    log_error "Please use cosign v2.6.0 or later."^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6385022Z ^[[36;1m    log_error "See https://github.com/sigstore/cosign/releases for available versions."^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6385511Z ^[[36;1m    exit 1^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6385761Z ^[[36;1m  fi^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6385991Z ^[[36;1mfi^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6386399Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6386651Z ^[[36;1mmkdir -p "${install_dir}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6386952Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6387232Z ^[[36;1mif [[ "${input_cosign_release}" == "main" ]]; then^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6387705Z ^[[36;1m  log_info "installing cosign via 'go install' from its main version"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6388139Z ^[[36;1m  GOBIN=$(go env GOPATH)/bin^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6388531Z ^[[36;1m  go install github.com/sigstore/cosign/v3/cmd/cosign@main^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6388974Z ^[[36;1m  ln -s "$GOBIN/cosign" "${install_dir}/cosign"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6389309Z ^[[36;1m  exit 0^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6389542Z ^[[36;1mfi^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6389771Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6389988Z ^[[36;1mshaprog() {^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6390247Z ^[[36;1m  case ${runner_os} in^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6390537Z ^[[36;1m    Linux|linux)^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6390830Z ^[[36;1m      sha256sum "$1" | cut -d' ' -f1^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6391150Z ^[[36;1m      ;;^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6391389Z ^[[36;1m    macOS|macos)^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6391682Z ^[[36;1m      shasum -a256 "$1" | cut -d' ' -f1^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6391999Z ^[[36;1m      ;;^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6392235Z ^[[36;1m    Windows|windows)^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6392791Z ^[[36;1m      powershell -command "(Get-FileHash $1 -Algorithm SHA256 | Select-Object -ExpandProperty Hash).ToLower()"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6393349Z ^[[36;1m      ;;^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6393887Z ^[[36;1m    *)^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6394171Z ^[[36;1m      log_error "unsupported OS ${runner_os}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6394505Z ^[[36;1m      exit 1^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6394747Z ^[[36;1m      ;;^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6394974Z ^[[36;1m  esac^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6395204Z ^[[36;1m}^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6395421Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6395869Z ^[[36;1m## curl -sL https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign_checksums.txt |\^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6396668Z ^[[36;1m##   gawk 'match($2,/^cosign-([[:alnum:]]+)-([[:alnum:]]+)(\.[[:alnum:]]+)?$/,a){printf "bootstrap_%s_%s_sha=\"%s\"\n",a[1],a[2],$1}' |\^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6397239Z ^[[36;1m##   LANG=C sort^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6397523Z ^[[36;1mbootstrap_version='v3.0.6'^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6398058Z ^[[36;1mbootstrap_darwin_amd64_sha="4c3e7af8372d3ca3296e62fa56f23fcbb5721cc6ac1827900d398f110d7cd280"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6398797Z ^[[36;1mbootstrap_darwin_arm64_sha="5fadd012ae6381a6a29ff86a7d39aa873878852f1073fc90b15995961ecfb084"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6399525Z ^[[36;1mbootstrap_linux_amd64_sha="c956e5dfcac53d52bcf058360d579472f0c1d2d9b69f55209e256fe7783f4c74"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6400246Z ^[[36;1mbootstrap_linux_arm64_sha="bedac92e8c3729864e13d4a17048007cfafa79d5deca993a43a90ffe018ef2b8"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6400968Z ^[[36;1mbootstrap_linux_arm_sha="67bd25d32daff5664caf51208c95defcb2ad7ac1296f394fa677bb8bacee62f5"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6401709Z ^[[36;1mbootstrap_linux_ppc64le_sha="08c3e5e0a09c440f49e9a69d8639d37fbec522ec8c5c0ac805243b098e6ea512"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6402445Z ^[[36;1mbootstrap_linux_riscv64_sha="e25952e798958b0f9168d044153ccc353f5469ca4b71a1707dffad0534d27017"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6403169Z ^[[36;1mbootstrap_linux_s390x_sha="3cf4b769258ed9cc3c2a93268c0d5c1cc3fbd094af8df21035cbac8fb0d7c088"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6404045Z ^[[36;1mbootstrap_windows_amd64_sha="9b85a88ebff2d9dd30ff4984a6f61f2cedc232dd87d81fa7f2ff3c0ed96c241c"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6404574Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6404812Z ^[[36;1mcosign_executable_name=cosign^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6405116Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6405349Z ^[[36;1mtrap "popd >/dev/null" EXIT^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6405644Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6405885Z ^[[36;1mpushd "${install_dir}" > /dev/null^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6406194Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6406416Z ^[[36;1mcase ${runner_os} in^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6406697Z ^[[36;1m  Linux|linux)^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6406968Z ^[[36;1m    case ${runner_arch} in^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6407393Z ^[[36;1m      X64|amd64)^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6407720Z ^[[36;1m        bootstrap_filename='cosign-linux-amd64'^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6408133Z ^[[36;1m        bootstrap_sha=${bootstrap_linux_amd64_sha}^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6408549Z ^[[36;1m        desired_cosign_filename='cosign-linux-amd64'^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6408903Z ^[[36;1m        ;;^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6409137Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6409356Z ^[[36;1m      ARM|arm)^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6409663Z ^[[36;1m        bootstrap_filename='cosign-linux-arm'^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6410057Z ^[[36;1m        bootstrap_sha=${bootstrap_linux_arm_sha}^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6410458Z ^[[36;1m        desired_cosign_filename='cosign-linux-arm'^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6410802Z ^[[36;1m        ;;^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6411042Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6411269Z ^[[36;1m      ARM64|arm64)^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6411592Z ^[[36;1m        bootstrap_filename='cosign-linux-arm64'^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6411980Z ^[[36;1m        bootstrap_sha=${bootstrap_linux_arm64_sha}^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6412384Z ^[[36;1m        desired_cosign_filename='cosign-linux-arm64'^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6412733Z ^[[36;1m        ;;^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6412964Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6413178Z ^[[36;1m      *)^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6413613Z ^[[36;1m        log_error "unsupported architecture ${runner_arch}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6413992Z ^[[36;1m        exit 1^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6414244Z ^[[36;1m        ;;^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6414599Z ^[[36;1m    esac^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6414826Z ^[[36;1m    ;;^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6415053Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6415271Z ^[[36;1m  macOS|macos)^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6415537Z ^[[36;1m    case ${runner_arch} in^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6415828Z ^[[36;1m      X64|amd64)^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6416140Z ^[[36;1m        bootstrap_filename='cosign-darwin-amd64'^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6416549Z ^[[36;1m        bootstrap_sha=${bootstrap_darwin_amd64_sha}^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6416979Z ^[[36;1m        desired_cosign_filename='cosign-darwin-amd64'^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6417329Z ^[[36;1m        ;;^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6417563Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6417780Z ^[[36;1m      ARM64|arm64)^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6418094Z ^[[36;1m        bootstrap_filename='cosign-darwin-arm64'^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6418489Z ^[[36;1m        bootstrap_sha=${bootstrap_darwin_arm64_sha}^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6418897Z ^[[36;1m        desired_cosign_filename='cosign-darwin-arm64'^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6419250Z ^[[36;1m        ;;^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6419485Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6419695Z ^[[36;1m      *)^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6420010Z ^[[36;1m        log_error "unsupported architecture ${runner_arch}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6420384Z ^[[36;1m        exit 1^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6420636Z ^[[36;1m        ;;^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6420876Z ^[[36;1m    esac^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6421108Z ^[[36;1m    ;;^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6421336Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6421563Z ^[[36;1m  Windows|windows)^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6421851Z ^[[36;1m    case ${runner_arch} in^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6422140Z ^[[36;1m      X64|amd64)^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6422472Z ^[[36;1m        bootstrap_filename='cosign-windows-amd64.exe'^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6422889Z ^[[36;1m        bootstrap_sha=${bootstrap_windows_amd64_sha}^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6423315Z ^[[36;1m        desired_cosign_filename='cosign-windows-amd64.exe'^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6424033Z ^[[36;1m        cosign_executable_name=cosign.exe^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6424368Z ^[[36;1m        ;;^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6424607Z ^[[36;1m      *)^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6424923Z ^[[36;1m        log_error "unsupported architecture ${runner_arch}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6425297Z ^[[36;1m        exit 1^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6425545Z ^[[36;1m        ;;^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6425781Z ^[[36;1m    esac^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6426010Z ^[[36;1m    ;;^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6426274Z ^[[36;1m  *)^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6426558Z ^[[36;1m    log_error "unsupported os ${runner_os}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6426894Z ^[[36;1m    exit 1^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6427258Z ^[[36;1m    ;;^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6427495Z ^[[36;1mesac^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6427714Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6427924Z ^[[36;1mSUDO=^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6428273Z ^[[36;1mif [[ "${input_use_sudo}" == "true" ]] && command -v sudo >/dev/null; then^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6428688Z ^[[36;1m  SUDO=sudo^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6428929Z ^[[36;1mfi^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6429159Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6429465Z ^[[36;1mexpected_bootstrap_version_digest=${bootstrap_sha}^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6430476Z ^[[36;1mlog_info "Downloading bootstrap version '${bootstrap_version}' of cosign to verify version to be installed...\n      https://github.com/sigstore/cosign/releases/download/${bootstrap_version}/${bootstrap_filename}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6431893Z ^[[36;1m$SUDO curl --retry "${CURL_RETRIES}" -fsSL "https://github.com/sigstore/cosign/releases/download/${bootstrap_version}/${bootstrap_filename}" -o "${cosign_executable_name}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6432758Z ^[[36;1mshaBootstrap=$(shaprog "${cosign_executable_name}")^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6433260Z ^[[36;1mif [[ "$shaBootstrap" != "${expected_bootstrap_version_digest}" ]]; then^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6433994Z ^[[36;1m  log_error "Unable to validate cosign version: '${input_cosign_release}'"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6434429Z ^[[36;1m  exit 1^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6434659Z ^[[36;1mfi^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6434930Z ^[[36;1m$SUDO chmod +x "${cosign_executable_name}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6435377Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6435734Z ^[[36;1m# If the bootstrap and specified `cosign` releases are the same, we're done.^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6436275Z ^[[36;1mif [[ "${input_cosign_release}" == "${bootstrap_version}" ]]; then^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6436924Z ^[[36;1m  log_info "bootstrap version successfully verified and matches requested version so nothing else to do"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6437470Z ^[[36;1m  exit 0^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6437700Z ^[[36;1mfi^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6437918Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6438215Z ^[[36;1msemver='^v([0-9]+\.){0,2}(\*|[0-9]+)(-?r?c?)(\.[0-9]+)$'^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6438644Z ^[[36;1mif [[ "${input_cosign_release}" =~ $semver ]]; then^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6439134Z ^[[36;1m  log_info "Custom cosign version '${input_cosign_release}' requested"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6439552Z ^[[36;1melse^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6439956Z ^[[36;1m  log_error "Unable to validate requested cosign version: '${input_cosign_release}'"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6440430Z ^[[36;1m  exit 1^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6440662Z ^[[36;1mfi^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6440879Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6441107Z ^[[36;1m# Download custom cosign^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6441979Z ^[[36;1mlog_info "Downloading platform-specific version '${input_cosign_release}' of cosign...\n      https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${desired_cosign_filename}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6443373Z ^[[36;1m$SUDO curl --retry "${CURL_RETRIES}" -fsSL "https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${desired_cosign_filename}" -o "cosign_${input_cosign_release}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6444394Z ^[[36;1mshaCustom=$(shaprog "cosign_${input_cosign_release}");^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6444767Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6445026Z ^[[36;1m# same hash means it is the same release^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6445411Z ^[[36;1mif [[ "$shaCustom" != "$shaBootstrap" ]]; then^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6446287Z ^[[36;1m  log_info "Downloading cosign public key '${input_cosign_release}' of cosign...\n    https://raw.githubusercontent.com/sigstore/cosign/${input_cosign_release}/release/release-cosign.pub"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6447452Z ^[[36;1m  RELEASE_COSIGN_PUB_KEY=https://raw.githubusercontent.com/sigstore/cosign/${input_cosign_release}/release/release-cosign.pub^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6448303Z ^[[36;1m  RELEASE_COSIGN_PUB_KEY_SHA='f4cea466e5e887a45da5031757fa1d32655d83420639dc1758749b744179f126'^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6448815Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6449238Z ^[[36;1m  log_info "Verifying public key matches expected value"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6449785Z ^[[36;1m  $SUDO curl --retry "${CURL_RETRIES}" -fsSL "$RELEASE_COSIGN_PUB_KEY" -o public.key^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6450293Z ^[[36;1m  sha_fetched_key=$(shaprog public.key)^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6450731Z ^[[36;1m  if [[ "$sha_fetched_key" != "$RELEASE_COSIGN_PUB_KEY_SHA" ]]; then^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6451258Z ^[[36;1m    log_error "Fetched public key does not match expected digest, exiting"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6451689Z ^[[36;1m    exit 1^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6451928Z ^[[36;1m  fi^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6452151Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6452417Z ^[[36;1m  if is_version_ge "3.0.1" "$version_num"; then^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6452861Z ^[[36;1m    # we're trying to get something greater than or equal to v3.0.1^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6453383Z ^[[36;1m    keyless_signature_file=${desired_cosign_filename}.sigstore.json^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6454571Z ^[[36;1m    log_info "Downloading keyless verification bundle for platform-specific '${input_cosign_release}' of cosign...\n      https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${keyless_signature_file}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6455928Z ^[[36;1m    $SUDO curl --retry "${CURL_RETRIES}" -fsSLO "https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${keyless_signature_file}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6456636Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6457070Z ^[[36;1m    log_info "Using bootstrap cosign to verify keyless signature of desired cosign version"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6458466Z ^[[36;1m    "./${cosign_executable_name}" verify-blob --certificate-identity=keyless@projectsigstore.iam.gserviceaccount.com --certificate-oidc-issuer=https://accounts.google.com --bundle "${keyless_signature_file}" "cosign_${input_cosign_release}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6459519Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6459800Z ^[[36;1m    if is_version_ge "3.0.3" "$version_num"; then^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6460256Z ^[[36;1m      # we're trying to get something greater than or equal to v3.0.3^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6460777Z ^[[36;1m      kms_signature_file=${desired_cosign_filename}-kms.sigstore.json^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6461840Z ^[[36;1m      log_info "Downloading KMS verification bundle for platform-specific '${input_cosign_release}' of cosign...\n      https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${kms_signature_file}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6463162Z ^[[36;1m      $SUDO curl --retry "${CURL_RETRIES}" -fsSLO "https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${kms_signature_file}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6464190Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6464589Z ^[[36;1m      log_info "Using bootstrap cosign to verify signature of desired cosign version"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6465382Z ^[[36;1m      "./${cosign_executable_name}" verify-blob --key public.key --bundle "${kms_signature_file}" "cosign_${input_cosign_release}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6465987Z ^[[36;1m    fi^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6466223Z ^[[36;1m  else^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6466529Z ^[[36;1m    signature_file=${desired_cosign_filename}.sig^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6467484Z ^[[36;1m    log_info "Downloading detached signature for platform-specific '${input_cosign_release}' of cosign...\n      https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${signature_file}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6468751Z ^[[36;1m    $SUDO curl --retry "${CURL_RETRIES}" -fsSLO "https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${signature_file}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6469432Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6469823Z ^[[36;1m    log_info "Using bootstrap cosign to verify signature of desired cosign version"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6470601Z ^[[36;1m    "./${cosign_executable_name}" verify-blob --key public.key --signature "${signature_file}" "cosign_${input_cosign_release}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6471210Z ^[[36;1m  fi^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6471443Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6471696Z ^[[36;1m  $SUDO rm "${cosign_executable_name}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6472277Z ^[[36;1m  $SUDO mv "cosign_${input_cosign_release}" "${cosign_executable_name}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6472754Z ^[[36;1m  $SUDO chmod +x "${cosign_executable_name}"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6473130Z ^[[36;1m  log_info "Installation complete!"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6473453Z ^[[36;1mfi^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6512377Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6512756Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6512996Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6513323Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6513930Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6514408Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6514768Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6515145Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6515668Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6516174Z   UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6516608Z   UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6516968Z   input_cosign_release: v3.0.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6517262Z   input_install_dir: $HOME/.cosign
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6517554Z   input_use_sudo: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6517810Z   runner_arch: X64
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6518050Z   runner_os: Linux
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6518284Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6643059Z ^[[1;32mINFO^[[0m: Downloading bootstrap version 'v3.0.6' of cosign to verify version to be installed...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:01.6644691Z       https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-linux-amd64
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:02.1158416Z ^[[1;32mINFO^[[0m: Custom cosign version 'v3.0.3' requested
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:02.1159663Z ^[[1;32mINFO^[[0m: Downloading platform-specific version 'v3.0.3' of cosign...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:02.1160641Z       https://github.com/sigstore/cosign/releases/download/v3.0.3/cosign-linux-amd64
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:02.8297914Z ^[[1;32mINFO^[[0m: Downloading cosign public key 'v3.0.3' of cosign...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:02.8299645Z     https://raw.githubusercontent.com/sigstore/cosign/v3.0.3/release/release-cosign.pub
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:02.8300712Z ^[[1;32mINFO^[[0m: Verifying public key matches expected value
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:02.8691824Z ^[[1;32mINFO^[[0m: Downloading keyless verification bundle for platform-specific 'v3.0.3' of cosign...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:02.8693995Z       https://github.com/sigstore/cosign/releases/download/v3.0.3/cosign-linux-amd64.sigstore.json
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.0342402Z ^[[1;32mINFO^[[0m: Using bootstrap cosign to verify keyless signature of desired cosign version
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.3389774Z Verified OK
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.3482782Z ^[[1;32mINFO^[[0m: Downloading KMS verification bundle for platform-specific 'v3.0.3' of cosign...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.3484171Z       https://github.com/sigstore/cosign/releases/download/v3.0.3/cosign-linux-amd64-kms.sigstore.json
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.4958282Z ^[[1;32mINFO^[[0m: Using bootstrap cosign to verify signature of desired cosign version
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.7567459Z Verified OK
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.7882330Z ^[[1;32mINFO^[[0m: Installation complete!
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.7892881Z ##[end-action id=__sigstore_cosign-installer.__run;outcome=success;conclusion=success;duration_ms=2153]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.7897562Z ##[start-action display=Run envsubst <<<"${input_install_dir}" >> "$GITHUB_PATH";id=__sigstore_cosign-installer.__run_2]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.7917274Z ##[group]Run envsubst <<<"${input_install_dir}" >> "$GITHUB_PATH"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.7917759Z ^[[36;1menvsubst <<<"${input_install_dir}" >> "$GITHUB_PATH"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.7957358Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.7957756Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.7958003Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.7958336Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.7958762Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.7959433Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.7959811Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.7960189Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.7960715Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.7961215Z   UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.7961648Z   UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.7962015Z   input_install_dir: $HOME/.cosign
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.7962310Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.8038661Z ##[end-action id=__sigstore_cosign-installer.__run_2;outcome=success;conclusion=success;duration_ms=14]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.8041866Z ##[start-action display=Run $install_dir = $ExecutionContext.InvokeCommand.ExpandString("${env:input_install_dir}");id=__sigstore_cosign-installer.__run_3]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.8046227Z ##[end-action id=__sigstore_cosign-installer.__run_3;outcome=skipped;conclusion=skipped;duration_ms=0]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.8082863Z ##[group]Run anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.8083355Z with:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.8083903Z   run: download-syft
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.8084167Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.8084403Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.8084715Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.8085123Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.8085784Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.8086136Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.8086512Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.8087032Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.8087531Z   UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.8087951Z   UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:03.8088327Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:04.0083364Z [command]/usr/bin/sh /home/runner/work/_temp/a919c614-8f4d-444d-bd2f-2e141294eef1 -d -b /home/runner/work/_temp/a919c614-8f4d-444d-bd2f-2e141294eef1_syft v1.42.3
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:04.0134558Z [info] checking github for release tag='v1.42.3' 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:04.0172957Z [debug] http_download(url=https://github.com/anchore/syft/releases/v1.42.3) 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:04.2331838Z [info] fetching release script for tag='v1.42.3' 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:04.2356491Z [debug] http_download(url=https://get.anchore.io/syft/v1.42.3/install.sh) 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:04.3215990Z [info] checking github for release tag='v1.42.3' 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:04.3252417Z [debug] http_download(url=https://github.com/anchore/syft/releases/v1.42.3) 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:04.3845764Z [info] using release tag='v1.42.3' version='1.42.3' os='linux' arch='amd64' 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:04.3867096Z [debug] downloading files into /home/runner/work/_temp/tmp.ygYa0CKI2C 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:04.3904141Z [debug] http_download(url=https://github.com/anchore/syft/releases/download/v1.42.3/syft_1.42.3_checksums.txt) 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:04.4696150Z [debug] http_download(url=https://github.com/anchore/syft/releases/download/v1.42.3/syft_1.42.3_linux_amd64.tar.gz) 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.1949760Z [info] installed /home/runner/work/_temp/a919c614-8f4d-444d-bd2f-2e141294eef1_syft/syft 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.2600611Z ##[group]Run task setup
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.2600961Z ^[[36;1mtask setup^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.2640343Z shell: /usr/bin/bash -e {0}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.2640638Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.2640881Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.2641205Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.2641608Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.2642079Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.2642429Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.2642810Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.2643344Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.2644112Z   UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.2644561Z   UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.2644902Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.4434341Z ^[[32mtask: [setup] go mod tidy
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.7034683Z ^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.7062637Z ##[group]Run task build
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.7063169Z ^[[36;1mtask build^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.7103859Z shell: /usr/bin/bash -e {0}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.7104166Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.7104408Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.7104737Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.7105152Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.7105648Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.7106005Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.7106377Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.7106935Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.7107449Z   UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.7107887Z   UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.7108227Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:05.7787778Z ^[[32mtask: [build] go build
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:11.1419630Z ^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:11.1456984Z ##[group]Run task test TEST_OPTIONS=-count=1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:11.1457395Z ^[[36;1mtask test TEST_OPTIONS=-count=1^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:11.1496245Z shell: /usr/bin/bash -e {0}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:11.1496540Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:11.1496783Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:11.1497107Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:11.1497520Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:11.1497987Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:11.1498349Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:11.1498730Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:11.1499255Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:11.1499750Z   UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:11.1500173Z   UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:11.1500545Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:11.2099975Z ^[[32mtask: [test] go test -count=1 -failfast -race -coverpkg=./... -covermode=atomic -coverprofile=coverage.txt ./... -run . -timeout=15m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:22.2345961Z ok  	github.com/goreleaser/goreleaser/v2	1.281s	coverage: 0.5% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:47.4748573Z ok  	github.com/goreleaser/goreleaser/v2/cmd	25.265s	coverage: 18.5% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:47.4752386Z ok  	github.com/goreleaser/goreleaser/v2/internal/archivefiles	1.208s	coverage: 0.8% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:47.4755414Z ok  	github.com/goreleaser/goreleaser/v2/internal/artifact	1.280s	coverage: 2.0% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:47.4757907Z ok  	github.com/goreleaser/goreleaser/v2/internal/builders/base	1.166s	coverage: 0.8% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:47.4760382Z ok  	github.com/goreleaser/goreleaser/v2/internal/builders/bun	2.892s	coverage: 1.9% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:47.4762772Z ok  	github.com/goreleaser/goreleaser/v2/internal/builders/deno	3.541s	coverage: 1.7% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:47.4765462Z ok  	github.com/goreleaser/goreleaser/v2/internal/builders/golang	5.989s	coverage: 5.4% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:05:47.4767892Z ok  	github.com/goreleaser/goreleaser/v2/internal/builders/golang/gomain	1.194s	coverage: 0.4% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6746543Z ok  	github.com/goreleaser/goreleaser/v2/internal/builders/node	69.565s	coverage: 2.8% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6748346Z ok  	github.com/goreleaser/goreleaser/v2/internal/builders/poetry	9.083s	coverage: 1.8% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6750065Z ok  	github.com/goreleaser/goreleaser/v2/internal/builders/rust	31.159s	coverage: 2.3% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6751798Z ok  	github.com/goreleaser/goreleaser/v2/internal/builders/uv	1.459s	coverage: 1.8% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6753405Z ok  	github.com/goreleaser/goreleaser/v2/internal/builders/zig	22.459s	coverage: 2.2% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6755162Z ok  	github.com/goreleaser/goreleaser/v2/internal/cargo	1.225s	coverage: 0.0% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6756685Z ok  	github.com/goreleaser/goreleaser/v2/internal/changelog	1.260s	coverage: 0.1% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6760363Z ok  	github.com/goreleaser/goreleaser/v2/internal/client	11.134s	coverage: 10.8% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6762417Z ok  	github.com/goreleaser/goreleaser/v2/internal/commitauthor	1.168s	coverage: 0.4% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6764395Z ok  	github.com/goreleaser/goreleaser/v2/internal/deprecate	1.132s	coverage: 0.4% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6765864Z ok  	github.com/goreleaser/goreleaser/v2/internal/elf	1.323s	coverage: 0.1% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6767301Z ok  	github.com/goreleaser/goreleaser/v2/internal/exec	1.230s	coverage: 2.3% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6769262Z ok  	github.com/goreleaser/goreleaser/v2/internal/experimental	1.111s	coverage: 0.0% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6771218Z ok  	github.com/goreleaser/goreleaser/v2/internal/extrafiles	1.217s	coverage: 0.6% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6772640Z ok  	github.com/goreleaser/goreleaser/v2/internal/gerrors	1.196s	coverage: 0.2% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6773829Z ok  	github.com/goreleaser/goreleaser/v2/internal/gio	1.209s	coverage: 0.6% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6774963Z ok  	github.com/goreleaser/goreleaser/v2/internal/git	1.274s	coverage: 1.4% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6775967Z 	github.com/goreleaser/goreleaser/v2/internal/golden		coverage: 0.0% of statements
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6776915Z ok  	github.com/goreleaser/goreleaser/v2/internal/http	1.838s	coverage: 3.0% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6777952Z ok  	github.com/goreleaser/goreleaser/v2/internal/ids	1.168s	coverage: 0.0% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6778990Z ok  	github.com/goreleaser/goreleaser/v2/internal/logext	1.167s	coverage: 0.3% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6779777Z ?   	github.com/goreleaser/goreleaser/v2/internal/middleware	[no test files]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6780803Z ok  	github.com/goreleaser/goreleaser/v2/internal/middleware/errhandler	1.225s	coverage: 0.2% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6781967Z ok  	github.com/goreleaser/goreleaser/v2/internal/middleware/logging	1.211s	coverage: 0.1% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6783132Z ok  	github.com/goreleaser/goreleaser/v2/internal/middleware/skip	1.161s	coverage: 0.1% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6784412Z ok  	github.com/goreleaser/goreleaser/v2/internal/nodedist	1.142s	coverage: 0.5% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6785404Z ok  	github.com/goreleaser/goreleaser/v2/internal/packagejson	1.152s	coverage: 0.1% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6786304Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe	1.104s	coverage: 0.1% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6787207Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/announce	1.205s	coverage: 1.0% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6788206Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/archive	1.825s	coverage: 4.0% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6789251Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/artifactory	1.337s	coverage: 2.9% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6790173Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/aur	2.640s	coverage: 4.7% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6791326Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/aursources	2.268s	coverage: 4.5% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6793442Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/before	1.307s	coverage: 1.3% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6795395Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/blob	10.082s	coverage: 2.5% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6797139Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/bluesky	1.361s	coverage: 0.9% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6798827Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/brew	2.069s	coverage: 5.6% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6800484Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/build	1.321s	coverage: 4.1% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:36.6802138Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/cask	1.611s	coverage: 6.3% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:37.0565955Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/changelog	3.031s	coverage: 4.5% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:37.0567915Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/checksums	1.153s	coverage: 2.0% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:38.3017656Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/chocolatey	1.231s	coverage: 2.5% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:39.1661471Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/custompublishers	1.153s	coverage: 1.8% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:43.3982249Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/defaults	1.412s	coverage: 5.4% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:43.4144602Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/discord	1.186s	coverage: 0.7% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:43.5258095Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/discourse	1.148s	coverage: 0.8% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:06:43.6585725Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/dist	1.108s	coverage: 0.3% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2424430Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/docker	44.840s	coverage: 5.5% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2426553Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/docker/v2	11.088s	coverage: 6.0% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2428599Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/dockerdigest	1.136s	coverage: 0.9% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2430780Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/effectiveconfig	1.156s	coverage: 0.2% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2432783Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/env	1.214s	coverage: 1.3% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2434956Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/flatpak	3.805s	coverage: 2.6% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2436833Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/git	4.189s	coverage: 2.6% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2438641Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/gomod	2.138s	coverage: 1.3% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2440517Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/iru	1.397s	coverage: 3.0% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2442439Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/ko	27.941s	coverage: 3.2% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2445053Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/krew	1.468s	coverage: 4.6% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2447210Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/linkedin	1.183s	coverage: 1.1% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2449234Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/makeself	1.782s	coverage: 3.4% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2451234Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/mastodon	1.228s	coverage: 0.5% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2453298Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/mattermost	1.228s	coverage: 0.7% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2455532Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/mcp	1.265s	coverage: 1.5% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2457490Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/metadata	1.129s	coverage: 1.2% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2459620Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/milestone	1.297s	coverage: 1.9% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2461663Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/nfpm	13.080s	coverage: 3.6% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2463804Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/nix	2.334s	coverage: 4.0% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2465858Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/notary	1.413s	coverage: 0.8% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2468033Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/opencollective	1.229s	coverage: 1.0% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2470160Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/partial	1.230s	coverage: 0.5% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.2472300Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/prebuild	1.124s	coverage: 0.4% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:28.5455581Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/project	1.238s	coverage: 1.4% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:31.9819689Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/publish	1.283s	coverage: 1.2% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:31.9821493Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/reddit	1.175s	coverage: 0.5% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:32.0897021Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/release	1.342s	coverage: 4.7% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:32.6436607Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/reportsizes	1.114s	coverage: 0.6% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:34.5900833Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/sbom	2.713s	coverage: 3.3% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:34.5902709Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/scoop	1.274s	coverage: 5.2% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:34.5924861Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/semver	1.222s	coverage: 0.3% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:57.7725021Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/sign	23.394s	coverage: 4.7% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:57.7726350Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/slack	1.222s	coverage: 1.0% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:57.7727655Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/smtp	1.132s	coverage: 0.4% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:57.8704857Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/snapcraft	21.801s	coverage: 3.5% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:57.8705891Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/snapshot	1.172s	coverage: 0.6% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:57.8706864Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/sourcearchive	1.341s	coverage: 3.8% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:57.8707792Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/srpm	1.228s	coverage: 1.4% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:57.8708672Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/teams	1.245s	coverage: 0.5% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:57.8709580Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/telegram	1.235s	coverage: 0.7% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:57.8710531Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/twitter	1.190s	coverage: 0.5% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:57.8711474Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/universalbinary	1.669s	coverage: 3.2% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:57.8712408Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/upload	1.302s	coverage: 2.6% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:57.8713285Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/upx	1.318s	coverage: 1.4% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:57.8714642Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/webhook	1.310s	coverage: 1.0% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:57.8715701Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/winget	1.917s	coverage: 3.7% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:57.8716598Z ?   	github.com/goreleaser/goreleaser/v2/internal/pipeline	[no test files]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:57.8717411Z ok  	github.com/goreleaser/goreleaser/v2/internal/pyproject	1.227s	coverage: 0.1% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:57.8718419Z ok  	github.com/goreleaser/goreleaser/v2/internal/redact	1.189s	coverage: 0.2% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:57.8719402Z ok  	github.com/goreleaser/goreleaser/v2/internal/retryx	1.166s	coverage: 0.3% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:57.8720422Z ok  	github.com/goreleaser/goreleaser/v2/internal/semerrgroup	1.164s	coverage: 0.3% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:57.8891704Z ok  	github.com/goreleaser/goreleaser/v2/internal/shell	1.190s	coverage: 0.8% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:57.9612481Z ok  	github.com/goreleaser/goreleaser/v2/internal/skips	1.122s	coverage: 0.4% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:59.6752499Z ok  	github.com/goreleaser/goreleaser/v2/internal/static	1.204s	coverage: 0.2% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:59.6754602Z ok  	github.com/goreleaser/goreleaser/v2/internal/summary	1.176s	coverage: 0.1% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:07:59.6756410Z 	github.com/goreleaser/goreleaser/v2/internal/testctx		coverage: 0.0% of statements
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:00.2469302Z ok  	github.com/goreleaser/goreleaser/v2/internal/testlib	1.133s	coverage: 1.0% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:00.4461855Z ok  	github.com/goreleaser/goreleaser/v2/internal/tmpl	1.139s	coverage: 1.7% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:00.7948814Z ok  	github.com/goreleaser/goreleaser/v2/internal/yaml	1.115s	coverage: 0.1% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:01.9140598Z ok  	github.com/goreleaser/goreleaser/v2/pkg/archive	1.295s	coverage: 1.5% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:02.1614652Z ok  	github.com/goreleaser/goreleaser/v2/pkg/archive/gzip	1.182s	coverage: 0.1% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:02.7317300Z ok  	github.com/goreleaser/goreleaser/v2/pkg/archive/tar	1.122s	coverage: 0.5% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:03.0327011Z ok  	github.com/goreleaser/goreleaser/v2/pkg/archive/targz	1.140s	coverage: 0.3% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:04.0991292Z ok  	github.com/goreleaser/goreleaser/v2/pkg/archive/tarxz	1.206s	coverage: 0.3% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:04.4402831Z ok  	github.com/goreleaser/goreleaser/v2/pkg/archive/tarzst	1.195s	coverage: 0.3% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:04.5963377Z ok  	github.com/goreleaser/goreleaser/v2/pkg/archive/xz	1.110s	coverage: 0.1% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:05.2247794Z ok  	github.com/goreleaser/goreleaser/v2/pkg/archive/zip	1.146s	coverage: 0.3% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:05.7309728Z ok  	github.com/goreleaser/goreleaser/v2/pkg/build	1.112s	coverage: 0.3% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:06.1425945Z ok  	github.com/goreleaser/goreleaser/v2/pkg/config	1.139s	coverage: 0.8% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:06.2637283Z ok  	github.com/goreleaser/goreleaser/v2/pkg/context	1.108s	coverage: 0.1% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:06.2638137Z ?   	github.com/goreleaser/goreleaser/v2/pkg/defaults	[no test files]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.4947815Z ok  	github.com/goreleaser/goreleaser/v2/pkg/healthcheck	1.118s	coverage: 0.6% of statements in ./...
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6353884Z ^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6709358Z ##[warning]Unexpected input(s) 'file', valid inputs are ['base_sha', 'binary', 'codecov_yml_path', 'commit_parent', 'directory', 'disable_file_fixes', 'disable_search', 'disable_safe_directory', 'disable_telem', 'dry_run', 'env_vars', 'exclude', 'fail_ci_if_error', 'files', 'flags', 'force', 'git_service', 'gcov_args', 'gcov_executable', 'gcov_ignore', 'gcov_include', 'handle_no_reports_found', 'job_code', 'name', 'network_filter', 'network_prefix', 'os', 'override_branch', 'override_build', 'override_build_url', 'override_commit', 'override_pr', 'plugins', 'recurse_submodules', 'report_code', 'report_type', 'root_dir', 'run_command', 'skip_validation', 'slug', 'swift_project', 'token', 'url', 'use_legacy_upload_endpoint', 'use_oidc', 'use_pypi', 'verbose', 'version', 'working-directory']
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6723194Z ##[group]Run codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6723955Z with:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6724188Z   file: ./coverage.txt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6724479Z   disable_file_fixes: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6724749Z   disable_search: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6725014Z   disable_safe_directory: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6725287Z   disable_telem: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6725529Z   dry_run: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6725772Z   fail_ci_if_error: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6726035Z   git_service: github
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6726282Z   gcov_executable: gcov
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6726542Z   handle_no_reports_found: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6726828Z   recurse_submodules: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6727105Z   run_command: upload-coverage
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6727383Z   skip_validation: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6727658Z   use_legacy_upload_endpoint: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6727945Z   use_oidc: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6728181Z   use_pypi: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6728409Z   verbose: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6728634Z   version: latest
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6728857Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6729278Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6729591Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6729996Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6730462Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6730809Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6731166Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6731694Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6732181Z   UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6732594Z   UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6733045Z   CODECOV_TOKEN: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6733293Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6744405Z ##[start-action display=Check system dependencies;id=__codecov_codecov-action.__run]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6759678Z ##[group]Run missing_deps=""
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6760006Z ^[[36;1mmissing_deps=""^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6760267Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6760527Z ^[[36;1m# Check for always-required commands^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6760877Z ^[[36;1mfor cmd in bash git curl; do^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6761238Z ^[[36;1m  if ! command -v "$cmd" >/dev/null 2>&1; then^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6761664Z ^[[36;1m    missing_deps="$missing_deps $cmd"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6761979Z ^[[36;1m  fi^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6762203Z ^[[36;1mdone^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6762418Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6762720Z ^[[36;1m# Check for gpg only if validation is not being skipped^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6763143Z ^[[36;1mif [ "$INPUT_SKIP_VALIDATION" != "true" ]; then^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6763845Z ^[[36;1m  if ! command -v gpg >/dev/null 2>&1; then^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6764240Z ^[[36;1m    missing_deps="$missing_deps gpg"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6764555Z ^[[36;1m  fi^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6764773Z ^[[36;1mfi^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6764983Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6765236Z ^[[36;1m# Report missing required dependencies^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6765768Z ^[[36;1mif [ -n "$missing_deps" ]; then^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6766227Z ^[[36;1m  echo "Error: The following required dependencies are missing:$missing_deps"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6766791Z ^[[36;1m  echo "Please install these dependencies before using this action."^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6767206Z ^[[36;1m  exit 1^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6767431Z ^[[36;1mfi^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6767643Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6767938Z ^[[36;1mecho "All required system dependencies are available."^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6805737Z shell: /usr/bin/sh -e {0}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6806019Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6806253Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6806572Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6806988Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6807464Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6807805Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6808183Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6808697Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6809194Z   UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6809611Z   UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6810040Z   CODECOV_TOKEN: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6810309Z   INPUT_SKIP_VALIDATION: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6810593Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6863445Z All required system dependencies are available.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6868487Z ##[end-action id=__codecov_codecov-action.__run;outcome=success;conclusion=success;duration_ms=12]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6870585Z ##[start-action display=Action version;id=__codecov_codecov-action.__run_2]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6885820Z ##[group]Run CC_ACTION_VERSION=$(cat ${GITHUB_ACTION_PATH}/src/version)
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6886338Z ^[[36;1mCC_ACTION_VERSION=$(cat ${GITHUB_ACTION_PATH}/src/version)^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6887011Z ^[[36;1mecho -e "\033[0;32m==>\033[0m Running Action version $CC_ACTION_VERSION"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6921850Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6922227Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6922462Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6922782Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6923187Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6923872Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6924222Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6924580Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6925093Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6925574Z   UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6925995Z   UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6926554Z   CODECOV_TOKEN: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.6926870Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7004765Z ^[[0;32m==>^[[0m Running Action version 7.0.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7010463Z ##[end-action id=__codecov_codecov-action.__run_2;outcome=success;conclusion=success;duration_ms=13]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7012670Z ##[start-action display=Set safe directory;id=__codecov_codecov-action.__run_3]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7031188Z ##[group]Run git config --global --add safe.directory "/home/runner/work/goreleaser/goreleaser"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7031876Z ^[[36;1mgit config --global --add safe.directory "/home/runner/work/goreleaser/goreleaser"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7032472Z ^[[36;1mgit config --global --add safe.directory "$GITHUB_WORKSPACE"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7068203Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7068734Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7069042Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7069400Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7069798Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7070485Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7070853Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7071228Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7071750Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7072239Z   UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7072656Z   UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7073087Z   CODECOV_TOKEN: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7073342Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7178488Z ##[end-action id=__codecov_codecov-action.__run_3;outcome=success;conclusion=success;duration_ms=16]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7182681Z ##[start-action display=Set fork;id=__codecov_codecov-action.__run_4]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7197730Z ##[group]Run CC_FORK="false"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7198035Z ^[[36;1mCC_FORK="false"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7198667Z ^[[36;1mif [ -n "$GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME" ] && [ "$GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME" != "$GITHUB_REPOSITORY" ];^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7199306Z ^[[36;1mthen^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7199592Z ^[[36;1m  echo -e "\033[0;32m==>\033[0m Fork detected"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7199934Z ^[[36;1m  CC_FORK="true"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7200192Z ^[[36;1mfi^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7200452Z ^[[36;1mecho "CC_FORK=$CC_FORK" >> "$GITHUB_ENV"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7236486Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7236868Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7237100Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7237410Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7237812Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7238297Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7238646Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7239017Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7239678Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7240169Z   UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7240584Z   UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7241015Z   CODECOV_TOKEN: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7241295Z   GITHUB_EVENT_PULL_REQUEST_HEAD_LABEL: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7241654Z   GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7242021Z   GITHUB_REPOSITORY: goreleaser/goreleaser
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7242329Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7309552Z ##[end-action id=__codecov_codecov-action.__run_4;outcome=success;conclusion=success;duration_ms=12]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7312401Z ##[start-action display=Get OIDC token;id=__codecov_codecov-action.oidc]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7406321Z ##[group]Run actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7407056Z with:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7407952Z   script: if (process.env.CC_USE_OIDC === 'true' && process.env.CC_FORK != 'true') {
+test (ubuntu-latest)	UNKNOWN STEP	  const id_token = await core.getIDToken(process.env.CC_OIDC_AUDIENCE)
+test (ubuntu-latest)	UNKNOWN STEP	  return id_token
+test (ubuntu-latest)	UNKNOWN STEP	}
+test (ubuntu-latest)	UNKNOWN STEP	
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7410982Z   github-token: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7411246Z   debug: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7411502Z   user-agent: actions/github-script
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7411808Z   result-encoding: json
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7412058Z   retries: 0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7412329Z   retry-exempt-status-codes: 400,401,403,404,422
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7412651Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7412882Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7413181Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7413857Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7414393Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7414753Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7415117Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7415828Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7416328Z   UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7416745Z   UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7417081Z   CC_FORK: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7417390Z   CODECOV_TOKEN: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7417665Z   CC_OIDC_AUDIENCE: https://codecov.io
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7417974Z   CC_USE_OIDC: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.7418208Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.9946778Z ##[end-action id=__codecov_codecov-action.oidc;outcome=success;conclusion=success;duration_ms=263]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.9954255Z ##[start-action display=Get and set token;id=__codecov_codecov-action.__run_5]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.9970839Z ##[group]Run if [ "$INPUT_USE_OIDC" == 'true' ] && [ "$CC_FORK" != 'true' ];
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.9971370Z ^[[36;1mif [ "$INPUT_USE_OIDC" == 'true' ] && [ "$CC_FORK" != 'true' ];^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.9971758Z ^[[36;1mthen^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.9972084Z ^[[36;1m  echo "CC_TOKEN=$CC_OIDC_TOKEN" >> "$GITHUB_ENV"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.9972470Z ^[[36;1melif [ -n "$INPUT_CODECOV_TOKEN" ];^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.9972794Z ^[[36;1mthen^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.9973098Z ^[[36;1m  echo -e "\033[0;32m==>\033[0m Token set from env"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.9973821Z ^[[36;1m    echo "CC_TOKEN=$INPUT_CODECOV_TOKEN" >> "$GITHUB_ENV"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.9974218Z ^[[36;1melse^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.9974463Z ^[[36;1m  if [ -n "$INPUT_TOKEN" ];^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.9974751Z ^[[36;1m  then^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.9975057Z ^[[36;1m    echo -e "\033[0;32m==>\033[0m Token set from input"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.9975467Z ^[[36;1m    CC_TOKEN=$(echo "$INPUT_TOKEN" | tr -d '\n')^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.9975854Z ^[[36;1m    echo "CC_TOKEN=$CC_TOKEN" >> "$GITHUB_ENV"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.9976182Z ^[[36;1m  fi^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:07.9976399Z ^[[36;1mfi^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0015151Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0015702Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0015947Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0016272Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0016697Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0017173Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0017528Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0017897Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0018415Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0018903Z   UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0019322Z   UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0019658Z   CC_FORK: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0020048Z   CODECOV_TOKEN: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0020304Z   CC_OIDC_TOKEN: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0020575Z   CC_OIDC_AUDIENCE: https://codecov.io
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0020890Z   INPUT_USE_OIDC: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0021146Z   INPUT_TOKEN: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0021460Z   INPUT_CODECOV_TOKEN: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0021725Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0083360Z ^[[0;32m==>^[[0m Token set from env
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0089778Z ##[end-action id=__codecov_codecov-action.__run_5;outcome=success;conclusion=success;duration_ms=13]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0092854Z ##[start-action display=Override branch for forks;id=__codecov_codecov-action.__run_6]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0107691Z ##[group]Run if [ -z "$CC_BRANCH" ] && [ -z "$CC_TOKEN" ] && [ "$CC_FORK" == 'true' ]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0108235Z ^[[36;1mif [ -z "$CC_BRANCH" ] && [ -z "$CC_TOKEN" ] && [ "$CC_FORK" == 'true' ]^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0108641Z ^[[36;1mthen^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0109104Z ^[[36;1m  echo -e "\033[0;32m==>\033[0m Fork detected, setting branch to $GITHUB_EVENT_PULL_REQUEST_HEAD_LABEL"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0109703Z ^[[36;1m  TOKENLESS="$GITHUB_EVENT_PULL_REQUEST_HEAD_LABEL"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0110130Z ^[[36;1m  CC_BRANCH="$GITHUB_EVENT_PULL_REQUEST_HEAD_LABEL"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0110692Z ^[[36;1m  echo "TOKENLESS=$TOKENLESS" >> "$GITHUB_ENV"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0111041Z ^[[36;1mfi^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0111263Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0111526Z ^[[36;1mecho "CC_BRANCH=$CC_BRANCH" >> "$GITHUB_ENV"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0145968Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0146357Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0146590Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0146905Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0147307Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0147786Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0148141Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0148506Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0149024Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0149524Z   UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0149959Z   UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0150296Z   CC_FORK: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0150603Z   CC_TOKEN: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0150904Z   CODECOV_TOKEN: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0151150Z   CC_BRANCH: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0151399Z   GITHUB_EVENT_PULL_REQUEST_HEAD_LABEL: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0151750Z   GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0152103Z   GITHUB_REPOSITORY: goreleaser/goreleaser
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0152411Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0217787Z ##[end-action id=__codecov_codecov-action.__run_6;outcome=success;conclusion=success;duration_ms=12]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0221370Z ##[start-action display=Override commits and pr for pull requests;id=__codecov_codecov-action.__run_7]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0236716Z ##[group]Run if [ -z "$CC_SHA" ];
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0237035Z ^[[36;1mif [ -z "$CC_SHA" ];^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0237316Z ^[[36;1mthen^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0237752Z ^[[36;1m  CC_SHA="$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0238099Z ^[[36;1mfi^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0238385Z ^[[36;1mif [ -z "$CC_PR" ] && [ "$CC_FORK" == 'true' ];^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0238734Z ^[[36;1mthen^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0238991Z ^[[36;1m  CC_PR="$GITHUB_EVENT_NUMBER"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0239296Z ^[[36;1mfi^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0239513Z ^[[36;1m^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0239766Z ^[[36;1mecho "CC_SHA=$CC_SHA" >> "$GITHUB_ENV"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0240116Z ^[[36;1mecho "CC_PR=$CC_PR" >> "$GITHUB_ENV"^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0274485Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0274875Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0275107Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0275427Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0275835Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0276331Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0276689Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0277073Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0277604Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0278096Z   UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0278516Z   UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0278846Z   CC_FORK: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0279159Z   CC_TOKEN: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0279394Z   CC_BRANCH: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0279684Z   CODECOV_TOKEN: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0279927Z   CC_PR: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0280133Z   CC_SHA: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0280804Z   GITHUB_EVENT_NAME: push
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0281079Z   GITHUB_EVENT_NUMBER: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0281351Z   GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0281649Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0347732Z ##[end-action id=__codecov_codecov-action.__run_7;outcome=success;conclusion=success;duration_ms=12]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0354579Z ##[start-action display=Upload coverage to Codecov;id=__codecov_codecov-action.__run_8]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0369413Z ##[group]Run ${GITHUB_ACTION_PATH}/dist/codecov.sh
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0369806Z ^[[36;1m${GITHUB_ACTION_PATH}/dist/codecov.sh^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0404282Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0404663Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0404916Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0405230Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0405636Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0406109Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0406473Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0406852Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0407398Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0407912Z   UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0408361Z   UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0408697Z   CC_FORK: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0409004Z   CC_TOKEN: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0409242Z   CC_BRANCH: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0409463Z   CC_SHA: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0409672Z   CC_PR: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0409947Z   CODECOV_TOKEN: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0410191Z   CC_BASE_SHA: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0410708Z   CC_BINARY: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0411056Z   CC_BUILD: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0411460Z   CC_BUILD_URL: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0411851Z   CC_CODE: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0412233Z   CC_DIR: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0434467Z   CC_DISABLE_FILE_FIXES: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0434822Z   CC_DISABLE_SEARCH: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0435150Z   CC_DISABLE_TELEM: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0435428Z   CC_DRY_RUN: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0435672Z   CC_ENTERPRISE_URL: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0435912Z   CC_ENV: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0436130Z   CC_EXCLUDES: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0436371Z   CC_FAIL_ON_ERROR: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0436827Z   CC_FILES: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0437047Z   CC_FLAGS: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0437258Z   CC_FORCE: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0437467Z   CC_GCOV_ARGS: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0437712Z   CC_GCOV_EXECUTABLE: gcov
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0437974Z   CC_GCOV_IGNORE: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0438208Z   CC_GCOV_INCLUDE: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0438448Z   CC_GIT_SERVICE: github
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0438721Z   CC_HANDLE_NO_REPORTS_FOUND: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0439010Z   CC_JOB_CODE: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0439237Z   CC_LEGACY: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0439469Z   CC_NAME: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0439688Z   CC_NETWORK_FILTER: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0439938Z   CC_NETWORK_PREFIX: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0440180Z   CC_NETWORK_ROOT_FOLDER: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0440434Z   CC_OS: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0440645Z   CC_PARENT_SHA: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0440875Z   CC_PLUGINS: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0441112Z   CC_RECURSE_SUBMODULES: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0441392Z   CC_REPORT_TYPE: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0441650Z   CC_RUN_CMD: upload-coverage
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0441936Z   CC_SERVICE: github
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0442193Z   CC_SKIP_VALIDATION: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0442451Z   CC_SLUG: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0442671Z   CC_SWIFT_PROJECT: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0442912Z   CC_USE_PYPI: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0443145Z   CC_VERBOSE: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0443379Z   CC_VERSION: latest
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0443889Z   CC_YML_PATH: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0444141Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0529855Z      _____          _
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0530390Z     / ____|        | |
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0530856Z    | |     ___   __| | ___  ___ _____   __
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0531281Z    | |    / _ \ / _` |/ _ \/ __/ _ \ \ / /
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0531686Z    | |___| (_) | (_| |  __/ (_| (_) \ V /
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0532103Z     \_____\___/ \__,_|\___|\___\___/ \_/
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0532984Z                            ^[[0;31m Wrapper-0.2.9^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0533454Z                            
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0587963Z ^[[0;32m==>^[[0m Detected ^[[0;36mlinux^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0589261Z ^[[0;32m ->^[[0m Downloading ^[[0;36mhttps://cli.codecov.io/latest/linux/codecov^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0646225Z   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0648191Z                                  Dload  Upload   Total   Spent    Left  Speed
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.0648692Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.1885306Z   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.1886309Z 100  9.9M  100  9.9M    0     0  80.0M      0 --:--:-- --:--:-- --:--:-- 80.6M
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.1908003Z ^[[0;32m==>^[[0m Finishing downloading ^[[0;36mlinux:latest^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.2320619Z       Version: ^[[0;36mv11.3.1^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.2321152Z  
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.3018634Z gpg: /home/runner/.gnupg/trustdb.gpg: trustdb created
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.3020382Z gpg: key 806BB28AED779869: public key "Codecov Uploader (Codecov Uploader Verification Key) <security@codecov.io>" imported
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.3100804Z gpg: Total number processed: 1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.3101476Z gpg:               imported: 1
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.3108494Z ^[[0;32m==>^[[0m Verifying GPG signature integrity
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.3110590Z ^[[0;32m ->^[[0m Downloading ^[[0;36mhttps://cli.codecov.io/latest/linux/codecov.SHA256SUM^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.3112834Z ^[[0;32m ->^[[0m Downloading ^[[0;36mhttps://cli.codecov.io/latest/linux/codecov.SHA256SUM.sig^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.3114017Z  
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.3874705Z gpg: Signature made Thu Jul  9 01:37:57 2026 UTC
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.3875868Z gpg:                using RSA key 27034E7FDB850E0BBC2C62FF806BB28AED779869
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.3877493Z gpg: Good signature from "Codecov Uploader (Codecov Uploader Verification Key) <security@codecov.io>" [unknown]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.3878385Z gpg: WARNING: This key is not certified with a trusted signature!
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.3879534Z gpg:          There is no indication that the signature belongs to the owner.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.3881170Z Primary key fingerprint: 2703 4E7F DB85 0E0B BC2C  62FF 806B B28A ED77 9869
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.4706527Z codecov: OK
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.4715532Z ^[[0;32m==>^[[0m CLI integrity verified
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.4715939Z 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.5285846Z ^[[0;32m ->^[[0m Token length: 36
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.5286780Z ^[[0;32m==>^[[0m Running upload-coverage
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.5294963Z       ^[[0;36m./codecov  upload-coverage -t <redacted> --git-service github --gcov-executable gcov^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.8799535Z info - 2026-08-30 05:08:08,879 -- ci service found: github-actions
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.8888728Z warning - 2026-08-30 05:08:08,888 -- No config file could be found. Ignoring config.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.9204713Z warning - 2026-08-30 05:08:08,920 -- xcrun is not installed or can't be found.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.9611299Z warning - 2026-08-30 05:08:08,960 -- No gcov data found.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:08.9616218Z warning - 2026-08-30 05:08:08,961 -- coverage.py is not installed or can't be found.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:09.0230089Z info - 2026-08-30 05:08:09,022 -- Found 1 coverage files to report
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:09.0231569Z info - 2026-08-30 05:08:09,022 -- > /home/runner/work/goreleaser/goreleaser/coverage.txt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.1008650Z info - 2026-08-30 05:08:11,100 -- Your upload is now queued for processing. When finished, results will be available at: https://app.codecov.io/github/goreleaser/goreleaser/commit/36e43dd08f724956b188af2f6f3bcfd5efd355ec
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.1010731Z info - 2026-08-30 05:08:11,100 -- Sending upload (10827272 bytes) to storage
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.5766887Z info - 2026-08-30 05:08:11,576 -- Upload queued for processing complete
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.6556102Z ##[end-action id=__codecov_codecov-action.__run_8;outcome=success;conclusion=success;duration_ms=3620]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.6597156Z ##[group]Run git diff
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.6597467Z ^[[36;1mgit diff^[[0m
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.6636304Z shell: /usr/bin/bash -e {0}
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.6636595Z env:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.6636832Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.6637167Z   TMPDIR: /home/runner/work/_temp
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.6637581Z   NIX_PROFILES: /nix/var/nix/profiles/default /home/runner/.nix-profile
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.6638065Z   NIX_SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.6638416Z   GOTOOLCHAIN: local
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.6638785Z   ZIG_GLOBAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.6639327Z   ZIG_LOCAL_CACHE_DIR: /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.6639829Z   UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.6640257Z   UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.6640607Z   CC_FORK: false
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.6640978Z   CC_TOKEN: ***
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.6641225Z   CC_BRANCH: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.6641449Z   CC_SHA: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.6641657Z   CC_PR: 
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.6641872Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.6844207Z Post job cleanup.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.8059570Z UV_CACHE_DIR is already set to /home/runner/work/_temp/setup-uv-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.8071558Z UV_PYTHON_INSTALL_DIR is already set to /home/runner/work/_temp/uv-python-dir
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.8072831Z Cache hit occurred on key setup-uv-2-x86_64-unknown-linux-gnu-ubuntu-24.04-3.12.3-1472b101372efdfaea191c0f58d7baafced473780cbe79c2e88e1ffee5d9ceb3, not saving cache.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:11.9181813Z Post job cleanup.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:12.0474227Z Caching is not enabled. Caching is skipped.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:12.0634352Z Post job cleanup.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:12.2501263Z Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:12.2504018Z Post job cleanup.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:12.4929531Z Checking size of cache directory at /home/runner/work/goreleaser/goreleaser/.zig-cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:12.5575032Z Cache directory is 143505307 bytes, below limit of 2147483648 bytes; keeping intact
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:12.5580976Z Failed to read build.zig.zon (using latest): Error: ENOENT: no such file or directory, open 'build.zig.zon'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:13.0630532Z Saving Zig cache with key 'setup-zig-cache-v2-test-zig-x86_64-linux-0.16.0--33293816383-1'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:13.0815695Z [command]/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/goreleaser/goreleaser --files-from manifest.txt --use-compress-program zstdmt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:13.9231358Z Sent 33087614 of 33087614 (100.0%), 73.2 MBs/sec
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:14.0296881Z Post job cleanup.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:14.1550803Z Post job cleanup.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:14.2743320Z [command]/opt/hostedtoolcache/go/1.27.0/x64/bin/go env GOMODCACHE
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:14.2795180Z [command]/opt/hostedtoolcache/go/1.27.0/x64/bin/go env GOCACHE
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:14.2815157Z /home/runner/go/pkg/mod
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:14.2840207Z /home/runner/.cache/go-build
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:14.2847375Z Cache hit occurred on the primary key setup-go-Linux-x64-ubuntu24-go-1.27.0-4effc5d79fd735aa8ad13170a172cf2e131e53a29f71095d44234c448ca04db9, not saving cache.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:14.2959820Z Post job cleanup.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:14.4292293Z Cache hit occurred on the primary key flatpak-Linux-freedesktop-24.08, not saving cache.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:14.4414049Z Post job cleanup.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:14.6264420Z ##[group]Removing builder
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:14.7435092Z [command]/usr/bin/docker buildx rm builder-87029ac1-86b4-4cd4-a8a7-496bf34c6438
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:14.9937353Z builder-87029ac1-86b4-4cd4-a8a7-496bf34c6438 removed
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:14.9974954Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:14.9976878Z ##[group]Cleaning up certificates
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:14.9980303Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:14.9981001Z ##[group]Post cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:14.9982330Z State not set
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:14.9982775Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.0141063Z Post job cleanup.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.1565359Z ##[group]Post cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.1568233Z Caching docker.io--tonistiigi--binfmt-latest-linux-x64 to GitHub Actions cache
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.1807654Z [command]/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/goreleaser/goreleaser --files-from manifest.txt --use-compress-program zstdmt
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.5259368Z Failed to save: Unable to reserve cache with key docker.io--tonistiigi--binfmt-latest-linux-x64, another job may be creating this cache.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.5290000Z ##[endgroup]
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.5447714Z Post job cleanup.
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.6344969Z [command]/usr/bin/git version
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.6389769Z git version 2.55.0
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.6421860Z Copying '/home/runner/.gitconfig' to '/home/runner/work/_temp/955b6668-5a8e-4b53-b4f0-0b46a7141531/.gitconfig'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.6431072Z Temporarily overriding HOME='/home/runner/work/_temp/955b6668-5a8e-4b53-b4f0-0b46a7141531' before making global git config changes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.6432553Z Adding repository directory to the temporary git global config as a safe directory
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.6436689Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/goreleaser/goreleaser
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.6465944Z Removing SSH command configuration
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.6484983Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.6509264Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.6750917Z Removing HTTP extra header
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.6755924Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.6788694Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.7010746Z Removing includeIf entries pointing to credentials config files
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.7017866Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.7040865Z includeif.gitdir:/home/runner/work/goreleaser/goreleaser/.git.path
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.7041720Z includeif.gitdir:/home/runner/work/goreleaser/goreleaser/.git/worktrees/*.path
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.7042375Z includeif.gitdir:/github/workspace/.git.path
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.7042968Z includeif.gitdir:/github/workspace/.git/worktrees/*.path
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.7050029Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/home/runner/work/goreleaser/goreleaser/.git.path
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.7071445Z /home/runner/work/_temp/git-credentials-d68c473e-b985-464a-82b1-61057d331eb9.config
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.7082206Z [command]/usr/bin/git config --local --unset includeif.gitdir:/home/runner/work/goreleaser/goreleaser/.git.path \/home\/runner\/work\/_temp\/git\-credentials\-d68c473e\-b985\-464a\-82b1\-61057d331eb9\.config
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.7116053Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/home/runner/work/goreleaser/goreleaser/.git/worktrees/*.path
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.7139133Z /home/runner/work/_temp/git-credentials-d68c473e-b985-464a-82b1-61057d331eb9.config
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.7149105Z [command]/usr/bin/git config --local --unset includeif.gitdir:/home/runner/work/goreleaser/goreleaser/.git/worktrees/*.path \/home\/runner\/work\/_temp\/git\-credentials\-d68c473e\-b985\-464a\-82b1\-61057d331eb9\.config
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.7179203Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/github/workspace/.git.path
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.7199867Z /github/runner_temp/git-credentials-d68c473e-b985-464a-82b1-61057d331eb9.config
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.7210271Z [command]/usr/bin/git config --local --unset includeif.gitdir:/github/workspace/.git.path \/github\/runner_temp\/git\-credentials\-d68c473e\-b985\-464a\-82b1\-61057d331eb9\.config
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.7241098Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/github/workspace/.git/worktrees/*.path
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.7261733Z /github/runner_temp/git-credentials-d68c473e-b985-464a-82b1-61057d331eb9.config
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.7271760Z [command]/usr/bin/git config --local --unset includeif.gitdir:/github/workspace/.git/worktrees/*.path \/github\/runner_temp\/git\-credentials\-d68c473e\-b985\-464a\-82b1\-61057d331eb9\.config
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.7305389Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.7525785Z Removing credentials config '/home/runner/work/_temp/git-credentials-d68c473e-b985-464a-82b1-61057d331eb9.config'
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.7672792Z Cleaning up orphan processes
+test (ubuntu-latest)	UNKNOWN STEP	2026-08-30T05:08:15.8353405Z ##[warning]Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+test (windows-latest)	UNKNOWN STEP	﻿2026-08-30T05:02:50.0624923Z Current runner version: '2.336.0'
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0682809Z ##[group]Runner Image Provisioner
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0684172Z Hosted Compute Agent
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0685118Z Version: 20260819.586
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0686067Z Commit: 3cc4a88dfa507ef76119ad1bb3eccc6378bb2b76
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0687251Z Build Date: 2026-08-18T23:20:18Z
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0688363Z Worker ID: {5a78fca7-8279-4371-b032-b6f6ae0bcb16}
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0689410Z Azure Region: eastus2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0690282Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0692835Z ##[group]Operating System
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0693886Z Microsoft Windows Server 2025
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0694827Z 10.0.26100
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0695545Z Datacenter
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0696401Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0697206Z ##[group]Runner Image
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0698147Z Image: windows-2025-vs2026
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0699015Z Version: 20260824.214.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0701492Z Included Software: https://github.com/actions/runner-images/blob/win25-vs2026/20260824.214/images/windows/Windows2025-VS2026-Readme.md
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0704192Z Image Release: https://github.com/actions/runner-images/releases/tag/win25-vs2026%2F20260824.214
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0705781Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0707502Z ##[group]GITHUB_TOKEN Permissions
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0710667Z Contents: read
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0711510Z Metadata: read
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0712656Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0715529Z Secret source: Actions
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.0717397Z Prepare workflow directory
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.1133863Z Prepare all required actions
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.1181461Z Getting action download info
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.3865765Z Download action repository 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1' (SHA:3d3c42e5aac5ba805825da76410c181273ba90b1)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.5148163Z Download action repository 'go-task/setup-task@a00fbb05ce67b35648be3c78cbc9fd85354c757e' (SHA:a00fbb05ce67b35648be3c78cbc9fd85354c757e)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.7884816Z Download action repository 'docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8' (SHA:96fe6ef7f33517b61c61be40b68a1882f3264fb8)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:50.9762350Z Download action repository 'docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e' (SHA:37fe631027851001ddb9b187196cc803df7f5f0e)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:51.5154861Z Download action repository 'crazy-max/ghaction-upx@c83f378efc804f828e988debb88ed6116feb2368' (SHA:c83f378efc804f828e988debb88ed6116feb2368)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:51.7981712Z Download action repository 'actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9' (SHA:55cc8345863c7cc4c66a329aec7e433d2d1c52a9)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:51.9376360Z Download action repository 'cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24' (SHA:13d8dd58da0234aa297dedd986986ccb8e7f3e24)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:52.0545799Z Download action repository 'actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e' (SHA:b7ad1dad31e06c5925ef5d2fc7ad053ef454303e)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:52.2760584Z Download action repository 'actions/setup-node@820762786026740c76f36085b0efc47a31fe5020' (SHA:820762786026740c76f36085b0efc47a31fe5020)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:52.4249443Z Download action repository 'mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29' (SHA:d1434d08867e3ee9daa34448df10607b98908d29)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:56.9407914Z Download action repository 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6' (SHA:0c5077e51419868618aeaa5fe8019c62421857d6)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:57.0784395Z Download action repository 'denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed' (SHA:22d081ff2d3a40755e97629de92e3bcbfa7cf2ed)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:57.3335569Z Download action repository 'cargo-bins/cargo-binstall@75b4bfae1b2c753a6806bbce6e6cb89b602de33c' (SHA:75b4bfae1b2c753a6806bbce6e6cb89b602de33c)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:57.6593667Z Download action repository 'astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d' (SHA:20cfd1bf945f4377ade1205e4dbc17946fc9a30d)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:57.8841676Z Download action repository 'sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6' (SHA:6f9f17788090df1f26f669e9d70d6ae9567deba6)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:57.9727542Z Download action repository 'anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610' (SHA:e22c389904149dbc22b58101806040fa8d37a610)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:58.1651243Z Download action repository 'codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f' (SHA:fb8b3582c8e4def4969c97caa2f19720cb33a72f)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:58.4980023Z Getting action download info
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:58.5628562Z Download action repository 'actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd' (SHA:ed597411d8f924073f98dfc5c65a23a2325f34cd)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:58.7835859Z Complete job name: test (windows-latest)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:58.9312613Z ##[group]Run actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:58.9313513Z with:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:58.9313724Z   fetch-depth: 0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:58.9313946Z   repository: goreleaser/goreleaser
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:58.9316850Z   token: ***
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:58.9317070Z   ssh-strict: true
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:58.9317279Z   ssh-user: git
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:58.9317484Z   persist-credentials: true
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:58.9317707Z   clean: true
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:58.9317903Z   sparse-checkout-cone-mode: true
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:58.9318153Z   fetch-tags: false
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:58.9318350Z   show-progress: true
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:58.9318546Z   lfs: false
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:58.9318732Z   submodules: false
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:58.9318953Z   set-safe-directory: true
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:58.9319182Z   allow-unsafe-pr-checkout: false
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:58.9319595Z env:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:58.9319782Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:58.9320025Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.0771199Z Syncing repository: goreleaser/goreleaser
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.0772589Z ##[group]Getting Git version info
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.0773635Z Working directory is 'D:\a\goreleaser\goreleaser'
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.1791088Z [command]"C:\Program Files\Git\bin\git.exe" version
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.5942908Z git version 2.55.0.windows.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.5998133Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.6015835Z Temporarily overriding HOME='D:\a\_temp\de996030-b4d9-4f54-9b46-461e84eb6ea5' before making global git config changes
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.6017092Z Adding repository directory to the temporary git global config as a safe directory
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.6027630Z [command]"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\goreleaser\goreleaser
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.6630164Z Deleting the contents of 'D:\a\goreleaser\goreleaser'
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.6634954Z ##[group]Determining repository object format
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.6636811Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.6637605Z ##[group]Initializing the repository
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.6645542Z [command]"C:\Program Files\Git\bin\git.exe" init D:\a\goreleaser\goreleaser
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.7716853Z Initialized empty Git repository in D:/a/goreleaser/goreleaser/.git/
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.7764754Z [command]"C:\Program Files\Git\bin\git.exe" remote add origin https://github.com/goreleaser/goreleaser
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.8354363Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.8354828Z ##[group]Disabling automatic garbage collection
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.8364273Z [command]"C:\Program Files\Git\bin\git.exe" config --local gc.auto 0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.8672761Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.8674048Z ##[group]Setting up auth
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.8674612Z Removing SSH command configuration
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.8685801Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp core\.sshCommand
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:02:59.9040818Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:01.3142660Z Removing HTTP extra header
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:01.3158305Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:01.3458962Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :\""
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:01.9161086Z Removing includeIf entries pointing to credentials config files
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:01.9172174Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp ^includeIf\.gitdir:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:01.9482537Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "git config --local --show-origin --name-only --get-regexp remote.origin.url"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:02.4710878Z [command]"C:\Program Files\Git\bin\git.exe" config --file D:\a\_temp\git-credentials-39e3b392-9639-4b42-97e8-20980f59b021.config http.https://github.com/.extraheader "AUTHORIZATION: basic ***"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:02.5033795Z [command]"C:\Program Files\Git\bin\git.exe" config --local includeIf.gitdir:D:/a/goreleaser/goreleaser/.git.path D:\a\_temp\git-credentials-39e3b392-9639-4b42-97e8-20980f59b021.config
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:02.5352369Z [command]"C:\Program Files\Git\bin\git.exe" config --local includeIf.gitdir:D:/a/goreleaser/goreleaser/.git/worktrees/*.path D:\a\_temp\git-credentials-39e3b392-9639-4b42-97e8-20980f59b021.config
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:02.5720140Z [command]"C:\Program Files\Git\bin\git.exe" config --local includeIf.gitdir:/github/workspace/.git.path /github/runner_temp/git-credentials-39e3b392-9639-4b42-97e8-20980f59b021.config
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:02.6059912Z [command]"C:\Program Files\Git\bin\git.exe" config --local includeIf.gitdir:/github/workspace/.git/worktrees/*.path /github/runner_temp/git-credentials-39e3b392-9639-4b42-97e8-20980f59b021.config
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:02.6400828Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:02.6401455Z ##[group]Fetching the repository
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:02.6414541Z [command]"C:\Program Files\Git\bin\git.exe" -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7697164Z From https://github.com/goreleaser/goreleaser
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7697837Z  * [new branch]        artifacts-vars           -> origin/artifacts-vars
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7698437Z  * [new branch]        ci                       -> origin/ci
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7699250Z  * [new branch]        copilot/fix-argo-cd-secondary-rate-limit -> origin/copilot/fix-argo-cd-secondary-rate-limit
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7700098Z  * [new branch]        copilot/fix-test         -> origin/copilot/fix-test
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7701037Z  * [new branch]        fix-termux-package-architecture -> origin/fix-termux-package-architecture
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7702071Z  * [new branch]        fix/winget-arm64-duplicate-check -> origin/fix/winget-arm64-duplicate-check
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7702862Z  * [new branch]        goarm-fix                -> origin/goarm-fix
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7703535Z  * [new branch]        goreleaser-bugs2         -> origin/goreleaser-bugs2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7704340Z  * [new branch]        goreleaser-install-script -> origin/goreleaser-install-script
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7705045Z  * [new branch]        main                     -> origin/main
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7705590Z  * [new branch]        nix                      -> origin/nix
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7706165Z  * [new branch]        nodejs-sea2              -> origin/nodejs-sea2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7706849Z  * [new branch]        nodejs-wip               -> origin/nodejs-wip
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7707434Z  * [new branch]        patch-1                  -> origin/patch-1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7708099Z  * [new branch]        quill-update             -> origin/quill-update
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7708822Z  * [new branch]        release-token            -> origin/release-token
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7709465Z  * [new branch]        zig-cache                -> origin/zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7710017Z  * [new tag]           nightly                  -> nightly
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7710837Z  * [new tag]           v0.0.1                   -> v0.0.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7711316Z  * [new tag]           v0.0.2                   -> v0.0.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7711774Z  * [new tag]           v0.0.3                   -> v0.0.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7712228Z  * [new tag]           v0.0.4                   -> v0.0.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7712689Z  * [new tag]           v0.0.5                   -> v0.0.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7713154Z  * [new tag]           v0.0.6                   -> v0.0.6
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7713616Z  * [new tag]           v0.0.7                   -> v0.0.7
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7714075Z  * [new tag]           v0.0.8                   -> v0.0.8
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7715838Z  * [new tag]           v0.0.9                   -> v0.0.9
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7716388Z  * [new tag]           v0.1.0                   -> v0.1.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7717169Z  * [new tag]           v0.1.1                   -> v0.1.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7717639Z  * [new tag]           v0.1.2                   -> v0.1.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7718112Z  * [new tag]           v0.1.3                   -> v0.1.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7718566Z  * [new tag]           v0.1.4                   -> v0.1.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7719069Z  * [new tag]           v0.1.5                   -> v0.1.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7719540Z  * [new tag]           v0.1.6                   -> v0.1.6
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7719982Z  * [new tag]           v0.1.7                   -> v0.1.7
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7720419Z  * [new tag]           v0.1.8                   -> v0.1.8
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7720860Z  * [new tag]           v0.1.9                   -> v0.1.9
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7721297Z  * [new tag]           v0.10.0                  -> v0.10.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7721738Z  * [new tag]           v0.100.0                 -> v0.100.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7722198Z  * [new tag]           v0.101.0                 -> v0.101.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7722635Z  * [new tag]           v0.102.0                 -> v0.102.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7723077Z  * [new tag]           v0.103.0                 -> v0.103.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7723507Z  * [new tag]           v0.103.1                 -> v0.103.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7723949Z  * [new tag]           v0.104.0                 -> v0.104.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7724402Z  * [new tag]           v0.104.1                 -> v0.104.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7724739Z  * [new tag]           v0.104.2                 -> v0.104.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7725036Z  * [new tag]           v0.104.3                 -> v0.104.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7725481Z  * [new tag]           v0.105.0                 -> v0.105.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7726194Z  * [new tag]           v0.106.0                 -> v0.106.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7726559Z  * [new tag]           v0.107.0                 -> v0.107.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7726991Z  * [new tag]           v0.108.0                 -> v0.108.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7727286Z  * [new tag]           v0.109.0                 -> v0.109.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7727577Z  * [new tag]           v0.11.0                  -> v0.11.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7727873Z  * [new tag]           v0.11.1                  -> v0.11.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7728173Z  * [new tag]           v0.110.0                 -> v0.110.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7728488Z  * [new tag]           v0.111.0                 -> v0.111.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7728777Z  * [new tag]           v0.112.0                 -> v0.112.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7729057Z  * [new tag]           v0.112.1                 -> v0.112.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7729358Z  * [new tag]           v0.112.2                 -> v0.112.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7729643Z  * [new tag]           v0.113.0                 -> v0.113.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7729926Z  * [new tag]           v0.113.1                 -> v0.113.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7730267Z  * [new tag]           v0.114.0                 -> v0.114.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7730707Z  * [new tag]           v0.114.1                 -> v0.114.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7731162Z  * [new tag]           v0.115.0                 -> v0.115.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7731794Z  * [new tag]           v0.116.0                 -> v0.116.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7732209Z  * [new tag]           v0.117.0                 -> v0.117.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7732658Z  * [new tag]           v0.117.1                 -> v0.117.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7733078Z  * [new tag]           v0.117.2                 -> v0.117.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7733493Z  * [new tag]           v0.118.0                 -> v0.118.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7733926Z  * [new tag]           v0.118.1                 -> v0.118.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7734370Z  * [new tag]           v0.118.2                 -> v0.118.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7734816Z  * [new tag]           v0.119.0                 -> v0.119.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7735389Z  * [new tag]           v0.12.0                  -> v0.12.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7735839Z  * [new tag]           v0.12.1                  -> v0.12.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7736264Z  * [new tag]           v0.12.2                  -> v0.12.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7736695Z  * [new tag]           v0.12.3                  -> v0.12.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7737092Z  * [new tag]           v0.120.0                 -> v0.120.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7737515Z  * [new tag]           v0.120.1                 -> v0.120.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7737941Z  * [new tag]           v0.120.2                 -> v0.120.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7738405Z  * [new tag]           v0.120.3                 -> v0.120.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7738863Z  * [new tag]           v0.120.4                 -> v0.120.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7739319Z  * [new tag]           v0.120.5                 -> v0.120.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7739785Z  * [new tag]           v0.120.6                 -> v0.120.6
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7740258Z  * [new tag]           v0.120.7                 -> v0.120.7
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7740723Z  * [new tag]           v0.120.8                 -> v0.120.8
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7741124Z  * [new tag]           v0.121.0                 -> v0.121.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7741586Z  * [new tag]           v0.122.0                 -> v0.122.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7742046Z  * [new tag]           v0.123.0                 -> v0.123.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7742508Z  * [new tag]           v0.123.1                 -> v0.123.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7743014Z  * [new tag]           v0.123.2                 -> v0.123.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7743479Z  * [new tag]           v0.123.3                 -> v0.123.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7743939Z  * [new tag]           v0.124.0                 -> v0.124.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7744377Z  * [new tag]           v0.124.1                 -> v0.124.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7744847Z  * [new tag]           v0.125.0                 -> v0.125.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7745343Z  * [new tag]           v0.126.0                 -> v0.126.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7745814Z  * [new tag]           v0.127.0                 -> v0.127.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7746547Z  * [new tag]           v0.128.0                 -> v0.128.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7746999Z  * [new tag]           v0.129.0                 -> v0.129.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7747462Z  * [new tag]           v0.13.0                  -> v0.13.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7747905Z  * [new tag]           v0.13.1                  -> v0.13.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7748324Z  * [new tag]           v0.13.2                  -> v0.13.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7748782Z  * [new tag]           v0.13.3                  -> v0.13.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7749244Z  * [new tag]           v0.13.4                  -> v0.13.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7749734Z  * [new tag]           v0.13.5                  -> v0.13.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7750164Z  * [new tag]           v0.13.6                  -> v0.13.6
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7750660Z  * [new tag]           v0.130.0                 -> v0.130.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7751170Z  * [new tag]           v0.130.1                 -> v0.130.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7751656Z  * [new tag]           v0.130.2                 -> v0.130.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7752138Z  * [new tag]           v0.131.0                 -> v0.131.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7752623Z  * [new tag]           v0.131.1                 -> v0.131.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7753933Z  * [new tag]           v0.132.0                 -> v0.132.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7754413Z  * [new tag]           v0.132.1                 -> v0.132.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7754880Z  * [new tag]           v0.133.0                 -> v0.133.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7755356Z  * [new tag]           v0.134.0                 -> v0.134.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7755783Z  * [new tag]           v0.135.0                 -> v0.135.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7756188Z  * [new tag]           v0.136.0                 -> v0.136.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7756667Z  * [new tag]           v0.137.0                 -> v0.137.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7757263Z  * [new tag]           v0.138.0                 -> v0.138.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7757756Z  * [new tag]           v0.139.0                 -> v0.139.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7758231Z  * [new tag]           v0.14.0                  -> v0.14.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7758731Z  * [new tag]           v0.140.0                 -> v0.140.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7759208Z  * [new tag]           v0.140.1                 -> v0.140.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7759649Z  * [new tag]           v0.141.0                 -> v0.141.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7760096Z  * [new tag]           v0.142.0                 -> v0.142.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7760556Z  * [new tag]           v0.143.0                 -> v0.143.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7761031Z  * [new tag]           v0.144.0                 -> v0.144.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7761467Z  * [new tag]           v0.144.1                 -> v0.144.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7761936Z  * [new tag]           v0.145.0                 -> v0.145.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7762409Z  * [new tag]           v0.146.0                 -> v0.146.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7762848Z  * [new tag]           v0.147.0                 -> v0.147.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7763316Z  * [new tag]           v0.147.1                 -> v0.147.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7763791Z  * [new tag]           v0.147.2                 -> v0.147.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7764280Z  * [new tag]           v0.148.0                 -> v0.148.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7764740Z  * [new tag]           v0.149.0                 -> v0.149.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7765202Z  * [new tag]           v0.15.0                  -> v0.15.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7765677Z  * [new tag]           v0.15.1                  -> v0.15.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7766421Z  * [new tag]           v0.150.0                 -> v0.150.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7766867Z  * [new tag]           v0.150.1                 -> v0.150.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7767326Z  * [new tag]           v0.151.0                 -> v0.151.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7767793Z  * [new tag]           v0.151.1                 -> v0.151.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7768280Z  * [new tag]           v0.151.2                 -> v0.151.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7768748Z  * [new tag]           v0.152.0                 -> v0.152.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7769199Z  * [new tag]           v0.153.0                 -> v0.153.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7769654Z  * [new tag]           v0.154.0                 -> v0.154.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7770109Z  * [new tag]           v0.155.0                 -> v0.155.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7770585Z  * [new tag]           v0.155.1                 -> v0.155.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7771041Z  * [new tag]           v0.155.2                 -> v0.155.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7771513Z  * [new tag]           v0.156.0                 -> v0.156.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7771972Z  * [new tag]           v0.156.1                 -> v0.156.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7772431Z  * [new tag]           v0.156.2                 -> v0.156.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7772904Z  * [new tag]           v0.157.0                 -> v0.157.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7773325Z  * [new tag]           v0.158.0                 -> v0.158.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7773819Z  * [new tag]           v0.159.0                 -> v0.159.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7774216Z  * [new tag]           v0.16.0                  -> v0.16.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7774514Z  * [new tag]           v0.16.1                  -> v0.16.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7774960Z  * [new tag]           v0.160.0                 -> v0.160.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7775242Z  * [new tag]           v0.161.0                 -> v0.161.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7775536Z  * [new tag]           v0.161.1                 -> v0.161.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7775816Z  * [new tag]           v0.162.0                 -> v0.162.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7776104Z  * [new tag]           v0.162.1                 -> v0.162.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7776379Z  * [new tag]           v0.163.0                 -> v0.163.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7776659Z  * [new tag]           v0.163.1                 -> v0.163.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7776946Z  * [new tag]           v0.164.0                 -> v0.164.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7777776Z  * [new tag]           v0.165.0                 -> v0.165.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7778071Z  * [new tag]           v0.166.0                 -> v0.166.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7778350Z  * [new tag]           v0.166.1                 -> v0.166.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7778629Z  * [new tag]           v0.166.2                 -> v0.166.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7778912Z  * [new tag]           v0.167.0                 -> v0.167.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7779198Z  * [new tag]           v0.168.0                 -> v0.168.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7779473Z  * [new tag]           v0.168.1                 -> v0.168.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7779752Z  * [new tag]           v0.168.2                 -> v0.168.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7780029Z  * [new tag]           v0.169.0                 -> v0.169.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7780311Z  * [new tag]           v0.17.0                  -> v0.17.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7780597Z  * [new tag]           v0.17.1                  -> v0.17.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7780886Z  * [new tag]           v0.17.2                  -> v0.17.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7781165Z  * [new tag]           v0.17.3                  -> v0.17.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7781444Z  * [new tag]           v0.17.4                  -> v0.17.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7781716Z  * [new tag]           v0.17.5                  -> v0.17.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7781999Z  * [new tag]           v0.17.6                  -> v0.17.6
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7782302Z  * [new tag]           v0.170.0                 -> v0.170.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7782596Z  * [new tag]           v0.171.0                 -> v0.171.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7782873Z  * [new tag]           v0.172.0                 -> v0.172.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7783168Z  * [new tag]           v0.172.1                 -> v0.172.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7783462Z  * [new tag]           v0.173.0                 -> v0.173.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7783743Z  * [new tag]           v0.173.1                 -> v0.173.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7784038Z  * [new tag]           v0.173.2                 -> v0.173.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7784393Z  * [new tag]           v0.174.0                 -> v0.174.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7784862Z  * [new tag]           v0.174.1                 -> v0.174.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7785181Z  * [new tag]           v0.174.2                 -> v0.174.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7785472Z  * [new tag]           v0.175.0                 -> v0.175.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7785759Z  * [new tag]           v0.176.0                 -> v0.176.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7786043Z  * [new tag]           v0.177.0                 -> v0.177.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7786634Z  * [new tag]           v0.178.0                 -> v0.178.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7786921Z  * [new tag]           v0.179.0                 -> v0.179.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7787316Z  * [new tag]           v0.18.0                  -> v0.18.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7787797Z  * [new tag]           v0.18.1                  -> v0.18.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7788279Z  * [new tag]           v0.180.0                 -> v0.180.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7788656Z  * [new tag]           v0.180.1                 -> v0.180.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7788934Z  * [new tag]           v0.180.2                 -> v0.180.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7789210Z  * [new tag]           v0.180.3                 -> v0.180.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7789491Z  * [new tag]           v0.181.0                 -> v0.181.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7789919Z  * [new tag]           v0.181.1                 -> v0.181.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7790204Z  * [new tag]           v0.182.0                 -> v0.182.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7790484Z  * [new tag]           v0.182.1                 -> v0.182.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7790765Z  * [new tag]           v0.183.0                 -> v0.183.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7791046Z  * [new tag]           v0.184.0                 -> v0.184.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7791330Z  * [new tag]           v0.19.0                  -> v0.19.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7791627Z  * [new tag]           v0.2.0                   -> v0.2.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7792013Z  * [new tag]           v0.2.1                   -> v0.2.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7792296Z  * [new tag]           v0.2.2                   -> v0.2.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7792581Z  * [new tag]           v0.2.3                   -> v0.2.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7793000Z  * [new tag]           v0.2.4                   -> v0.2.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7793279Z  * [new tag]           v0.2.5                   -> v0.2.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7793565Z  * [new tag]           v0.2.6                   -> v0.2.6
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7793841Z  * [new tag]           v0.2.7                   -> v0.2.7
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7794114Z  * [new tag]           v0.2.8                   -> v0.2.8
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7794390Z  * [new tag]           v0.2.9                   -> v0.2.9
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7794826Z  * [new tag]           v0.20.0                  -> v0.20.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7795226Z  * [new tag]           v0.20.1                  -> v0.20.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7795504Z  * [new tag]           v0.20.2                  -> v0.20.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7795790Z  * [new tag]           v0.20.3                  -> v0.20.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7796068Z  * [new tag]           v0.20.4                  -> v0.20.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7796344Z  * [new tag]           v0.21.0                  -> v0.21.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7796621Z  * [new tag]           v0.21.1                  -> v0.21.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7796926Z  * [new tag]           v0.21.2                  -> v0.21.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7797201Z  * [new tag]           v0.21.3                  -> v0.21.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7797481Z  * [new tag]           v0.21.4                  -> v0.21.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7797765Z  * [new tag]           v0.21.5                  -> v0.21.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7798039Z  * [new tag]           v0.22.0                  -> v0.22.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7798318Z  * [new tag]           v0.22.1                  -> v0.22.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7798597Z  * [new tag]           v0.22.2                  -> v0.22.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7798872Z  * [new tag]           v0.23.0                  -> v0.23.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7799156Z  * [new tag]           v0.23.1                  -> v0.23.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7799436Z  * [new tag]           v0.24.0                  -> v0.24.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7799709Z  * [new tag]           v0.25.0                  -> v0.25.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7799987Z  * [new tag]           v0.26.0                  -> v0.26.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7800261Z  * [new tag]           v0.26.1                  -> v0.26.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7800537Z  * [new tag]           v0.27.0                  -> v0.27.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7800821Z  * [new tag]           v0.27.1                  -> v0.27.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7801097Z  * [new tag]           v0.27.2                  -> v0.27.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7801375Z  * [new tag]           v0.27.3                  -> v0.27.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7801650Z  * [new tag]           v0.27.4                  -> v0.27.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7801929Z  * [new tag]           v0.27.5                  -> v0.27.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7802217Z  * [new tag]           v0.28.0                  -> v0.28.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7802511Z  * [new tag]           v0.28.1                  -> v0.28.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7802790Z  * [new tag]           v0.28.2                  -> v0.28.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7803069Z  * [new tag]           v0.28.3                  -> v0.28.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7803461Z  * [new tag]           v0.28.4                  -> v0.28.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7803737Z  * [new tag]           v0.28.5                  -> v0.28.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7804019Z  * [new tag]           v0.28.6                  -> v0.28.6
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7804299Z  * [new tag]           v0.28.7                  -> v0.28.7
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7804579Z  * [new tag]           v0.28.8                  -> v0.28.8
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7804863Z  * [new tag]           v0.28.9                  -> v0.28.9
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7805247Z  * [new tag]           v0.3.0                   -> v0.3.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7805688Z  * [new tag]           v0.3.1                   -> v0.3.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7806306Z  * [new tag]           v0.3.2                   -> v0.3.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7807072Z  * [new tag]           v0.3.4                   -> v0.3.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7807533Z  * [new tag]           v0.3.5                   -> v0.3.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7808018Z  * [new tag]           v0.3.6                   -> v0.3.6
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7808499Z  * [new tag]           v0.30.0                  -> v0.30.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7808931Z  * [new tag]           v0.30.1                  -> v0.30.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7809395Z  * [new tag]           v0.30.2                  -> v0.30.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7809884Z  * [new tag]           v0.30.3                  -> v0.30.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7810351Z  * [new tag]           v0.30.4                  -> v0.30.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7810860Z  * [new tag]           v0.30.5                  -> v0.30.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7811348Z  * [new tag]           v0.31.0                  -> v0.31.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7811854Z  * [new tag]           v0.31.1                  -> v0.31.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7812276Z  * [new tag]           v0.32.0                  -> v0.32.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7812716Z  * [new tag]           v0.32.1                  -> v0.32.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7813195Z  * [new tag]           v0.32.2                  -> v0.32.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7813681Z  * [new tag]           v0.33.0                  -> v0.33.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7814138Z  * [new tag]           v0.33.1                  -> v0.33.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7814607Z  * [new tag]           v0.33.2                  -> v0.33.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7815039Z  * [new tag]           v0.34.0                  -> v0.34.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7815489Z  * [new tag]           v0.34.1                  -> v0.34.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7815953Z  * [new tag]           v0.34.2                  -> v0.34.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7816397Z  * [new tag]           v0.34.3                  -> v0.34.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7816869Z  * [new tag]           v0.34.4                  -> v0.34.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7817339Z  * [new tag]           v0.34.5                  -> v0.34.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7817841Z  * [new tag]           v0.35.0                  -> v0.35.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7818294Z  * [new tag]           v0.35.1                  -> v0.35.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7818758Z  * [new tag]           v0.35.2                  -> v0.35.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7819204Z  * [new tag]           v0.35.3                  -> v0.35.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7819668Z  * [new tag]           v0.35.4                  -> v0.35.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7820106Z  * [new tag]           v0.35.5                  -> v0.35.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7820549Z  * [new tag]           v0.35.6                  -> v0.35.6
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7821040Z  * [new tag]           v0.35.7                  -> v0.35.7
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7821490Z  * [new tag]           v0.36.0                  -> v0.36.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7821935Z  * [new tag]           v0.36.1                  -> v0.36.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7822381Z  * [new tag]           v0.37.0                  -> v0.37.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7822839Z  * [new tag]           v0.37.1                  -> v0.37.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7823297Z  * [new tag]           v0.37.10                 -> v0.37.10
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7823787Z  * [new tag]           v0.37.2                  -> v0.37.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7825239Z  * [new tag]           v0.37.3                  -> v0.37.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7825778Z  * [new tag]           v0.37.4                  -> v0.37.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7826265Z  * [new tag]           v0.37.5                  -> v0.37.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7827065Z  * [new tag]           v0.37.6                  -> v0.37.6
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7827509Z  * [new tag]           v0.37.7                  -> v0.37.7
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7827942Z  * [new tag]           v0.37.8                  -> v0.37.8
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7828436Z  * [new tag]           v0.37.9                  -> v0.37.9
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7828924Z  * [new tag]           v0.38.0                  -> v0.38.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7829612Z  * [new tag]           v0.39.0                  -> v0.39.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7830115Z  * [new tag]           v0.4.0                   -> v0.4.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7830615Z  * [new tag]           v0.4.1                   -> v0.4.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7831075Z  * [new tag]           v0.4.2                   -> v0.4.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7831530Z  * [new tag]           v0.4.3                   -> v0.4.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7831981Z  * [new tag]           v0.4.4                   -> v0.4.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7832439Z  * [new tag]           v0.4.5                   -> v0.4.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7832887Z  * [new tag]           v0.40.0                  -> v0.40.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7833322Z  * [new tag]           v0.40.1                  -> v0.40.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7833789Z  * [new tag]           v0.40.2                  -> v0.40.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7834271Z  * [new tag]           v0.40.3                  -> v0.40.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7834616Z  * [new tag]           v0.40.4                  -> v0.40.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7834907Z  * [new tag]           v0.40.5                  -> v0.40.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7835186Z  * [new tag]           v0.40.6                  -> v0.40.6
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7835464Z  * [new tag]           v0.41.0                  -> v0.41.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7835750Z  * [new tag]           v0.41.1                  -> v0.41.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7836044Z  * [new tag]           v0.42.0                  -> v0.42.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7836324Z  * [new tag]           v0.42.1                  -> v0.42.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7836600Z  * [new tag]           v0.42.2                  -> v0.42.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7836875Z  * [new tag]           v0.43.0                  -> v0.43.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7837153Z  * [new tag]           v0.44.0                  -> v0.44.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7837434Z  * [new tag]           v0.44.1                  -> v0.44.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7837708Z  * [new tag]           v0.44.2                  -> v0.44.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7837986Z  * [new tag]           v0.45.0                  -> v0.45.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7838258Z  * [new tag]           v0.45.1                  -> v0.45.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7838536Z  * [new tag]           v0.45.2                  -> v0.45.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7838813Z  * [new tag]           v0.45.3                  -> v0.45.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7839102Z  * [new tag]           v0.45.4                  -> v0.45.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7839378Z  * [new tag]           v0.45.5                  -> v0.45.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7839654Z  * [new tag]           v0.46.0                  -> v0.46.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7839928Z  * [new tag]           v0.46.1                  -> v0.46.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7840205Z  * [new tag]           v0.46.2                  -> v0.46.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7840484Z  * [new tag]           v0.46.3                  -> v0.46.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7840762Z  * [new tag]           v0.46.4                  -> v0.46.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7841048Z  * [new tag]           v0.47.0                  -> v0.47.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7841324Z  * [new tag]           v0.47.1                  -> v0.47.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7841597Z  * [new tag]           v0.48.0                  -> v0.48.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7841873Z  * [new tag]           v0.49.0                  -> v0.49.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7842363Z  * [new tag]           v0.49.1                  -> v0.49.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7842658Z  * [new tag]           v0.49.2                  -> v0.49.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7842939Z  * [new tag]           v0.49.3                  -> v0.49.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7843227Z  * [new tag]           v0.5.0                   -> v0.5.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7843515Z  * [new tag]           v0.5.1                   -> v0.5.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7843809Z  * [new tag]           v0.5.2                   -> v0.5.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7844084Z  * [new tag]           v0.5.3                   -> v0.5.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7844359Z  * [new tag]           v0.5.4                   -> v0.5.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7845206Z  * [new tag]           v0.5.5                   -> v0.5.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7845510Z  * [new tag]           v0.5.6                   -> v0.5.6
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7845794Z  * [new tag]           v0.5.7                   -> v0.5.7
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7846078Z  * [new tag]           v0.5.8                   -> v0.5.8
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7846364Z  * [new tag]           v0.5.9                   -> v0.5.9
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7846645Z  * [new tag]           v0.50.0                  -> v0.50.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7847334Z  * [new tag]           v0.50.1                  -> v0.50.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7847618Z  * [new tag]           v0.51.0                  -> v0.51.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7847898Z  * [new tag]           v0.52.0                  -> v0.52.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7848181Z  * [new tag]           v0.52.1                  -> v0.52.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7848458Z  * [new tag]           v0.52.2                  -> v0.52.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7848738Z  * [new tag]           v0.52.3                  -> v0.52.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7849012Z  * [new tag]           v0.53.0                  -> v0.53.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7849289Z  * [new tag]           v0.54.0                  -> v0.54.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7849579Z  * [new tag]           v0.54.1                  -> v0.54.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7849858Z  * [new tag]           v0.54.2                  -> v0.54.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7850136Z  * [new tag]           v0.54.3                  -> v0.54.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7850407Z  * [new tag]           v0.55.0                  -> v0.55.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7850683Z  * [new tag]           v0.55.1                  -> v0.55.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7850962Z  * [new tag]           v0.56.0                  -> v0.56.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7851246Z  * [new tag]           v0.57.0                  -> v0.57.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7851520Z  * [new tag]           v0.57.1                  -> v0.57.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7851799Z  * [new tag]           v0.57.2                  -> v0.57.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7852076Z  * [new tag]           v0.58.0                  -> v0.58.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7852353Z  * [new tag]           v0.58.1                  -> v0.58.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7852640Z  * [new tag]           v0.58.2                  -> v0.58.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7852916Z  * [new tag]           v0.58.3                  -> v0.58.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7853198Z  * [new tag]           v0.59.0                  -> v0.59.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7853475Z  * [new tag]           v0.59.1                  -> v0.59.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7853749Z  * [new tag]           v0.6.0                   -> v0.6.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7854024Z  * [new tag]           v0.6.1                   -> v0.6.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7854304Z  * [new tag]           v0.6.2                   -> v0.6.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7854581Z  * [new tag]           v0.60.0                  -> v0.60.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7854858Z  * [new tag]           v0.61.0                  -> v0.61.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7855131Z  * [new tag]           v0.61.1                  -> v0.61.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7855406Z  * [new tag]           v0.61.2                  -> v0.61.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7855679Z  * [new tag]           v0.61.3                  -> v0.61.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7855963Z  * [new tag]           v0.62.0                  -> v0.62.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7856352Z  * [new tag]           v0.62.1                  -> v0.62.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7856629Z  * [new tag]           v0.62.2                  -> v0.62.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7856903Z  * [new tag]           v0.62.3                  -> v0.62.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7857178Z  * [new tag]           v0.62.4                  -> v0.62.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7857459Z  * [new tag]           v0.62.5                  -> v0.62.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7857729Z  * [new tag]           v0.62.6                  -> v0.62.6
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7858005Z  * [new tag]           v0.63.0                  -> v0.63.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7858276Z  * [new tag]           v0.63.1                  -> v0.63.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7858635Z  * [new tag]           v0.64.0                  -> v0.64.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7858911Z  * [new tag]           v0.65.0                  -> v0.65.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7859202Z  * [new tag]           v0.66.0                  -> v0.66.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7859487Z  * [new tag]           v0.66.1                  -> v0.66.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7859995Z  * [new tag]           v0.67.0                  -> v0.67.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7860306Z  * [new tag]           v0.68.0                  -> v0.68.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7860588Z  * [new tag]           v0.69.0                  -> v0.69.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7860872Z  * [new tag]           v0.7.0                   -> v0.7.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7861148Z  * [new tag]           v0.7.1                   -> v0.7.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7861425Z  * [new tag]           v0.7.2                   -> v0.7.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7861702Z  * [new tag]           v0.7.3                   -> v0.7.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7861987Z  * [new tag]           v0.7.4                   -> v0.7.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7862260Z  * [new tag]           v0.7.5                   -> v0.7.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7862546Z  * [new tag]           v0.7.6                   -> v0.7.6
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7862823Z  * [new tag]           v0.7.7                   -> v0.7.7
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7863103Z  * [new tag]           v0.7.8                   -> v0.7.8
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7863377Z  * [new tag]           v0.7.9                   -> v0.7.9
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7863655Z  * [new tag]           v0.70.0                  -> v0.70.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7863934Z  * [new tag]           v0.71.0                  -> v0.71.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7864376Z  * [new tag]           v0.71.1                  -> v0.71.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7864853Z  * [new tag]           v0.72.0                  -> v0.72.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7865334Z  * [new tag]           v0.73.0                  -> v0.73.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7865796Z  * [new tag]           v0.73.1                  -> v0.73.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7866240Z  * [new tag]           v0.73.2                  -> v0.73.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7866747Z  * [new tag]           v0.74.0                  -> v0.74.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7867554Z  * [new tag]           v0.75.0                  -> v0.75.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7868026Z  * [new tag]           v0.76.0                  -> v0.76.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7868401Z  * [new tag]           v0.76.1                  -> v0.76.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7868694Z  * [new tag]           v0.77.0                  -> v0.77.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7869178Z  * [new tag]           v0.77.1                  -> v0.77.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7869656Z  * [new tag]           v0.77.2                  -> v0.77.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7890123Z  * [new tag]           v0.78.0                  -> v0.78.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7890709Z  * [new tag]           v0.79.0                  -> v0.79.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7891169Z  * [new tag]           v0.79.1                  -> v0.79.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7891627Z  * [new tag]           v0.79.2                  -> v0.79.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7892095Z  * [new tag]           v0.8.0                   -> v0.8.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7892550Z  * [new tag]           v0.8.1                   -> v0.8.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7892973Z  * [new tag]           v0.8.2                   -> v0.8.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7893648Z  * [new tag]           v0.8.3                   -> v0.8.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7894065Z  * [new tag]           v0.8.4                   -> v0.8.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7894519Z  * [new tag]           v0.8.5                   -> v0.8.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7894984Z  * [new tag]           v0.8.6                   -> v0.8.6
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7895482Z  * [new tag]           v0.8.7                   -> v0.8.7
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7895954Z  * [new tag]           v0.8.8                   -> v0.8.8
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7896427Z  * [new tag]           v0.8.9                   -> v0.8.9
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7896917Z  * [new tag]           v0.80.0                  -> v0.80.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7897600Z  * [new tag]           v0.80.1                  -> v0.80.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7898100Z  * [new tag]           v0.80.2                  -> v0.80.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7898578Z  * [new tag]           v0.81.0                  -> v0.81.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7899065Z  * [new tag]           v0.81.1                  -> v0.81.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7899576Z  * [new tag]           v0.82.0                  -> v0.82.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7900077Z  * [new tag]           v0.82.1                  -> v0.82.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7900558Z  * [new tag]           v0.82.2                  -> v0.82.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7901069Z  * [new tag]           v0.83.0                  -> v0.83.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7901553Z  * [new tag]           v0.83.1                  -> v0.83.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7902036Z  * [new tag]           v0.83.2                  -> v0.83.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7902511Z  * [new tag]           v0.83.3                  -> v0.83.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7902970Z  * [new tag]           v0.84.0                  -> v0.84.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7903481Z  * [new tag]           v0.85.0                  -> v0.85.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7903953Z  * [new tag]           v0.85.1                  -> v0.85.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7904413Z  * [new tag]           v0.85.2                  -> v0.85.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7905168Z  * [new tag]           v0.85.3                  -> v0.85.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7905541Z  * [new tag]           v0.86.0                  -> v0.86.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7905831Z  * [new tag]           v0.86.1                  -> v0.86.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7906127Z  * [new tag]           v0.87.0                  -> v0.87.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7906408Z  * [new tag]           v0.88.0                  -> v0.88.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7906719Z  * [new tag]           v0.89.0                  -> v0.89.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7907007Z  * [new tag]           v0.9.0                   -> v0.9.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7907299Z  * [new tag]           v0.9.1                   -> v0.9.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7907584Z  * [new tag]           v0.9.2                   -> v0.9.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7907883Z  * [new tag]           v0.9.3                   -> v0.9.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7908177Z  * [new tag]           v0.9.4                   -> v0.9.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7908460Z  * [new tag]           v0.9.5                   -> v0.9.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7908743Z  * [new tag]           v0.9.6                   -> v0.9.6
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7909026Z  * [new tag]           v0.9.7                   -> v0.9.7
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7909310Z  * [new tag]           v0.9.8                   -> v0.9.8
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7909614Z  * [new tag]           v0.90.0                  -> v0.90.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7909899Z  * [new tag]           v0.91.0                  -> v0.91.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7910175Z  * [new tag]           v0.91.1                  -> v0.91.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7910451Z  * [new tag]           v0.91.2                  -> v0.91.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7910730Z  * [new tag]           v0.92.0                  -> v0.92.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7911016Z  * [new tag]           v0.92.1                  -> v0.92.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7911291Z  * [new tag]           v0.93.0                  -> v0.93.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7911569Z  * [new tag]           v0.93.1                  -> v0.93.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7911844Z  * [new tag]           v0.93.2                  -> v0.93.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7912332Z  * [new tag]           v0.94.0                  -> v0.94.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7912680Z  * [new tag]           v0.95.0                  -> v0.95.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7913094Z  * [new tag]           v0.95.1                  -> v0.95.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7913397Z  * [new tag]           v0.95.2                  -> v0.95.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7913690Z  * [new tag]           v0.96.0                  -> v0.96.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7913973Z  * [new tag]           v0.97.0                  -> v0.97.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7914254Z  * [new tag]           v0.98.0                  -> v0.98.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7914650Z  * [new tag]           v0.99.0                  -> v0.99.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7914949Z  * [new tag]           v1.0.0                   -> v1.0.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7915262Z  * [new tag]           v1.1.0                   -> v1.1.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7915592Z  * [new tag]           v1.10.0                  -> v1.10.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7915881Z  * [new tag]           v1.10.1                  -> v1.10.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7916167Z  * [new tag]           v1.10.2                  -> v1.10.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7916455Z  * [new tag]           v1.10.3                  -> v1.10.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7916736Z  * [new tag]           v1.11.0                  -> v1.11.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7917004Z  * [new tag]           v1.11.1                  -> v1.11.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7917271Z  * [new tag]           v1.11.2                  -> v1.11.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7917547Z  * [new tag]           v1.11.3                  -> v1.11.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7917834Z  * [new tag]           v1.11.4                  -> v1.11.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7918102Z  * [new tag]           v1.11.5                  -> v1.11.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7918380Z  * [new tag]           v1.12.0                  -> v1.12.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7918658Z  * [new tag]           v1.12.1                  -> v1.12.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7918932Z  * [new tag]           v1.12.2                  -> v1.12.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7919213Z  * [new tag]           v1.12.3                  -> v1.12.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7919571Z  * [new tag]           v1.13.0                  -> v1.13.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7919944Z  * [new tag]           v1.13.1                  -> v1.13.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7920234Z  * [new tag]           v1.14.0                  -> v1.14.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7920508Z  * [new tag]           v1.14.1                  -> v1.14.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7920788Z  * [new tag]           v1.15.0                  -> v1.15.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7921064Z  * [new tag]           v1.15.1                  -> v1.15.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7921333Z  * [new tag]           v1.15.2                  -> v1.15.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7921605Z  * [new tag]           v1.16.0                  -> v1.16.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7921875Z  * [new tag]           v1.16.1                  -> v1.16.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7922138Z  * [new tag]           v1.16.2                  -> v1.16.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7922413Z  * [new tag]           v1.17.0                  -> v1.17.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7922687Z  * [new tag]           v1.17.1                  -> v1.17.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7922956Z  * [new tag]           v1.17.2                  -> v1.17.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7923230Z  * [new tag]           v1.18.0                  -> v1.18.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7923499Z  * [new tag]           v1.18.1                  -> v1.18.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7923768Z  * [new tag]           v1.18.2                  -> v1.18.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7924036Z  * [new tag]           v1.19.0                  -> v1.19.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7924304Z  * [new tag]           v1.19.1                  -> v1.19.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7924584Z  * [new tag]           v1.19.2                  -> v1.19.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7924873Z  * [new tag]           v1.2.0                   -> v1.2.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7925445Z  * [new tag]           v1.2.1                   -> v1.2.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7925729Z  * [new tag]           v1.2.2                   -> v1.2.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7926106Z  * [new tag]           v1.2.3                   -> v1.2.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7926373Z  * [new tag]           v1.2.4                   -> v1.2.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7926648Z  * [new tag]           v1.2.5                   -> v1.2.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7926921Z  * [new tag]           v1.20.0                  -> v1.20.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7927192Z  * [new tag]           v1.21.0                  -> v1.21.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7927469Z  * [new tag]           v1.21.1                  -> v1.21.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7927747Z  * [new tag]           v1.21.2                  -> v1.21.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7928111Z  * [new tag]           v1.22.0                  -> v1.22.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7928465Z  * [new tag]           v1.22.1                  -> v1.22.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7928928Z  * [new tag]           v1.23.0                  -> v1.23.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7929396Z  * [new tag]           v1.24.0                  -> v1.24.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7929877Z  * [new tag]           v1.25.0                  -> v1.25.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7930351Z  * [new tag]           v1.25.1                  -> v1.25.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7930820Z  * [new tag]           v1.26.0                  -> v1.26.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7931282Z  * [new tag]           v1.26.1                  -> v1.26.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7931762Z  * [new tag]           v1.26.2                  -> v1.26.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7932196Z  * [new tag]           v1.3.0                   -> v1.3.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7932672Z  * [new tag]           v1.3.1                   -> v1.3.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7933148Z  * [new tag]           v1.4.0                   -> v1.4.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7933635Z  * [new tag]           v1.4.1                   -> v1.4.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7934127Z  * [new tag]           v1.5.0                   -> v1.5.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7934605Z  * [new tag]           v1.6.0                   -> v1.6.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7935061Z  * [new tag]           v1.6.1                   -> v1.6.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7935524Z  * [new tag]           v1.6.2                   -> v1.6.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7935987Z  * [new tag]           v1.6.3                   -> v1.6.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7936459Z  * [new tag]           v1.7.0                   -> v1.7.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7936938Z  * [new tag]           v1.8.0                   -> v1.8.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7937446Z  * [new tag]           v1.8.1                   -> v1.8.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7937918Z  * [new tag]           v1.8.2                   -> v1.8.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7938405Z  * [new tag]           v1.8.3                   -> v1.8.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7938875Z  * [new tag]           v1.9.0                   -> v1.9.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7939364Z  * [new tag]           v1.9.1                   -> v1.9.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7939851Z  * [new tag]           v1.9.2                   -> v1.9.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7940335Z  * [new tag]           v2.0.0                   -> v2.0.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7940824Z  * [new tag]           v2.0.1                   -> v2.0.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7941312Z  * [new tag]           v2.1.0                   -> v2.1.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7941795Z  * [new tag]           v2.10.0                  -> v2.10.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7942272Z  * [new tag]           v2.10.1                  -> v2.10.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7942737Z  * [new tag]           v2.10.2                  -> v2.10.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7943199Z  * [new tag]           v2.11.0                  -> v2.11.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7943557Z  * [new tag]           v2.11.1                  -> v2.11.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7943836Z  * [new tag]           v2.11.2                  -> v2.11.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7944127Z  * [new tag]           v2.12.0                  -> v2.12.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7944405Z  * [new tag]           v2.12.1                  -> v2.12.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7944676Z  * [new tag]           v2.12.2                  -> v2.12.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7944948Z  * [new tag]           v2.12.3                  -> v2.12.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7945785Z  * [new tag]           v2.12.4                  -> v2.12.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7946067Z  * [new tag]           v2.12.5                  -> v2.12.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7946351Z  * [new tag]           v2.12.6                  -> v2.12.6
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7946622Z  * [new tag]           v2.12.7                  -> v2.12.7
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7946893Z  * [new tag]           v2.13.0                  -> v2.13.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7947167Z  * [new tag]           v2.13.1                  -> v2.13.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7947435Z  * [new tag]           v2.13.2                  -> v2.13.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7947710Z  * [new tag]           v2.13.3                  -> v2.13.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7948091Z  * [new tag]           v2.14.0                  -> v2.14.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7948372Z  * [new tag]           v2.14.1                  -> v2.14.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7948648Z  * [new tag]           v2.14.2                  -> v2.14.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7948935Z  * [new tag]           v2.14.3                  -> v2.14.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7949228Z  * [new tag]           v2.15.0                  -> v2.15.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7949512Z  * [new tag]           v2.15.1                  -> v2.15.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7949782Z  * [new tag]           v2.15.2                  -> v2.15.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7950055Z  * [new tag]           v2.15.3                  -> v2.15.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7950327Z  * [new tag]           v2.15.4                  -> v2.15.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7950610Z  * [new tag]           v2.16.0                  -> v2.16.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7950908Z  * [new tag]           v2.17.0                  -> v2.17.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7951193Z  * [new tag]           v2.17.1                  -> v2.17.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7951465Z  * [new tag]           v2.18.0                  -> v2.18.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7951797Z  * [new tag]           v2.18.0-52825890-nightly -> v2.18.0-52825890-nightly
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7952177Z  * [new tag]           v2.18.0-97002309-nightly -> v2.18.0-97002309-nightly
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7952541Z  * [new tag]           v2.18.0-a38ac317-nightly -> v2.18.0-a38ac317-nightly
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7952904Z  * [new tag]           v2.18.0-cd616d2c-nightly -> v2.18.0-cd616d2c-nightly
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7953264Z  * [new tag]           v2.19.0-315a4fdf-nightly -> v2.19.0-315a4fdf-nightly
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7953626Z  * [new tag]           v2.19.0-8afe0bba-nightly -> v2.19.0-8afe0bba-nightly
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7953954Z  * [new tag]           v2.2.0                   -> v2.2.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7954236Z  * [new tag]           v2.3.0                   -> v2.3.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7954517Z  * [new tag]           v2.3.1                   -> v2.3.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7954794Z  * [new tag]           v2.3.2                   -> v2.3.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7955068Z  * [new tag]           v2.4.0                   -> v2.4.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7955340Z  * [new tag]           v2.4.1                   -> v2.4.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7955620Z  * [new tag]           v2.4.2                   -> v2.4.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7955890Z  * [new tag]           v2.4.3                   -> v2.4.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7956165Z  * [new tag]           v2.4.4                   -> v2.4.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7956438Z  * [new tag]           v2.4.5                   -> v2.4.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7956710Z  * [new tag]           v2.4.6                   -> v2.4.6
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7956979Z  * [new tag]           v2.4.7                   -> v2.4.7
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7957443Z  * [new tag]           v2.4.8                   -> v2.4.8
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7957913Z  * [new tag]           v2.5.0                   -> v2.5.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7958391Z  * [new tag]           v2.5.1                   -> v2.5.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7958861Z  * [new tag]           v2.6.0                   -> v2.6.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7959321Z  * [new tag]           v2.6.1                   -> v2.6.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7959822Z  * [new tag]           v2.7.0                   -> v2.7.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7960475Z  * [new tag]           v2.8.0                   -> v2.8.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7960948Z  * [new tag]           v2.8.1                   -> v2.8.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7961415Z  * [new tag]           v2.8.2                   -> v2.8.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7961891Z  * [new tag]           v2.9.0                   -> v2.9.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.7963228Z [command]"C:\Program Files\Git\bin\git.exe" branch --list --remote origin/main
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8401690Z   origin/main
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8448344Z [command]"C:\Program Files\Git\bin\git.exe" rev-parse refs/remotes/origin/main
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8815996Z 36e43dd08f724956b188af2f6f3bcfd5efd355ec
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8849779Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8850430Z ##[group]Determining the checkout info
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8850928Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.8859677Z [command]"C:\Program Files\Git\bin\git.exe" sparse-checkout disable
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.9300061Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset-all extensions.worktreeConfig
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.9587741Z ##[group]Checking out the ref
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:05.9595531Z [command]"C:\Program Files\Git\bin\git.exe" checkout --progress --force -B main refs/remotes/origin/main
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:06.2942532Z Switched to a new branch 'main'
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:06.3002840Z branch 'main' set up to track 'origin/main'.
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:06.3063630Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:06.3453907Z [command]"C:\Program Files\Git\bin\git.exe" log -1 --format=%H
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:06.3718175Z 36e43dd08f724956b188af2f6f3bcfd5efd355ec
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:06.4136226Z ##[group]Run New-Item -ItemType Directory -Force -Path D:\tmp, D:\gocache, D:\gomodcache | Out-Null
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:06.4137056Z ^[[36;1mNew-Item -ItemType Directory -Force -Path D:\tmp, D:\gocache, D:\gomodcache | Out-Null^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:06.4137504Z ^[[36;1m@(^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:06.4137694Z ^[[36;1m  "GOTMPDIR=D:\tmp"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:06.4137923Z ^[[36;1m  "TMP=D:\tmp"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:06.4138157Z ^[[36;1m  "TEMP=D:\tmp"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:06.4138368Z ^[[36;1m  "GOCACHE=D:\gocache"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:06.4138620Z ^[[36;1m  "GOMODCACHE=D:\gomodcache"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:06.4138975Z ^[[36;1m) | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5991455Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5991833Z env:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5992067Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:06.5992314Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0982375Z ##[group]Run go-task/setup-task@a00fbb05ce67b35648be3c78cbc9fd85354c757e
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0982818Z with:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0983003Z   version: 3.x
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0986142Z   repo-token: ***
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0986353Z   max-retries: 3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0986540Z env:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0986719Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0986958Z   GOTMPDIR: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0987154Z   TMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0987334Z   TEMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0987536Z   GOCACHE: D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0987737Z   GOMODCACHE: D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:07.0987942Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:09.8091254Z [command]"C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$ErrorActionPreference = 'Stop' ; try { Add-Type -AssemblyName System.IO.Compression.ZipFile } catch { } ; try { [System.IO.Compression.ZipFile]::ExtractToDirectory('D:\a\_temp\9761ee1d-a60d-4154-849c-c05530b97793', 'D:\a\_temp\77638782-1106-410f-8455-2d34c8e21339', $true) } catch { if (($_.Exception.GetType().FullName -eq 'System.Management.Automation.MethodException') -or ($_.Exception.GetType().FullName -eq 'System.Management.Automation.RuntimeException') ){ Expand-Archive -LiteralPath 'D:\a\_temp\9761ee1d-a60d-4154-849c-c05530b97793' -DestinationPath 'D:\a\_temp\77638782-1106-410f-8455-2d34c8e21339' -Force } else { throw $_ } } ;"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:10.3287096Z Successfully setup Task version v3.53.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:10.3660308Z ##[group]Run crazy-max/ghaction-upx@c83f378efc804f828e988debb88ed6116feb2368
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:10.3660829Z with:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:10.3661031Z   install-only: true
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:10.3661241Z   version: latest
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:10.3661427Z env:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:10.3661610Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:10.3661858Z   GOTMPDIR: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:10.3662044Z   TMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:10.3662219Z   TEMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:10.3662411Z   GOCACHE: D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:10.3662616Z   GOMODCACHE: D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:10.3662829Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:10.5493695Z UPX 5.2.0 found
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:10.5497699Z ##[group]Downloading https://github.com/upx/upx/releases/download/v5.2.0/upx-5.2.0-win64.zip...
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:10.7689806Z Downloaded to D:\a\_temp\3da5db19-0e5b-42d7-afaa-a820fa9fc300
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:10.8426153Z [command]"C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$ErrorActionPreference = 'Stop' ; try { Add-Type -AssemblyName System.IO.Compression.ZipFile } catch { } ; try { [System.IO.Compression.ZipFile]::ExtractToDirectory('D:\a\_temp\3da5db19-0e5b-42d7-afaa-a820fa9fc300', 'D:\a\_temp\02503098-dfd0-4d17-b7f6-21b8856601f0', $true) } catch { if (($_.Exception.GetType().FullName -eq 'System.Management.Automation.MethodException') -or ($_.Exception.GetType().FullName -eq 'System.Management.Automation.RuntimeException') ){ Expand-Archive -LiteralPath 'D:\a\_temp\3da5db19-0e5b-42d7-afaa-a820fa9fc300' -DestinationPath 'D:\a\_temp\02503098-dfd0-4d17-b7f6-21b8856601f0' -Force } else { throw $_ } } ;"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:11.3220471Z Extracted to D:\a\_temp\02503098-dfd0-4d17-b7f6-21b8856601f0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:11.3365925Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:11.3719905Z ##[group]Run actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:11.3720579Z with:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:11.3720884Z   go-version-file: go.mod
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:11.3721334Z   cache-dependency-path: go.sum
+test (windows-latest)	UNKNOWN STEP	Taskfile.yml
+test (windows-latest)	UNKNOWN STEP	
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:11.3721802Z   check-latest: false
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:11.3726802Z   token: ***
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:11.3727094Z   cache: true
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:11.3727376Z env:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:11.3727665Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:11.3728057Z   GOTMPDIR: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:11.3728354Z   TMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:11.3728848Z   TEMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:11.3729136Z   GOCACHE: D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:11.3729470Z   GOMODCACHE: D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:11.3729817Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:11.5245666Z Setup go version spec 1.27.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:11.5256466Z Attempting to download 1.27.0...
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:11.9446622Z matching 1.27.0...
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:11.9450420Z Acquiring 1.27.0 from https://github.com/actions/go-versions/releases/download/1.27.0-32325163857/go-1.27.0-win32-x64.zip
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:12.5239224Z Extracting Go...
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:12.5893352Z [command]"C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$ErrorActionPreference = 'Stop' ; try { Add-Type -AssemblyName System.IO.Compression.ZipFile } catch { } ; try { [System.IO.Compression.ZipFile]::ExtractToDirectory('D:\a\_temp\go-1.27.0-win32-x64.zip', 'D:\a\_temp\641e0cfb-7a38-47d9-bce6-2f4a8ce8ebd4', $true) } catch { if (($_.Exception.GetType().FullName -eq 'System.Management.Automation.MethodException') -or ($_.Exception.GetType().FullName -eq 'System.Management.Automation.RuntimeException') ){ Expand-Archive -LiteralPath 'D:\a\_temp\go-1.27.0-win32-x64.zip' -DestinationPath 'D:\a\_temp\641e0cfb-7a38-47d9-bce6-2f4a8ce8ebd4' -Force } else { throw $_ } } ;"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:17.4913423Z Successfully extracted go to D:\a\_temp\641e0cfb-7a38-47d9-bce6-2f4a8ce8ebd4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:17.4913933Z Adding to the cache ...
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:27.6959586Z Created link C:\hostedtoolcache\windows\go\1.27.0\x64 => D:\hostedtoolcache\windows\go\1.27.0\x64
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:27.6962879Z Created link C:\hostedtoolcache\windows\go\1.27.0\x64.complete => D:\hostedtoolcache\windows\go\1.27.0\x64.complete
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:27.6964217Z Successfully cached go to C:\hostedtoolcache\windows\go\1.27.0\x64
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:27.6969124Z Added go to the path
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:27.6971396Z Successfully set up Go version 1.27.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:28.0246141Z [command]C:\hostedtoolcache\windows\go\1.27.0\x64\bin\go.exe env GOMODCACHE
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:28.0302506Z [command]C:\hostedtoolcache\windows\go\1.27.0\x64\bin\go.exe env GOCACHE
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:28.0559320Z D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:28.0584559Z D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:28.2422196Z Cache hit for: setup-go-Windows-x64-go-1.27.0-4effc5d79fd735aa8ad13170a172cf2e131e53a29f71095d44234c448ca04db9
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:29.2963447Z Received 205520896 of 1148820726 (17.9%), 193.9 MBs/sec
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:30.3044021Z Received 402653184 of 1148820726 (35.0%), 190.2 MBs/sec
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:31.3138977Z Received 616562688 of 1148820726 (53.7%), 194.1 MBs/sec
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:32.3145607Z Received 805306368 of 1148820726 (70.1%), 190.6 MBs/sec
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:33.3257166Z Received 1027604480 of 1148820726 (89.4%), 194.4 MBs/sec
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:34.0404665Z Received 1148820726 of 1148820726 (100.0%), 190.4 MBs/sec
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:34.0407109Z Cache Size: ~1096 MB (1148820726 B)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:03:34.0445021Z [command]"C:\Program Files\Git\usr\bin\tar.exe" -xf D:/a/_temp/f567e581-5401-454f-80c5-b004497171b9/cache.tzst -P -C D:/a/goreleaser/goreleaser --force-local --use-compress-program "zstd -d"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:07.8454742Z Cache restored successfully
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:07.9166137Z Cache restored from key: setup-go-Windows-x64-go-1.27.0-4effc5d79fd735aa8ad13170a172cf2e131e53a29f71095d44234c448ca04db9
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:07.9195325Z go version go1.27.0 windows/amd64
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:07.9195708Z 
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:07.9196169Z ##[group]go env
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2974535Z set AR=ar
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2974879Z set CC=gcc
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2975216Z set CGO_CFLAGS=-O2 -g
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2975666Z set CGO_CPPFLAGS=
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2976027Z set CGO_CXXFLAGS=-O2 -g
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2976367Z set CGO_ENABLED=1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2976676Z set CGO_FFLAGS=-O2 -g
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2976906Z set CGO_LDFLAGS=-O2 -g
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2977128Z set CXX=g++
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2977327Z set GCCGO=gccgo
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2977527Z set GO111MODULE=
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2977725Z set GOAMD64=v1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2977955Z set GOARCH=amd64
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2978236Z set GOAUTH=netrc
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2978539Z set GOBIN=C:\Users\runneradmin\go\bin
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2978990Z set GOCACHE=D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2979681Z set GOCACHEPROG=
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2979967Z set GODEBUG=
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2980736Z set GOENV=C:\Users\runneradmin\AppData\Roaming\go\env
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2981077Z set GOEXE=.exe
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2981300Z set GOEXPERIMENT=
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2981511Z set GOFIPS140=off
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2981967Z set GOFLAGS=
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2983278Z set GOGCCFLAGS=-m64 -pthread -Wl,--no-gc-sections -fmessage-length=0 -ffile-prefix-map=D:\tmp\go-build2634921477=/tmp/go-build -gno-record-gcc-switches
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2984322Z set GOHOSTARCH=amd64
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2984644Z set GOHOSTOS=windows
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2984979Z set GOINSECURE=
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2985343Z set GOMOD=D:\a\goreleaser\goreleaser\go.mod
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2985810Z set GOMODCACHE=D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2986195Z set GONOPROXY=
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2986498Z set GONOSUMDB=
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2986794Z set GOOS=windows
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2987114Z set GOPACKAGESDRIVER=
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2987498Z set GOPATH=C:\Users\runneradmin\go
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2987902Z set GOPRIVATE=
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2988330Z set GOPROXY=https://proxy.golang.org,direct
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2988914Z set GOROOT=C:\hostedtoolcache\windows\go\1.27.0\x64
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2989432Z set GOSUMDB=sum.golang.org
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2989805Z set GOTELEMETRY=local
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2990709Z set GOTELEMETRYDIR=C:\Users\runneradmin\AppData\Roaming\go\telemetry
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2991339Z set GOTMPDIR=D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2991670Z set GOTOOLCHAIN=local
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2992254Z set GOTOOLDIR=C:\hostedtoolcache\windows\go\1.27.0\x64\pkg\tool\windows_amd64
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2992891Z set GOVCS=
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2993179Z set GOVERSION=go1.27.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2993506Z set GOWORK=
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2993829Z set PKG_CONFIG=pkg-config
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2994092Z 
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.2994608Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.3536350Z ##[group]Run actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.3536843Z with:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.3537050Z   node-version: 25
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.3537276Z   check-latest: false
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.3540433Z   token: ***
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.3540666Z   package-manager-cache: true
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.3540913Z env:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.3541124Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.3541408Z   GOTMPDIR: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.3541610Z   TMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.3541804Z   TEMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.3541997Z   GOCACHE: D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.3542215Z   GOMODCACHE: D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.3542461Z   GOTOOLCHAIN: local
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.3542670Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:08.6257105Z Attempting to download 25...
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:09.0699979Z Not found in manifest. Falling back to download directly from Node
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:09.1571381Z Acquiring 25.9.0 - x64 from https://nodejs.org/dist/v25.9.0/node-v25.9.0-win-x64.7z
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:09.3896019Z Extracting ...
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:11.8388820Z Adding to the cache ...
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:14.7529936Z Done
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:14.7536055Z ##[group]Environment details
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:15.9411774Z node: v25.9.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:15.9412054Z npm: 11.12.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:15.9412264Z yarn: 1.22.22
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:15.9412775Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:15.9727117Z Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:15.9728584Z ##[group]Run mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:15.9728943Z with:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:15.9729140Z   use-cache: true
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:15.9729348Z   cache-size-limit: 2048
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:15.9729563Z env:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:15.9729769Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:15.9730021Z   GOTMPDIR: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:15.9730216Z   TMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:15.9730409Z   TEMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:15.9730606Z   GOCACHE: D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:15.9730824Z   GOMODCACHE: D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:15.9731051Z   GOTOOLCHAIN: local
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:15.9731289Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:16.3198138Z Using tool-cache: false
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:16.3262631Z Failed to read build.zig.zon (using latest): Error: ENOENT: no such file or directory, open 'D:\a\goreleaser\goreleaser\build.zig.zon'
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:17.0171934Z Fetching zig-x86_64-windows-0.16.0.zip
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:17.1378116Z Cache hit for: setup-zig-tarball-zig-x86_64-windows-0.16.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:17.7393066Z Received 91486638 of 91486638 (100.0%), 153.3 MBs/sec
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:17.7396646Z Cache Size: ~87 MB (91486638 B)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:17.7435820Z [command]"C:\Program Files\Git\usr\bin\tar.exe" -xf D:/a/_temp/aacbf050-57de-41e1-b812-5a89e53957b6/cache.tzst -P -C D:/a/goreleaser/goreleaser --force-local --use-compress-program "zstd -d"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:17.9453290Z Cache restored successfully
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:17.9519014Z Fetch took 935 ms
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:17.9519664Z Extracting tarball zig-x86_64-windows-0.16.0.zip
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:18.0078924Z [command]"C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$ErrorActionPreference = 'Stop' ; try { Add-Type -AssemblyName System.IO.Compression.ZipFile } catch { } ; try { [System.IO.Compression.ZipFile]::ExtractToDirectory('D:\a\_temp\zig-x86_64-windows-0.16.0.zip', 'D:\a\_temp\4c95b079-311a-4da7-8b8b-034d8ab711cc', $true) } catch { if (($_.Exception.GetType().FullName -eq 'System.Management.Automation.MethodException') -or ($_.Exception.GetType().FullName -eq 'System.Management.Automation.RuntimeException') ){ Expand-Archive -LiteralPath 'D:\a\_temp\zig-x86_64-windows-0.16.0.zip' -DestinationPath 'D:\a\_temp\4c95b079-311a-4da7-8b8b-034d8ab711cc' -Force } else { throw $_ } } ;"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:23.5921176Z Extract took 5640 ms
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:23.6568206Z [command]D:\a\_temp\4c95b079-311a-4da7-8b8b-034d8ab711cc\zig-x86_64-windows-0.16.0\zig.exe version
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:23.8501245Z 0.16.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:23.8555852Z Resolved Zig version 0.16.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:23.8568804Z Attempting restore of Zig cache with prefix 'setup-zig-cache-v2-test-zig-x86_64-windows-0.16.0--'
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:23.9847161Z Cache hit for restore-key: setup-zig-cache-v2-test-zig-x86_64-windows-0.16.0--33293313030-1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:24.2324088Z Received 33852837 of 33852837 (100.0%), 144.1 MBs/sec
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:24.2324935Z Cache Size: ~32 MB (33852837 B)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:24.2404336Z [command]"C:\Program Files\Git\usr\bin\tar.exe" -xf D:/a/_temp/3dfdda8f-359b-4c67-908a-fd7d262ba25a/cache.tzst -P -C D:/a/goreleaser/goreleaser --force-local --use-compress-program "zstd -d"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:24.7863893Z Cache restored successfully
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:24.7893910Z Cache hit (key 'setup-zig-cache-v2-test-zig-x86_64-windows-0.16.0--33293313030-1'): populating Zig cache directory at D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:24.8297199Z ##[group]Run oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:24.8297794Z with:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:24.8298034Z   no-cache: false
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:24.8301379Z   token: ***
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:24.8301841Z env:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:24.8302119Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:24.8302449Z   GOTMPDIR: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:24.8302696Z   TMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:24.8303054Z   TEMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:24.8303353Z   GOCACHE: D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:24.8303624Z   GOMODCACHE: D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:24.8303911Z   GOTOOLCHAIN: local
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:24.8304260Z   ZIG_GLOBAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:24.8304732Z   ZIG_LOCAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:24.8305110Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:25.3702604Z Downloading a new version of Bun: https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-windows-x64.zip
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:25.8611262Z [command]"C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$ErrorActionPreference = 'Stop' ; try { Add-Type -AssemblyName System.IO.Compression.ZipFile } catch { } ; try { [System.IO.Compression.ZipFile]::ExtractToDirectory('D:\a\_temp\5b6a1590-5720-4fef-9b58-df1cfafa3d97.zip', 'D:\a\_temp\f90a4baa-7901-4745-af6b-8f311d6358e5', $true) } catch { if (($_.Exception.GetType().FullName -eq 'System.Management.Automation.MethodException') -or ($_.Exception.GetType().FullName -eq 'System.Management.Automation.RuntimeException') ){ Expand-Archive -LiteralPath 'D:\a\_temp\5b6a1590-5720-4fef-9b58-df1cfafa3d97.zip' -DestinationPath 'D:\a\_temp\f90a4baa-7901-4745-af6b-8f311d6358e5' -Force } else { throw $_ } } ;"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:26.6128073Z [command]C:\Users\runneradmin\.bun\bin\bun.exe --revision
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:27.1070847Z 1.4.0+34cbb9a40
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:27.1472369Z ##[group]Run denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:27.1472912Z with:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:27.1473157Z   deno-version: 2.x
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:27.1473421Z   deno-binary-name: deno
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:27.1473694Z   cache: false
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:27.1473917Z env:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:27.1474150Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:27.1474702Z   GOTMPDIR: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:27.1474938Z   TMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:27.1475159Z   TEMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:27.1475385Z   GOCACHE: D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:27.1475650Z   GOMODCACHE: D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:27.1475915Z   GOTOOLCHAIN: local
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:27.1476253Z   ZIG_GLOBAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:27.1476727Z   ZIG_LOCAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:27.1477082Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:27.4812851Z Going to install stable version 2.9.6.
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:27.4826154Z Downloading Deno from https://github.com/denoland/deno/releases/download/v2.9.6/deno-x86_64-pc-windows-msvc.zip.
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:27.9615313Z [command]"C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$ErrorActionPreference = 'Stop' ; try { Add-Type -AssemblyName System.IO.Compression.ZipFile } catch { } ; try { [System.IO.Compression.ZipFile]::ExtractToDirectory('D:\a\_temp\73f1f647-5ba7-4963-84a0-b6ec7f4b3ebb', 'D:\a\_temp\1db8630a-4f65-4526-8722-cd55bbe6cd64', $true) } catch { if (($_.Exception.GetType().FullName -eq 'System.Management.Automation.MethodException') -or ($_.Exception.GetType().FullName -eq 'System.Management.Automation.RuntimeException') ){ Expand-Archive -LiteralPath 'D:\a\_temp\73f1f647-5ba7-4963-84a0-b6ec7f4b3ebb' -DestinationPath 'D:\a\_temp\1db8630a-4f65-4526-8722-cd55bbe6cd64' -Force } else { throw $_ } } ;"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.5961633Z Cached Deno to C:\hostedtoolcache\windows\deno\2.9.6\x64.
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.5977155Z Installation complete.
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6287380Z ##[group]Run cargo-bins/cargo-binstall@75b4bfae1b2c753a6806bbce6e6cb89b602de33c
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6287910Z with:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6288105Z env:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6288312Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6288590Z   GOTMPDIR: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6288804Z   TMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6289032Z   TEMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6289224Z   GOCACHE: D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6289459Z   GOMODCACHE: D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6289697Z   GOTOOLCHAIN: local
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6289981Z   ZIG_GLOBAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6290383Z   ZIG_LOCAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6290688Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6353399Z ##[start-action display=Install cargo-binstall;id=__cargo-bins_cargo-binstall.__run]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6359656Z ##[end-action id=__cargo-bins_cargo-binstall.__run;outcome=skipped;conclusion=skipped;duration_ms=0]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6362665Z ##[start-action display=Install cargo-binstall;id=__cargo-bins_cargo-binstall.__run_2]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6490355Z ##[group]Run Set-ExecutionPolicy Unrestricted -Scope Process; iex "$Env:GITHUB_ACTION_PATH/install-from-binstall-release.ps1"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6491234Z ^[[36;1mSet-ExecutionPolicy Unrestricted -Scope Process; iex "$Env:GITHUB_ACTION_PATH/install-from-binstall-release.ps1"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6562281Z shell: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.EXE -command ". '{0}'"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6562718Z env:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6562941Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6563216Z   GOTMPDIR: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6563443Z   TMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6563638Z   TEMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6563849Z   GOCACHE: D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6564082Z   GOMODCACHE: D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6564316Z   GOTOOLCHAIN: local
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6564630Z   ZIG_GLOBAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6565040Z   ZIG_LOCAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6565624Z   BINSTALL_VERSION: 
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:28.6565871Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:43.9916683Z VERBOSE: Download: 1 seconds
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:45.0540376Z VERBOSE: Installation: 1 seconds
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:45.0605591Z VERBOSE: Path addition: 0 seconds
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:45.1118528Z ##[end-action id=__cargo-bins_cargo-binstall.__run_2;outcome=success;conclusion=success;duration_ms=16475]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:45.1272572Z ##[group]Run rustup default stable
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:45.1273007Z ^[[36;1mrustup default stable^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:45.1273295Z ^[[36;1mcargo binstall cargo-zigbuild^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:45.1374350Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:45.1374745Z env:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:45.1374966Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:45.1375241Z   GOTMPDIR: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:45.1375452Z   TMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:45.1375639Z   TEMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:45.1375864Z   GOCACHE: D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:45.1376091Z   GOMODCACHE: D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:45.1376330Z   GOTOOLCHAIN: local
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:45.1376628Z   ZIG_GLOBAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:45.1377027Z   ZIG_LOCAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:45.1377368Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:46.1575655Z info: using existing install for stable-x86_64-pc-windows-msvc
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:46.1752948Z info: default toolchain set to stable-x86_64-pc-windows-msvc
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:46.1797888Z 
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:49.1557703Z   stable-x86_64-pc-windows-msvc unchanged - rustc 1.98.0 (88d9e12ae 2026-08-18)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:49.1558142Z 
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:50.5596046Z 
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:50.5597623Z  INFO the current QuickInstall statistics endpoint url="https://cargo-quickinstall-stats-server.fly.dev/record-install"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:50.5599090Z Binstall would like to collect install statistics for the QuickInstall project
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:50.5600807Z to help inform which packages should be included in its index in the future.
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:50.5601893Z If you agree, please type 'yes'. If you disagree, telemetry will not be sent.
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:50.5602893Z You can change this at any time by editing the binstall settings file.
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:50.5604150Z Opt in to telemetry? yes/[no]  INFO Settings saved path="C:\\Users\\runneradmin\\.cargo\\binstall.toml"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:50.5694604Z  INFO resolve: Resolving package: 'cargo-zigbuild'
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.1214002Z  WARN The package cargo-zigbuild v0.23.3 (x86_64-pc-windows-msvc) has been downloaded from github.com
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.1214791Z  INFO This will install the following binaries:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.1216224Z  INFO   - cargo-zigbuild.exe => C:\Users\runneradmin\.cargo\bin\cargo-zigbuild.exe
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.1216900Z Do you wish to continue? [yes]/no  INFO Installing binaries...
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.1239716Z  INFO Done in 4.5655221s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2779078Z ##[group]Run astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2779649Z with:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2779906Z   activate-environment: false
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2780166Z   no-project: false
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2780640Z   working-directory: D:\a\goreleaser\goreleaser
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2783608Z   github-token: ***
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2783878Z   enable-cache: auto
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2784475Z   cache-dependency-glob: **/*requirements*.txt
+test (windows-latest)	UNKNOWN STEP	**/*requirements*.in
+test (windows-latest)	UNKNOWN STEP	**/*constraints*.txt
+test (windows-latest)	UNKNOWN STEP	**/*constraints*.in
+test (windows-latest)	UNKNOWN STEP	**/pyproject.toml
+test (windows-latest)	UNKNOWN STEP	**/uv.lock
+test (windows-latest)	UNKNOWN STEP	**/*.py.lock
+test (windows-latest)	UNKNOWN STEP	
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2785136Z   restore-cache: true
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2785385Z   save-cache: true
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2785625Z   prune-cache: false
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2785866Z   cache-python: false
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2786115Z   ignore-nothing-to-cache: false
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2786421Z   ignore-empty-workdir: false
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2786704Z   download-from-astral-mirror: true
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2787054Z   add-problem-matchers: true
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2787308Z   quiet: false
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2787551Z   resolution-strategy: highest
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2787806Z env:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2788029Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2788292Z   GOTMPDIR: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2788517Z   TMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2788983Z   TEMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2789183Z   GOCACHE: D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2789424Z   GOMODCACHE: D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2789669Z   GOTOOLCHAIN: local
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2789966Z   ZIG_GLOBAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2790374Z   ZIG_LOCAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.2790694Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.5566930Z Trying to find version for uv in: D:\a\goreleaser\goreleaser\uv.toml
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.5567932Z Could not find file: D:\a\goreleaser\goreleaser\uv.toml
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.5568942Z Trying to find version for uv in: D:\a\goreleaser\goreleaser\pyproject.toml
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.5569921Z Could not find file: D:\a\goreleaser\goreleaser\pyproject.toml
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.5570926Z Could not determine uv version from uv.toml or pyproject.toml. Falling back to latest.
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.5574181Z Fetching manifest data from https://raw.githubusercontent.com/astral-sh/versions/main/v1/uv.ndjson ...
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:55.6233703Z Downloading uv from "https://releases.astral.sh/github/uv/releases/download/0.12.7/uv-x86_64-pc-windows-msvc.zip" ...
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:56.0085158Z [command]C:\Windows\system32\tar.exe x -C D:\a\_temp\40acd5c8-a392-4c96-b72c-3a631c25e52f -f D:\a\_temp\f302a08e-23d4-475f-9e89-7c7422da7c1f
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1908721Z Set UV_TOOL_BIN_DIR to D:\a\_temp\uv-tool-bin-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1913327Z Added D:\a\_temp\uv-tool-bin-dir to the path
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1922571Z Added C:\hostedtoolcache\windows\uv\0.12.7\x86_64 to the path
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1925390Z Set UV_TOOL_DIR to D:\a\_temp\uv-tool-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1929022Z Set UV_PYTHON_INSTALL_DIR to D:\a\_temp\uv-python-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1930790Z Added D:\a\_temp\uv-python-dir to the path
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1936805Z Set UV_CACHE_DIR to D:\a\_temp\setup-uv-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:56.1940532Z Successfully installed uv version 0.12.7
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:57.6375315Z Searching files using cache dependency glob: D:\a\goreleaser\goreleaser\**\*requirements*.txt,D:\a\goreleaser\goreleaser\**\*requirements*.in,D:\a\goreleaser\goreleaser\**\*constraints*.txt,D:\a\goreleaser\goreleaser\**\*constraints*.in,D:\a\goreleaser\goreleaser\**\pyproject.toml,D:\a\goreleaser\goreleaser\**\uv.lock,D:\a\goreleaser\goreleaser\**\*.py.lock
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:57.9478742Z D:\a\goreleaser\goreleaser\internal\builders\poetry\testdata\pyproject.toml
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:57.9524082Z D:\a\goreleaser\goreleaser\internal\builders\uv\testdata\pyproject.toml
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.1152315Z D:\a\goreleaser\goreleaser\internal\pyproject\testdata\pyproject.toml
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.2070079Z Found 3 files to hash.
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.2105316Z Trying to restore cache from GitHub Actions cache with key: setup-uv-2-x86_64-pc-windows-msvc-windows-2025-3.12.10-1472b101372efdfaea191c0f58d7baafced473780cbe79c2e88e1ffee5d9ceb3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.3398010Z Cache hit for: setup-uv-2-x86_64-pc-windows-msvc-windows-2025-3.12.10-1472b101372efdfaea191c0f58d7baafced473780cbe79c2e88e1ffee5d9ceb3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.4274155Z Received 1124 of 1124 (100.0%), 0.0 MBs/sec
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.4275649Z Cache Size: ~0 MB (1124 B)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.4298163Z [command]"C:\Program Files\Git\usr\bin\tar.exe" -xf D:/a/_temp/636ec70e-3bc5-4673-85d3-b54493e118d6/cache.tzst -P -C D:/a/goreleaser/goreleaser --force-local --use-compress-program "zstd -d"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.4677103Z Cache restored successfully
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.4687638Z cache restored from GitHub Actions cache with key: setup-uv-2-x86_64-pc-windows-msvc-windows-2025-3.12.10-1472b101372efdfaea191c0f58d7baafced473780cbe79c2e88e1ffee5d9ceb3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.6043918Z ##[group]Run uv tool install poetry
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.6044330Z ^[[36;1muv tool install poetry^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.6146183Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.6146557Z env:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.6146781Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.6147062Z   GOTMPDIR: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.6147506Z   TMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.6147708Z   TEMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.6147916Z   GOCACHE: D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.6148151Z   GOMODCACHE: D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.6148411Z   GOTOOLCHAIN: local
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.6148720Z   ZIG_GLOBAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.6149138Z   ZIG_LOCAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.6149488Z   UV_TOOL_BIN_DIR: D:\a\_temp\uv-tool-bin-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.6149803Z   UV_TOOL_DIR: D:\a\_temp\uv-tool-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.6150144Z   UV_PYTHON_INSTALL_DIR: D:\a\_temp\uv-python-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.6150464Z   UV_CACHE_DIR: D:\a\_temp\setup-uv-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:58.6150735Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.2610482Z Resolved 43 packages in 364ms
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.3509583Z Downloading virtualenv (5.1MiB)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.3638674Z Downloading rapidfuzz (1.5MiB)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.3678693Z Downloading dulwich (1.0MiB)
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.5740495Z  Downloaded rapidfuzz
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.5998459Z  Downloaded dulwich
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6251491Z  Downloaded virtualenv
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.6513101Z Prepared 43 packages in 358ms
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7882922Z Installed 43 packages in 136ms
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7884383Z  + anyio==4.14.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7885935Z  + backports-zstd==1.7.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7887212Z  + build==1.6.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7888976Z  + cachecontrol==0.14.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7890149Z  + certifi==2026.7.22
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7892219Z  + charset-normalizer==3.5.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7893950Z  + cleo==2.1.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7895331Z  + colorama==0.4.6
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7896522Z  + crashtest==0.4.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7897800Z  + distlib==0.4.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7899088Z  + dulwich==1.2.14
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7900429Z  + fastjsonschema==2.22.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7901771Z  + filelock==3.32.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7903220Z  + findpython==0.8.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7904293Z  + h11==0.16.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7905626Z  + httpcore==1.0.9
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7906887Z  + httpx==0.28.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7907960Z  + idna==3.19
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7909063Z  + installer==1.0.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7910148Z  + jaraco-classes==3.4.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7911570Z  + jaraco-context==6.1.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7913021Z  + jaraco-functools==4.6.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7914264Z  + keyring==25.7.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7915666Z  + more-itertools==11.1.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7916839Z  + msgpack==1.2.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7917982Z  + packaging==26.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7919401Z  + pbs-installer==2026.8.25
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7920395Z  + pkginfo==1.13
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7921684Z  + platformdirs==4.11.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7923082Z  + poetry==2.4.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7924334Z  + poetry-core==2.4.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7925759Z  + pyproject-hooks==1.2.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7926945Z  + python-discovery==1.6.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7928218Z  + pywin32-ctypes==0.2.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7929515Z  + rapidfuzz==3.14.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7930648Z  + requests==2.34.2
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7932275Z  + requests-toolbelt==1.0.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7932690Z  + shellingham==1.5.4
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7934346Z  + tomlkit==0.15.1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7935841Z  + trove-classifiers==2026.6.1.19
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7937153Z  + typing-extensions==4.16.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7938484Z  + urllib3==2.7.0
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7939690Z  + virtualenv==21.7.7
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.7973604Z Installed 1 executable: poetry
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.9311408Z ##[group]Run echo "C:\Users\runneradmin\.local\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.9312288Z ^[[36;1mecho "C:\Users\runneradmin\.local\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.9412217Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.9412601Z env:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.9412829Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.9413102Z   GOTMPDIR: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.9413546Z   TMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.9413747Z   TEMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.9413965Z   GOCACHE: D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.9414203Z   GOMODCACHE: D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.9414449Z   GOTOOLCHAIN: local
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.9414751Z   ZIG_GLOBAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.9415170Z   ZIG_LOCAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.9415577Z   UV_TOOL_BIN_DIR: D:\a\_temp\uv-tool-bin-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.9415881Z   UV_TOOL_DIR: D:\a\_temp\uv-tool-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.9416187Z   UV_PYTHON_INSTALL_DIR: D:\a\_temp\uv-python-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.9416595Z   UV_CACHE_DIR: D:\a\_temp\setup-uv-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:04:59.9417024Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3554645Z ##[group]Run sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3555187Z with:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3555410Z   cosign-release: v3.0.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3555679Z   install-dir: $HOME/.cosign
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3555960Z   use-sudo: false
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3556163Z env:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3556377Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3556650Z   GOTMPDIR: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3556861Z   TMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3557065Z   TEMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3557269Z   GOCACHE: D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3557505Z   GOMODCACHE: D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3557742Z   GOTOOLCHAIN: local
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3558041Z   ZIG_GLOBAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3558449Z   ZIG_LOCAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3558802Z   UV_TOOL_BIN_DIR: D:\a\_temp\uv-tool-bin-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3559144Z   UV_TOOL_DIR: D:\a\_temp\uv-tool-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3559449Z   UV_PYTHON_INSTALL_DIR: D:\a\_temp\uv-python-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3559785Z   UV_CACHE_DIR: D:\a\_temp\setup-uv-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3560068Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3565979Z ##[start-action display=Run #!/bin/bash;id=__sigstore_cosign-installer.__run]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3693829Z ##[group]Run #!/bin/bash
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3694570Z ^[[36;1m#!/bin/bash^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3694892Z ^[[36;1m# Substitute environment variables in install-dir input^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3695328Z ^[[36;1minstall_dir=$(envsubst <<<"${input_install_dir}")^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3695667Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3695873Z ^[[36;1m# cosign install script^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3696155Z ^[[36;1mshopt -s expand_aliases^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3696431Z ^[[36;1mif [ -z "$NO_COLOR" ]; then^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3696758Z ^[[36;1m  alias log_info="echo -e \"\033[1;32mINFO\033[0m:\""^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3697163Z ^[[36;1m  alias log_error="echo -e \"\033[1;31mERROR\033[0m:\""^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3697490Z ^[[36;1melse^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3697722Z ^[[36;1m  alias log_info="echo \"INFO:\""^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3698019Z ^[[36;1m  alias log_error="echo \"ERROR:\""^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3698307Z ^[[36;1mfi^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3698506Z ^[[36;1mset -e^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3698715Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3698907Z ^[[36;1mCURL_RETRIES=3^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3699133Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3699363Z ^[[36;1m# This function helps compare versions.^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3699723Z ^[[36;1m# Returns 0 if version1 >= version2, 1 otherwise.^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3700082Z ^[[36;1m# Usage: is_version_ge "3.0.0" "$version_num"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3700392Z ^[[36;1mis_version_ge() {^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3700709Z ^[[36;1m    [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" == "$1" ]^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3701038Z ^[[36;1m}^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3701226Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3701525Z ^[[36;1m# Check for unsupported old versions (anything below v2.0.0)^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3701946Z ^[[36;1mif [[ "${input_cosign_release}" != "main" ]]; then^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3702334Z ^[[36;1m  # Extract version without 'v' prefix for comparison^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3702928Z ^[[36;1m  version_num="${input_cosign_release}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3703240Z ^[[36;1m  version_num="${version_num#v}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3703511Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3703732Z ^[[36;1m  # Check if version is less than v2.0.0^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3704072Z ^[[36;1m  if ! is_version_ge "2.0.0" "$version_num"; then^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3704495Z ^[[36;1m    log_error "cosign versions below v2.0.0 are no longer supported."^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3704960Z ^[[36;1m    log_error "Requested version: ${input_cosign_release}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3705352Z ^[[36;1m    log_error "Please use cosign v2.6.0 or later."^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3707579Z ^[[36;1m    log_error "See https://github.com/sigstore/cosign/releases for available versions."^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3708103Z ^[[36;1m    exit 1^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3708327Z ^[[36;1m  fi^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3708522Z ^[[36;1mfi^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3708913Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3709131Z ^[[36;1mmkdir -p "${install_dir}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3709398Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3709661Z ^[[36;1mif [[ "${input_cosign_release}" == "main" ]]; then^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3710124Z ^[[36;1m  log_info "installing cosign via 'go install' from its main version"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3710529Z ^[[36;1m  GOBIN=$(go env GOPATH)/bin^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3710880Z ^[[36;1m  go install github.com/sigstore/cosign/v3/cmd/cosign@main^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3711280Z ^[[36;1m  ln -s "$GOBIN/cosign" "${install_dir}/cosign"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3711587Z ^[[36;1m  exit 0^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3711796Z ^[[36;1mfi^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3711990Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3712187Z ^[[36;1mshaprog() {^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3712432Z ^[[36;1m  case ${runner_os} in^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3712695Z ^[[36;1m    Linux|linux)^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3712968Z ^[[36;1m      sha256sum "$1" | cut -d' ' -f1^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3713255Z ^[[36;1m      ;;^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3713470Z ^[[36;1m    macOS|macos)^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3713726Z ^[[36;1m      shasum -a256 "$1" | cut -d' ' -f1^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3714201Z ^[[36;1m      ;;^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3714429Z ^[[36;1m    Windows|windows)^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3714961Z ^[[36;1m      powershell -command "(Get-FileHash $1 -Algorithm SHA256 | Select-Object -ExpandProperty Hash).ToLower()"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3715496Z ^[[36;1m      ;;^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3715700Z ^[[36;1m    *)^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3715962Z ^[[36;1m      log_error "unsupported OS ${runner_os}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3716267Z ^[[36;1m      exit 1^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3716489Z ^[[36;1m      ;;^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3716688Z ^[[36;1m  esac^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3716888Z ^[[36;1m}^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3717076Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3717501Z ^[[36;1m## curl -sL https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign_checksums.txt |\^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3718250Z ^[[36;1m##   gawk 'match($2,/^cosign-([[:alnum:]]+)-([[:alnum:]]+)(\.[[:alnum:]]+)?$/,a){printf "bootstrap_%s_%s_sha=\"%s\"\n",a[1],a[2],$1}' |\^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3718765Z ^[[36;1m##   LANG=C sort^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3719009Z ^[[36;1mbootstrap_version='v3.0.6'^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3719509Z ^[[36;1mbootstrap_darwin_amd64_sha="4c3e7af8372d3ca3296e62fa56f23fcbb5721cc6ac1827900d398f110d7cd280"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3720196Z ^[[36;1mbootstrap_darwin_arm64_sha="5fadd012ae6381a6a29ff86a7d39aa873878852f1073fc90b15995961ecfb084"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3720884Z ^[[36;1mbootstrap_linux_amd64_sha="c956e5dfcac53d52bcf058360d579472f0c1d2d9b69f55209e256fe7783f4c74"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3721569Z ^[[36;1mbootstrap_linux_arm64_sha="bedac92e8c3729864e13d4a17048007cfafa79d5deca993a43a90ffe018ef2b8"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3722253Z ^[[36;1mbootstrap_linux_arm_sha="67bd25d32daff5664caf51208c95defcb2ad7ac1296f394fa677bb8bacee62f5"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3722953Z ^[[36;1mbootstrap_linux_ppc64le_sha="08c3e5e0a09c440f49e9a69d8639d37fbec522ec8c5c0ac805243b098e6ea512"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3723634Z ^[[36;1mbootstrap_linux_riscv64_sha="e25952e798958b0f9168d044153ccc353f5469ca4b71a1707dffad0534d27017"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3724487Z ^[[36;1mbootstrap_linux_s390x_sha="3cf4b769258ed9cc3c2a93268c0d5c1cc3fbd094af8df21035cbac8fb0d7c088"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3725181Z ^[[36;1mbootstrap_windows_amd64_sha="9b85a88ebff2d9dd30ff4984a6f61f2cedc232dd87d81fa7f2ff3c0ed96c241c"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3725651Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3725867Z ^[[36;1mcosign_executable_name=cosign^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3726138Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3726338Z ^[[36;1mtrap "popd >/dev/null" EXIT^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3726601Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3726814Z ^[[36;1mpushd "${install_dir}" > /dev/null^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3727087Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3727841Z ^[[36;1mcase ${runner_os} in^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3728115Z ^[[36;1m  Linux|linux)^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3728363Z ^[[36;1m    case ${runner_arch} in^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3728623Z ^[[36;1m      X64|amd64)^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3729128Z ^[[36;1m        bootstrap_filename='cosign-linux-amd64'^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3729516Z ^[[36;1m        bootstrap_sha=${bootstrap_linux_amd64_sha}^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3729902Z ^[[36;1m        desired_cosign_filename='cosign-linux-amd64'^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3730220Z ^[[36;1m        ;;^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3730435Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3730636Z ^[[36;1m      ARM|arm)^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3730910Z ^[[36;1m        bootstrap_filename='cosign-linux-arm'^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3731258Z ^[[36;1m        bootstrap_sha=${bootstrap_linux_arm_sha}^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3731633Z ^[[36;1m        desired_cosign_filename='cosign-linux-arm'^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3731934Z ^[[36;1m        ;;^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3732134Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3732330Z ^[[36;1m      ARM64|arm64)^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3732602Z ^[[36;1m        bootstrap_filename='cosign-linux-arm64'^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3732953Z ^[[36;1m        bootstrap_sha=${bootstrap_linux_arm64_sha}^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3733320Z ^[[36;1m        desired_cosign_filename='cosign-linux-arm64'^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3733644Z ^[[36;1m        ;;^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3733844Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3734085Z ^[[36;1m      *)^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3734486Z ^[[36;1m        log_error "unsupported architecture ${runner_arch}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3734829Z ^[[36;1m        exit 1^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3735040Z ^[[36;1m        ;;^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3735241Z ^[[36;1m    esac^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3735437Z ^[[36;1m    ;;^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3735630Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3735818Z ^[[36;1m  macOS|macos)^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3736058Z ^[[36;1m    case ${runner_arch} in^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3736320Z ^[[36;1m      X64|amd64)^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3736591Z ^[[36;1m        bootstrap_filename='cosign-darwin-amd64'^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3736958Z ^[[36;1m        bootstrap_sha=${bootstrap_darwin_amd64_sha}^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3737335Z ^[[36;1m        desired_cosign_filename='cosign-darwin-amd64'^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3737653Z ^[[36;1m        ;;^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3737849Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3738039Z ^[[36;1m      ARM64|arm64)^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3738324Z ^[[36;1m        bootstrap_filename='cosign-darwin-arm64'^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3738668Z ^[[36;1m        bootstrap_sha=${bootstrap_darwin_arm64_sha}^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3739031Z ^[[36;1m        desired_cosign_filename='cosign-darwin-arm64'^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3739337Z ^[[36;1m        ;;^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3739538Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3739713Z ^[[36;1m      *)^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3739991Z ^[[36;1m        log_error "unsupported architecture ${runner_arch}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3740319Z ^[[36;1m        exit 1^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3740528Z ^[[36;1m        ;;^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3740725Z ^[[36;1m    esac^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3740915Z ^[[36;1m    ;;^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3741107Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3741292Z ^[[36;1m  Windows|windows)^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3741536Z ^[[36;1m    case ${runner_arch} in^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3741926Z ^[[36;1m      X64|amd64)^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3742214Z ^[[36;1m        bootstrap_filename='cosign-windows-amd64.exe'^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3742596Z ^[[36;1m        bootstrap_sha=${bootstrap_windows_amd64_sha}^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3742991Z ^[[36;1m        desired_cosign_filename='cosign-windows-amd64.exe'^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3743359Z ^[[36;1m        cosign_executable_name=cosign.exe^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3743646Z ^[[36;1m        ;;^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3743848Z ^[[36;1m      *)^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3744117Z ^[[36;1m        log_error "unsupported architecture ${runner_arch}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3744440Z ^[[36;1m        exit 1^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3744700Z ^[[36;1m        ;;^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3745000Z ^[[36;1m    esac^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3745192Z ^[[36;1m    ;;^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3745390Z ^[[36;1m  *)^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3745638Z ^[[36;1m    log_error "unsupported os ${runner_os}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3745945Z ^[[36;1m    exit 1^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3746146Z ^[[36;1m    ;;^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3746346Z ^[[36;1mesac^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3746538Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3746714Z ^[[36;1mSUDO=^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3747042Z ^[[36;1mif [[ "${input_use_sudo}" == "true" ]] && command -v sudo >/dev/null; then^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3747423Z ^[[36;1m  SUDO=sudo^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3747630Z ^[[36;1mfi^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3747813Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3748076Z ^[[36;1mexpected_bootstrap_version_digest=${bootstrap_sha}^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3749208Z ^[[36;1mlog_info "Downloading bootstrap version '${bootstrap_version}' of cosign to verify version to be installed...\n      https://github.com/sigstore/cosign/releases/download/${bootstrap_version}/${bootstrap_filename}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3750529Z ^[[36;1m$SUDO curl --retry "${CURL_RETRIES}" -fsSL "https://github.com/sigstore/cosign/releases/download/${bootstrap_version}/${bootstrap_filename}" -o "${cosign_executable_name}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3751328Z ^[[36;1mshaBootstrap=$(shaprog "${cosign_executable_name}")^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3751779Z ^[[36;1mif [[ "$shaBootstrap" != "${expected_bootstrap_version_digest}" ]]; then^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3752291Z ^[[36;1m  log_error "Unable to validate cosign version: '${input_cosign_release}'"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3752678Z ^[[36;1m  exit 1^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3752879Z ^[[36;1mfi^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3753113Z ^[[36;1m$SUDO chmod +x "${cosign_executable_name}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3753397Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3753717Z ^[[36;1m# If the bootstrap and specified `cosign` releases are the same, we're done.^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3754291Z ^[[36;1mif [[ "${input_cosign_release}" == "${bootstrap_version}" ]]; then^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3754994Z ^[[36;1m  log_info "bootstrap version successfully verified and matches requested version so nothing else to do"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3755505Z ^[[36;1m  exit 0^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3755705Z ^[[36;1mfi^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3755898Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3756152Z ^[[36;1msemver='^v([0-9]+\.){0,2}(\*|[0-9]+)(-?r?c?)(\.[0-9]+)$'^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3756540Z ^[[36;1mif [[ "${input_cosign_release}" =~ $semver ]]; then^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3756976Z ^[[36;1m  log_info "Custom cosign version '${input_cosign_release}' requested"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3757355Z ^[[36;1melse^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3757717Z ^[[36;1m  log_error "Unable to validate requested cosign version: '${input_cosign_release}'"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3758146Z ^[[36;1m  exit 1^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3758345Z ^[[36;1mfi^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3758523Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3758720Z ^[[36;1m# Download custom cosign^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3759539Z ^[[36;1mlog_info "Downloading platform-specific version '${input_cosign_release}' of cosign...\n      https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${desired_cosign_filename}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3760834Z ^[[36;1m$SUDO curl --retry "${CURL_RETRIES}" -fsSL "https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${desired_cosign_filename}" -o "cosign_${input_cosign_release}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3761794Z ^[[36;1mshaCustom=$(shaprog "cosign_${input_cosign_release}");^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3762129Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3762356Z ^[[36;1m# same hash means it is the same release^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3762701Z ^[[36;1mif [[ "$shaCustom" != "$shaBootstrap" ]]; then^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3763517Z ^[[36;1m  log_info "Downloading cosign public key '${input_cosign_release}' of cosign...\n    https://raw.githubusercontent.com/sigstore/cosign/${input_cosign_release}/release/release-cosign.pub"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3764693Z ^[[36;1m  RELEASE_COSIGN_PUB_KEY=https://raw.githubusercontent.com/sigstore/cosign/${input_cosign_release}/release/release-cosign.pub^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3765488Z ^[[36;1m  RELEASE_COSIGN_PUB_KEY_SHA='f4cea466e5e887a45da5031757fa1d32655d83420639dc1758749b744179f126'^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3765951Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3766223Z ^[[36;1m  log_info "Verifying public key matches expected value"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3766717Z ^[[36;1m  $SUDO curl --retry "${CURL_RETRIES}" -fsSL "$RELEASE_COSIGN_PUB_KEY" -o public.key^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3767170Z ^[[36;1m  sha_fetched_key=$(shaprog public.key)^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3767588Z ^[[36;1m  if [[ "$sha_fetched_key" != "$RELEASE_COSIGN_PUB_KEY_SHA" ]]; then^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3768089Z ^[[36;1m    log_error "Fetched public key does not match expected digest, exiting"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3768485Z ^[[36;1m    exit 1^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3768688Z ^[[36;1m  fi^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3768882Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3769292Z ^[[36;1m  if is_version_ge "3.0.1" "$version_num"; then^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3769711Z ^[[36;1m    # we're trying to get something greater than or equal to v3.0.1^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3770179Z ^[[36;1m    keyless_signature_file=${desired_cosign_filename}.sigstore.json^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3771198Z ^[[36;1m    log_info "Downloading keyless verification bundle for platform-specific '${input_cosign_release}' of cosign...\n      https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${keyless_signature_file}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3772498Z ^[[36;1m    $SUDO curl --retry "${CURL_RETRIES}" -fsSLO "https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${keyless_signature_file}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3773132Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3773509Z ^[[36;1m    log_info "Using bootstrap cosign to verify keyless signature of desired cosign version"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3774865Z ^[[36;1m    "./${cosign_executable_name}" verify-blob --certificate-identity=keyless@projectsigstore.iam.gserviceaccount.com --certificate-oidc-issuer=https://accounts.google.com --bundle "${keyless_signature_file}" "cosign_${input_cosign_release}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3775846Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3776093Z ^[[36;1m    if is_version_ge "3.0.3" "$version_num"; then^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3776510Z ^[[36;1m      # we're trying to get something greater than or equal to v3.0.3^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3776986Z ^[[36;1m      kms_signature_file=${desired_cosign_filename}-kms.sigstore.json^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3777952Z ^[[36;1m      log_info "Downloading KMS verification bundle for platform-specific '${input_cosign_release}' of cosign...\n      https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${kms_signature_file}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3779168Z ^[[36;1m      $SUDO curl --retry "${CURL_RETRIES}" -fsSLO "https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${kms_signature_file}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3779787Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3780143Z ^[[36;1m      log_info "Using bootstrap cosign to verify signature of desired cosign version"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3780865Z ^[[36;1m      "./${cosign_executable_name}" verify-blob --key public.key --bundle "${kms_signature_file}" "cosign_${input_cosign_release}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3781407Z ^[[36;1m    fi^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3781726Z ^[[36;1m  else^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3781988Z ^[[36;1m    signature_file=${desired_cosign_filename}.sig^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3782872Z ^[[36;1m    log_info "Downloading detached signature for platform-specific '${input_cosign_release}' of cosign...\n      https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${signature_file}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3784040Z ^[[36;1m    $SUDO curl --retry "${CURL_RETRIES}" -fsSLO "https://github.com/sigstore/cosign/releases/download/${input_cosign_release}/${signature_file}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3784641Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3784992Z ^[[36;1m    log_info "Using bootstrap cosign to verify signature of desired cosign version"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3786227Z ^[[36;1m    "./${cosign_executable_name}" verify-blob --key public.key --signature "${signature_file}" "cosign_${input_cosign_release}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3786785Z ^[[36;1m  fi^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3786975Z ^[[36;1m^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3787205Z ^[[36;1m  $SUDO rm "${cosign_executable_name}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3787620Z ^[[36;1m  $SUDO mv "cosign_${input_cosign_release}" "${cosign_executable_name}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3788050Z ^[[36;1m  $SUDO chmod +x "${cosign_executable_name}"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3788376Z ^[[36;1m  log_info "Installation complete!"^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3788657Z ^[[36;1mfi^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3810895Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3811324Z env:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3811549Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3811841Z   GOTMPDIR: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3812053Z   TMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3812261Z   TEMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3812487Z   GOCACHE: D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3812724Z   GOMODCACHE: D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3812966Z   GOTOOLCHAIN: local
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3813269Z   ZIG_GLOBAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3813683Z   ZIG_LOCAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3814048Z   UV_TOOL_BIN_DIR: D:\a\_temp\uv-tool-bin-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3814343Z   UV_TOOL_DIR: D:\a\_temp\uv-tool-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3814660Z   UV_PYTHON_INSTALL_DIR: D:\a\_temp\uv-python-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3814983Z   UV_CACHE_DIR: D:\a\_temp\setup-uv-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3815268Z   input_cosign_release: v3.0.3
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3815545Z   input_install_dir: $HOME/.cosign
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3815811Z   input_use_sudo: false
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3816041Z   runner_arch: X64
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3816251Z   runner_os: Windows
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.3816470Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.7792402Z ^[[1;32mINFO^[[0m: Downloading bootstrap version 'v3.0.6' of cosign to verify version to be installed...
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:00.7793361Z       https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-windows-amd64.exe
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:02.4237959Z ^[[1;32mINFO^[[0m: Custom cosign version 'v3.0.3' requested
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:02.4238753Z ^[[1;32mINFO^[[0m: Downloading platform-specific version 'v3.0.3' of cosign...
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:02.4239501Z       https://github.com/sigstore/cosign/releases/download/v3.0.3/cosign-windows-amd64.exe
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:04.1121265Z ^[[1;32mINFO^[[0m: Downloading cosign public key 'v3.0.3' of cosign...
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:04.1122103Z     https://raw.githubusercontent.com/sigstore/cosign/v3.0.3/release/release-cosign.pub
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:04.1122794Z ^[[1;32mINFO^[[0m: Verifying public key matches expected value
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:04.7212218Z ^[[1;32mINFO^[[0m: Downloading keyless verification bundle for platform-specific 'v3.0.3' of cosign...
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:04.7213859Z       https://github.com/sigstore/cosign/releases/download/v3.0.3/cosign-windows-amd64.exe.sigstore.json
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:04.9915496Z ^[[1;32mINFO^[[0m: Using bootstrap cosign to verify keyless signature of desired cosign version
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:06.8929752Z Verified OK
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:06.9601184Z ^[[1;32mINFO^[[0m: Downloading KMS verification bundle for platform-specific 'v3.0.3' of cosign...
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:06.9603178Z       https://github.com/sigstore/cosign/releases/download/v3.0.3/cosign-windows-amd64.exe-kms.sigstore.json
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:07.1873587Z ^[[1;32mINFO^[[0m: Using bootstrap cosign to verify signature of desired cosign version
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:07.6406156Z Verified OK
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:08.9881121Z ^[[1;32mINFO^[[0m: Installation complete!
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:08.9931814Z ##[end-action id=__sigstore_cosign-installer.__run;outcome=success;conclusion=success;duration_ms=8636]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:08.9935741Z ##[start-action display=Run envsubst <<<"${input_install_dir}" >> "$GITHUB_PATH";id=__sigstore_cosign-installer.__run_2]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:08.9942651Z ##[end-action id=__sigstore_cosign-installer.__run_2;outcome=skipped;conclusion=skipped;duration_ms=0]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:08.9945443Z ##[start-action display=Run $install_dir = $ExecutionContext.InvokeCommand.ExpandString("${env:input_install_dir}");id=__sigstore_cosign-installer.__run_3]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.0084767Z ##[group]Run $install_dir = $ExecutionContext.InvokeCommand.ExpandString("${env:input_install_dir}")
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.0085523Z ^[[36;1m$install_dir = $ExecutionContext.InvokeCommand.ExpandString("${env:input_install_dir}")^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.0086183Z ^[[36;1mecho "${install_dir}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.0186132Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.0186521Z env:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.0186748Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.0187023Z   GOTMPDIR: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.0187252Z   TMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.0187464Z   TEMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.0187687Z   GOCACHE: D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.0187931Z   GOMODCACHE: D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.0188194Z   GOTOOLCHAIN: local
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.0188502Z   ZIG_GLOBAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.0188906Z   ZIG_LOCAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.0189271Z   UV_TOOL_BIN_DIR: D:\a\_temp\uv-tool-bin-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.0189574Z   UV_TOOL_DIR: D:\a\_temp\uv-tool-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.0189879Z   UV_PYTHON_INSTALL_DIR: D:\a\_temp\uv-python-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.0190205Z   UV_CACHE_DIR: D:\a\_temp\setup-uv-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.0190498Z   input_install_dir: $HOME/.cosign
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.0190758Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.4279801Z ##[end-action id=__sigstore_cosign-installer.__run_3;outcome=success;conclusion=success;duration_ms=433]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.4435482Z ##[group]Run anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.4436001Z with:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.4436217Z   run: download-syft
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.4436440Z env:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.4436644Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.4436912Z   GOTMPDIR: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.4437130Z   TMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.4437336Z   TEMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.4437555Z   GOCACHE: D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.4437788Z   GOMODCACHE: D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.4438027Z   GOTOOLCHAIN: local
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.4438331Z   ZIG_GLOBAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.4438731Z   ZIG_LOCAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.4439082Z   UV_TOOL_BIN_DIR: D:\a\_temp\uv-tool-bin-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.4439378Z   UV_TOOL_DIR: D:\a\_temp\uv-tool-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.4439677Z   UV_PYTHON_INSTALL_DIR: D:\a\_temp\uv-python-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.4440032Z   UV_CACHE_DIR: D:\a\_temp\setup-uv-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.4440296Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:09.6327905Z Downloading syft from https://github.com/anchore/syft/releases/download/v1.42.3/syft_1.42.3_windows_amd64.zip
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:10.0392302Z [command]"C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$ErrorActionPreference = 'Stop' ; try { Add-Type -AssemblyName System.IO.Compression.ZipFile } catch { } ; try { [System.IO.Compression.ZipFile]::ExtractToDirectory('D:\a\_temp\ccc96020-e770-4506-a350-08032c0870df', 'D:\a\_temp\84e704a2-db02-4b0b-b3a8-c18a888ac485', $true) } catch { if (($_.Exception.GetType().FullName -eq 'System.Management.Automation.MethodException') -or ($_.Exception.GetType().FullName -eq 'System.Management.Automation.RuntimeException') ){ Expand-Archive -LiteralPath 'D:\a\_temp\ccc96020-e770-4506-a350-08032c0870df' -DestinationPath 'D:\a\_temp\84e704a2-db02-4b0b-b3a8-c18a888ac485' -Force } else { throw $_ } } ;"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:10.6686538Z ##[group]Run task setup
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:10.6686939Z ^[[36;1mtask setup^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:10.6789665Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:10.6790056Z env:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:10.6790276Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:10.6790559Z   GOTMPDIR: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:10.6790771Z   TMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:10.6790990Z   TEMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:10.6791201Z   GOCACHE: D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:10.6791436Z   GOMODCACHE: D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:10.6791686Z   GOTOOLCHAIN: local
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:10.6791999Z   ZIG_GLOBAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:10.6792421Z   ZIG_LOCAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:10.6792785Z   UV_TOOL_BIN_DIR: D:\a\_temp\uv-tool-bin-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:10.6793094Z   UV_TOOL_DIR: D:\a\_temp\uv-tool-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:10.6793393Z   UV_PYTHON_INSTALL_DIR: D:\a\_temp\uv-python-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:10.6793764Z   UV_CACHE_DIR: D:\a\_temp\setup-uv-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:10.6794036Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:11.0253551Z ^[[32mtask: [setup] go mod tidy
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:11.4583554Z ^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:11.4856492Z ##[group]Run task build
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:11.4856833Z ^[[36;1mtask build^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:11.4961378Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:11.4961790Z env:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:11.4962014Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:11.4962297Z   GOTMPDIR: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:11.4962515Z   TMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:11.4962722Z   TEMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:11.4962941Z   GOCACHE: D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:11.4963175Z   GOMODCACHE: D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:11.4963423Z   GOTOOLCHAIN: local
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:11.4963977Z   ZIG_GLOBAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:11.4964395Z   ZIG_LOCAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:11.4964742Z   UV_TOOL_BIN_DIR: D:\a\_temp\uv-tool-bin-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:11.4965046Z   UV_TOOL_DIR: D:\a\_temp\uv-tool-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:11.4965356Z   UV_PYTHON_INSTALL_DIR: D:\a\_temp\uv-python-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:11.4965715Z   UV_CACHE_DIR: D:\a\_temp\setup-uv-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:11.4965996Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:11.8727428Z ^[[32mtask: [build] go build
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:19.4374425Z ^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:19.4658449Z ##[group]Run task test RACE=false COVER=false TEST_OPTIONS=-count=1
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:19.4659103Z ^[[36;1mtask test RACE=false COVER=false TEST_OPTIONS=-count=1^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:19.4764730Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:19.4765156Z env:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:19.4765409Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:19.4765687Z   GOTMPDIR: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:19.4765912Z   TMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:19.4766119Z   TEMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:19.4766325Z   GOCACHE: D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:19.4766568Z   GOMODCACHE: D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:19.4766822Z   GOTOOLCHAIN: local
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:19.4767131Z   ZIG_GLOBAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:19.4767542Z   ZIG_LOCAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:19.4767918Z   UV_TOOL_BIN_DIR: D:\a\_temp\uv-tool-bin-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:19.4768250Z   UV_TOOL_DIR: D:\a\_temp\uv-tool-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:19.4768649Z   UV_PYTHON_INSTALL_DIR: D:\a\_temp\uv-python-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:19.4769952Z   UV_CACHE_DIR: D:\a\_temp\setup-uv-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:19.4770233Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:19.8097237Z ^[[32mtask: [test] go test -count=1 -failfast   ./... -run . -timeout=15m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:05:27.0096472Z ok  	github.com/goreleaser/goreleaser/v2	0.167s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:08.8208527Z ok  	github.com/goreleaser/goreleaser/v2/cmd	40.289s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:08.8210643Z ok  	github.com/goreleaser/goreleaser/v2/internal/archivefiles	0.154s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:08.8275582Z ok  	github.com/goreleaser/goreleaser/v2/internal/artifact	0.057s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:08.8317671Z ok  	github.com/goreleaser/goreleaser/v2/internal/builders/base	0.221s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:08.8348238Z ok  	github.com/goreleaser/goreleaser/v2/internal/builders/bun	5.403s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:08.8369622Z ok  	github.com/goreleaser/goreleaser/v2/internal/builders/deno	3.682s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:08.8398378Z ok  	github.com/goreleaser/goreleaser/v2/internal/builders/golang	14.762s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:08.8402343Z ok  	github.com/goreleaser/goreleaser/v2/internal/builders/golang/gomain	0.807s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:08.8406601Z ok  	github.com/goreleaser/goreleaser/v2/internal/builders/node	13.343s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:08.8408481Z ok  	github.com/goreleaser/goreleaser/v2/internal/builders/poetry	16.602s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4572680Z ok  	github.com/goreleaser/goreleaser/v2/internal/builders/rust	41.845s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4574977Z ok  	github.com/goreleaser/goreleaser/v2/internal/builders/uv	0.773s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4582148Z ok  	github.com/goreleaser/goreleaser/v2/internal/builders/zig	30.705s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4602060Z ok  	github.com/goreleaser/goreleaser/v2/internal/cargo	0.048s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4616980Z ok  	github.com/goreleaser/goreleaser/v2/internal/changelog	0.016s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4634515Z ok  	github.com/goreleaser/goreleaser/v2/internal/client	16.891s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4637310Z ok  	github.com/goreleaser/goreleaser/v2/internal/commitauthor	0.038s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4639193Z ok  	github.com/goreleaser/goreleaser/v2/internal/deprecate	0.028s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4640436Z ok  	github.com/goreleaser/goreleaser/v2/internal/elf	0.368s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4643162Z ok  	github.com/goreleaser/goreleaser/v2/internal/exec	0.910s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4660229Z ok  	github.com/goreleaser/goreleaser/v2/internal/experimental	0.047s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4666899Z ok  	github.com/goreleaser/goreleaser/v2/internal/extrafiles	0.054s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4687309Z ok  	github.com/goreleaser/goreleaser/v2/internal/gerrors	0.019s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4704497Z ok  	github.com/goreleaser/goreleaser/v2/internal/gio	0.110s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4707749Z ok  	github.com/goreleaser/goreleaser/v2/internal/git	2.534s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4721902Z ?   	github.com/goreleaser/goreleaser/v2/internal/golden	[no test files]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4732264Z ok  	github.com/goreleaser/goreleaser/v2/internal/http	0.756s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4744973Z ok  	github.com/goreleaser/goreleaser/v2/internal/ids	0.021s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4749755Z ok  	github.com/goreleaser/goreleaser/v2/internal/logext	0.027s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4754196Z ?   	github.com/goreleaser/goreleaser/v2/internal/middleware	[no test files]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4756068Z ok  	github.com/goreleaser/goreleaser/v2/internal/middleware/errhandler	0.100s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4767942Z ok  	github.com/goreleaser/goreleaser/v2/internal/middleware/logging	0.205s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4768903Z ok  	github.com/goreleaser/goreleaser/v2/internal/middleware/skip	0.232s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4769795Z ok  	github.com/goreleaser/goreleaser/v2/internal/nodedist	0.102s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4781123Z ok  	github.com/goreleaser/goreleaser/v2/internal/packagejson	0.054s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4785881Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe	0.161s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4786770Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/announce	0.124s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4787739Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/archive	0.528s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:27.4789007Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/artifactory	0.148s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:39.4439013Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/aur	13.431s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:40.3560802Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/aursources	13.332s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:40.3575311Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/before	0.752s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:40.3579845Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/blob	0.100s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:40.3593645Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/bluesky	0.119s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:40.3634975Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/brew	1.365s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:40.3638550Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/build	0.463s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:40.3641033Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/cask	1.223s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:50.4573939Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/changelog	13.874s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:50.4575123Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/checksums	0.094s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:50.4576175Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/chocolatey	0.057s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:50.4577260Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/custompublishers	0.098s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:50.4578962Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/defaults	1.366s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:50.4579950Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/discord	0.060s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:50.4580909Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/discourse	0.058s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:50.4581842Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/dist	0.046s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:52.7273617Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/docker	6.607s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:52.8672901Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/docker/v2	6.615s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:52.8675545Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/dockerdigest	0.039s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:52.8725707Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/effectiveconfig	0.020s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:52.8727285Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/env	0.065s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:06:52.8830181Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/flatpak	0.058s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3274662Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/git	30.592s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3276271Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/gomod	2.231s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3278893Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/iru	0.169s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3279859Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/ko	5.901s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3280783Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/krew	0.983s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3282887Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/linkedin	0.065s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3283853Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/makeself	0.049s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3287663Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/mastodon	0.061s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3288816Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/mattermost	0.060s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3290882Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/mcp	0.110s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3299157Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/metadata	0.091s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3305048Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/milestone	1.016s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3312366Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/nfpm	2.055s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3313552Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/nix	0.651s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3314810Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/notary	0.070s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3319414Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/opencollective	0.065s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3320890Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/partial	0.035s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3322072Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/prebuild	0.053s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3323367Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/project	1.201s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3325659Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/publish	0.173s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3328324Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/reddit	0.067s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3369848Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/release	3.009s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3373132Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/reportsizes	0.030s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3374678Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/sbom	2.767s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3375844Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/scoop	1.338s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:21.3379257Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/semver	0.132s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4104244Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/sign	22.306s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4105183Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/slack	0.095s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4106342Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/smtp	0.042s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4107437Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/snapcraft	0.064s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4108421Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/snapshot	0.055s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4109424Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/sourcearchive	1.240s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4110337Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/srpm	0.050s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4111254Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/teams	0.045s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4112146Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/telegram	0.116s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4112806Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/twitter	0.077s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4113393Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/universalbinary	1.027s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4114319Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/upload	0.271s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4114882Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/upx	0.359s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4115410Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/webhook	0.147s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4115951Z ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/winget	0.426s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4116510Z ?   	github.com/goreleaser/goreleaser/v2/internal/pipeline	[no test files]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4117068Z ok  	github.com/goreleaser/goreleaser/v2/internal/pyproject	0.065s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4117584Z ok  	github.com/goreleaser/goreleaser/v2/internal/redact	0.025s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4118067Z ok  	github.com/goreleaser/goreleaser/v2/internal/retryx	0.044s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4118782Z ok  	github.com/goreleaser/goreleaser/v2/internal/semerrgroup	0.035s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4119301Z ok  	github.com/goreleaser/goreleaser/v2/internal/shell	0.114s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4119778Z ok  	github.com/goreleaser/goreleaser/v2/internal/skips	0.028s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4120551Z ok  	github.com/goreleaser/goreleaser/v2/internal/static	0.028s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4121075Z ok  	github.com/goreleaser/goreleaser/v2/internal/summary	0.034s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4121614Z ?   	github.com/goreleaser/goreleaser/v2/internal/testctx	[no test files]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4122146Z ok  	github.com/goreleaser/goreleaser/v2/internal/testlib	0.377s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4122627Z ok  	github.com/goreleaser/goreleaser/v2/internal/tmpl	0.059s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4123108Z ok  	github.com/goreleaser/goreleaser/v2/internal/yaml	0.025s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4123573Z ok  	github.com/goreleaser/goreleaser/v2/pkg/archive	0.119s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4124244Z ok  	github.com/goreleaser/goreleaser/v2/pkg/archive/gzip	0.042s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4124748Z ok  	github.com/goreleaser/goreleaser/v2/pkg/archive/tar	0.070s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4125289Z ok  	github.com/goreleaser/goreleaser/v2/pkg/archive/targz	0.062s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4125789Z ok  	github.com/goreleaser/goreleaser/v2/pkg/archive/tarxz	0.073s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4126299Z ok  	github.com/goreleaser/goreleaser/v2/pkg/archive/tarzst	0.090s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4126992Z ok  	github.com/goreleaser/goreleaser/v2/pkg/archive/xz	0.054s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4127481Z ok  	github.com/goreleaser/goreleaser/v2/pkg/archive/zip	0.096s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4127955Z ok  	github.com/goreleaser/goreleaser/v2/pkg/build	0.091s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4128407Z ok  	github.com/goreleaser/goreleaser/v2/pkg/config	0.034s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4128856Z ok  	github.com/goreleaser/goreleaser/v2/pkg/context	0.022s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4129483Z ?   	github.com/goreleaser/goreleaser/v2/pkg/defaults	[no test files]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.4130055Z ok  	github.com/goreleaser/goreleaser/v2/pkg/healthcheck	0.056s
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.7570039Z ^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.7930325Z ##[group]Run git diff
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.7930695Z ^[[36;1mgit diff^[[0m
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.8036015Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.8036408Z env:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.8036636Z   DOCKER_CLI_EXPERIMENTAL: enabled
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.8036925Z   GOTMPDIR: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.8037166Z   TMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.8037377Z   TEMP: D:\tmp
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.8037589Z   GOCACHE: D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.8037821Z   GOMODCACHE: D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.8038072Z   GOTOOLCHAIN: local
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.8038380Z   ZIG_GLOBAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.8038809Z   ZIG_LOCAL_CACHE_DIR: D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.8039162Z   UV_TOOL_BIN_DIR: D:\a\_temp\uv-tool-bin-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.8039474Z   UV_TOOL_DIR: D:\a\_temp\uv-tool-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.8039808Z   UV_PYTHON_INSTALL_DIR: D:\a\_temp\uv-python-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.8040186Z   UV_CACHE_DIR: D:\a\_temp\setup-uv-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:39.8040474Z ##[endgroup]
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:40.2701222Z Post job cleanup.
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:40.4214558Z UV_CACHE_DIR is already set to D:\a\_temp\setup-uv-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:40.4219911Z UV_PYTHON_INSTALL_DIR is already set to D:\a\_temp\uv-python-dir
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:40.4222889Z Cache hit occurred on key setup-uv-2-x86_64-pc-windows-msvc-windows-2025-3.12.10-1472b101372efdfaea191c0f58d7baafced473780cbe79c2e88e1ffee5d9ceb3, not saving cache.
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:40.5573820Z Post job cleanup.
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:40.7067720Z Caching is not enabled. Caching is skipped.
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:40.7358539Z Post job cleanup.
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:40.9700476Z Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:40.9701953Z Post job cleanup.
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:41.3200672Z Checking size of cache directory at D:\a\goreleaser\goreleaser\.zig-cache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:41.3912913Z Cache directory is 110231486 bytes, below limit of 2147483648 bytes; keeping intact
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:41.3920593Z Failed to read build.zig.zon (using latest): Error: ENOENT: no such file or directory, open 'D:\a\goreleaser\goreleaser\build.zig.zon'
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:41.9314686Z Saving Zig cache with key 'setup-zig-cache-v2-test-zig-x86_64-windows-0.16.0--33293816383-1'
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:42.0353240Z [command]"C:\Program Files\Git\usr\bin\tar.exe" --posix -cf cache.tzst --exclude cache.tzst -P -C D:/a/goreleaser/goreleaser --files-from manifest.txt --force-local --use-compress-program "zstd -T0"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:43.3621723Z Sent 33854329 of 33854329 (100.0%), 47.7 MBs/sec
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:43.5274060Z Post job cleanup.
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:43.7022786Z Post job cleanup.
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:43.9367686Z [command]C:\hostedtoolcache\windows\go\1.27.0\x64\bin\go.exe env GOCACHE
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:43.9445369Z [command]C:\hostedtoolcache\windows\go\1.27.0\x64\bin\go.exe env GOMODCACHE
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:43.9723160Z D:\gocache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:43.9746678Z D:\gomodcache
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:43.9768603Z Cache hit occurred on the primary key setup-go-Windows-x64-go-1.27.0-4effc5d79fd735aa8ad13170a172cf2e131e53a29f71095d44234c448ca04db9, not saving cache.
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:44.0061698Z Post job cleanup.
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:44.2003600Z [command]"C:\Program Files\Git\bin\git.exe" version
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:44.2280424Z git version 2.55.0.windows.5
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:44.2339254Z Temporarily overriding HOME='D:\a\_temp\cd4d7b59-6124-4ab6-a150-e57e8a7fece0' before making global git config changes
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:44.2340253Z Adding repository directory to the temporary git global config as a safe directory
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:44.2350216Z [command]"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\goreleaser\goreleaser
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:44.2648837Z Removing SSH command configuration
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:44.2660186Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp core\.sshCommand
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:44.2967515Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:44.8444382Z Removing HTTP extra header
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:44.8460246Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:44.8758809Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :\""
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:45.4178017Z Removing includeIf entries pointing to credentials config files
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:45.4190187Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp ^includeIf\.gitdir:
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:45.4451685Z includeif.gitdir:D:/a/goreleaser/goreleaser/.git.path
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:45.4452765Z includeif.gitdir:D:/a/goreleaser/goreleaser/.git/worktrees/*.path
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:45.4453285Z includeif.gitdir:/github/workspace/.git.path
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:45.4453792Z includeif.gitdir:/github/workspace/.git/worktrees/*.path
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:45.4494198Z [command]"C:\Program Files\Git\bin\git.exe" config --local --get-all includeif.gitdir:D:/a/goreleaser/goreleaser/.git.path
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:45.4754977Z D:\a\_temp\git-credentials-39e3b392-9639-4b42-97e8-20980f59b021.config
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:45.4798651Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset includeif.gitdir:D:/a/goreleaser/goreleaser/.git.path D\:\\a\\_temp\\git\-credentials\-39e3b392\-9639\-4b42\-97e8\-20980f59b021\.config
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:45.5149957Z [command]"C:\Program Files\Git\bin\git.exe" config --local --get-all includeif.gitdir:D:/a/goreleaser/goreleaser/.git/worktrees/*.path
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:45.5401526Z D:\a\_temp\git-credentials-39e3b392-9639-4b42-97e8-20980f59b021.config
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:45.5439897Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset includeif.gitdir:D:/a/goreleaser/goreleaser/.git/worktrees/*.path D\:\\a\\_temp\\git\-credentials\-39e3b392\-9639\-4b42\-97e8\-20980f59b021\.config
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:45.5736074Z [command]"C:\Program Files\Git\bin\git.exe" config --local --get-all includeif.gitdir:/github/workspace/.git.path
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:45.5983456Z /github/runner_temp/git-credentials-39e3b392-9639-4b42-97e8-20980f59b021.config
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:45.6022600Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset includeif.gitdir:/github/workspace/.git.path \/github\/runner_temp\/git\-credentials\-39e3b392\-9639\-4b42\-97e8\-20980f59b021\.config
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:45.6316843Z [command]"C:\Program Files\Git\bin\git.exe" config --local --get-all includeif.gitdir:/github/workspace/.git/worktrees/*.path
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:45.6562469Z /github/runner_temp/git-credentials-39e3b392-9639-4b42-97e8-20980f59b021.config
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:45.6601445Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset includeif.gitdir:/github/workspace/.git/worktrees/*.path \/github\/runner_temp\/git\-credentials\-39e3b392\-9639\-4b42\-97e8\-20980f59b021\.config
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:45.6892202Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "git config --local --show-origin --name-only --get-regexp remote.origin.url"
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:46.2092270Z Removing credentials config 'D:\a\_temp\git-credentials-39e3b392-9639-4b42-97e8-20980f59b021.config'
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:46.2297988Z Cleaning up orphan processes
+test (windows-latest)	UNKNOWN STEP	2026-08-30T05:07:46.2505781Z ##[warning]Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+semgrep / scan	UNKNOWN STEP	﻿2026-08-30T05:02:50.9563612Z Current runner version: '2.336.0'
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9609927Z ##[group]Runner Image Provisioner
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9610810Z Hosted Compute Agent
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9611410Z Version: 20260819.586
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9612408Z Commit: 3cc4a88dfa507ef76119ad1bb3eccc6378bb2b76
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9613164Z Build Date: 2026-08-18T23:20:18Z
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9613840Z Worker ID: {6a688053-a24d-4797-bd76-856027d35e4a}
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9614636Z Azure Region: westcentralus
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9615298Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9616845Z ##[group]Operating System
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9617562Z Ubuntu
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9618079Z 24.04.4
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9618676Z LTS
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9619209Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9619853Z ##[group]Runner Image
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9620492Z Image: ubuntu-24.04
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9621077Z Version: 20260823.283.1
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9622907Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260823.283/images/ubuntu/Ubuntu2404-Readme.md
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9624898Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260823.283
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9625937Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9627108Z ##[group]GITHUB_TOKEN Permissions
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9628996Z Contents: read
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9629651Z Metadata: read
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9630316Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9632646Z Secret source: Actions
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:50.9633795Z Prepare workflow directory
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.0063120Z Prepare all required actions
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.0109515Z Getting action download info
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.2830183Z Download action repository 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' (SHA:11bd71901bbe5b1630ceea73d27597364c9af683)
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.4924118Z Uses: caarlos0/meta/.github/workflows/semgrep.yml@c7f17af352dac91fa6c785d06ebac8547f1abdd3
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.4928411Z Complete job name: semgrep / scan
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.5440177Z ##[group]Checking docker version
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.5453429Z ##[command]/usr/bin/docker version --format '{{.Server.APIVersion}}'
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.6304182Z '1.48'
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.6320440Z Docker daemon API version: '1.48'
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.6321217Z ##[command]/usr/bin/docker version --format '{{.Client.APIVersion}}'
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.6475235Z '1.48'
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.6488486Z Docker client API version: '1.48'
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.6493872Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.6497239Z ##[group]Clean up resources from previous jobs
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.6503424Z ##[command]/usr/bin/docker ps --all --quiet --no-trunc --filter "label=6a289b"
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.6644606Z ##[command]/usr/bin/docker network prune --force --filter "label=6a289b"
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.6770805Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.6771323Z ##[group]Create local container network
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.6781118Z ##[command]/usr/bin/docker network create --label 6a289b github_network_ccb3031f6a32474d83c9a2ec256f3eaf
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.7274073Z 8b80f5ddf5676b2a5e366f073a856da0a58e90a5aefa5292298466be375d97e4
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.7290747Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.7314132Z ##[group]Starting job container
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.7334830Z ##[command]/usr/bin/docker pull returntocorp/semgrep
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:51.7432474Z Using default tag: latest
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:52.7814370Z latest: Pulling from returntocorp/semgrep
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.6804574Z e6f31ffc071e: Pulling fs layer
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.6805420Z 3ffe04bd0c61: Pulling fs layer
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.6805965Z bd9ddc54bea9: Pulling fs layer
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.6806613Z 530825806c17: Pulling fs layer
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.6807024Z 7c783a7dab56: Pulling fs layer
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.6807796Z 153ebbd71817: Pulling fs layer
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.6808509Z b81f4fa42ca7: Pulling fs layer
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.6809209Z a26ca32878e9: Pulling fs layer
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.6810566Z 5ece59f7e06f: Pulling fs layer
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.6811350Z 44ff57672fe6: Pulling fs layer
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.6812336Z 34e41733e944: Pulling fs layer
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.6813319Z e7004f04c956: Pulling fs layer
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.6814463Z e5f1faee6872: Pulling fs layer
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.6815679Z 530825806c17: Waiting
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.6816196Z 7c783a7dab56: Waiting
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.6816550Z 153ebbd71817: Waiting
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.6816909Z b81f4fa42ca7: Waiting
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.6817259Z a26ca32878e9: Waiting
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.6817616Z 5ece59f7e06f: Waiting
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.6817971Z 44ff57672fe6: Waiting
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.6818317Z 34e41733e944: Waiting
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.6818728Z e7004f04c956: Waiting
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.6819253Z e5f1faee6872: Waiting
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.8810074Z bd9ddc54bea9: Verifying Checksum
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:53.8811443Z bd9ddc54bea9: Download complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:54.0567289Z e6f31ffc071e: Verifying Checksum
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:54.0568807Z e6f31ffc071e: Download complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:54.1903112Z 3ffe04bd0c61: Download complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:54.2030877Z e6f31ffc071e: Pull complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:54.2390747Z 530825806c17: Verifying Checksum
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:54.2391651Z 530825806c17: Download complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:54.6136322Z b81f4fa42ca7: Verifying Checksum
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:54.6137962Z b81f4fa42ca7: Download complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:54.8172673Z a26ca32878e9: Verifying Checksum
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:54.8173950Z a26ca32878e9: Download complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:55.0103587Z 7c783a7dab56: Verifying Checksum
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:55.0104424Z 7c783a7dab56: Download complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:55.0243223Z 5ece59f7e06f: Verifying Checksum
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:55.0244328Z 5ece59f7e06f: Download complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:55.2132994Z 44ff57672fe6: Verifying Checksum
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:55.2134459Z 44ff57672fe6: Download complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:55.2213744Z 34e41733e944: Verifying Checksum
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:55.2215964Z 34e41733e944: Download complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:55.2590288Z 153ebbd71817: Verifying Checksum
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:55.2592021Z 153ebbd71817: Download complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:55.4157989Z e7004f04c956: Verifying Checksum
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:55.4159103Z e7004f04c956: Download complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:55.4232979Z e5f1faee6872: Download complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:58.1821475Z 3ffe04bd0c61: Pull complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:58.1923271Z bd9ddc54bea9: Pull complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:58.2312598Z 530825806c17: Pull complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:02:58.9619434Z 7c783a7dab56: Pull complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:04.8149052Z 153ebbd71817: Pull complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:04.8762420Z b81f4fa42ca7: Pull complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:04.8866319Z a26ca32878e9: Pull complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:04.8985375Z 5ece59f7e06f: Pull complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:04.9064063Z 44ff57672fe6: Pull complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:04.9163262Z 34e41733e944: Pull complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:04.9244984Z e7004f04c956: Pull complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:04.9324339Z e5f1faee6872: Pull complete
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:04.9361539Z Digest: sha256:f1f7b71861c7b28b6e0f661225a2c4f58a484f5d0f182465c6d6b3b22f972ade
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:04.9373603Z Status: Downloaded newer image for returntocorp/semgrep:latest
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:04.9382366Z docker.io/returntocorp/semgrep:latest
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:04.9459889Z ##[command]/usr/bin/docker create --name f58d3680f978468795bcbea2d21998ba_returntocorpsemgrep_856123 --label 6a289b --workdir /__w/goreleaser/goreleaser --network github_network_ccb3031f6a32474d83c9a2ec256f3eaf  -e "HOME=/github/home" -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work":"/__w" -v "/home/runner/actions-runner/cached/2.336.0/externals":"/__e":ro -v "/home/runner/work/_temp":"/__w/_temp" -v "/home/runner/work/_actions":"/__w/_actions" -v "/opt/hostedtoolcache":"/__t" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" --entrypoint "tail" returntocorp/semgrep "-f" "/dev/null"
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:04.9697296Z a2f04c1bd5223b9430b33af04b043f8645bb35927bc8cf17805e280beca5df3d
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:04.9719059Z ##[command]/usr/bin/docker start a2f04c1bd5223b9430b33af04b043f8645bb35927bc8cf17805e280beca5df3d
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.1484616Z a2f04c1bd5223b9430b33af04b043f8645bb35927bc8cf17805e280beca5df3d
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.1513780Z ##[command]/usr/bin/docker ps --all --filter id=a2f04c1bd5223b9430b33af04b043f8645bb35927bc8cf17805e280beca5df3d --filter status=running --no-trunc --format "{{.ID}} {{.Status}}"
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.1632956Z a2f04c1bd5223b9430b33af04b043f8645bb35927bc8cf17805e280beca5df3d Up Less than a second
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.1652749Z ##[command]/usr/bin/docker inspect --format "{{range .Config.Env}}{{println .}}{{end}}" a2f04c1bd5223b9430b33af04b043f8645bb35927bc8cf17805e280beca5df3d
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.1766660Z GITHUB_ACTIONS=true
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.1767310Z CI=true
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.1767813Z HOME=/github/home
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.1768505Z PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.1769273Z SEMGREP_IN_DOCKER=1
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.1769651Z SEMGREP_USER_AGENT_APPEND=Docker
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.1770092Z PYTHONIOENCODING=utf8
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.1770415Z PYTHONUNBUFFERED=1
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.1771301Z DOCKER_OTEL_RESOURCE_ATTRIBUTES=vcs.ref.head.name=release-1.174.0,vcs.ref.head.revision=33bca4bcee88023b5ca72b287029bc50f59f1977,vcs.repository.url.full=github.com/semgrep/semgrep-proprietary,docker.base_image=alpine:3.23
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.1772433Z DD_SERVICE=semgrep-core
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.1772694Z TSAN_OPTIONS=exitcode=0 report_signal_unsafe=0
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.1785389Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.1794224Z ##[group]Waiting for all services to be ready
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.1795935Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.2081072Z Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.2089171Z ##[group]Run actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.2089711Z with:
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.2089936Z   repository: goreleaser/goreleaser
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.2092630Z   token: ***
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.2092864Z   ssh-strict: true
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.2093073Z   ssh-user: git
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.2093288Z   persist-credentials: true
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.2093523Z   clean: true
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.2093741Z   sparse-checkout-cone-mode: true
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.2093995Z   fetch-depth: 1
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.2094192Z   fetch-tags: false
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.2094394Z   show-progress: true
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.2094637Z   lfs: false
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.2094818Z   submodules: false
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.2095100Z   set-safe-directory: true
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.2095605Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.2157130Z ##[command]/usr/bin/docker exec  a2f04c1bd5223b9430b33af04b043f8645bb35927bc8cf17805e280beca5df3d sh -c "cat /etc/*release | grep ^ID"
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4341416Z Syncing repository: goreleaser/goreleaser
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4417883Z ##[group]Getting Git version info
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4418640Z Working directory is '/__w/goreleaser/goreleaser'
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4419630Z [command]/usr/bin/git version
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4420141Z git version 2.52.0
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4422272Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4427376Z Temporarily overriding HOME='/__w/_temp/5687015f-f65c-424e-b963-0cafe4291468' before making global git config changes
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4428704Z Adding repository directory to the temporary git global config as a safe directory
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4429818Z [command]/usr/bin/git config --global --add safe.directory /__w/goreleaser/goreleaser
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4458780Z Deleting the contents of '/__w/goreleaser/goreleaser'
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4462853Z ##[group]Initializing the repository
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4467485Z [command]/usr/bin/git init /__w/goreleaser/goreleaser
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4514108Z hint: Using 'master' as the name for the initial branch. This default branch name
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4515346Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4516266Z hint: to use in all of your new repositories, which will suppress this warning,
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4517267Z hint: call:
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4517680Z hint:
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4518234Z hint: 	git config --global init.defaultBranch <name>
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4518859Z hint:
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4519446Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4520049Z hint: 'development'. The just-created branch can be renamed via this command:
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4520611Z hint:
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4520926Z hint: 	git branch -m <name>
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4521237Z hint:
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4521642Z hint: Disable this message with "git config set advice.defaultBranchName false"
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4523931Z Initialized empty Git repository in /__w/goreleaser/goreleaser/.git/
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4527892Z [command]/usr/bin/git remote add origin https://github.com/goreleaser/goreleaser
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4558034Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4558473Z ##[group]Disabling automatic garbage collection
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4563434Z [command]/usr/bin/git config --local gc.auto 0
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4590355Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4590810Z ##[group]Setting up auth
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4598406Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4629810Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4820384Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.4849315Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.5045697Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.5079713Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.5080489Z ##[group]Fetching the repository
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:05.5093995Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +36e43dd08f724956b188af2f6f3bcfd5efd355ec:refs/remotes/origin/main
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.4783172Z From https://github.com/goreleaser/goreleaser
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.4783670Z  * [new ref]         36e43dd08f724956b188af2f6f3bcfd5efd355ec -> origin/main
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.4808145Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.4808672Z ##[group]Determining the checkout info
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.4815219Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.4818475Z [command]/usr/bin/git sparse-checkout disable
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.4862269Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.4886038Z ##[group]Checking out the ref
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.4893929Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6224065Z branch 'main' set up to track 'origin/main'.
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6227030Z Switched to a new branch 'main'
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6238511Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6282296Z [command]/usr/bin/git log -1 --format=%H
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6306254Z 36e43dd08f724956b188af2f6f3bcfd5efd355ec
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6600340Z Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6602371Z ##[group]Run actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6602738Z with:
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6602946Z   repository: dgryski/semgrep-go
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6603191Z   path: rules
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6605477Z   token: ***
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6605679Z   ssh-strict: true
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6605882Z   ssh-user: git
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6606089Z   persist-credentials: true
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6606506Z   clean: true
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6606713Z   sparse-checkout-cone-mode: true
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6606965Z   fetch-depth: 1
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6607159Z   fetch-tags: false
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6607393Z   show-progress: true
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6607602Z   lfs: false
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6607789Z   submodules: false
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6607998Z   set-safe-directory: true
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6608222Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.6616040Z ##[command]/usr/bin/docker exec  a2f04c1bd5223b9430b33af04b043f8645bb35927bc8cf17805e280beca5df3d sh -c "cat /etc/*release | grep ^ID"
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8639763Z Syncing repository: dgryski/semgrep-go
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8653136Z ##[group]Getting Git version info
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8653813Z Working directory is '/__w/goreleaser/goreleaser/rules'
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8684504Z [command]/usr/bin/git version
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8724024Z git version 2.52.0
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8750134Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8766128Z Temporarily overriding HOME='/__w/_temp/4b17f898-60b9-46d5-955b-6d99ade3d586' before making global git config changes
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8767724Z Adding repository directory to the temporary git global config as a safe directory
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8773501Z [command]/usr/bin/git config --global --add safe.directory /__w/goreleaser/goreleaser/rules
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8803352Z ##[group]Initializing the repository
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8809706Z [command]/usr/bin/git init /__w/goreleaser/goreleaser/rules
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8854948Z hint: Using 'master' as the name for the initial branch. This default branch name
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8856536Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8857999Z hint: to use in all of your new repositories, which will suppress this warning,
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8859081Z hint: call:
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8859676Z hint:
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8860512Z hint: 	git config --global init.defaultBranch <name>
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8860885Z hint:
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8861593Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8862446Z hint: 'development'. The just-created branch can be renamed via this command:
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8863175Z hint:
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8863523Z hint: 	git branch -m <name>
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8863775Z hint:
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8864294Z hint: Disable this message with "git config set advice.defaultBranchName false"
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8864831Z Initialized empty Git repository in /__w/goreleaser/goreleaser/rules/.git/
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8869188Z [command]/usr/bin/git remote add origin https://github.com/dgryski/semgrep-go
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8901498Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8902389Z ##[group]Disabling automatic garbage collection
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8907638Z [command]/usr/bin/git config --local gc.auto 0
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8934488Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8935139Z ##[group]Setting up auth
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8942569Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.8973349Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.9159579Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.9188337Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.9377239Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.9409963Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.9410637Z ##[group]Determining the default branch
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:06.9417527Z Retrieving the default branch name
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:07.3716967Z Default branch 'master'
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:07.3718537Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:07.3719772Z ##[group]Fetching the repository
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:07.3727575Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/master:refs/remotes/origin/master
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:08.0200168Z From https://github.com/dgryski/semgrep-go
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:08.0200934Z  * [new branch]      master     -> origin/master
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:08.0224170Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:08.0224719Z ##[group]Determining the checkout info
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:08.0229415Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:08.0237400Z [command]/usr/bin/git sparse-checkout disable
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:08.0277796Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:08.0302256Z ##[group]Checking out the ref
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:08.0307370Z [command]/usr/bin/git checkout --progress --force -B master refs/remotes/origin/master
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:08.0417656Z branch 'master' set up to track 'origin/master'.
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:08.0422484Z Reset branch 'master'
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:08.0432166Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:08.0471197Z [command]/usr/bin/git log -1 --format=%H
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:08.0496737Z db0227c03f4b3c4e71d900188d51db4c81d66932
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:08.0677669Z ##[group]Run semgrep scan --error --enable-nosem -f ./rules .
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:08.0678205Z ^[[36;1msemgrep scan --error --enable-nosem -f ./rules .^[[0m
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:08.0682193Z shell: sh -e {0}
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:08.0682440Z ##[endgroup]
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:12.4100576Z                
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:12.4100902Z                
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:12.4101365Z ┌─────────────┐
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:12.4102117Z │ Scan Status │
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:12.4102522Z └─────────────┘
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:12.4106235Z   Scanning 962 files tracked by git with 66 Code rules:
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:12.4261655Z   Scanning 217 files with 66 go rules.
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.1837458Z                 
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.1837900Z                 
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.1838510Z ┌──────────────┐
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.1838931Z │ Scan Summary │
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.1839361Z └──────────────┘
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.1839780Z ✅ Scan completed successfully.
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.1840287Z  • Findings: 0 (0 blocking)
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.1840763Z  • Rules run: 66
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.1841173Z  • Targets scanned: 217
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.1841629Z  • Parsed lines: ~99.9%
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.1842413Z  • Scan skipped: 
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.1842958Z    ◦ Files matching .semgrepignore patterns: 181
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.1843644Z  • Scan was limited to files tracked by git
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.1844578Z  • For a detailed list of skipped files and lines, run semgrep with the --verbose flag
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.1845323Z Ran 66 rules on 217 files: 0 findings.
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.3014000Z If Semgrep missed a finding, please send us feedback to let us know!
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.3014628Z See https://semgrep.dev/docs/reporting-false-negatives/
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.4997982Z Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.4999243Z Post job cleanup.
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.5006323Z ##[command]/usr/bin/docker exec  a2f04c1bd5223b9430b33af04b043f8645bb35927bc8cf17805e280beca5df3d sh -c "cat /etc/*release | grep ^ID"
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.7012921Z [command]/usr/bin/git version
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.7060414Z git version 2.52.0
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.7148525Z Copying '/github/home/.gitconfig' to '/__w/_temp/a9b103b6-aa0c-4610-9de4-316b55b4eabc/.gitconfig'
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.7153674Z Temporarily overriding HOME='/__w/_temp/a9b103b6-aa0c-4610-9de4-316b55b4eabc' before making global git config changes
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.7156099Z Adding repository directory to the temporary git global config as a safe directory
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.7166569Z [command]/usr/bin/git config --global --add safe.directory /__w/goreleaser/goreleaser/rules
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.7203603Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.7246512Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.7455895Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.7467970Z http.https://github.com/.extraheader
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.7484812Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.7518294Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.7887260Z Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.7888580Z Post job cleanup.
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.7895779Z ##[command]/usr/bin/docker exec  a2f04c1bd5223b9430b33af04b043f8645bb35927bc8cf17805e280beca5df3d sh -c "cat /etc/*release | grep ^ID"
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.9935486Z [command]/usr/bin/git version
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:14.9976142Z git version 2.52.0
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:15.0019119Z Copying '/github/home/.gitconfig' to '/__w/_temp/bd5a900a-fba9-4244-999d-b56c5622eff8/.gitconfig'
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:15.0029976Z Temporarily overriding HOME='/__w/_temp/bd5a900a-fba9-4244-999d-b56c5622eff8' before making global git config changes
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:15.0038009Z Adding repository directory to the temporary git global config as a safe directory
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:15.0039006Z [command]/usr/bin/git config --global --add safe.directory /__w/goreleaser/goreleaser
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:15.0070262Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:15.0110382Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:15.0309421Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:15.0336242Z http.https://github.com/.extraheader
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:15.0349581Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:15.0381531Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:15.0714750Z Stop and remove container: f58d3680f978468795bcbea2d21998ba_returntocorpsemgrep_856123
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:15.0719148Z ##[command]/usr/bin/docker rm --force a2f04c1bd5223b9430b33af04b043f8645bb35927bc8cf17805e280beca5df3d
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:15.2758129Z a2f04c1bd5223b9430b33af04b043f8645bb35927bc8cf17805e280beca5df3d
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:15.2799078Z Remove container network: github_network_ccb3031f6a32474d83c9a2ec256f3eaf
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:15.2806213Z ##[command]/usr/bin/docker network rm github_network_ccb3031f6a32474d83c9a2ec256f3eaf
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:15.3762884Z github_network_ccb3031f6a32474d83c9a2ec256f3eaf
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:15.3830962Z Cleaning up orphan processes
+semgrep / scan	UNKNOWN STEP	2026-08-30T05:03:15.4214907Z ##[warning]Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,11 +55,11 @@ jobs:
           # identical flags apart from -count=1, 331s with the cache on and
           # 129s without.
           - os: ubuntu-latest
-            test-args: TEST_OPTIONS=-count=1
+            test-args: TEST_OPTIONS=-count=1,-json
           # the race detector is OS-independent and coverage is only uploaded
           # from ubuntu, so skip both on windows to speed up the slowest job.
           - os: windows-latest
-            test-args: RACE=false COVER=false TEST_OPTIONS=-count=1
+            test-args: RACE=false COVER=false TEST_OPTIONS=-count=1,-json
     runs-on: ${{ matrix.os }}
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -43,7 +43,7 @@ tasks:
       RACE: '{{if eq (default "true" .RACE) "true"}}-race{{end}}'
       COVER: '{{if eq (default "true" .COVER) "true"}}-coverpkg=./... -covermode=atomic -coverprofile=coverage.txt{{end}}'
     cmds:
-      - go test {{.TEST_OPTIONS}} -failfast {{.RACE}} {{.COVER}} {{.SOURCE_FILES}} -run {{.TEST_PATTERN}} -timeout=15m
+      - go test {{splitList "," .TEST_OPTIONS | join " "}} -failfast {{.RACE}} {{.COVER}} {{.SOURCE_FILES}} -run {{.TEST_PATTERN}} -timeout=15m
 
   fuzz:tmpl:
     cmds:


### PR DESCRIPTION
Temporary measurement branch: emits `go test -json` so per-test durations show up in the job logs. Not for merge.