### PR TITLE
test(cmd): stop repeating work the tests already cover

### DIFF
--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -12,18 +12,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBuild(t *testing.T) {
-	setup(t)
-	cmd := newBuildCmd()
-	cmd.cmd.SetArgs([]string{"--snapshot", "--timeout=1m", "--parallelism=2", "--deprecated"})
-	require.NoError(t, cmd.cmd.Execute())
-}
-
 func TestBuildAutoSnapshot(t *testing.T) {
+	// --auto-snapshot on a clean tree does not imply --snapshot, so this also
+	// covers a build that runs the validation pipe.
 	t.Run("clean", func(t *testing.T) {
 		setup(t)
 		cmd := newBuildCmd()
-		cmd.cmd.SetArgs([]string{"--auto-snapshot"})
+		cmd.cmd.SetArgs([]string{"--auto-snapshot", "--timeout=1m", "--parallelism=2", "--deprecated"})
 		require.NoError(t, cmd.cmd.Execute())
 		matches, err := filepath.Glob("./dist/fake_*/fake")
 		require.NoError(t, err)
@@ -34,7 +29,7 @@ func TestBuildAutoSnapshot(t *testing.T) {
 		setup(t)
 		createFile(t, "foo", "force dirty tree")
 		cmd := newBuildCmd()
-		cmd.cmd.SetArgs([]string{"--auto-snapshot"})
+		cmd.cmd.SetArgs([]string{"--auto-snapshot", "--timeout=1m", "--parallelism=2", "--deprecated"})
 		require.NoError(t, cmd.cmd.Execute())
 		matches, err := filepath.Glob("./dist/fake_*/fake_snapshot")
 		require.NoError(t, err)

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -19,7 +19,8 @@ func TestConfigFlagNotSetButExists(t *testing.T) {
 		"goreleaser.yaml",
 	} {
 		t.Run(name, func(t *testing.T) {
-			folder := setup(t)
+			folder := mktmp(t)
+			createGoReleaserYaml(t)
 			require.NoError(t, os.MkdirAll(filepath.Dir(name), 0o755))
 			require.NoError(t, os.Rename(
 				filepath.Join(folder, "goreleaser.yml"),
@@ -38,7 +39,7 @@ some_possibly_pro_option: {}
 `
 
 func TestProConfigFile(t *testing.T) {
-	folder := setup(t)
+	folder := mktmp(t)
 	require.NoError(t, os.WriteFile(
 		filepath.Join(folder, "goreleaser.yml"),
 		[]byte(proConfig),
@@ -64,18 +65,14 @@ func TestProConfigFile(t *testing.T) {
 }
 
 func TestConfigFileDoesntExist(t *testing.T) {
-	folder := setup(t)
-	err := os.Remove(filepath.Join(folder, "goreleaser.yml"))
-	require.NoError(t, err)
+	mktmp(t)
 	proj, err := loadConfig(true, "")
 	require.NoError(t, err)
 	require.Equal(t, config.Project{}, proj)
 }
 
 func TestConfigFileFromStdin(t *testing.T) {
-	folder := setup(t)
-	err := os.Remove(filepath.Join(folder, "goreleaser.yml"))
-	require.NoError(t, err)
+	mktmp(t)
 	proj, err := loadConfig(true, "-")
 	require.NoError(t, err)
 	require.Equal(t, config.Project{}, proj)

--- a/cmd/release_test.go
+++ b/cmd/release_test.go
@@ -11,18 +11,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRelease(t *testing.T) {
-	setup(t)
-	cmd := newReleaseCmd()
-	cmd.cmd.SetArgs([]string{"--snapshot", "--timeout=1m", "--parallelism=2", "--deprecated"})
-	require.NoError(t, cmd.cmd.Execute())
-}
-
 func TestReleaseAutoSnapshot(t *testing.T) {
+	// --auto-snapshot on a clean tree does not imply --snapshot, so this also
+	// covers a release that runs the validation pipe.
 	t.Run("clean", func(t *testing.T) {
 		setup(t)
 		cmd := newReleaseCmd()
-		cmd.cmd.SetArgs([]string{"--auto-snapshot", "--skip=publish"})
+		cmd.cmd.SetArgs([]string{"--auto-snapshot", "--skip=publish", "--timeout=1m", "--parallelism=2", "--deprecated"})
 		require.NoError(t, cmd.cmd.Execute())
 		require.FileExists(t, "dist/fake_0.0.2_checksums.txt", "should have created checksums when run with --snapshot")
 	})
@@ -31,7 +26,7 @@ func TestReleaseAutoSnapshot(t *testing.T) {
 		setup(t)
 		createFile(t, "foo", "force dirty tree")
 		cmd := newReleaseCmd()
-		cmd.cmd.SetArgs([]string{"--auto-snapshot", "--skip=publish"})
+		cmd.cmd.SetArgs([]string{"--auto-snapshot", "--skip=publish", "--timeout=1m", "--parallelism=2", "--deprecated"})
 		require.NoError(t, cmd.cmd.Execute())
 		matches, err := filepath.Glob("./dist/fake_0.0.2-SNAPSHOT-*_checksums.txt")
 		require.NoError(t, err)

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -17,7 +17,12 @@ func (e *exitMemento) Exit(i int) {
 	e.code = i
 }
 
-func setup(tb testing.TB) string {
+// mktmp makes an empty directory the working directory of the test.
+//
+// Use it instead of [setup] when the test does not run a pipeline: setup also
+// creates a buildable Go module and a git repository with four commits and two
+// tags, which costs nine git processes.
+func mktmp(tb testing.TB) string {
 	tb.Helper()
 
 	_ = os.Unsetenv("GITHUB_TOKEN")
@@ -26,6 +31,13 @@ func setup(tb testing.TB) string {
 
 	folder := tb.TempDir()
 	tb.Chdir(folder)
+	return folder
+}
+
+func setup(tb testing.TB) string {
+	tb.Helper()
+
+	folder := mktmp(tb)
 
 	createGoReleaserYaml(tb)
 	createMainGo(tb)


### PR DESCRIPTION
The cmd package was the slowest package on the windows job (40s) and the
fifth slowest on ubuntu (25s). Two things account for most of it.

`TestBuild` and `TestRelease` ran a full pipeline and asserted only that it
returned no error. The `dirty` case of `TestBuildAutoSnapshot` and
`TestReleaseAutoSnapshot` runs the same pipeline in the same snapshot mode --
`--auto-snapshot` on a dirty tree sets `ctx.Snapshot`, which applies exactly
the skips `--snapshot` applies -- and additionally asserts the snapshot name
reached the artifacts. The flags the two dropped tests passed move to the
auto-snapshot cases, so `--timeout`, `--parallelism` and `--deprecated` stay
covered, and four pipeline runs become two.

The config tests called `setup`, which creates a buildable Go module and a
git repository with four commits and two tags. None of them runs a pipeline;
they only need a config file to find. `TestConfigFlagNotSetButExists` paid
for that fixture six times. They now use a new `mktmp` helper, which saves 54
git processes -- expensive on windows, where the package spent 5.6s in that
one test.

Verified the remaining tests still fail for the right reason: forcing the
`options.autoSnapshot && git.CheckDirty(ctx) != nil` branch to false fails
`TestBuildAutoSnapshot/dirty` and `TestReleaseAutoSnapshot/dirty`, and
nothing else.

Measured locally, `go test ./cmd/`: 8.46s/9.20s before, 5.85s/6.37s after.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Signed-off-by: Carlos Alexandro Becker <caarlos0@users.noreply.github.com>