### PR TITLE
test(client): stop paying for a retry that tests nothing

### DIFF
--- a/internal/client/gitlab_test.go
+++ b/internal/client/gitlab_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"text/template"
 
@@ -194,7 +193,6 @@ func TestGitLabURLsDownloadTemplate(t *testing.T) {
 	}
 
 	for _, version := range []string{"16.3.4", "17.1.2"} {
-		var first atomic.Bool
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			defer r.Body.Close()
 
@@ -208,11 +206,6 @@ func TestGitLabURLsDownloadTemplate(t *testing.T) {
 				_, _ = io.Copy(io.Discard, r.Body)
 				w.WriteHeader(http.StatusOK)
 				fmt.Fprint(w, "{}")
-				return
-			}
-
-			if first.CompareAndSwap(false, true) {
-				http.Error(w, `{"error":"service unavailable"}`, http.StatusServiceUnavailable)
 				return
 			}
 
@@ -245,7 +238,6 @@ func TestGitLabURLsDownloadTemplate(t *testing.T) {
 		t.Cleanup(srv.Close)
 
 		for _, tt := range tests {
-			first.Store(false)
 			t.Run(tt.name+"_"+version, func(t *testing.T) {
 				ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 					ProjectName: "projectname",
@@ -257,14 +249,12 @@ func TestGitLabURLsDownloadTemplate(t *testing.T) {
 							Owner: "test",
 							Name:  "test",
 						},
-						ReplaceExistingArtifacts: true,
 					},
 					GitLabURLs: config.GitLabURLs{
 						API:                srv.URL,
 						Download:           tt.downloadURL,
 						UsePackageRegistry: tt.usePackageRegistry,
 					},
-					Retry: config.Retry{Attempts: 2},
 				}, testctx.WithVersion("1.0.0"))
 
 				tmpFile, err := os.CreateTemp(t.TempDir(), "")


### PR DESCRIPTION
`TestGitLabURLsDownloadTemplate` made the first `assets/links` request of
each version return 503. That cost 0.8s per subtest, 6.6s for the test --
6.2s on ubuntu and 6.5s on windows, the second slowest test in the package on
both.

None of it exercised goreleaser. go-gitlab wraps its transport in
`retryablehttp` with `RetryMax: 5` and `RetryWaitMin: 100ms`, so the SDK
absorbs the 503 and sleeps on its own; `retryx` never sees a failure. The
`Retry{Attempts: 2}` and the twelve backoffs bought nothing.

The 503 arrived in #6528, which replaced a 400 `has already been taken`.
That one did exercise goreleaser: it drove the `ReplaceExistingArtifacts`
branch in `gitlabClient.Upload`. Restoring it now fails, because
`ReleaseLinks.CreateReleaseLink` returns a nil link on error, so the
`releaseLink != nil` guard is never true and the branch is unreachable. That
is a separate bug, reported in #6832; this commit removes the leftover
`ReplaceExistingArtifacts: true` rather than leave it implying coverage that
does not exist.

Measured locally: 6.60s -> 0.43s.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Signed-off-by: Carlos Alexandro Becker <caarlos0@users.noreply.github.com>