### PR TITLE
test: stop cloning repositories from github

### DIFF
--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -1238,8 +1238,16 @@ func TestBuildTests(t *testing.T) {
 
 func TestRunPipeWithProxiedRepo(t *testing.T) {
 	folder := testlib.Mktmp(t)
-	out, err := exec.CommandContext(t.Context(), "git", "clone", "https://github.com/goreleaser/test-mod", "-b", "v0.1.1", "--depth=1", ".").CombinedOutput()
-	require.NoError(t, err, string(out))
+	// the unproxied dir only has to hold a main package: build.Build parses it
+	// to check that UnproxiedMain has a main function. Writing it beats
+	// cloning goreleaser/test-mod, which needs the network to say the same
+	// thing.
+	writeGoodMain(t, folder)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(folder, "go.mod"),
+		[]byte("module github.com/goreleaser/test-mod\n"),
+		0o666,
+	))
 
 	proxied := filepath.Join(folder, "dist/proxy/default")
 	require.NoError(t, os.MkdirAll(proxied, 0o750))
@@ -1260,7 +1268,7 @@ import _ "github.com/goreleaser/test-mod"
 
 	cmd := exec.CommandContext(t.Context(), "go", "mod", "tidy")
 	cmd.Dir = proxied
-	out, err = cmd.CombinedOutput()
+	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(out))
 
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -159,18 +159,29 @@ func TestRemoteURLContainsWithUsernameAndTokenWithInvalidURL(t *testing.T) {
 }
 
 func TestShallowClone(t *testing.T) {
+	// build the upstream in its own directory, then shallow clone it. The
+	// pipe only looks for .git/shallow, so a local clone proves the same
+	// thing as cloning goreleaser from github, without the network.
+	upstream := testlib.Mktmp(t)
+	testlib.GitInit(t)
+	testlib.GitCommit(t, "first")
+	testlib.GitTag(t, "v0.0.1")
+	testlib.GitCommit(t, "second")
+	testlib.GitTag(t, "v0.0.2")
+
 	folder := testlib.Mktmp(t)
-	require.NoError(
-		t,
-		exec.CommandContext(
-			t.Context(),
-			"git", "clone",
-			"--depth", "1",
-			"--branch", "v0.160.0",
-			"https://github.com/goreleaser/goreleaser",
-			folder,
-		).Run(),
-	)
+	out, err := exec.CommandContext(
+		t.Context(),
+		"git", "clone",
+		"--depth", "1",
+		"--branch", "v0.0.2",
+		// --depth is ignored for a plain local path, which clones everything.
+		"file://"+filepath.ToSlash(upstream),
+		folder,
+	).CombinedOutput()
+	require.NoError(t, err, string(out))
+	require.FileExists(t, filepath.Join(folder, ".git", "shallow"))
+
 	t.Run("all checks up", func(t *testing.T) {
 		// its just a warning now
 		require.NoError(t, Pipe{}.Run(testctx.Wrap(t.Context())))


### PR DESCRIPTION
Two tests cloned a repository over the network to set up a fixture they
could have written themselves.

`TestShallowClone` cloned goreleaser at v0.160.0. The pipe only looks for
`.git/shallow`, so any shallow clone proves the same thing: the test now
builds a two-commit repository and shallow clones it over `file://`, which
`--depth` needs because a plain local path clones everything. It also asserts
`.git/shallow` exists, so the test fails at the setup rather than silently
becoming a non-shallow clone check.

`TestRunPipeWithProxiedRepo` cloned goreleaser/test-mod into the working
directory. All it needed from it was a main package, because `Build` parses
`UnproxiedDir` to check `UnproxiedMain` has a main function -- dropping the
clone without a replacement fails with "build for foo does not contain a main
function". A `writeGoodMain` and a one-line go.mod say the same thing. The
proxied build still resolves test-mod through the module proxy, which is the
point of the test.

Both packages now pass with `GOPROXY=off`. Measured locally: `TestShallowClone`
1.48s -> 0.66s, `TestRunPipeWithProxiedRepo` 1.47s -> 0.28s. On CI they cost
3.33s and 7.40s on windows, 3.02s for the proxied one on ubuntu.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Signed-off-by: Carlos Alexandro Becker <caarlos0@users.noreply.github.com>