### PR TITLE
test: stop spawning docker to watch it fail slowly

### DIFF
--- a/cmd/healthcheck_test.go
+++ b/cmd/healthcheck_test.go
@@ -36,7 +36,11 @@ func TestCheckPath(t *testing.T) {
 	checked := &sync.Map{}
 	require.NoError(t, checkPath(t.Context(), checked, "go"))
 	require.NoError(t, checkPath(t.Context(), checked, "git version"))
-	require.Error(t, checkPath(t.Context(), checked, "docker something-inalid"))
+	// `go` rather than `docker`: this case is about a tool that is on PATH but
+	// whose command fails, and docker is not guaranteed to be installed -- when
+	// it is not, the LookPath branch answers instead and the case proves
+	// nothing. It is also slow to refuse: 5.26s on the windows job.
+	require.Error(t, checkPath(t.Context(), checked, "go something-invalid"))
 	require.Error(t, checkPath(t.Context(), checked, "some invalid command"))
 }
 

--- a/internal/pipe/docker/v2/docker_test.go
+++ b/internal/pipe/docker/v2/docker_test.go
@@ -374,7 +374,9 @@ func TestDisable(t *testing.T) {
 }
 
 func TestIsDockerDaemonAvailableNoDaemon(t *testing.T) {
-	t.Setenv("DOCKER_HOST", "unix:///nonexistent.sock")
+	// loopback refuses the connection at once. A missing unix socket makes the
+	// docker CLI on windows think about it for 5.46s.
+	t.Setenv("DOCKER_HOST", "tcp://127.0.0.1:1")
 	require.False(t, isDockerDaemonAvailable(t.Context()))
 }
 


### PR DESCRIPTION
Two tests invoke the docker CLI only to observe a failure, and pay for it on
the windows job.

`TestCheckPath` ran `docker something-inalid` for the "tool is on PATH but
the command fails" case: 5.26s, the fifth slowest test in the cmd package on
windows. `go something-invalid` exercises the same branch, and does so
reliably -- `go` is always present when the tests run, whereas without docker
installed the LookPath branch answers first and the case proves nothing.

`TestIsDockerDaemonAvailableNoDaemon` pointed DOCKER_HOST at a missing unix
socket, which takes the windows docker CLI 5.46s to give up on.
`tcp://127.0.0.1:1` is refused immediately, and is honest about the platform:
a unix socket path is not what an unreachable daemon looks like on windows.

Measured locally: 5.26s -> 0.02s and 0.17s -> 0.16s (the unix socket case is
only slow on windows).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Signed-off-by: Carlos Alexandro Becker <caarlos0@users.noreply.github.com>