### PR TITLE
fix(cmd): drop setup's unused return value

### DIFF
--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -34,10 +34,10 @@ func mktmp(tb testing.TB) string {
 	return folder
 }
 
-func setup(tb testing.TB) string {
+func setup(tb testing.TB) {
 	tb.Helper()
 
-	folder := mktmp(tb)
+	mktmp(tb)
 
 	createGoReleaserYaml(tb)
 	createMainGo(tb)
@@ -51,8 +51,6 @@ func setup(tb testing.TB) string {
 	testlib.GitCommit(tb, "assd")
 	testlib.GitTag(tb, "v0.0.2")
 	testlib.GitRemoteAdd(tb, "git@github.com:goreleaser/fake.git")
-
-	return folder
 }
 
 func createFile(tb testing.TB, filename, contents string) {


### PR DESCRIPTION
<!-- If applied, this commit will... -->

Fix `lint` on `main`.

<!-- Why is this change being made? -->

#6831 removed the last caller that used `setup`'s return value, so `unparam`
now fails on `main`:

```
cmd/util_test.go:37:27: setup - result 0 (string) is never used (unparam)
func setup(tb testing.TB) string {
                          ^
```

All eleven callers (`cmd/build_test.go`, `cmd/release_test.go`,
`cmd/root_test.go`) already ignore it. `mktmp` keeps its return value, which
`cmd/config_test.go` still uses.

`golangci-lint run cmd/...` and `go test ./cmd/` are both green with this.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

Broke in #6831. Found while merging `main` into #6844.
