### PR TITLE
fix(client): stop TestGitLabRateLimitRetryAfter racing the clock

### DIFF
--- a/internal/client/gitlab_test.go
+++ b/internal/client/gitlab_test.go
@@ -1173,6 +1173,11 @@ func TestGitLabRateLimitRetryAfter(t *testing.T) {
 	for name, tt := range map[string]struct {
 		header http.Header
 		want   time.Duration
+		// resetAt, when set, expects the time remaining until it, measured
+		// when the subtest runs. A constant goes stale here: the header
+		// carries an absolute instant, and t.Parallel() defers the subtest
+		// by however long the scheduler takes.
+		resetAt time.Time
 	}{
 		"no headers": {
 			header: http.Header{},
@@ -1181,7 +1186,7 @@ func TestGitLabRateLimitRetryAfter(t *testing.T) {
 			header: http.Header{
 				"Ratelimit-Reset": {strconv.FormatInt(reset.Unix(), 10)},
 			},
-			want: 42 * time.Second,
+			resetAt: reset,
 		},
 		"reset in the past falls back to retry-after": {
 			header: http.Header{
@@ -1208,9 +1213,13 @@ func TestGitLabRateLimitRetryAfter(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+			want := tt.want
+			if !tt.resetAt.IsZero() {
+				want = time.Until(tt.resetAt)
+			}
 			got := rateLimitRetryAfter(tt.header)
-			// the reset branch is computed against time.Now, so allow a second.
-			require.InDelta(t, tt.want, got, float64(time.Second))
+			// Unix() truncated the header to whole seconds.
+			require.InDelta(t, want, got, float64(time.Second))
 		})
 	}
 }


### PR DESCRIPTION
<!-- If applied, this commit will... -->

Stop `TestGitLabRateLimitRetryAfter/reset_in_the_future` failing at random.

<!-- Why is this change being made? -->

It failed on `test (windows-latest)` in an unrelated PR:

```
--- FAIL: TestGitLabRateLimitRetryAfter/reset_in_the_future
    Max difference between 42s and 38.3184682s allowed is 1e+09,
    but difference was 3.6815318e+09
```

`main` went green on the same commit, so this is a race rather than a break.

### Mechanism

The parent captures `reset := time.Now().Add(42 * time.Second)` and stores
`reset.Unix()` in the header. The subtest then asserts the result is within 1s
of a hardcoded `42 * time.Second`.

But the subtest calls `t.Parallel()`, so it does not run when the table is
built — it is deferred until the parent returns, then competes with every other
parallel test in the package. `rateLimitRetryAfter` returns
`time.Until(time.Unix(v, 0))`, so every second of that scheduling gap comes
straight off the returned duration. The Windows runner lost 3.68s, and the
tolerance is 1s.

The expectation was a constant while the actual value was wall-clock relative.

### Fix

Expect the time remaining until the reset instant, measured when the subtest
actually runs. The 1s tolerance then covers only `Unix()`'s truncation to whole
seconds, which is what the existing comment already claimed it was for.

Nothing about the production path changes, and the other four cases are
untouched — they use fixed durations or an instant an hour in the past, so
scheduling delay cannot affect them.

### Verification

- Injecting `time.Sleep(2 * time.Second)` before the assertion reproduces the
  CI failure exactly on the current code
  (`Max difference between 42s and 39.774494s`), and passes with this change.
- The assertion still bites: making `rateLimitRetryAfter` return `wait + 5s`
  fails the test.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

Introduced by #6843. Found while merging `main` into #6844.
