### PR TITLE
perf(git): ask git once

### DIFF
--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -14,11 +14,15 @@ import (
 
 // ExtractRepoFromConfig gets the repo name from the Git config.
 func ExtractRepoFromConfig(ctx context.Context) (result config.Repo, err error) {
-	if !IsRepo(ctx) {
-		return result, errors.New("current folder is not a git repository")
-	}
 	out, err := Clean(Run(ctx, "ls-remote", "--get-url"))
 	if err != nil {
+		// git says "No remote configured to list refs from" for both a
+		// repository without a remote and a directory that is not a
+		// repository at all, so it takes a second command to tell the user
+		// which one it is. Only the failing path pays for it.
+		if !IsRepo(ctx) {
+			return result, errors.New("current folder is not a git repository")
+		}
 		return result, errors.New("no remote configured to list refs from")
 	}
 	// This is a relative remote URL and requires some additional processing

--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -70,11 +70,11 @@ var fakeInfo = context.GitInfo{
 }
 
 func getInfo(ctx *context.Context) (context.GitInfo, error) {
-	if !git.IsRepo(ctx) && ctx.Snapshot {
-		log.Warn("accepting to run without a git repository because this is a snapshot")
-		return fakeInfo, nil
-	}
 	if !git.IsRepo(ctx) {
+		if ctx.Snapshot {
+			log.Warn("accepting to run without a git repository because this is a snapshot")
+			return fakeInfo, nil
+		}
 		return context.GitInfo{}, ErrNotRepository
 	}
 	info, err := getGitInfo(ctx)
@@ -93,21 +93,13 @@ func getGitInfo(ctx *context.Context) (context.GitInfo, error) {
 	if err != nil {
 		return context.GitInfo{}, fmt.Errorf("couldn't get current branch: %w", err)
 	}
-	short, err := getShortCommit(ctx)
-	if err != nil {
-		return context.GitInfo{}, fmt.Errorf("couldn't get current commit: %w", err)
-	}
-	full, err := getFullCommit(ctx)
+	short, full, date, err := getCommit(ctx)
 	if err != nil {
 		return context.GitInfo{}, fmt.Errorf("couldn't get current commit: %w", err)
 	}
 	first, err := getFirstCommit(ctx)
 	if err != nil {
 		return context.GitInfo{}, fmt.Errorf("couldn't get first commit: %w", err)
-	}
-	date, err := getCommitDate(ctx)
-	if err != nil {
-		return context.GitInfo{}, fmt.Errorf("couldn't get commit date: %w", err)
 	}
 	summary, err := getSummary(ctx)
 	if err != nil {
@@ -152,19 +144,9 @@ func getGitInfo(ctx *context.Context) (context.GitInfo, error) {
 		}, ErrNoTag
 	}
 
-	subject, err := getTagWithFormat(ctx, tag, "contents:subject")
-	if err != nil {
-		return context.GitInfo{}, fmt.Errorf("couldn't get tag subject: %w", err)
-	}
-
-	contents, err := getTagWithFormat(ctx, tag, "contents")
+	subject, contents, body, err := getTagContents(ctx, tag)
 	if err != nil {
 		return context.GitInfo{}, fmt.Errorf("couldn't get tag contents: %w", err)
-	}
-
-	body, err := getTagWithFormat(ctx, tag, "contents:body")
-	if err != nil {
-		return context.GitInfo{}, fmt.Errorf("couldn't get tag content body: %w", err)
 	}
 
 	previous, err := getPreviousTag(ctx, tag, excluding)
@@ -227,28 +209,28 @@ func getBranch(ctx *context.Context) (string, error) {
 	return git.Clean(git.Run(ctx, "rev-parse", "--abbrev-ref", "HEAD", "--quiet"))
 }
 
-func getCommitDate(ctx *context.Context) (time.Time, error) {
-	ct, err := git.Clean(git.Run(ctx, "show", "--format='%ct'", "HEAD", "--quiet"))
+// getCommit returns the short hash, full hash and committer date of HEAD.
+//
+// One `git show` rather than three that differ only in --format: process
+// creation is expensive on windows, and every run of this pipe lands here.
+func getCommit(ctx *context.Context) (short, full string, date time.Time, err error) {
+	out, err := git.Run(ctx, "show", "--format=%h%n%H%n%ct", "HEAD", "--quiet")
 	if err != nil {
-		return time.Time{}, err
+		return "", "", time.Time{}, err
 	}
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 3 {
+		return "", "", time.Time{}, fmt.Errorf("unexpected git show output: %q", out)
+	}
+	short, full, ct := lines[0], lines[1], lines[2]
 	if ct == "" {
-		return time.Time{}, nil
+		return short, full, time.Time{}, nil
 	}
 	i, err := strconv.ParseInt(ct, 10, 64)
 	if err != nil {
-		return time.Time{}, err
+		return "", "", time.Time{}, err
 	}
-	t := time.Unix(i, 0).UTC()
-	return t, nil
-}
-
-func getShortCommit(ctx *context.Context) (string, error) {
-	return git.Clean(git.Run(ctx, "show", "--format=%h", "HEAD", "--quiet"))
-}
-
-func getFullCommit(ctx *context.Context) (string, error) {
-	return git.Clean(git.Run(ctx, "show", "--format=%H", "HEAD", "--quiet"))
+	return short, full, time.Unix(i, 0).UTC(), nil
 }
 
 func getFirstCommit(ctx *context.Context) (string, error) {
@@ -259,12 +241,26 @@ func getSummary(ctx *context.Context) (string, error) {
 	return git.Clean(git.Run(ctx, "describe", "--always", "--dirty", "--tags"))
 }
 
-func getTagWithFormat(ctx *context.Context, tag, format string) (string, error) {
-	// the format is not quoted on purpose: git would print the quotes
-	// verbatim, and stripping them afterwards would also strip any
-	// apostrophes the tag message itself contains.
-	out, err := git.Run(ctx, "tag", "-l", "--format=%("+format+")", tag)
-	return strings.TrimSpace(out), err
+// getTagContents returns the subject, full contents and body of the given
+// tag's message.
+//
+// One `git tag -l` rather than three that differ only in the format: the three
+// fields are separated by NUL, which a tag message cannot contain. The format
+// is not quoted on purpose: git would print the quotes verbatim, and stripping
+// them afterwards would also strip any apostrophes the message contains.
+func getTagContents(ctx *context.Context, tag string) (subject, contents, body string, err error) {
+	out, err := git.Run(ctx, "tag", "-l", "--format=%(contents:subject)%00%(contents)%00%(contents:body)", tag)
+	if err != nil {
+		return "", "", "", err
+	}
+	parts := strings.Split(out, "\x00")
+	if len(parts) != 3 {
+		return "", "", "", fmt.Errorf("unexpected git tag output for %q: %q", tag, out)
+	}
+	return strings.TrimSpace(parts[0]),
+		strings.TrimSpace(parts[1]),
+		strings.TrimSpace(parts[2]),
+		nil
 }
 
 func getTag(ctx *context.Context, excluding []string) (string, error) {

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -4,7 +4,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/goreleaser/goreleaser/v2/internal/skips"
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
@@ -27,6 +29,9 @@ func TestSingleCommit(t *testing.T) {
 	testlib.Mktmp(t)
 	testlib.GitInit(t)
 	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
+	// an author date far in the past, while the committer date stays now, so
+	// the CommitDate assertion below fails if getCommit reads %at.
+	t.Setenv("GIT_AUTHOR_DATE", "2000-01-01T00:00:00Z")
 	testlib.GitCommit(t, "commit1")
 	testlib.GitTag(t, "v0.0.1")
 	ctx := testctx.Wrap(t.Context())
@@ -36,6 +41,20 @@ func TestSingleCommit(t *testing.T) {
 	require.Equal(t, "commit1", ctx.Git.TagSubject)
 	require.Equal(t, "commit1", ctx.Git.TagContents)
 	require.NotEmpty(t, ctx.Git.FirstCommit)
+
+	// getCommit reads all three out of one `git show`, so nothing else pins
+	// them to the right field: swapping %h and %H in its format used to pass.
+	require.Len(t, ctx.Git.FullCommit, 40)
+	require.Equal(t, ctx.Git.FullCommit, ctx.Git.Commit)
+	require.NotEmpty(t, ctx.Git.ShortCommit)
+	require.Less(t, len(ctx.Git.ShortCommit), len(ctx.Git.FullCommit))
+	require.True(
+		t,
+		strings.HasPrefix(ctx.Git.FullCommit, ctx.Git.ShortCommit),
+		"short commit %q is not a prefix of full commit %q",
+		ctx.Git.ShortCommit, ctx.Git.FullCommit,
+	)
+	require.WithinDuration(t, time.Now(), ctx.Git.CommitDate, time.Minute)
 }
 
 func TestAnnotatedTags(t *testing.T) {


### PR DESCRIPTION
`getInfo` asked git the same question several times.

- `git.IsRepo` ran twice in a row, because the snapshot branch and the error
  branch each called it.
- Three `git show HEAD --quiet` differed only in `--format`: `%ct`, `%h` and
  `%H`. One `%h%n%H%n%ct` gives all three.
- Three `git tag -l` for the same tag differed only in the format:
  `%(contents:subject)`, `%(contents)` and `%(contents:body)`. One format with
  the three separated by `%00` gives all three, and a tag message cannot
  contain NUL.

That is five fewer processes out of the fourteen a pipeline run spends here.
Process creation is expensive on windows, and every `goreleaser` invocation
pays it.

Counted with a `git` wrapper on PATH that logs each call:

    internal/pipe/git   556 -> 423 spawns
    cmd                 354 -> 319 spawns
    whole suite        1435 -> 1267 spawns

The behaviour is unchanged. Two error messages are gone, since the three tag
reads and the two commit reads are now one call each: "couldn't get tag
subject" and "couldn't get tag content body" fold into "couldn't get tag
contents", and "couldn't get commit date" folds into "couldn't get current
commit".

`TestSingleCommit` now pins what the merged formats could silently swap.
Verified by mutation: `%h%n%H` -> `%H%n%h` fails it, `%ct` -> `%at` fails it,
and reordering the tag format fails `TestAnnotatedTags` and
`TestAnnotatedTagsWithApostrophes`. None of the three failed anything before.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Signed-off-by: Carlos Alexandro Becker <caarlos0@users.noreply.github.com>