### PR TITLE
fix(chocolatey): a skipped chocolatey entry stops the ones after it

### DIFF
--- a/internal/pipe/chocolatey/chocolatey.go
+++ b/internal/pipe/chocolatey/chocolatey.go
@@ -12,6 +12,7 @@ import (
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/client"
+	"github.com/goreleaser/goreleaser/v2/internal/pipe"
 	"github.com/goreleaser/goreleaser/v2/internal/skips"
 	"github.com/goreleaser/goreleaser/v2/internal/summary"
 	"github.com/goreleaser/goreleaser/v2/internal/tmpl"
@@ -22,8 +23,9 @@ import (
 var (
 	errNoWindowsArchive = errors.New("chocolatey requires at least one windows archive")
 	// a chocolateyinstall.ps1 may only have one url/checksum pair per
-	// architecture.
-	errMultipleArchives = errors.New("found multiple archives for the same platform, please consider filtering by id")
+	// architecture. This is a per-entry skip so a chocolatey entry with
+	// duplicate archives does not stop the ones after it, same as winget.
+	errMultipleArchives = pipe.Skip("found multiple archives for the same platform, please consider filtering by id")
 )
 
 // nuget package extension.
@@ -77,13 +79,20 @@ func (Pipe) Run(ctx *context.Context) error {
 		return err
 	}
 
+	// even if one of them is skipped, we still go through all of them, and
+	// return the skips all at once in the end.
+	skips := pipe.SkipMemento{}
 	for _, choco := range ctx.Config.Chocolateys {
-		if err := doRun(ctx, cli, choco); err != nil {
+		err := doRun(ctx, cli, choco)
+		if err != nil && pipe.IsSkip(err) {
+			skips.Remember(err)
+			continue
+		}
+		if err != nil {
 			return err
 		}
 	}
-
-	return nil
+	return skips.Evaluate()
 }
 
 // Publish packages.

--- a/internal/pipe/chocolatey/skip_test.go
+++ b/internal/pipe/chocolatey/skip_test.go
@@ -1,0 +1,76 @@
+package chocolatey
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/goreleaser/goreleaser/v2/internal/artifact"
+	"github.com/goreleaser/goreleaser/v2/internal/pipe"
+	"github.com/goreleaser/goreleaser/v2/internal/testctx"
+	"github.com/goreleaser/goreleaser/v2/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunSkippedChocolateyDoesNotStopOthers covers the same shape as
+// winget's TestRunPipeSkippedWingetDoesNotStopOthers: a chocolatey entry
+// whose config errors on multiple archives for the same platform must not
+// stop the valid entries after it.
+func TestRunSkippedChocolateyDoesNotStopOthers(t *testing.T) {
+	folder := t.TempDir()
+	file := filepath.Join(folder, "archive")
+	require.NoError(t, os.WriteFile(file, []byte("lorem ipsum"), 0o644))
+
+	cmd = fakeCmd{execFn: func(_ string, _ ...string) ([]byte, error) {
+		return []byte("success"), nil
+	}}
+	t.Cleanup(func() { cmd = stdCmd{} })
+
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Dist:        folder,
+		ProjectName: "foo",
+		Chocolateys: []config.Chocolatey{
+			// two amd64 archives for the same entry: skipped by
+			// errMultipleArchives.
+			{Name: "skipped", IDs: []string{"dupe"}, Goamd64: "v1"},
+			// valid entry pointing at the 386 archive.
+			{Name: "valid", IDs: []string{"good"}, Goamd64: "v1"},
+		},
+	}, testctx.WithCurrentTag("v1.0.1"), testctx.WithVersion("1.0.1"), testctx.GitHubTokenType)
+
+	for _, n := range []string{"a", "b"} {
+		ctx.Artifacts.Add(&artifact.Artifact{
+			Name:    n + "_1.0.1_windows_amd64.zip",
+			Path:    file,
+			Goos:    "windows",
+			Goarch:  "amd64",
+			Goamd64: "v1",
+			Type:    artifact.UploadableArchive,
+			Extra: map[string]any{
+				artifact.ExtraID:     "dupe",
+				artifact.ExtraFormat: "zip",
+			},
+		})
+	}
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name:    "good_1.0.1_windows_386.zip",
+		Path:    file,
+		Goos:    "windows",
+		Goarch:  "386",
+		Goamd64: "v1",
+		Type:    artifact.UploadableArchive,
+		Extra: map[string]any{
+			artifact.ExtraID:     "good",
+			artifact.ExtraFormat: "zip",
+		},
+	})
+
+	p := Pipe{}
+	require.NoError(t, p.Default(ctx))
+
+	err := p.Run(ctx)
+	require.True(t, pipe.IsSkip(err), "expected a skip error, got %v", err)
+
+	// the entry after the skipped one must still have produced its package.
+	require.Len(t, ctx.Artifacts.Filter(artifact.ByType(artifact.PublishableChocolatey)).List(), 1)
+}


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->

<!-- If applied, this commit will... -->

Chocolatey packages no longer stop midway when one chocolatey entry is skipped, every entry still runs, and the skips are reported together at the end

<!-- Why is this change being made? -->

`chocolatey.Run` was returning on the first error, including a pipe skip, so a single chocolatey entry that skipped (its config resolves to multiple archives for the same platform) silently prevented every entry after it from generating a package, winget already treats this same condition as a per-entry skip and keeps going, and this brings chocolatey in line with that pattern

`errMultipleArchives` becomes a `pipe.Skip` (same message), and the `Run` loop now uses `pipe.SkipMemento` so a skipped entry does not stop the ones after it, `errNoWindowsArchive` deliberately stays a hard error, a chocolatey config with no windows archives at all is still a real mistake, same as winget's `errNoArchivesFound`

Before, with two entries where only the first has duplicate amd64 archives:
```
• chocolatey packages
  • pipe skipped or partially skipped   reason=found multiple archives for the same platform, please consider filtering by id
```
(no package produced for the valid second entry, release fails)

After:
```
• chocolatey packages
  • packing   nuspec=dist/valid.choco/valid.nuspec
  • pipe skipped or partially skipped   reason=found multiple archives for the same platform, please consider filtering by id
```
(valid entry still packages, release continues)

Tests: `TestRunSkippedChocolateyDoesNotStopOthers` proves the entry after the skipped one still produces its package, and it fails without this change

<details><summary>AI disclosure (required by CONTRIBUTING)</summary>
This change was written with AI assistance and reviewed, tested, and validated by me before sending
</details>

<!-- # Provide links to any relevant tickets, URLs or other resources -->

Pattern precedent: #6783, #6784, #6785, #6786, #6787, #6788, #6797 (the same SkipMemento continue change merged across the other package pipes), the guard being fixed comes from #6792
