### PR TITLE
fix: map every 32-bit ARM variant to Termux's "arm"

### DIFF
--- a/internal/pipe/nfpm/nfpm.go
+++ b/internal/pipe/nfpm/nfpm.go
@@ -207,11 +207,17 @@ func isSupportedArchlinuxArch(goarch, goarm string) bool {
 	}
 }
 
+// Termux knows four architectures: aarch64, arm, i686 and x86_64. Every 32-bit
+// ARM variant is just "arm" there.
+// Order matters: strings.Replacer takes the first listed match at a position,
+// so "arm64" has to stay ahead of the "armN" entries.
 var termuxArchReplacer = strings.NewReplacer(
 	"386", "i686",
 	"amd64", "x86_64",
 	"arm64", "aarch64",
+	"arm5", "arm",
 	"arm6", "arm",
+	"arm7", "arm",
 )
 
 // debArchVariant returns the Debian architecture variant for the given

--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -2057,53 +2057,67 @@ func TestTemplateExt(t *testing.T) {
 }
 
 func TestTermuxArch(t *testing.T) {
-	dist := t.TempDir()
-	require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0o755))
-	binPath := filepath.Join(dist, "mybin", "mybin")
-	require.NoError(t, os.WriteFile(binPath, []byte("binary"), 0o755))
+	// the same binary must keep Termux's expected arch on `termux.deb` while
+	// being normalized to Debian's on a regular `deb`. Termux knows only
+	// aarch64, arm, i686 and x86_64.
+	// See https://github.com/goreleaser/nfpm/issues/1103.
+	for _, tt := range []struct {
+		goarch string
+		goarm  string
+		want   map[string]string
+	}{
+		{goarch: "arm64", want: map[string]string{"deb": "arm64", "termux.deb": "aarch64"}},
+		{goarch: "386", want: map[string]string{"deb": "i386", "termux.deb": "i686"}},
+		{goarch: "amd64", want: map[string]string{"deb": "amd64", "termux.deb": "x86_64"}},
+		{goarch: "arm", goarm: "5", want: map[string]string{"deb": "armel", "termux.deb": "arm"}},
+		{goarch: "arm", goarm: "6", want: map[string]string{"deb": "armhf", "termux.deb": "arm"}},
+		{goarch: "arm", goarm: "7", want: map[string]string{"deb": "armhf", "termux.deb": "arm"}},
+	} {
+		t.Run(tt.goarch+tt.goarm, func(t *testing.T) {
+			dist := t.TempDir()
+			require.NoError(t, os.Mkdir(filepath.Join(dist, "mybin"), 0o755))
+			binPath := filepath.Join(dist, "mybin", "mybin")
+			require.NoError(t, os.WriteFile(binPath, []byte("binary"), 0o755))
 
-	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
-		ProjectName: "mybin",
-		Dist:        dist,
-		NFPMs: []config.NFPM{
-			{
-				ID:          "someid",
-				Maintainer:  "me@me",
-				IDs:         []string{"default"},
-				Formats:     []string{"deb", "termux.deb"},
-				PackageName: "foo",
-			},
-		},
-	})
-	for _, goos := range []string{"linux", "android"} {
-		ctx.Artifacts.Add(&artifact.Artifact{
-			Name:   "mybin",
-			Path:   binPath,
-			Goos:   goos,
-			Goarch: "arm64",
-			Type:   artifact.Binary,
-			Extra:  map[string]any{artifact.ExtraID: "default"},
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+				ProjectName: "mybin",
+				Dist:        dist,
+				NFPMs: []config.NFPM{
+					{
+						ID:          "someid",
+						Maintainer:  "me@me",
+						IDs:         []string{"default"},
+						Formats:     []string{"deb", "termux.deb"},
+						PackageName: "foo",
+					},
+				},
+			})
+			for _, goos := range []string{"linux", "android"} {
+				ctx.Artifacts.Add(&artifact.Artifact{
+					Name:   "mybin",
+					Path:   binPath,
+					Goos:   goos,
+					Goarch: tt.goarch,
+					Goarm:  tt.goarm,
+					Type:   artifact.Binary,
+					Extra:  map[string]any{artifact.ExtraID: "default"},
+				})
+			}
+
+			require.NoError(t, Pipe{}.Default(ctx))
+			require.NoError(t, Pipe{}.Run(ctx))
+
+			packages := ctx.Artifacts.Filter(artifact.ByType(artifact.LinuxPackage)).List()
+			require.Len(t, packages, 2)
+
+			got := map[string]string{}
+			for _, pkg := range packages {
+				got[pkg.Format()] = debControlField(t, pkg.Path, "Architecture")
+			}
+
+			require.Equal(t, tt.want, got)
 		})
 	}
-
-	require.NoError(t, Pipe{}.Default(ctx))
-	require.NoError(t, Pipe{}.Run(ctx))
-
-	packages := ctx.Artifacts.Filter(artifact.ByType(artifact.LinuxPackage)).List()
-	require.Len(t, packages, 2)
-
-	got := map[string]string{}
-	for _, pkg := range packages {
-		got[pkg.Format()] = debControlField(t, pkg.Path, "Architecture")
-	}
-
-	// the same arm64 binary must keep Termux's expected `aarch64` arch on
-	// `termux.deb`, while being normalized to Debian's `arm64` on a regular
-	// `deb`. See https://github.com/goreleaser/nfpm/issues/1103.
-	require.Equal(t, map[string]string{
-		"deb":        "arm64",
-		"termux.deb": "aarch64",
-	}, got)
 }
 
 // debControlField reads the given field from the control file of the


### PR DESCRIPTION
`termuxArchReplacer` maps `386`, `amd64`, `arm64` and `arm6`, but `infoArch` is `Goarch + Goarm + Gomips`, so a Termux build at `goarm: 7` (or `5`) passes through unchanged. `create` then sets `info.Deb.Arch = infoArch` for the termux format, and nfpm's `ensureValidArch` short-circuits on a non-empty `Deb.Arch`, so its own `archToDebian` table never gets to normalise it.

Reading the `Architecture` field back out of the packages goreleaser actually writes (via the suite's own `debControlField`):

```
GOARCH=arm64 GOARM=""  -> deb: "arm64" | termux.deb: "aarch64"
GOARCH=386   GOARM=""  -> deb: "i386"  | termux.deb: "i686"
GOARCH=amd64 GOARM=""  -> deb: "amd64" | termux.deb: "x86_64"
GOARCH=arm   GOARM="5" -> deb: "armel" | termux.deb: "arm5"    <- not a Termux architecture
GOARCH=arm   GOARM="6" -> deb: "armhf" | termux.deb: "arm"
GOARCH=arm   GOARM="7" -> deb: "armhf" | termux.deb: "arm7"    <- not a Termux architecture
```

Termux has four, and 32-bit ARM is just `arm` at every level — which is why `arm6` already maps to it. From `termux/termux-packages`: `scripts/build/termux_step_setup_variables.sh` line 2 is `` : "${TERMUX_ARCH:="aarch64"}" # arm, aarch64, i686 or x86_64. ``, and `build-package.sh` loops `for arch in 'aarch64' 'arm' 'i686' 'x86_64'`. `archToSnap` next door already covers `arm`, `arm6` and `arm7`.

Two things worth a look:

* **The ordering is load-bearing.** `strings.Replacer` takes the first listed match at a position, so `"arm64"` has to stay ahead of the `armN` entries. I ran the other ordering as a check and `arm64` comes out as `arm4`. There's a comment on the var now so the next edit doesn't step on it.
* **`arm5` is in scope because it is reachable** — `isSupportedTermuxArch` accepts any `android/arm` regardless of `goarm` — and it is wrong in the same way. `archToSnap` covers only `arm`/`arm6`/`arm7`; happy to drop the `arm5` line if you'd rather match that exactly.

`TestTermuxArch` was the only test that opened a package and read the control file, and it used `arm64` — the single ARM case the replacer already handled. It is now a table over every architecture `isSupportedTermuxArch` accepts, keeping the original arm64 expectation as the first row.

Scope, so as not to oversell it: `experimental.DefaultGOARM()` still returns `"6"`, so a default Termux build is unaffected today. This bites anyone setting `goarm: 7` explicitly, and `GORELEASER_EXPERIMENTAL=defaultgoarm` already returns `"7"`. I verified the field written into the control file, not an install on a device — I don't have one, so I am not claiming what `dpkg` does with the value.

Ran `go test ./internal/... ./pkg/...`: 120 packages ok, two failing packages, both environmental and both reproduced on an unmodified worktree at this same commit:

* `internal/builders/node` `TestBuild` — `node.js SEA requires Node.js >= v25.5.0, got v24.14.1`.
* `internal/pipe/sign` `TestBinarySign` / `TestSignArtifacts` — gpg exits 2 against local GnuPG 2.5.21.

Neither goes near `internal/pipe/nfpm`.

*(Correcting myself: an earlier version of this description said "83 packages ok" with a single failure. I read the test log while the run was still writing to it and missed the second, slower package. The numbers above are from the completed run, and both failures were then re-checked on a clean worktree.)*

Per the AI usage guidelines: this was written with Claude Code (Claude Opus 5, `claude-opus-5`), the commit carries an `Assisted-by` marker, and every measurement above was run and reviewed before opening this.
