### PR TITLE
chore: update to Go 1.27.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM gcr.io/projectsigstore/cosign:v3.1.3@sha256:9e5c2f2edc34351160407ca3416c618
 FROM docker:29.5.3-cli-alpine3.23@sha256:873de13208aab9c1de73fe984fd45883e01464fcfcc85efa20aa56a9ccfe7aa6 AS docker
 FROM docker/buildx-bin:0.36.1@sha256:1f2f6b2be4a2511ada67336e76892f1a588c89746009dd4b21069e4d867465be AS buildx
 
-FROM golang:1.27.0-alpine@sha256:4c9fe60190a2a3350ddc51de80d0224b8a6698d12bdfc999fee45ea9d6c46dbc
+FROM golang:1.27.1-alpine@sha256:cf6fca6641884b8433441b2b0652976f975e1d0fdd26d177eaaf8596087f3125
 
 ARG TARGETPLATFORM
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/goreleaser/goreleaser/v2
 
-go 1.27.0
+go 1.27.1
 
 require (
 	charm.land/lipgloss/v2 v2.0.6

--- a/www/go.mod
+++ b/www/go.mod
@@ -1,5 +1,5 @@
 module github.com/goreleaser/goreleaser/hugo-docs
 
-go 1.27.0
+go 1.27.1
 
 require github.com/imfing/hextra v0.12.3 // indirect


### PR DESCRIPTION
<!-- If applied, this commit will... -->

Update the root and documentation modules to Go 1.27.1.

It also updates the digest-pinned `golang:1.27.1-alpine` build image.

<!-- Why is this change being made? -->

Keep GoReleaser on the latest Go 1.27 patch release.

<!-- # Provide links to any relevant tickets, URLs or other resources -->
