### PR TITLE
fix(docker): only use wheels of the configured ids

### DIFF
--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -185,14 +185,19 @@ func (Pipe) Run(ctx *context.Context) error {
 				filters = append(filters, artifact.ByIDs(docker.IDs...))
 			}
 
+			filter := artifact.And(filters...)
+			matched := ctx.Artifacts.Filter(filter)
 			artifacts := ctx.Artifacts.Filter(
 				artifact.Or(
-					artifact.And(filters...),
-					artifact.ByType(artifact.PyWheel),
+					filter,
+					artifact.And(
+						artifact.ByType(artifact.PyWheel),
+						artifact.ByIDs(docker.IDs...),
+					),
 				),
 			)
-			if d := len(docker.IDs); d > 0 && len(artifacts.GroupByID()) != d {
-				return pipe.Skipf("expected to find %d artifacts for ids %v, found %d\nLearn more at https://goreleaser.com/errors/docker-build\n", d, docker.IDs, len(artifacts.List()))
+			if d := len(docker.IDs); d > 0 && len(matched.GroupByID()) != d {
+				return pipe.Skipf("expected to find %d artifacts for ids %v, found %d\nLearn more at https://goreleaser.com/errors/docker-build\n", d, docker.IDs, len(matched.List()))
 			}
 			log.WithField("artifacts", artifacts.Paths()).Debug("found artifacts")
 			return process(ctx, docker, artifacts.List())

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -753,6 +753,41 @@ func TestRunPipe(t *testing.T) {
 			assertImageLabels: noLabels,
 			assertError:       shouldErr("failed to build localhost:5050/goreleaser/test_build_args:latest"),
 		},
+		// a wheel of another id must not be counted against docker's ids, nor
+		// copied into the build context.
+		"valid with ids and an unrelated wheel": {
+			dockers: []config.Docker{
+				{
+					ImageTemplates: []string{
+						registry + "goreleaser/test_run_pipe_wheel:latest",
+					},
+					Goos:       "linux",
+					Goarch:     "amd64",
+					Dockerfile: "testdata/Dockerfile",
+					IDs:        []string{"mybin"},
+				},
+			},
+			expect: []string{
+				registry + "goreleaser/test_run_pipe_wheel:latest",
+			},
+			assertImageLabels:   noLabels,
+			assertError:         shouldNotErr,
+			pubAssertError:      shouldNotErr,
+			manifestAssertError: shouldNotErr,
+			extraPrepare: func(t *testing.T, ctx *context.Context) {
+				t.Helper()
+				ctx.Artifacts.Add(&artifact.Artifact{
+					Name:   "mytool-1.0.0-py3-none-any.whl",
+					Path:   "testdata/Dockerfile",
+					Goos:   "all",
+					Goarch: "all",
+					Type:   artifact.PyWheel,
+					Extra: map[string]any{
+						artifact.ExtraID: "mytool",
+					},
+				})
+			},
+		},
 		"bad_dockerfile": {
 			dockers: []config.Docker{
 				{

--- a/internal/pipe/docker/v2/docker.go
+++ b/internal/pipe/docker/v2/docker.go
@@ -542,7 +542,10 @@ func contextArtifacts(ctx *context.Context, d config.DockerV2) []*artifact.Artif
 	artifacts := ctx.Artifacts.Filter(
 		artifact.Or(
 			artifact.And(filters...),
-			artifact.ByType(artifact.PyWheel),
+			artifact.And(
+				artifact.ByType(artifact.PyWheel),
+				artifact.ByIDs(d.IDs...),
+			),
 		),
 	)
 

--- a/internal/pipe/docker/v2/docker_test.go
+++ b/internal/pipe/docker/v2/docker_test.go
@@ -501,11 +501,30 @@ func TestContextArtifacts(t *testing.T) {
 		})
 	}
 
+	for _, id := range []string{"id1", "id2"} {
+		ctx.Artifacts.Add(&artifact.Artifact{
+			Name:   id + "-1.0.0-py3-none-any.whl",
+			Goos:   "all",
+			Goarch: "all",
+			Type:   artifact.PyWheel,
+			Extra: artifact.Extras{
+				artifact.ExtraID: id,
+			},
+		})
+	}
+
 	arts := contextArtifacts(ctx, config.DockerV2{
 		Platforms: []string{"linux/arm/v7", "linux/amd64", "linux/arm64"},
 		IDs:       []string{"id1"},
 	})
-	require.Len(t, arts, 3)
+	require.Len(t, arts, 4)
+
+	t.Run("no ids", func(t *testing.T) {
+		arts := contextArtifacts(ctx, config.DockerV2{
+			Platforms: []string{"linux/arm/v7", "linux/amd64", "linux/arm64"},
+		})
+		require.Len(t, arts, 5)
+	})
 }
 
 func TestIsRetriableBuild(t *testing.T) {


### PR DESCRIPTION
Docker builds must only use the Python wheels of the `ids` they configure.

## What is wrong

The wheel filter is in an `Or` with no ID filter, in both Docker pipes:

```go
artifact.Or(
	artifact.And(filters...),
	artifact.ByType(artifact.PyWheel),
)
```

Thus each wheel goes into each Docker build context, also when the wheel has a different `id`.

In the v1 pipe this has a second, worse effect. The wheel is part of `artifacts`, thus the ID count test `len(artifacts.GroupByID()) != d` counts it, and the build stops with an incorrect message. A project that has a `uv` or `poetry` builder and a Docker image with `ids` fails:

```
expected to find 1 artifacts for ids [mybin], found 3
```

The defect came in with #5652 (`uv` builder) and #5793 (`docker/v2`).

## The change

- The wheel filter now also uses the configured `ids`.
- The v1 count test uses a set that has no wheels.

With no `ids` configured, `ByIDs` gives `nil`, which `And` ignores. Thus projects that do not use `ids` see no change.

## Verification

Two regression tests, one for each pipe. Both fail without the change:

- `docker/v2`: `contextArtifacts` gave 5 artifacts for `ids: [id1]`, 2 of them wheels.
- `docker`: `expected to find 1 artifacts for ids [mybin], found 3`.

The full `./internal/pipe/docker/...` suites pass with the change.
