### PR TITLE
fix(gomod): don't read the module path from stderr

### DIFF
--- a/internal/pipe/gomod/gomod.go
+++ b/internal/pipe/gomod/gomod.go
@@ -1,6 +1,7 @@
 package gomod
 
 import (
+	"bytes"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -48,16 +49,23 @@ func (Pipe) Run(ctx *context.Context) error {
 	if dir := ctx.Config.GoMod.Dir; dir != "" {
 		cmd.Dir = dir
 	}
-	out, err := cmd.CombinedOutput()
-	result := strings.TrimSpace(string(out))
-	if strings.HasPrefix(result, goPreModulesError) {
+	// Keep stdout and stderr apart: `go` prints diagnostics, e.g. toolchain
+	// download notices, to stderr, and they would otherwise corrupt the module
+	// path.
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	result := strings.TrimSpace(stdout.String())
+	errResult := strings.TrimSpace(stderr.String())
+	if strings.HasPrefix(errResult, goPreModulesError) {
 		return pipe.Skip("go version does not support modules")
 	}
-	if result == go115NotAGoModuleError || result == go116NotAGoModuleError {
+	if errResult == go115NotAGoModuleError || result == go116NotAGoModuleError {
 		return pipe.Skip("not a go module")
 	}
 	if err != nil {
-		return fmt.Errorf("failed to get module path: %w: %s", err, string(out))
+		return fmt.Errorf("failed to get module path: %w: %s", err, errResult)
 	}
 
 	// Splits and use the first line in case a `go.work` file exists with multiple modules.

--- a/internal/pipe/gomod/gomod_test.go
+++ b/internal/pipe/gomod/gomod_test.go
@@ -163,12 +163,30 @@ func TestRunCommandError(t *testing.T) {
 	require.Empty(t, ctx.ModulePath)
 }
 
-func TestRunOldGoVersion(t *testing.T) {
+func TestRunToolchainNotice(t *testing.T) {
 	bin := filepath.Join(t.TempDir(), "go.bin")
-	content := []byte("#!/bin/sh\necho \"flag provided but not defined: -m\"\nexit 1")
+	content := []byte("#!/bin/sh\necho \"go: downloading go1.27.0 (linux/arm64)\" >&2\necho github.com/foo/bar\n")
 	if testlib.IsWindows() {
 		bin = strings.Replace(bin, ".bin", ".bat", 1)
-		content = []byte("@echo off\r\necho flag provided but not defined: -m\r\nexit /b 1")
+		content = []byte("@echo off\r\necho go: downloading go1.27.0 (linux/arm64) 1>&2\r\necho github.com/foo/bar\r\n")
+	}
+	require.NoError(t, os.WriteFile(bin, content, 0o755))
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		GoMod: config.GoMod{
+			GoBinary: bin,
+		},
+	})
+
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, "github.com/foo/bar", ctx.ModulePath)
+}
+
+func TestRunOldGoVersion(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "go.bin")
+	content := []byte("#!/bin/sh\necho \"flag provided but not defined: -m\" >&2\nexit 1")
+	if testlib.IsWindows() {
+		bin = strings.Replace(bin, ".bin", ".bat", 1)
+		content = []byte("@echo off\r\necho flag provided but not defined: -m 1>&2\r\nexit /b 1")
 	}
 	require.NoError(t, os.WriteFile(bin, content, 0o755))
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{

--- a/internal/pipe/project/project.go
+++ b/internal/pipe/project/project.go
@@ -54,12 +54,15 @@ func cargoName() string {
 }
 
 func moduleName(ctx *context.Context) string {
-	bts, err := exec.CommandContext(ctx, "go", "list", "-m").CombinedOutput()
+	// Only stdout: `go` prints diagnostics, e.g. toolchain download notices, to
+	// stderr, and they would otherwise corrupt the module path.
+	bts, err := exec.CommandContext(ctx, "go", "list", "-m").Output()
 	if err != nil {
 		return ""
 	}
 
-	mod := strings.TrimSpace(string(bts))
+	// First line only, as a `go.work` file might list multiple modules.
+	mod, _, _ := strings.Cut(strings.TrimSpace(string(bts)), "\n")
 
 	// this is the default module used when go runs without a go module.
 	// https://pkg.go.dev/cmd/go@master#hdr-Package_lists_and_patterns

--- a/internal/pipe/project/project_test.go
+++ b/internal/pipe/project/project_test.go
@@ -3,6 +3,7 @@ package project
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -79,6 +80,22 @@ func TestEmptyProjectName_DefaultsToGoModPath(t *testing.T) {
 	require.NoError(t, exec.CommandContext(t.Context(), "go", "mod", "init", "github.com/foo/bar").Run())
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, "bar", ctx.Config.ProjectName)
+}
+
+func TestEmptyProjectName_GoModPathIgnoresToolchainNotice(t *testing.T) {
+	dir := testlib.Mktmp(t)
+	name := "go"
+	content := "#!/bin/sh\necho \"go: downloading go1.27.0 (linux/arm64)\" >&2\necho demo\n"
+	if testlib.IsWindows() {
+		name = "go.bat"
+		content = "@echo off\r\necho go: downloading go1.27.0 (linux/arm64) 1>&2\r\necho demo\r\n"
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	ctx := testctx.Wrap(t.Context())
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, "demo", ctx.Config.ProjectName)
 }
 
 func TestEmptyProjectName_DefaultsToCargo(t *testing.T) {


### PR DESCRIPTION
Read the Go module path from stdout only, so `go` diagnostics on stderr can no longer corrupt it.

`go list -m` writes diagnostics to stderr. The one that hurts is the notice `GOTOOLCHAIN=auto` prints on the first invocation after a toolchain change:

```
go: downloading go1.27.0 (linux/arm64)
demo
```

Both call sites read the *combined* output, so the notice became part of the module path. For the auto-detected `project_name` the last `/` then fell inside `(linux/arm64)`:

```
expected:  demo
actual:    "arm64)\ndemo"
```

The corrupted name spread to the build `id`, `nfpms.package_name`, binary paths and the `gomod` key in `dist/config.yaml` — and goreleaser still exited 0, so the breakage only surfaced much later. A warm toolchain cache hides it, which made it look flaky.

Changes:

- `internal/pipe/project`: use `Output()` instead of `CombinedOutput()`, and take the first line, so a `go.work` listing several modules does not corrupt the name either.
- `internal/pipe/gomod`: keep the two streams apart. The module path comes from stdout; the "not using modules" and pre-modules skips and the error text come from stderr, where `go` writes them. `command-line-arguments` keeps coming from stdout, where `go` prints it.

Both regression tests use a fake `go` that prints the notice on stderr only, so no toolchain download is needed. Against the unfixed code the project test reports exactly `"arm64)\ndemo"`, the value from the report. `TestRunOldGoVersion` now writes to stderr, which is where Go's `flag` package writes it.

Closes #6863
