### PR TITLE
fix(cask): deprecate url.verified

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -194,8 +194,6 @@ homebrew_casks:
       bash: "completions/goreleaser.bash"
       zsh: "completions/goreleaser.zsh"
       fish: "completions/goreleaser.fish"
-    url:
-      verified: github.com/goreleaser/goreleaser/releases/download
 
 nix:
   - name: goreleaser

--- a/internal/pipe/cask/cask.go
+++ b/internal/pipe/cask/cask.go
@@ -83,6 +83,9 @@ func (Pipe) Default(ctx *context.Context) error {
 			deprecate.Notice(ctx, "homebrew_casks.manpage")
 			brew.Manpages = append(brew.Manpages, brew.Manpage)
 		}
+		if brew.URL.Verified != "" {
+			deprecate.Notice(ctx, "homebrew_casks.url.verified")
+		}
 		for _, conflict := range brew.Conflicts {
 			if conflict.Formula != "" {
 				deprecate.Notice(ctx, "homebrew_casks.conflicts.formula")
@@ -430,7 +433,6 @@ func dataFor(ctx *context.Context, cfg config.HomebrewCask, cl client.ReleaseURL
 		}
 
 		url := downloadURL{
-			Verified:  cfg.URL.Verified,
 			Using:     cfg.URL.Using,
 			Cookies:   cfg.URL.Cookies,
 			Referer:   cfg.URL.Referer,

--- a/internal/pipe/cask/cask_test.go
+++ b/internal/pipe/cask/cask_test.go
@@ -482,6 +482,7 @@ func TestFullPipe(t *testing.T) {
 				ctx.Config.Casks[0].Repository.Name = "test"
 				ctx.Config.Casks[0].Homepage = "https://dummyhost-url-parameters.com/"
 				ctx.Config.Casks[0].URL.Using = ":post"
+				ctx.Config.Casks[0].URL.Verified = "https://dummyhost/download/"
 				ctx.Config.Casks[0].URL.Headers = []string{"Accept: application/octet-stream"}
 				ctx.Config.Casks[0].URL.Data = map[string]string{"payload": "hello_world"}
 			},
@@ -1233,6 +1234,7 @@ func TestDefaultDeprecated(t *testing.T) {
 	require.True(t, ctx.Deprecated)
 	require.Equal(t, []string{"bin"}, ctx.Config.Casks[0].Binaries)
 	require.Equal(t, []string{"man"}, ctx.Config.Casks[0].Manpages)
+	require.Contains(t, ctx.NotifiedDeprecations, "homebrew_casks.url.verified")
 }
 
 func TestGHFolder(t *testing.T) {

--- a/internal/pipe/cask/cask_test.go
+++ b/internal/pipe/cask/cask_test.go
@@ -482,7 +482,6 @@ func TestFullPipe(t *testing.T) {
 				ctx.Config.Casks[0].Repository.Name = "test"
 				ctx.Config.Casks[0].Homepage = "https://dummyhost-url-parameters.com/"
 				ctx.Config.Casks[0].URL.Using = ":post"
-				ctx.Config.Casks[0].URL.Verified = "https://dummyhost/download/"
 				ctx.Config.Casks[0].URL.Headers = []string{"Accept: application/octet-stream"}
 				ctx.Config.Casks[0].URL.Data = map[string]string{"payload": "hello_world"}
 			},
@@ -1223,6 +1222,9 @@ func TestDefaultDeprecated(t *testing.T) {
 			{
 				Binary:  "bin",
 				Manpage: "man",
+				URL: config.HomebrewCaskURL{
+					Verified: "github.com/foo/bar",
+				},
 			},
 		},
 	}, testctx.GitHubTokenType)

--- a/internal/pipe/cask/template.go
+++ b/internal/pipe/cask/template.go
@@ -33,7 +33,6 @@ type releasePackage struct {
 
 type downloadURL struct {
 	Download  string
-	Verified  string
 	Using     string
 	Cookies   map[string]string
 	Referer   string

--- a/internal/pipe/cask/templates/additional_url_params.rb
+++ b/internal/pipe/cask/templates/additional_url_params.rb
@@ -1,7 +1,4 @@
 {{- define "additional_url_params" }}
-{{- if .Verified }},
-      verified: "{{ .Verified }}"
-{{- end }}
 {{- if .Using }},
       using: {{ .Using }}
 {{- end }}

--- a/internal/pipe/cask/testdata/TestFullPipe/url_parameters_post.rb.golden
+++ b/internal/pipe/cask/testdata/TestFullPipe/url_parameters_post.rb.golden
@@ -6,7 +6,6 @@ cask "url_parameters_post" do
     on_arm do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.txz",
-        verified: "https://dummyhost/download/",
         using: :post,
         header: [
           "Accept: application/octet-stream",
@@ -18,7 +17,6 @@ cask "url_parameters_post" do
     on_intel do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.tgz",
-        verified: "https://dummyhost/download/",
         using: :post,
         header: [
           "Accept: application/octet-stream",
@@ -32,7 +30,6 @@ cask "url_parameters_post" do
     on_intel do
       sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       url "https://dummyhost/download/v#{version}/bin.tar.zst",
-        verified: "https://dummyhost/download/",
         using: :post,
         header: [
           "Accept: application/octet-stream",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -255,13 +255,15 @@ type HomebrewCaskURL struct {
 	Template string `yaml:"template,omitempty" json:"template,omitempty"`
 
 	// additional url parameters (https://docs.brew.sh/Cask-Cookbook#additional-url-parameters):
-	Verified  string            `yaml:"verified,omitempty" json:"verified,omitempty"`
 	Using     string            `yaml:"using,omitempty" json:"using,omitempty"`
 	Cookies   map[string]string `yaml:"cookies,omitempty" json:"cookies,omitempty"`
 	Referer   string            `yaml:"referer,omitempty" json:"referer,omitempty"`
 	Headers   []string          `yaml:"headers,omitempty" json:"headers,omitempty"` // Homebrew Cask DSL actually requires `header` key, but we use `headers` for consistency with Homebrew Formula config.
 	UserAgent string            `yaml:"user_agent,omitempty" json:"user_agent,omitempty"`
 	Data      map[string]string `yaml:"data,omitempty" json:"data,omitempty"`
+
+	// Deprecated: by Homebrew.
+	Verified string `yaml:"verified,omitempty" json:"verified,omitempty" jsonschema:"deprecated=true"`
 }
 
 type HomebrewCaskUninstall struct {

--- a/www/content/customization/publish/homebrew_casks.md
+++ b/www/content/customization/publish/homebrew_casks.md
@@ -117,10 +117,6 @@ homebrew_casks:
       # Templates: allowed.
       template: "https://github.mycompany.com/foo/bar/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
 
-      # Used when the domains of `url` and `homepage` differ.
-      # Templates: allowed.
-      verified: "github.com/owner/repo/"
-
       # Download strategy or format specification
       # See official Cask Cookbook for allowed values.
       # Templates: allowed.
@@ -418,7 +414,6 @@ homebrew_casks:
       # Replace <owner>/<repo> with your private GitHub repository.
       template: "https://github.com/<owner>/<repo>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
       using: GitHubPrivateRepositoryReleaseDownloadStrategy
-      verified: github.com/<owner>/<repo>/
 ```
 
 Users still need `HOMEBREW_GITHUB_API_TOKEN` exported in their

--- a/www/content/resources/deprecations.md
+++ b/www/content/resources/deprecations.md
@@ -49,6 +49,34 @@ foo: bar
 
 -->
 
+### homebrew_casks.url.verified
+
+> since v2.18.1
+
+[Homebrew deprecated it](https://github.com/Homebrew/brew/pull/23280), and now
+uses the default URL verification behavior.
+GoReleaser does not write it into the Cask anymore.
+
+{{< tabs >}}
+{{< tab "Before" >}}
+
+```yaml
+homebrew_casks:
+  - url:
+      verified: github.com/myorg/myrepo
+```
+
+{{< /tab >}}
+{{< tab "After" >}}
+
+```yaml
+homebrew_casks:
+  - {}
+```
+
+{{< /tab >}}
+{{< /tabs >}}
+
 ### dockers_v2.retry
 
 > since v2.15.3
@@ -497,10 +525,6 @@ homebrew_casks:
   - name: foo
     # Optional: either set it to Casks, or remove it:
     directory: Casks
-
-    # Optional: helps pass `homebrew audit` if homepage is different from download domain:
-    url:
-      verified: github.com/myorg/myrepo
 
     # Optional: if your app/binary isn't signed and notarized, you'll need this:
     hooks:


### PR DESCRIPTION
Deprecate `homebrew_casks.url.verified`, and stop writing the `verified:` parameter into generated Casks.

## Why

Homebrew deprecated the `verified:` parameter of the Cask `url` stanza, and now uses the default URL verification behaviour. Every generated Cask made `brew` print a warning to the end user, and told them to report it to the tap:

```
Warning: Calling the `verified` parameter in the `url` stanza is deprecated! Use the default URL verification behaviour instead.
Please report this issue to the caarlos0/homebrew-tap tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/caarlos0/homebrew-tap/Casks/pinata.rb:13
```

The parameter only affected `brew audit`, so removing it from the output does not change how a Cask installs. It will become an error in a future Homebrew release, so we remove it now.

## What

- `homebrew_casks.url.verified` now prints a deprecation notice, and `goreleaser check` reports it.
- The `verified:` parameter is no longer written into the Cask.
- Removed the option from the Homebrew Casks documentation and from the `brews` migration guide.
- Added the deprecation notice page entry.
- Removed `url.verified` from this project's own `.goreleaser.yaml`.

## Links

- https://github.com/Homebrew/brew/pull/23280
