### PR TITLE
ci: remove notify-goreleaser-cross

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,22 +8,6 @@ on:
 permissions:
   contents: read
 jobs:
-  notify-goreleaser-cross:
-    runs-on: ubuntu-latest
-    needs: [goreleaser]
-    steps:
-      - name: get version
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-      - name: notify goreleaser-cross with new release
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: benc-uk/workflow-dispatch@d004979be141727c7a17c28f603e2facc40d0855 # v1.3.3
-        with:
-          token: ${{ secrets.GH_PAT }}
-          repo: goreleaser/goreleaser-cross
-          ref: master
-          workflow: goreleaser-bump
-          inputs: '{ "tag" : "${{ env.RELEASE_TAG }}" }'
   verify:
     runs-on: ubuntu-latest
     needs: [goreleaser]


### PR DESCRIPTION
token has no perms, it will always fail.

my internal release workflow handles it
