### PR TITLE
chore: cc maintainer on winget pull requests

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -224,6 +224,8 @@ winget:
       branch: "goreleaser-{{.Version}}"
       pull_request:
         enabled: true
+        body: |
+          cc/ @caarlos0
         base:
           owner: microsoft
           name: winget-pkgs


### PR DESCRIPTION
Mention the maintainer in the pull requests that the `winget` publisher opens.

Sets `pull_request.body` on the `winget` repository configuration in
`.goreleaser.yaml`:

```yaml
pull_request:
  enabled: true
  body: |
    cc/ @caarlos0
```

Why:

- The `winget` publisher opens its pull requests on `microsoft/winget-pkgs`.
  Without a mention, there is no notification when the release pull request
  needs attention there.
- It is the only publisher in this configuration that opens pull requests. The
  Homebrew, Scoop, and Nix publishers push directly.

Notes:

- `pull_request.body` is a GoReleaser Pro option (v2.12+). All release and check
  workflows in this repository use the `goreleaser-pro` distribution, thus
  `goreleaser check` accepts the field.
- The base repository pull request template is appended after this body, so the
  mention stays at the top.

No product code changes, thus no tests are added.
