### PR TITLE
fix(docker): quote entrypoint paths and forward arguments verbatim

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -28,5 +28,4 @@ fi
 # prevents git from complaining about unsafe dir, specially when using github actions
 git config --global --add safe.directory "$PWD"
 
-# shellcheck disable=SC2068
-exec goreleaser $@
+exec goreleaser "$@"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -26,7 +26,7 @@ if [ -n "$CI_REGISTRY_PASSWORD" ]; then
 fi
 
 # prevents git from complaining about unsafe dir, specially when using github actions
-git config --global --add safe.directory $PWD
+git config --global --add safe.directory "$PWD"
 
 # shellcheck disable=SC2068
 exec goreleaser $@


### PR DESCRIPTION
Fixes a group of related bugs in the container image entrypoint shell script.

- Closes #6956: quote the safe.directory working-directory path so directories containing spaces remain one git operand.
- Closes #6955: forward entrypoint arguments with "$@" so paths, globs, and empty arguments are preserved verbatim.