### PR TITLE
fix(scripts): correct pre-commit hook exit status, quoting and restaging

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -e
+
 FILES=$(git diff --cached --name-only --diff-filter=ACMR)
 
 gofumpt -l -w .

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 set -e
 
-FILES=$(git diff --cached --name-only --diff-filter=ACMR)
+FILES=()
+while IFS= read -r -d '' file; do
+	FILES+=("$file")
+done < <(git diff --cached --name-only -z --diff-filter=ACMR)
 
 gofumpt -l -w .
 golangci-lint run --new --fix
 
-git add $FILES
+if ((${#FILES[@]})); then
+	git add -- "${FILES[@]}"
+fi

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,14 +1,5 @@
 #!/usr/bin/env bash
 set -e
 
-FILES=()
-while IFS= read -r -d '' file; do
-	FILES+=("$file")
-done < <(git diff --cached --name-only -z --diff-filter=ACMR)
-
 gofumpt -l -w .
 golangci-lint run --new --fix
-
-if ((${#FILES[@]})); then
-	git add -- "${FILES[@]}"
-fi


### PR DESCRIPTION
Fixes a group of related bugs in the repository pre-commit hook shell script.

- Closes #6961: stop the hook when formatter or linter commands fail.
- Closes #6960: handle staged paths with spaces while restaging remained in place.
- Closes #6959: stop whole-file restaging so deliberately unstaged edits stay unstaged.