### PR TITLE
fix(tmpl): deduplicate aggregate errors and stop mutating input

### DIFF
--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -335,7 +335,7 @@ func (t *Template) ApplyAll(sps ...*string) error {
 		s := *sp
 		result, err := t.Apply(s)
 		if err != nil {
-			return newTmplError(s, err)
+			return err
 		}
 		*sp = result
 	}
@@ -367,7 +367,7 @@ func (t *Template) Slice(in []string, opts ...SliceOpt) ([]string, error) {
 	for _, s := range in {
 		applied, err := t.Apply(s)
 		if err != nil {
-			return nil, newTmplError(s, err)
+			return nil, err
 		}
 		if opt.filtering != nil && !opt.filtering(applied) {
 			continue

--- a/internal/tmpl/tmpl.go
+++ b/internal/tmpl/tmpl.go
@@ -556,7 +556,7 @@ func readFile(path string) string {
 }
 
 func englishJoin(ss []string) string {
-	ss = slices.DeleteFunc(ss, func(s string) bool {
+	ss = slices.DeleteFunc(slices.Clone(ss), func(s string) bool {
 		return strings.TrimSpace(s) == ""
 	})
 	if len(ss) == 0 {

--- a/internal/tmpl/tmpl_test.go
+++ b/internal/tmpl/tmpl_test.go
@@ -1,9 +1,11 @@
 package tmpl
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"text/template"
 	"time"
@@ -495,7 +497,9 @@ func TestApplyAll(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		foo := "{{.Env.FOO}}"
 		bar := "{{.Env.NOPE}}"
-		require.Error(t, tpl.ApplyAll(&foo, &bar))
+		err := tpl.ApplyAll(&foo, &bar)
+		require.Error(t, err)
+		requireTemplateErrorOnce(t, err, bar)
 		require.Equal(t, "bar", foo)
 		require.Equal(t, "{{.Env.NOPE}}", bar)
 	})
@@ -512,7 +516,9 @@ func TestApplySlice(t *testing.T) {
 	})
 	t.Run("failure", func(t *testing.T) {
 		foo := []string{"{{.Env.BAR}}"}
-		require.Error(t, tpl.ApplySlice(&foo))
+		err := tpl.ApplySlice(&foo)
+		require.Error(t, err)
+		requireTemplateErrorOnce(t, err, foo[0])
 		require.Equal(t, "{{.Env.BAR}}", foo[0])
 	})
 }
@@ -767,6 +773,14 @@ func TestSliceInvalid(t *testing.T) {
 	require.Nil(t, flags)
 }
 
+func TestSliceErrorIsNotWrappedTwice(t *testing.T) {
+	source := []string{"{{ .NotAField }}"}
+	flags, err := New(testctx.Wrap(t.Context())).Slice(source)
+	require.Error(t, err)
+	requireTemplateErrorOnce(t, err, source[0])
+	require.Nil(t, flags)
+}
+
 func TestSliceIgnoreEmptyFlags(t *testing.T) {
 	ctx := testctx.Wrap(t.Context())
 	source := []string{
@@ -787,6 +801,17 @@ type testTarget struct {
 }
 
 func (t testTarget) String() string { return t.Target }
+
+func requireTemplateErrorOnce(t *testing.T, err error, tmpl string) {
+	t.Helper()
+
+	require.ErrorAs(t, err, &Error{})
+
+	var inner Error
+	require.False(t, errors.As(errors.Unwrap(err), &inner))
+
+	require.Equal(t, 1, strings.Count(err.Error(), `template: failed to apply "`+tmpl+`"`))
+}
 
 func (t testTarget) Fields() map[string]string {
 	return map[string]string{

--- a/internal/tmpl/tmpl_test.go
+++ b/internal/tmpl/tmpl_test.go
@@ -485,6 +485,26 @@ func TestReadFile(t *testing.T) {
 	})
 }
 
+func TestEnglishJoinDoesNotMutateInput(t *testing.T) {
+	items := []string{"a", " ", "b"}
+	tpl := New(testctx.Wrap(t.Context())).WithExtraFields(Fields{
+		"Items": items,
+	})
+
+	got, err := tpl.Apply(`{{ .Items | englishJoin }}`)
+	require.NoError(t, err)
+	require.Equal(t, "a and b", got)
+	require.Equal(t, []string{"a", " ", "b"}, items)
+}
+
+func TestEnglishJoinDoesNotMutateTemplateList(t *testing.T) {
+	got, err := New(testctx.Wrap(t.Context())).Apply(
+		`{{ $items := list "a" "" "b" }}{{ $items | englishJoin }}|{{ index $items 1 | printf "%q" }}/{{ index $items 2 | printf "%q" }}`,
+	)
+	require.NoError(t, err)
+	require.Equal(t, `a and b|""/"b"`, got)
+}
+
 func TestApplyAll(t *testing.T) {
 	tpl := New(testctx.Wrap(t.Context())).WithEnvS([]string{
 		"FOO=bar",


### PR DESCRIPTION
Fixes a group of related bugs in template engine and helpers (internal/tmpl).

- Closes #6993: aggregate helpers now return the existing template error without duplicating diagnostics.
- Closes #6992: englishJoin now filters on a cloned slice so template formatting does not mutate caller data.