### PR TITLE
fix(docker): v1 wheel build IDs, push flags and empty manifests

### DIFF
--- a/internal/pipe/docker/api_docker.go
+++ b/internal/pipe/docker/api_docker.go
@@ -55,8 +55,10 @@ type dockerImager struct {
 
 var dockerDigestPattern = regexp.MustCompile("sha256:[a-z0-9]{64}")
 
-func (i dockerImager) Push(ctx *context.Context, image string, _ []string) (string, error) {
-	bts, err := runCommandWithOutput(ctx, ".", "docker", "push", image)
+func (i dockerImager) Push(ctx *context.Context, image string, flags []string) (string, error) {
+	args := append([]string{"push"}, flags...)
+	args = append(args, image)
+	bts, err := runCommandWithOutput(ctx, ".", "docker", args...)
 	if err != nil {
 		return "", fmt.Errorf("failed to push %s: %w", image, err)
 	}

--- a/internal/pipe/docker/docker.go
+++ b/internal/pipe/docker/docker.go
@@ -186,7 +186,6 @@ func (Pipe) Run(ctx *context.Context) error {
 			}
 
 			filter := artifact.And(filters...)
-			matched := ctx.Artifacts.Filter(filter)
 			artifacts := ctx.Artifacts.Filter(
 				artifact.Or(
 					filter,
@@ -196,8 +195,8 @@ func (Pipe) Run(ctx *context.Context) error {
 					),
 				),
 			)
-			if d := len(docker.IDs); d > 0 && len(matched.GroupByID()) != d {
-				return pipe.Skipf("expected to find %d artifacts for ids %v, found %d\nLearn more at https://goreleaser.com/errors/docker-build\n", d, docker.IDs, len(matched.List()))
+			if d := len(docker.IDs); d > 0 && len(artifacts.GroupByID()) != d {
+				return pipe.Skipf("expected to find %d artifacts for ids %v, found %d\nLearn more at https://goreleaser.com/errors/docker-build\n", d, docker.IDs, len(artifacts.List()))
 			}
 			log.WithField("artifacts", artifacts.Paths()).Debug("found artifacts")
 			return process(ctx, docker, artifacts.List())

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -1557,6 +1557,71 @@ func (i *countingImager) Push(*context.Context, string, []string) (string, error
 	return "", nil
 }
 
+type wheelIDImager struct {
+	calls atomic.Int32
+}
+
+func (i *wheelIDImager) Build(_ *context.Context, root string, _ []string, _ []string) error {
+	i.calls.Add(1)
+	if _, err := os.Stat(filepath.Join(root, "mytool-1.0.0-py3-none-any.whl")); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (i *wheelIDImager) Push(*context.Context, string, []string) (string, error) {
+	return "", nil
+}
+
+func TestRunWithSelectedWheelID(t *testing.T) {
+	const imagerName = "test-wheel-id"
+	lock.Lock()
+	previous, existed := imagers[imagerName]
+	lock.Unlock()
+	t.Cleanup(func() {
+		lock.Lock()
+		defer lock.Unlock()
+		if existed {
+			imagers[imagerName] = previous
+		} else {
+			delete(imagers, imagerName)
+		}
+	})
+
+	dir := t.TempDir()
+	wheel := filepath.Join(dir, "mytool-1.0.0-py3-none-any.whl")
+	require.NoError(t, os.WriteFile(wheel, []byte("wheel"), 0o644))
+	dockerfile := filepath.Join(dir, "Dockerfile")
+	require.NoError(t, os.WriteFile(dockerfile, []byte("FROM scratch\nCOPY mytool-1.0.0-py3-none-any.whl /wheel.whl\n"), 0o644))
+
+	im := &wheelIDImager{}
+	registerImager(imagerName, im)
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Dockers: []config.Docker{
+			{
+				Use:            imagerName,
+				Dockerfile:     dockerfile,
+				ImageTemplates: []string{"example.invalid/mytool:latest"},
+				IDs:            []string{"python"},
+			},
+		},
+	})
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name:   "mytool-1.0.0-py3-none-any.whl",
+		Path:   wheel,
+		Goos:   "all",
+		Goarch: "all",
+		Type:   artifact.PyWheel,
+		Extra: map[string]any{
+			artifact.ExtraID: "python",
+		},
+	})
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, int32(1), im.calls.Load())
+}
+
 func TestDockerBuildRetries(t *testing.T) {
 	for _, name := range []string{"test-build-retriable", "test-build-fatal"} {
 		lock.Lock()

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -1175,6 +1175,65 @@ func TestBuildCommand(t *testing.T) {
 	}
 }
 
+func TestDockerImagerPushUsesFlags(t *testing.T) {
+	const digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	dir := t.TempDir()
+	source := filepath.Join(dir, "main.go")
+	require.NoError(t, os.WriteFile(source, []byte(`package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	if err := os.WriteFile(os.Getenv("DOCKER_ARGS_FILE"), []byte(strings.Join(os.Args[1:], "\n")), 0o644); err != nil {
+		panic(err)
+	}
+	fmt.Println("digest: `+digest+`")
+}
+`), 0o644))
+	fakeDocker := filepath.Join(dir, "docker")
+	if os.PathSeparator == '\\' {
+		fakeDocker += ".exe"
+	}
+	out, err := exec.CommandContext(t.Context(), "go", "build", "-o", fakeDocker, source).CombinedOutput()
+	require.NoError(t, err, string(out))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	tests := []struct {
+		name  string
+		flags []string
+		want  []string
+	}{
+		{
+			name:  "empty flags",
+			flags: nil,
+			want:  []string{"push", "example.invalid/app:v1"},
+		},
+		{
+			name:  "configured flags",
+			flags: []string{"--disable-content-trust=false"},
+			want:  []string{"push", "--disable-content-trust=false", "example.invalid/app:v1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			argsFile := filepath.Join(t.TempDir(), "args")
+			t.Setenv("DOCKER_ARGS_FILE", argsFile)
+
+			gotDigest, err := dockerImager{}.Push(testctx.Wrap(t.Context()), "example.invalid/app:v1", tt.flags)
+			require.NoError(t, err)
+			require.Equal(t, digest, gotDigest)
+			bts, err := os.ReadFile(argsFile)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, strings.Split(string(bts), "\n"))
+		})
+	}
+}
+
 func TestDescription(t *testing.T) {
 	require.NotEmpty(t, Pipe{}.String())
 }

--- a/internal/pipe/docker/manifest.go
+++ b/internal/pipe/docker/manifest.go
@@ -199,7 +199,7 @@ func manifestImages(ctx *context.Context, manifest config.DockerManifest) ([]str
 			imgs = append(imgs, withDigest(str, artifacts))
 		}
 	}
-	if strings.TrimSpace(strings.Join(manifest.ImageTemplates, "")) == "" {
+	if strings.TrimSpace(strings.Join(imgs, "")) == "" {
 		return imgs, pipe.Skip("manifest has no images")
 	}
 	return imgs, nil

--- a/internal/pipe/docker/manifest_test.go
+++ b/internal/pipe/docker/manifest_test.go
@@ -3,11 +3,13 @@ package docker
 import (
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/pkg/config"
+	"github.com/goreleaser/goreleaser/v2/pkg/context"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,6 +32,93 @@ func TestValidateManifester(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+type recordingManifester struct {
+	createCalls atomic.Int32
+	pushCalls   atomic.Int32
+	images      []string
+}
+
+func (m *recordingManifester) Create(_ *context.Context, _ string, images, _ []string) error {
+	m.createCalls.Add(1)
+	m.images = slices.Clone(images)
+	return nil
+}
+
+func (m *recordingManifester) Push(*context.Context, string, []string) (string, error) {
+	m.pushCalls.Add(1)
+	return "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", nil
+}
+
+func registerTestManifester(t *testing.T, name string, impl manifester) {
+	t.Helper()
+
+	lock.Lock()
+	previous, existed := manifesters[name]
+	manifesters[name] = impl
+	lock.Unlock()
+	t.Cleanup(func() {
+		lock.Lock()
+		defer lock.Unlock()
+		if existed {
+			manifesters[name] = previous
+		} else {
+			delete(manifesters, name)
+		}
+	})
+}
+
+func TestManifestPublishSkipsRenderedEmptyImages(t *testing.T) {
+	t.Run("all rendered empty", func(t *testing.T) {
+		const use = "test-rendered-empty"
+		manifester := &recordingManifester{}
+		registerTestManifester(t, use, manifester)
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			DockerManifests: []config.DockerManifest{
+				{
+					Use:            use,
+					NameTemplate:   "example.invalid/app:latest",
+					ImageTemplates: []string{`{{ if .IsSnapshot }}example.invalid/app:snapshot{{ end }}`},
+				},
+			},
+		})
+
+		require.NoError(t, ManifestPipe{}.Default(ctx))
+		err := ManifestPipe{}.Publish(ctx)
+		require.ErrorContains(t, err, "manifest has no images")
+		require.Equal(t, int32(0), manifester.createCalls.Load())
+		require.Equal(t, int32(0), manifester.pushCalls.Load())
+	})
+
+	t.Run("mixed rendered images", func(t *testing.T) {
+		const use = "test-rendered-mixed"
+		manifester := &recordingManifester{}
+		registerTestManifester(t, use, manifester)
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			DockerManifests: []config.DockerManifest{
+				{
+					Use:          use,
+					NameTemplate: "example.invalid/app:latest",
+					ImageTemplates: []string{
+						`{{ if .IsSnapshot }}example.invalid/app:snapshot{{ end }}`,
+						"example.invalid/app:release",
+					},
+				},
+			},
+		})
+		ctx.Artifacts.Add(&artifact.Artifact{
+			Type:  artifact.DockerImage,
+			Name:  "example.invalid/app:release",
+			Extra: map[string]any{artifact.ExtraDigest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+		})
+
+		require.NoError(t, ManifestPipe{}.Default(ctx))
+		require.NoError(t, ManifestPipe{}.Publish(ctx))
+		require.Equal(t, int32(1), manifester.createCalls.Load())
+		require.Equal(t, int32(1), manifester.pushCalls.Load())
+		require.Equal(t, []string{"example.invalid/app:release@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}, manifester.images)
+	})
 }
 
 func Test_manifestImages(t *testing.T) {


### PR DESCRIPTION
Fixes a group of related bugs in Docker v1 pipe and docker manifests.

- Closes #6929: count selected Python wheels when validating Docker v1 IDs.
- Closes #6928: pass configured Docker v1 push flags to the docker push command.
- Closes #6930: skip Docker manifests when image templates all render empty.