### PR TITLE
fix(build): resolve dependent hook environment entries and hook dir templates

### DIFF
--- a/internal/pipe/build/build.go
+++ b/internal/pipe/build/build.go
@@ -188,15 +188,14 @@ func runHook(ctx *context.Context, opts builders.Options, buildEnv []string, hoo
 			return err
 		}
 		env = append(env, hookEnv...)
+		tpl = tpl.WithEnvS(env)
 
-		dir, err := tmpl.New(ctx).WithBuildOptions(opts).Apply(hook.Dir)
+		dir, err := tpl.Apply(hook.Dir)
 		if err != nil {
 			return err
 		}
 
-		sh, err := tmpl.New(ctx).WithBuildOptions(opts).
-			WithEnvS(env).
-			Apply(hook.Cmd)
+		sh, err := tpl.Apply(hook.Cmd)
 		if err != nil {
 			return err
 		}

--- a/internal/pipe/build/build.go
+++ b/internal/pipe/build/build.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/go-shellwords"
+	"github.com/goreleaser/goreleaser/v2/internal/builders/base"
 	"github.com/goreleaser/goreleaser/v2/internal/deprecate"
 	"github.com/goreleaser/goreleaser/v2/internal/gerrors"
 	"github.com/goreleaser/goreleaser/v2/internal/ids"
@@ -178,13 +179,15 @@ func runHook(ctx *context.Context, opts builders.Options, buildEnv []string, hoo
 		var env []string
 
 		env = append(env, ctx.Env.Strings()...)
-		for _, rawEnv := range append(buildEnv, hook.Env...) {
-			e, err := tmpl.New(ctx).WithBuildOptions(opts).Apply(rawEnv)
-			if err != nil {
-				return err
-			}
-			env = append(env, e)
+		tpl := tmpl.New(ctx).WithBuildOptions(opts).WithEnvS(env)
+		rawEnv := make([]string, 0, len(buildEnv)+len(hook.Env))
+		rawEnv = append(rawEnv, buildEnv...)
+		rawEnv = append(rawEnv, hook.Env...)
+		hookEnv, err := base.TemplateEnv(rawEnv, tpl)
+		if err != nil {
+			return err
 		}
+		env = append(env, hookEnv...)
 
 		dir, err := tmpl.New(ctx).WithBuildOptions(opts).Apply(hook.Dir)
 		if err != nil {

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -2,6 +2,7 @@ package build
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -176,6 +177,43 @@ func TestRunFullPipe(t *testing.T) {
 	require.FileExists(t, postOS)
 	require.FileExists(t, preOS)
 	require.FileExists(t, filepath.Join(folder, "build1_linux_amd64", "testing"))
+}
+
+func TestRunHookTemplatesDependentEnv(t *testing.T) {
+	testlib.SkipIfWindows(t, "subshells don't work in windows")
+	t.Parallel()
+
+	folder := t.TempDir()
+	out := filepath.Join(folder, "hook-env")
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Dist: folder,
+		Builds: []config.Build{
+			{
+				Builder: "fake",
+				Binary:  "testing",
+				Env: []string{
+					"A=value",
+					"B={{.Env.A}}",
+					"BUILD_REF={{.Env.B}}",
+				},
+				Hooks: config.BuildHookConfig{
+					Pre: []config.Hook{{
+						Cmd: fmt.Sprintf(`sh -c 'printf "%%s\n" "$A" "$B" "$BUILD_REF" "$C" "$D" > "$1"' sh %s`, out),
+						Env: []string{
+							"C={{.Env.B}}",
+							"D={{.Env.C}}",
+						},
+					}},
+				},
+				Targets: []string{"linux_amd64"},
+			},
+		},
+	}, testctx.WithCurrentTag("2.4.5"))
+
+	require.NoError(t, Pipe{}.Run(ctx))
+	contents, err := os.ReadFile(out)
+	require.NoError(t, err)
+	require.Equal(t, "value\nvalue\nvalue\nvalue\nvalue\n", string(contents))
 }
 
 func TestRunFullPipeFail(t *testing.T) {

--- a/internal/pipe/build/build_test.go
+++ b/internal/pipe/build/build_test.go
@@ -216,6 +216,64 @@ func TestRunHookTemplatesDependentEnv(t *testing.T) {
 	require.Equal(t, "value\nvalue\nvalue\nvalue\nvalue\n", string(contents))
 }
 
+func TestRunHookTemplatesDirWithHookEnv(t *testing.T) {
+	testlib.SkipIfWindows(t, "subshells don't work in windows")
+	t.Parallel()
+
+	for name, tt := range map[string]struct {
+		ctxEnv map[string]string
+	}{
+		"hook-only env": {},
+		"hook overrides global env": {
+			ctxEnv: map[string]string{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			folder := t.TempDir()
+			globalDir := filepath.Join(folder, "global")
+			hookDir := filepath.Join(folder, "hook")
+			require.NoError(t, os.MkdirAll(globalDir, 0o755))
+			require.NoError(t, os.MkdirAll(hookDir, 0o755))
+
+			if tt.ctxEnv != nil {
+				tt.ctxEnv["D"] = globalDir
+			}
+
+			out := filepath.Join(folder, "pwd")
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+				Dist: folder,
+				Builds: []config.Build{
+					{
+						Builder: "fake",
+						Binary:  "testing",
+						Hooks: config.BuildHookConfig{
+							Pre: []config.Hook{{
+								Cmd: fmt.Sprintf(`sh -c 'pwd > "$1"' sh %s`, out),
+								Dir: "{{.Env.D}}",
+								Env: []string{
+									"D=" + hookDir,
+								},
+							}},
+						},
+						Targets: []string{"linux_amd64"},
+					},
+				},
+			}, testctx.WithCurrentTag("2.4.5"), testctx.WithEnv(tt.ctxEnv))
+
+			require.NoError(t, Pipe{}.Run(ctx))
+			contents, err := os.ReadFile(out)
+			require.NoError(t, err)
+			actual, err := filepath.EvalSymlinks(strings.TrimSpace(string(contents)))
+			require.NoError(t, err)
+			expected, err := filepath.EvalSymlinks(hookDir)
+			require.NoError(t, err)
+			require.Equal(t, expected, actual)
+		})
+	}
+}
+
 func TestRunFullPipeFail(t *testing.T) {
 	t.Parallel()
 	folder := t.TempDir()


### PR DESCRIPTION
Fixes a group of related bugs in build hooks.

- Closes #6890: render build and hook environment entries sequentially so dependent hook env values resolve.
- Closes #6889: render hook directory templates with the same effective environment used by the hook command and process.