### PR TITLE
fix(ko): repository image names, digest ordering and signing references

### DIFF
--- a/internal/pipe/ko/ko.go
+++ b/internal/pipe/ko/ko.go
@@ -606,6 +606,7 @@ func copyImage(src, dst string) (string, error) {
 }
 
 func makeArtifact(id, name, digest string) *artifact.Artifact {
+	name = digestFreeReference(name)
 	art := &artifact.Artifact{
 		Type:  artifact.DockerManifest,
 		Name:  name,
@@ -619,4 +620,11 @@ func makeArtifact(id, name, digest string) *artifact.Artifact {
 		art.Extra[artifact.ExtraDigest] = digest
 	}
 	return art
+}
+
+func digestFreeReference(ref string) string {
+	if idx := strings.LastIndex(ref, "@"); idx != -1 {
+		return ref[:idx]
+	}
+	return ref
 }

--- a/internal/pipe/ko/ko.go
+++ b/internal/pipe/ko/ko.go
@@ -357,19 +357,36 @@ func doBuild(ctx *context.Context, ko config.Ko) error {
 	}
 
 	src := ref.Name()
-	for i := 1; i < len(opts.imageRepos); i++ {
-		for _, tag := range opts.tags {
-			dst := opts.imageRepos[i] + ":" + tag
-			digest, err := copyImage(src, dst)
-			if err != nil {
-				return err
-			}
-			ctx.Artifacts.Add(makeArtifact(ko.ID, dst, digest))
-			summary.Appendf("Pushed Docker image `%s`", dst)
+	for _, dst := range secondaryDestinations(opts) {
+		digest, err := copyImage(src, dst)
+		if err != nil {
+			return err
 		}
+		ctx.Artifacts.Add(makeArtifact(ko.ID, dst, digest))
+		summary.Appendf("Pushed Docker image `%s`", dst)
 	}
 
 	return nil
+}
+
+func secondaryDestinations(opts *buildOptions) []string {
+	var dsts []string
+	importPath := strings.ToLower(strings.TrimPrefix(opts.importPath, build.StrictScheme))
+	for i := 1; i < len(opts.imageRepos); i++ {
+		po := &options.PublishOptions{
+			DockerRepo:          opts.imageRepos[i],
+			Bare:                opts.bare,
+			PreserveImportPaths: opts.preserveImportPaths,
+			BaseImportPaths:     opts.baseImportPaths,
+			Tags:                opts.tags,
+			LocalDomain:         opts.localDomain,
+		}
+		namer := options.MakeNamer(po)
+		for _, tag := range opts.tags {
+			dsts = append(dsts, namer(opts.imageRepos[i], importPath)+":"+tag)
+		}
+	}
+	return dsts
 }
 
 func findBuild(ctx *context.Context, ko config.Ko) (config.Build, error) {

--- a/internal/pipe/ko/ko_test.go
+++ b/internal/pipe/ko/ko_test.go
@@ -161,6 +161,39 @@ func TestBuildBuildOptionsEmptyMain(t *testing.T) {
 	require.Equal(t, "testapp", opts.importPath)
 }
 
+func TestSecondaryDestinationsUseKoNamer(t *testing.T) {
+	one := &buildOptions{
+		importPath: "example.com/project/cmd/one",
+		imageRepos: []string{
+			"first.invalid/team",
+			"second.invalid/team",
+		},
+		tags: []string{"latest"},
+	}
+	two := &buildOptions{
+		importPath: "example.com/project/cmd/two",
+		imageRepos: []string{
+			"first.invalid/team",
+			"second.invalid/team",
+		},
+		tags: []string{"latest"},
+	}
+
+	require.Len(t, secondaryDestinations(one), 1)
+	require.Len(t, secondaryDestinations(two), 1)
+	require.NotEqual(t, secondaryDestinations(one), secondaryDestinations(two))
+	require.Regexp(t, `^second\.invalid/team/one-[a-f0-9]{32}:latest$`, secondaryDestinations(one)[0])
+	require.Regexp(t, `^second\.invalid/team/two-[a-f0-9]{32}:latest$`, secondaryDestinations(two)[0])
+
+	one.bare = true
+	two.bare = true
+	require.Equal(t, []string{"second.invalid/team:latest"}, secondaryDestinations(one))
+	require.Equal(t, secondaryDestinations(one), secondaryDestinations(two))
+
+	one.imageRepos = one.imageRepos[:1]
+	require.Empty(t, secondaryDestinations(one))
+}
+
 func TestPublishPipeNoMatchingBuild(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds: []config.Build{

--- a/internal/pipe/ko/ko_test.go
+++ b/internal/pipe/ko/ko_test.go
@@ -194,6 +194,24 @@ func TestSecondaryDestinationsUseKoNamer(t *testing.T) {
 	require.Empty(t, secondaryDestinations(one))
 }
 
+func TestMakeArtifactStoresDigestFreePath(t *testing.T) {
+	const digest = "sha256:d7bf8be1b156cc0cd9d2e33765a69bc968d4ef6b2dea9b207d63129b9709862a"
+
+	art := makeArtifact("default", "ghcr.io/acme/app:v1.2.3@"+digest, digest)
+	require.Equal(t, "ghcr.io/acme/app:v1.2.3", art.Name)
+	require.Equal(t, art.Name, art.Path)
+	require.Equal(t, "default", art.Extra[artifact.ExtraID])
+	require.Equal(t, digest, art.Extra[artifact.ExtraDigest])
+
+	signingRef := art.Path + "@" + artifact.ExtraOr(*art, artifact.ExtraDigest, "")
+	require.Equal(t, 1, strings.Count(signingRef, "@sha256:"))
+	_, err := name.ParseReference(signingRef)
+	require.NoError(t, err)
+
+	art = makeArtifact("default", "ghcr.io/acme/app:v1.2.3", digest)
+	require.Equal(t, "ghcr.io/acme/app:v1.2.3", art.Path)
+}
+
 func TestPublishPipeNoMatchingBuild(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 		Builds: []config.Build{

--- a/internal/pipe/publish/publish.go
+++ b/internal/pipe/publish/publish.go
@@ -53,8 +53,8 @@ func New() Pipe {
 			docker.Pipe{},
 			docker.ManifestPipe{},
 			dockerv2.Publish{},
-			dockerdigest.Pipe{},
 			ko.Pipe{},
+			dockerdigest.Pipe{},
 			sign.DockerPipe{},
 			snapcraft.Pipe{},
 			// This should be one of the last steps

--- a/internal/pipe/publish/publish_test.go
+++ b/internal/pipe/publish/publish_test.go
@@ -2,9 +2,12 @@ package publish
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
+	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe"
+	"github.com/goreleaser/goreleaser/v2/internal/pipe/dockerdigest"
 	"github.com/goreleaser/goreleaser/v2/internal/skips"
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/pkg/config"
@@ -24,6 +27,45 @@ func TestPublish(t *testing.T) {
 	}, testctx.GitHubTokenType)
 
 	require.NoError(t, New().Run(ctx))
+}
+
+func TestPublishPipelineWritesDockerDigestsAfterKo(t *testing.T) {
+	pipeline := New().pipeline
+	require.Less(t, publisherIndex(t, pipeline, "ko"), publisherIndex(t, pipeline, "docker digests"))
+	require.Less(t, publisherIndex(t, pipeline, "docker digests"), publisherIndex(t, pipeline, "signing docker images"))
+
+	ctx := testctx.Wrap(t.Context())
+	ctx.Config.Dist = t.TempDir()
+	ctx.Config.DockerDigest.NameTemplate = "digests.txt"
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name: "example.com/app:v1",
+		Type: artifact.DockerImage,
+		Extra: artifact.Extras{
+			artifact.ExtraDigest: "sha256:dockerdigest",
+		},
+	})
+
+	err := Pipe{
+		pipeline: []Publisher{
+			&testArtifactPublisher{
+				artifact: &artifact.Artifact{
+					Name: "example.com/ko:v1",
+					Type: artifact.DockerManifest,
+					Extra: artifact.Extras{
+						artifact.ExtraDigest: "sha256:kodigest",
+					},
+				},
+			},
+			dockerdigest.Pipe{},
+		},
+	}.Run(ctx)
+	require.NoError(t, err)
+
+	bts, err := os.ReadFile(ctx.Config.Dist + "/digests.txt")
+	require.NoError(t, err)
+	require.Equal(t, `dockerdigest  example.com/app:v1
+kodigest  example.com/ko:v1
+`, string(bts))
 }
 
 func TestPublishSuccess(t *testing.T) {
@@ -82,6 +124,27 @@ func TestSkip(t *testing.T) {
 	t.Run("dont skip", func(t *testing.T) {
 		require.False(t, Pipe{}.Skip(testctx.Wrap(t.Context())))
 	})
+}
+
+func publisherIndex(tb testing.TB, pipeline []Publisher, name string) int {
+	tb.Helper()
+	for i, publisher := range pipeline {
+		if publisher.String() == name {
+			return i
+		}
+	}
+	tb.Fatalf("publisher %q not found", name)
+	return -1
+}
+
+type testArtifactPublisher struct {
+	artifact *artifact.Artifact
+}
+
+func (t *testArtifactPublisher) String() string { return "test artifact publisher" }
+func (t *testArtifactPublisher) Publish(ctx *context.Context) error {
+	ctx.Artifacts.Add(t.artifact)
+	return nil
 }
 
 type testPublisher struct {


### PR DESCRIPTION
Fixes a group of related bugs in Ko publishing.

- Closes #6927: preserve Ko naming policy when copying images to secondary repositories.
- Closes #6926: run Docker digest generation after Ko publishes image artifacts.
- Closes #6925: store Ko artifact paths without digest suffixes so default Docker signing references are valid.