### PR TITLE
fix(builder/rust,builder/zig): toolchain context and wrapped binary copying

### DIFF
--- a/internal/builders/rust/build.go
+++ b/internal/builders/rust/build.go
@@ -221,7 +221,7 @@ func (b *Builder) Build(ctx *context.Context, build config.Build, options api.Op
 		return err
 	}
 
-	realPath := filepath.Join(build.Dir, "target", t.clean(), "release", options.Name)
+	realPath := filepath.Join(build.Dir, "target", t.clean(), "release", filepath.Base(options.Name))
 	if err := gio.Copy(realPath, options.Path); err != nil {
 		return err
 	}

--- a/internal/builders/rust/build.go
+++ b/internal/builders/rust/build.go
@@ -4,7 +4,6 @@ package rust
 import (
 	"errors"
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -53,12 +52,20 @@ func (b *Builder) AllowConcurrentBuilds() bool { return false }
 // Prepare implements build.PreparedBuilder.
 func (b *Builder) Prepare(ctx *context.Context, build config.Build) error {
 	for _, target := range build.Targets {
-		if clean, ok := stripGlibcVersion(target); ok {
-			target = clean
-		}
-		out, err := exec.CommandContext(ctx, "rustup", "target", "add", target).CombinedOutput()
+		env := ctx.Env.Strings()
+		tpl := tmpl.New(ctx).WithEnvS(env)
+		tenv, err := base.TemplateEnv(build.Env, tpl)
 		if err != nil {
-			return fmt.Errorf("could not add target %s: %w: %s", target, err, string(out))
+			return err
+		}
+		env = append(env, tenv...)
+
+		rustTarget := target
+		if clean, ok := stripGlibcVersion(rustTarget); ok {
+			rustTarget = clean
+		}
+		if err := base.Exec(ctx, []string{"rustup", "target", "add", rustTarget}, env, build.Dir); err != nil {
+			return fmt.Errorf("could not add target %s: %w", rustTarget, err)
 		}
 	}
 	return nil

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -86,6 +87,59 @@ func TestCustomGlibc(t *testing.T) {
 	})
 }
 
+func TestPrepareUsesBuildContext(t *testing.T) {
+	folder := testlib.Mktmp(t)
+	target := "aarch64-unknown-linux-gnu.2.17"
+
+	for name, tt := range map[string]struct {
+		projectEnv    []string
+		buildEnv      []string
+		wantToolchain string
+	}{
+		"nested rust-toolchain": {},
+		"project environment": {
+			projectEnv:    []string{"RUSTUP_TOOLCHAIN=1.95.0"},
+			wantToolchain: "1.95.0",
+		},
+		"build environment": {
+			projectEnv:    []string{"TOOLCHAIN=1.95.0"},
+			buildEnv:      []string{"RUSTUP_TOOLCHAIN={{.Env.TOOLCHAIN}}"},
+			wantToolchain: "1.95.0",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("RUSTUP_TOOLCHAIN", "")
+
+			dir := filepath.Join("nested", name)
+			require.NoError(t, os.MkdirAll(dir, 0o755))
+			require.NoError(t, os.WriteFile("rust-toolchain.toml", []byte("stable\n"), 0o644))
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "rust-toolchain.toml"), []byte("1.95.0\n"), 0o644))
+
+			log := filepath.Join(t.TempDir(), "rustup.log")
+			createFakeRustup(t, log)
+
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+				Env: tt.projectEnv,
+			})
+			err := Default.Prepare(ctx, config.Build{
+				Dir:     dir,
+				Targets: []string{target},
+				Env:     tt.buildEnv,
+			})
+			require.NoError(t, err)
+
+			got, err := os.ReadFile(log)
+			require.NoError(t, err)
+			wantDir := filepath.Join(folder, dir)
+			wantDir, err = filepath.EvalSymlinks(wantDir)
+			require.NoError(t, err)
+			require.Contains(t, string(got), "cwd="+wantDir+"\n")
+			require.Contains(t, string(got), "toolchain="+tt.wantToolchain+"\n")
+			require.Contains(t, string(got), "args=target add aarch64-unknown-linux-gnu\n")
+		})
+	}
+}
+
 func TestBuildWorkspaceErrorShowsAllMembers(t *testing.T) {
 	dir := testlib.Mktmp(t)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "Cargo.toml"), []byte(`
@@ -113,6 +167,30 @@ members = ["crate-a", "crate-b", "crate-c"]
 	require.Contains(t, err.Error(), "crate-a")
 	require.Contains(t, err.Error(), "crate-b")
 	require.Contains(t, err.Error(), "crate-c")
+}
+
+func createFakeRustup(tb testing.TB, log string) {
+	tb.Helper()
+	dir := tb.TempDir()
+	name := "rustup"
+	script := fmt.Sprintf(`#!/bin/sh
+{
+	printf 'cwd=%%s\n' "$(pwd)"
+	printf 'toolchain=%%s\n' "$RUSTUP_TOOLCHAIN"
+	printf 'args=%%s\n' "$*"
+} > %q
+`, log)
+	if runtime.GOOS == "windows" {
+		name += ".bat"
+		log = filepath.ToSlash(log)
+		script = fmt.Sprintf(`@echo off
+> "%s" echo cwd=%%CD%%
+>> "%s" echo toolchain=%%RUSTUP_TOOLCHAIN%%
+>> "%s" echo args=%%*
+`, log, log, log)
+	}
+	require.NoError(tb, os.WriteFile(filepath.Join(dir, name), []byte(script), 0o755))
+	tb.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
 func TestBuild(t *testing.T) {

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -169,6 +169,57 @@ members = ["crate-a", "crate-b", "crate-c"]
 	require.Contains(t, err.Error(), "crate-c")
 }
 
+func TestBuildCopiesCompilerBinaryBasename(t *testing.T) {
+	for name, tt := range map[string]struct {
+		binary string
+	}{
+		"unwrapped": {binary: "app"},
+		"wrapped":   {binary: filepath.Join("bin", "app")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			testlib.Mktmp(t)
+			require.NoError(t, os.WriteFile("Cargo.toml", []byte(`
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2021"
+`), 0o644))
+			createFakeCargoBuild(t, filepath.Join("target", "aarch64-apple-darwin", "release", "app"), "built by cargo")
+
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+				ProjectName: "app",
+			})
+			build, err := Default.WithDefaults(config.Build{
+				ID:      "default",
+				Dir:     ".",
+				Targets: []string{"aarch64-apple-darwin"},
+			})
+			require.NoError(t, err)
+
+			target, err := Default.Parse("aarch64-apple-darwin")
+			require.NoError(t, err)
+			options := api.Options{
+				Name:   tt.binary,
+				Path:   filepath.Join("dist", "default_aarch64-apple-darwin", tt.binary),
+				Target: target,
+			}
+			require.NoError(t, os.MkdirAll(filepath.Dir(options.Path), 0o755))
+
+			require.NoError(t, Default.Build(ctx, build, options))
+
+			got, err := os.ReadFile(options.Path)
+			require.NoError(t, err)
+			require.Equal(t, "built by cargo", string(got))
+
+			bins := ctx.Artifacts.List()
+			require.Len(t, bins, 1)
+			require.Equal(t, tt.binary, bins[0].Name)
+			require.Equal(t, filepath.ToSlash(options.Path), bins[0].Path)
+			require.Equal(t, "app", bins[0].Extra[artifact.ExtraBinary])
+		})
+	}
+}
+
 func createFakeRustup(tb testing.TB, log string) {
 	tb.Helper()
 	dir := tb.TempDir()
@@ -188,6 +239,27 @@ func createFakeRustup(tb testing.TB, log string) {
 >> "%s" echo toolchain=%%RUSTUP_TOOLCHAIN%%
 >> "%s" echo args=%%*
 `, log, log, log)
+	}
+	require.NoError(tb, os.WriteFile(filepath.Join(dir, name), []byte(script), 0o755))
+	tb.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func createFakeCargoBuild(tb testing.TB, output, contents string) {
+	tb.Helper()
+	dir := tb.TempDir()
+	name := "cargo"
+	script := fmt.Sprintf(`#!/bin/sh
+mkdir -p %q
+printf '%%s' %q > %q
+`, filepath.ToSlash(filepath.Dir(output)), contents, filepath.ToSlash(output))
+	if runtime.GOOS == "windows" {
+		name += ".bat"
+		output = filepath.Clean(output)
+		outputDir := filepath.Dir(output)
+		script = fmt.Sprintf(`@echo off
+if not exist "%s" mkdir "%s"
+> "%s" <nul set /p dummy=%s
+`, outputDir, outputDir, output, contents)
 	}
 	require.NoError(tb, os.WriteFile(filepath.Join(dir, name), []byte(script), 0o755))
 	tb.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -130,12 +131,13 @@ func TestPrepareUsesBuildContext(t *testing.T) {
 
 			got, err := os.ReadFile(log)
 			require.NoError(t, err)
+			gotLog := strings.ReplaceAll(string(got), "\r\n", "\n")
 			wantDir := filepath.Join(folder, dir)
 			wantDir, err = filepath.EvalSymlinks(wantDir)
 			require.NoError(t, err)
-			require.Contains(t, string(got), "cwd="+wantDir+"\n")
-			require.Contains(t, string(got), "toolchain="+tt.wantToolchain+"\n")
-			require.Contains(t, string(got), "args=target add aarch64-unknown-linux-gnu\n")
+			require.Contains(t, gotLog, "cwd="+wantDir+"\n")
+			require.Contains(t, gotLog, "toolchain="+tt.wantToolchain+"\n")
+			require.Contains(t, gotLog, "args=target add aarch64-unknown-linux-gnu\n")
 		})
 	}
 }

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -258,10 +258,13 @@ printf '%%s' %q > %q
 		name += ".bat"
 		output = filepath.Clean(output)
 		outputDir := filepath.Dir(output)
-		script = fmt.Sprintf(`@echo off
-if not exist "%s" mkdir "%s"
-> "%s" <nul set /p dummy=%s
-`, outputDir, outputDir, output, contents)
+		script = fmt.Sprintf(
+			"@echo off\r\nif not exist \"%s\" mkdir \"%s\"\r\n> \"%s\" <nul set /p dummy=%s\r\nexit /b 0\r\n",
+			outputDir,
+			outputDir,
+			output,
+			contents,
+		)
 	}
 	require.NoError(tb, os.WriteFile(filepath.Join(dir, name), []byte(script), 0o755))
 	tb.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))

--- a/internal/builders/zig/build.go
+++ b/internal/builders/zig/build.go
@@ -172,7 +172,7 @@ func (b *Builder) Build(ctx *context.Context, build config.Build, options api.Op
 		return err
 	}
 
-	realPath := filepath.Join(build.Dir, prefix, "bin", options.Name)
+	realPath := filepath.Join(build.Dir, prefix, "bin", filepath.Base(options.Name))
 	if err := gio.Copy(realPath, options.Path); err != nil {
 		return err
 	}

--- a/internal/builders/zig/build_test.go
+++ b/internal/builders/zig/build_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -96,6 +97,72 @@ func TestWithDefaults(t *testing.T) {
 		})
 		require.Error(t, err)
 	})
+}
+
+func TestBuildCopiesCompilerBinaryBasename(t *testing.T) {
+	for name, tt := range map[string]struct {
+		binary string
+	}{
+		"unwrapped": {binary: "app"},
+		"wrapped":   {binary: filepath.Join("bin", "app")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			testlib.Mktmp(t)
+			createFakeZigBuild(t, filepath.Join("zig-out", "aarch64-macos", "bin", "app"), "built by zig")
+
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+				ProjectName: "app",
+			})
+			build, err := Default.WithDefaults(config.Build{
+				ID:      "default",
+				Dir:     ".",
+				Targets: []string{"aarch64-macos"},
+			})
+			require.NoError(t, err)
+
+			target, err := Default.Parse("aarch64-macos")
+			require.NoError(t, err)
+			options := api.Options{
+				Name:   tt.binary,
+				Path:   filepath.Join("dist", "default_aarch64-macos", tt.binary),
+				Target: target,
+			}
+			require.NoError(t, os.MkdirAll(filepath.Dir(options.Path), 0o755))
+
+			require.NoError(t, Default.Build(ctx, build, options))
+
+			got, err := os.ReadFile(options.Path)
+			require.NoError(t, err)
+			require.Equal(t, "built by zig", string(got))
+
+			bins := ctx.Artifacts.List()
+			require.Len(t, bins, 1)
+			require.Equal(t, tt.binary, bins[0].Name)
+			require.Equal(t, filepath.ToSlash(options.Path), bins[0].Path)
+			require.Equal(t, "app", bins[0].Extra[artifact.ExtraBinary])
+		})
+	}
+}
+
+func createFakeZigBuild(tb testing.TB, output, contents string) {
+	tb.Helper()
+	dir := tb.TempDir()
+	name := "zig"
+	script := fmt.Sprintf(`#!/bin/sh
+mkdir -p %q
+printf '%%s' %q > %q
+`, filepath.ToSlash(filepath.Dir(output)), contents, filepath.ToSlash(output))
+	if runtime.GOOS == "windows" {
+		name += ".bat"
+		output = filepath.Clean(output)
+		outputDir := filepath.Dir(output)
+		script = fmt.Sprintf(`@echo off
+if not exist "%s" mkdir "%s"
+> "%s" <nul set /p dummy=%s
+`, outputDir, outputDir, output, contents)
+	}
+	require.NoError(tb, os.WriteFile(filepath.Join(dir, name), []byte(script), 0o755))
+	tb.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
 func TestBuild(t *testing.T) {

--- a/internal/builders/zig/build_test.go
+++ b/internal/builders/zig/build_test.go
@@ -156,10 +156,13 @@ printf '%%s' %q > %q
 		name += ".bat"
 		output = filepath.Clean(output)
 		outputDir := filepath.Dir(output)
-		script = fmt.Sprintf(`@echo off
-if not exist "%s" mkdir "%s"
-> "%s" <nul set /p dummy=%s
-`, outputDir, outputDir, output, contents)
+		script = fmt.Sprintf(
+			"@echo off\r\nif not exist \"%s\" mkdir \"%s\"\r\n> \"%s\" <nul set /p dummy=%s\r\nexit /b 0\r\n",
+			outputDir,
+			outputDir,
+			output,
+			contents,
+		)
 	}
 	require.NoError(tb, os.WriteFile(filepath.Join(dir, name), []byte(script), 0o755))
 	tb.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))


### PR DESCRIPTION
Fixes a group of related bugs in the Rust and Zig builders.

- Closes #6908: Rust target preparation now runs in the build directory with the effective build environment.
- Closes #6904: Rust and Zig now copy compiler outputs by binary basename while preserving wrapped artifact destinations.