### PR TITLE
fix(cmd): correct check counting and init gitignore and failure handling

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -54,14 +54,20 @@ func newCheckCmd() *checkCmd {
 				log.WithField("path", path).
 					Info(boldStyle.Render("checking"))
 
+				exit := 0
 				if err := (defaults.Pipe{}).Run(ctx); err != nil {
-					exits = append(exits, 1)
+					exit = 1
 					log.WithError(fmt.Errorf("configuration is invalid: %w", err)).Error(path)
 				}
 
 				if ctx.Deprecated {
-					exits = append(exits, 2)
+					if exit == 0 {
+						exit = 2
+					}
 					log.WithError(errors.New("configuration is valid, but uses deprecated properties")).Warn(path)
+				}
+				if exit > 0 {
+					exits = append(exits, exit)
 				}
 			}
 

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/goreleaser/goreleaser/v2/internal/gerrors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,7 +45,7 @@ func TestCheckConfigUnmarshalError(t *testing.T) {
 func TestCheckConfigInvalid(t *testing.T) {
 	cmd := newCheckCmd()
 	cmd.cmd.SetArgs([]string{"-f", "testdata/invalid.yml"})
-	require.Error(t, cmd.cmd.Execute())
+	require.EqualError(t, cmd.cmd.Execute(), "1 out of 1 configuration file(s) have issues")
 	require.Equal(t, 1, cmd.checked)
 }
 
@@ -58,6 +59,18 @@ func TestCheckConfigInvalidQuiet(t *testing.T) {
 func TestCheckConfigDeprecated(t *testing.T) {
 	cmd := newCheckCmd()
 	cmd.cmd.SetArgs([]string{"-f", "testdata/good.yml", "--deprecated"})
-	require.Error(t, cmd.cmd.Execute())
+	require.EqualError(t, cmd.cmd.Execute(), "1 out of 1 configuration file(s) have issues")
 	require.Equal(t, 1, cmd.checked)
+}
+
+func TestCheckConfigInvalidAndDeprecated(t *testing.T) {
+	cmd := newCheckCmd()
+	cmd.cmd.SetArgs([]string{"-f", "testdata/invalid.yml", "--deprecated"})
+	err := cmd.cmd.Execute()
+	require.EqualError(t, err, "1 out of 1 configuration file(s) have issues")
+	require.Equal(t, 1, cmd.checked)
+
+	var detailed gerrors.ErrDetailed
+	require.ErrorAs(t, err, &detailed)
+	require.Equal(t, 1, detailed.Exit())
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -41,13 +41,6 @@ func newInitCmd() *initCmd {
 			if _, err := os.Stat(root.config); err == nil {
 				return errors.New(root.config + " already exists, delete it and run the command again")
 			}
-			conf, err := os.OpenFile(root.config, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL, 0o644)
-			if err != nil {
-				return err
-			}
-			defer conf.Close()
-
-			log.Infof(boldStyle.Render("generating ") + codeStyle.Render(root.config))
 
 			gitignoreLines := []string{"dist/"}
 			var example []byte
@@ -75,6 +68,14 @@ func newInitCmd() *initCmd {
 			default:
 				return fmt.Errorf("invalid language: %s", root.lang)
 			}
+
+			conf, err := os.OpenFile(root.config, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL, 0o644)
+			if err != nil {
+				return err
+			}
+			defer conf.Close()
+
+			log.Infof(boldStyle.Render("generating ") + codeStyle.Render(root.config))
 
 			if _, err := conf.Write(example); err != nil {
 				return err

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -120,6 +120,10 @@ func newInitCmd() *initCmd {
 func setupGitignore(path string, lines []string) (bool, error) {
 	ignored, _ := os.ReadFile(path)
 	content := strings.ReplaceAll(string(ignored), "\r\n", "\n")
+	ignoredLines := map[string]bool{}
+	for _, line := range strings.Split(content, "\n") {
+		ignoredLines[line] = true
+	}
 
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
 	if err != nil {
@@ -135,7 +139,7 @@ func setupGitignore(path string, lines []string) (bool, error) {
 
 	var modified bool
 	for _, line := range lines {
-		if !strings.Contains(content, line+"\n") {
+		if !ignoredLines[line] {
 			if !modified {
 				line = "# Added by goreleaser init:\n" + line
 				modified = true

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -244,6 +244,20 @@ func TestSetupGitignore(t *testing.T) {
 			expectModified: false,
 		},
 		{
+			name:           "comment does not contain line",
+			existing:       "# dist/\n",
+			lines:          []string{"dist/"},
+			expectContent:  "# dist/\n# Added by goreleaser init:\ndist/\n",
+			expectModified: true,
+		},
+		{
+			name:           "suffix match does not contain line",
+			existing:       "otherdist/\n",
+			lines:          []string{"dist/"},
+			expectContent:  "otherdist/\n# Added by goreleaser init:\ndist/\n",
+			expectModified: true,
+		},
+		{
 			name:           "multiple lines",
 			existing:       "",
 			lines:          []string{"dist/", "target/", "build/"},

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -131,6 +131,26 @@ func TestInitConfigAlreadyExist(t *testing.T) {
 	require.Equal(t, string(content), string(bts))
 }
 
+func TestInitInvalidLanguageDoesNotCreateConfig(t *testing.T) {
+	folder := setupInitTest(t)
+	configPath := filepath.Join(folder, ".goreleaser.yaml")
+
+	cmd := newInitCmd().cmd
+	cmd.SetArgs([]string{"--language", "ggo"})
+	require.EqualError(t, cmd.Execute(), "invalid language: ggo")
+	require.NoFileExists(t, configPath)
+	require.NoFileExists(t, filepath.Join(folder, ".gitignore"))
+
+	cmd = newInitCmd().cmd
+	cmd.SetArgs([]string{"--language", "go"})
+	require.NoError(t, cmd.Execute())
+	require.FileExists(t, filepath.Join(folder, ".gitignore"))
+
+	bts, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	require.Equal(t, string(static.GoExampleConfig), string(bts))
+}
+
 func TestInitGitIgnoreExists(t *testing.T) {
 	folder := setupInitTest(t)
 	cmd := newInitCmd().cmd


### PR DESCRIPTION
Fixes a group of related bugs in the check and init commands.

- Closes #7050: invalid deprecated configurations now count as one checked file outcome, with invalidity taking precedence.
- Closes #7049: goreleaser init now matches .gitignore entries by complete normalized line before adding dist/.
- Closes #7048: goreleaser init now validates the language before creating the config file so corrected retries work.