### PR TITLE
fix(nix): formatter output, string escaping and post_install

### DIFF
--- a/internal/pipe/nix/nix.go
+++ b/internal/pipe/nix/nix.go
@@ -341,7 +341,7 @@ func preparePkg(
 		PostInstall:       postInstall,
 		Archives:          map[string]Archive{},
 		SourceRoots:       map[string]string{},
-		Description:       nix.Description,
+		Description:       nixString(nix.Description),
 		Homepage:          nix.Homepage,
 		License:           nix.License,
 		MainProgram:       nix.MainProgram,
@@ -620,6 +620,14 @@ func split(s string) []string {
 		result = append(result, line)
 	}
 	return result
+}
+
+func nixString(s string) string {
+	return strings.NewReplacer(
+		"\\", "\\\\",
+		"\"", "\\\"",
+		"${", "\\${",
+	).Replace(s)
 }
 
 func depNames(deps []config.NixDependency) []string {

--- a/internal/pipe/nix/nix.go
+++ b/internal/pipe/nix/nix.go
@@ -226,6 +226,33 @@ func format(ctx *context.Context, fmt, path string) bool {
 	}
 }
 
+func formatContent(ctx *context.Context, formatter, content string) (string, error) {
+	file, err := os.CreateTemp("", "goreleaser-nix-*.nix")
+	if err != nil {
+		return "", fmt.Errorf("create temporary nixpkg: %w", err)
+	}
+	path := file.Name()
+	defer func() { _ = os.Remove(path) }()
+
+	if _, err := file.WriteString(content); err != nil {
+		_ = file.Close()
+		return "", fmt.Errorf("write temporary nixpkg: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return "", fmt.Errorf("close temporary nixpkg: %w", err)
+	}
+
+	if !format(ctx, formatter, path) {
+		return content, nil
+	}
+
+	bts, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read temporary nixpkg: %w", err)
+	}
+	return string(bts), nil
+}
+
 func preparePkg(
 	ctx *context.Context,
 	nix config.Nix,
@@ -407,6 +434,12 @@ func doPublish(ctx *context.Context, hasher fileHasher, cl client.Client, pkg *a
 	content, err := preparePkg(ctx, nix, cl, hasher)
 	if err != nil {
 		return err
+	}
+	if fmt := nix.Formatter; fmt != "" {
+		content, err = formatContent(ctx, fmt, content)
+		if err != nil {
+			return err
+		}
 	}
 
 	if nix.Repository.Git.URL != "" {

--- a/internal/pipe/nix/nix_test.go
+++ b/internal/pipe/nix/nix_test.go
@@ -691,6 +691,78 @@ func TestRunPipeSomeSkipped(t *testing.T) {
 	)
 }
 
+func TestPublishFormatsContent(t *testing.T) {
+	testlib.SkipIfWindows(t, "nix.format won't work on Windows")
+
+	for _, formatter := range []string{"alejandra", "nixfmt"} {
+		t.Run(formatter, func(t *testing.T) {
+			bin := t.TempDir()
+			require.NoError(t, os.WriteFile(
+				filepath.Join(bin, formatter),
+				[]byte("#!/bin/sh\nprintf '\\n# formatted by "+formatter+"\\n' >> \"$1\"\n"),
+				0o755,
+			))
+			t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+			folder := t.TempDir()
+			ctx := testctx.WrapWithCfg(
+				t.Context(),
+				config.Project{
+					Dist:        folder,
+					ProjectName: "foo",
+				},
+				testctx.WithVersion("1.2.1"),
+				testctx.WithCurrentTag("v1.2.1"),
+			)
+
+			archiveName := "foo_linux_amd64v1.txz"
+			archivePath := filepath.Join(folder, "dist", archiveName)
+			require.NoError(t, os.MkdirAll(filepath.Dir(archivePath), 0o755))
+			require.NoError(t, os.WriteFile(archivePath, nil, 0o644))
+			ctx.Artifacts.Add(&artifact.Artifact{
+				Name:    archiveName,
+				Path:    archivePath,
+				Goos:    "linux",
+				Goarch:  "amd64",
+				Goamd64: "v1",
+				Type:    artifact.UploadableArchive,
+				Extra: map[string]any{
+					artifact.ExtraID:        "foo",
+					artifact.ExtraFormat:    "txz",
+					artifact.ExtraBinaries:  []string{"foo"},
+					artifact.ExtraWrappedIn: "",
+				},
+			})
+
+			nix := config.Nix{
+				Name:                  "foo",
+				Path:                  "pkgs/foo/default.nix",
+				IDs:                   []string{"foo"},
+				Goamd64:               "v1",
+				Formatter:             formatter,
+				CommitAuthor:          config.CommitAuthor{Name: "goreleaserbot", Email: "bot@goreleaser.com"},
+				CommitMessageTemplate: "publish",
+				Repository: config.RepoRef{
+					Owner: "foo",
+					Name:  "bar",
+				},
+			}
+			pkg := &artifact.Artifact{
+				Name: "default.nix",
+				Type: artifact.Nixpkg,
+				Extra: map[string]any{
+					nixConfigExtra: nix,
+				},
+			}
+			client := client.NewMock()
+
+			require.NoError(t, doPublish(ctx, fakeHasher{archiveName: "publication-sha"}, client, pkg))
+			require.Contains(t, client.Content, `x86_64-linux = "publication-sha";`)
+			require.Contains(t, client.Content, "# formatted by "+formatter)
+		})
+	}
+}
+
 func TestErrNoArchivesFound(t *testing.T) {
 	require.EqualError(t, errNoArchivesFound{
 		goamd64: "v1",

--- a/internal/pipe/nix/nix_test.go
+++ b/internal/pipe/nix/nix_test.go
@@ -804,6 +804,55 @@ func TestPreparePkgEscapesDescription(t *testing.T) {
 	require.Contains(t, content, `description = "Say \"hello\" from C:\\tools and \${system}";`)
 }
 
+func TestPreparePkgInstallPhaseRunsHooks(t *testing.T) {
+	folder := t.TempDir()
+	ctx := testctx.WrapWithCfg(
+		t.Context(),
+		config.Project{
+			Dist:        folder,
+			ProjectName: "foo",
+		},
+		testctx.WithVersion("1.2.1"),
+		testctx.WithCurrentTag("v1.2.1"),
+	)
+
+	archiveName := "foo_linux_amd64v1.txz"
+	archivePath := filepath.Join(folder, "dist", archiveName)
+	require.NoError(t, os.MkdirAll(filepath.Dir(archivePath), 0o755))
+	require.NoError(t, os.WriteFile(archivePath, nil, 0o644))
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name:    archiveName,
+		Path:    archivePath,
+		Goos:    "linux",
+		Goarch:  "amd64",
+		Goamd64: "v1",
+		Type:    artifact.UploadableArchive,
+		Extra: map[string]any{
+			artifact.ExtraID:        "foo",
+			artifact.ExtraFormat:    "txz",
+			artifact.ExtraBinaries:  []string{"foo"},
+			artifact.ExtraWrappedIn: "",
+		},
+	})
+
+	content, err := preparePkg(ctx, config.Nix{
+		Name:        "foo",
+		IDs:         []string{"foo"},
+		Goamd64:     "v1",
+		PostInstall: `printf 'post-install ran\n' > "$out/post-install.marker"`,
+	}, client.NewMock(), fakeHasher{archiveName: "sha"})
+	require.NoError(t, err)
+	require.Contains(t, content, `  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp -vr ./foo $out/bin/foo
+    runHook postInstall
+  '';`)
+	require.Contains(t, content, `  postInstall = ''
+    printf 'post-install ran\n' > "$out/post-install.marker"
+  '';`)
+}
+
 func TestErrNoArchivesFound(t *testing.T) {
 	require.EqualError(t, errNoArchivesFound{
 		goamd64: "v1",

--- a/internal/pipe/nix/nix_test.go
+++ b/internal/pipe/nix/nix_test.go
@@ -763,6 +763,47 @@ func TestPublishFormatsContent(t *testing.T) {
 	}
 }
 
+func TestPreparePkgEscapesDescription(t *testing.T) {
+	folder := t.TempDir()
+	ctx := testctx.WrapWithCfg(
+		t.Context(),
+		config.Project{
+			Dist:        folder,
+			ProjectName: "foo",
+		},
+		testctx.WithVersion("1.2.1"),
+		testctx.WithCurrentTag("v1.2.1"),
+	)
+
+	archiveName := "foo_linux_amd64v1.txz"
+	archivePath := filepath.Join(folder, "dist", archiveName)
+	require.NoError(t, os.MkdirAll(filepath.Dir(archivePath), 0o755))
+	require.NoError(t, os.WriteFile(archivePath, nil, 0o644))
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name:    archiveName,
+		Path:    archivePath,
+		Goos:    "linux",
+		Goarch:  "amd64",
+		Goamd64: "v1",
+		Type:    artifact.UploadableArchive,
+		Extra: map[string]any{
+			artifact.ExtraID:        "foo",
+			artifact.ExtraFormat:    "txz",
+			artifact.ExtraBinaries:  []string{"foo"},
+			artifact.ExtraWrappedIn: "",
+		},
+	})
+
+	content, err := preparePkg(ctx, config.Nix{
+		Name:        "foo",
+		IDs:         []string{"foo"},
+		Goamd64:     "v1",
+		Description: `Say "hello" from C:\tools and ${system}`,
+	}, client.NewMock(), fakeHasher{archiveName: "sha"})
+	require.NoError(t, err)
+	require.Contains(t, content, `description = "Say \"hello\" from C:\\tools and \${system}";`)
+}
+
 func TestErrNoArchivesFound(t *testing.T) {
 	require.EqualError(t, errNoArchivesFound{
 		goamd64: "v1",

--- a/internal/pipe/nix/testdata/TestDynamicallyLinked.golden
+++ b/internal/pipe/nix/testdata/TestDynamicallyLinked.golden
@@ -41,8 +41,10 @@ stdenvNoCC.mkDerivation {
   ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
+    runHook postInstall
   '';
 
   meta = {

--- a/internal/pipe/nix/testdata/TestRunPipe/deps_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/deps_build.nix.golden
@@ -46,9 +46,11 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles makeWrapper ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
     wrapProgram $out/bin/foo --prefix PATH : ${lib.makeBinPath (lib.optionals stdenvNoCC.isDarwin [ chromium ] ++ lib.optionals stdenvNoCC.isLinux [ ttyd ] ++ [ fish bash ])}
+    runHook postInstall
   '';
 
   meta = {

--- a/internal/pipe/nix/testdata/TestRunPipe/deps_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/deps_publish.nix.golden
@@ -46,9 +46,11 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles makeWrapper ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
     wrapProgram $out/bin/foo --prefix PATH : ${lib.makeBinPath (lib.optionals stdenvNoCC.isDarwin [ chromium ] ++ lib.optionals stdenvNoCC.isLinux [ ttyd ] ++ [ fish bash ])}
+    runHook postInstall
   '';
 
   meta = {

--- a/internal/pipe/nix/testdata/TestRunPipe/extra-install_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/extra-install_build.nix.golden
@@ -46,10 +46,12 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles makeWrapper ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
     wrapProgram $out/bin/foo --prefix PATH : ${lib.makeBinPath (lib.optionals stdenvNoCC.isDarwin [ chromium ] ++ lib.optionals stdenvNoCC.isLinux [ ttyd ] ++ [ fish bash ])}
     installManPage ./manpages/foo.1.gz
+    runHook postInstall
   '';
 
   meta = {

--- a/internal/pipe/nix/testdata/TestRunPipe/extra-install_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/extra-install_publish.nix.golden
@@ -46,10 +46,12 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles makeWrapper ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
     wrapProgram $out/bin/foo --prefix PATH : ${lib.makeBinPath (lib.optionals stdenvNoCC.isDarwin [ chromium ] ++ lib.optionals stdenvNoCC.isLinux [ ttyd ] ++ [ fish bash ])}
     installManPage ./manpages/foo.1.gz
+    runHook postInstall
   '';
 
   meta = {

--- a/internal/pipe/nix/testdata/TestRunPipe/main-program_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/main-program_build.nix.golden
@@ -41,8 +41,10 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp foo $out/bin/foo
+    runHook postInstall
   '';
 
   meta = {

--- a/internal/pipe/nix/testdata/TestRunPipe/main-program_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/main-program_publish.nix.golden
@@ -41,8 +41,10 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp foo $out/bin/foo
+    runHook postInstall
   '';
 
   meta = {

--- a/internal/pipe/nix/testdata/TestRunPipe/minimal_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/minimal_build.nix.golden
@@ -41,8 +41,10 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
+    runHook postInstall
   '';
 
   meta = {

--- a/internal/pipe/nix/testdata/TestRunPipe/minimal_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/minimal_publish.nix.golden
@@ -41,8 +41,10 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
+    runHook postInstall
   '';
 
   meta = {

--- a/internal/pipe/nix/testdata/TestRunPipe/open-pr_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/open-pr_build.nix.golden
@@ -41,8 +41,10 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
+    runHook postInstall
   '';
 
   meta = {

--- a/internal/pipe/nix/testdata/TestRunPipe/open-pr_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/open-pr_publish.nix.golden
@@ -41,8 +41,10 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
+    runHook postInstall
   '';
 
   meta = {

--- a/internal/pipe/nix/testdata/TestRunPipe/partial_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/partial_build.nix.golden
@@ -31,8 +31,10 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
+    runHook postInstall
   '';
 
   meta = {

--- a/internal/pipe/nix/testdata/TestRunPipe/partial_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/partial_publish.nix.golden
@@ -31,8 +31,10 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
+    runHook postInstall
   '';
 
   meta = {

--- a/internal/pipe/nix/testdata/TestRunPipe/skip-upload-auto_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/skip-upload-auto_build.nix.golden
@@ -41,8 +41,10 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
+    runHook postInstall
   '';
 
   meta = {

--- a/internal/pipe/nix/testdata/TestRunPipe/skip-upload_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/skip-upload_build.nix.golden
@@ -41,8 +41,10 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
+    runHook postInstall
   '';
 
   meta = {

--- a/internal/pipe/nix/testdata/TestRunPipe/unibin-replaces_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/unibin-replaces_build.nix.golden
@@ -37,8 +37,10 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
+    runHook postInstall
   '';
 
   meta = {

--- a/internal/pipe/nix/testdata/TestRunPipe/unibin-replaces_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/unibin-replaces_publish.nix.golden
@@ -37,8 +37,10 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
+    runHook postInstall
   '';
 
   meta = {

--- a/internal/pipe/nix/testdata/TestRunPipe/wrapped-in-dir_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/wrapped-in-dir_build.nix.golden
@@ -44,9 +44,11 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp foo $out/bin/foo
     installManPage ./manpages/foo.1.gz
+    runHook postInstall
   '';
   postInstall = ''
     echo "do something"

--- a/internal/pipe/nix/testdata/TestRunPipe/wrapped-in-dir_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/wrapped-in-dir_publish.nix.golden
@@ -44,9 +44,11 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp foo $out/bin/foo
     installManPage ./manpages/foo.1.gz
+    runHook postInstall
   '';
   postInstall = ''
     echo "do something"

--- a/internal/pipe/nix/testdata/TestRunPipe/zip-and-tar_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip-and-tar_build.nix.golden
@@ -34,8 +34,10 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles unzip ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
+    runHook postInstall
   '';
 
   meta = {

--- a/internal/pipe/nix/testdata/TestRunPipe/zip-and-tar_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip-and-tar_publish.nix.golden
@@ -34,8 +34,10 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles unzip ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
+    runHook postInstall
   '';
 
   meta = {

--- a/internal/pipe/nix/testdata/TestRunPipe/zip-with-dependencies_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip-with-dependencies_build.nix.golden
@@ -40,9 +40,11 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles makeWrapper unzip ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
     wrapProgram $out/bin/foo --prefix PATH : ${lib.makeBinPath ([ git ])}
+    runHook postInstall
   '';
 
   meta = {

--- a/internal/pipe/nix/testdata/TestRunPipe/zip-with-dependencies_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip-with-dependencies_publish.nix.golden
@@ -40,9 +40,11 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles makeWrapper unzip ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
     wrapProgram $out/bin/foo --prefix PATH : ${lib.makeBinPath ([ git ])}
+    runHook postInstall
   '';
 
   meta = {

--- a/internal/pipe/nix/testdata/TestRunPipe/zip_build.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip_build.nix.golden
@@ -38,8 +38,10 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles unzip ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
+    runHook postInstall
   '';
 
   meta = {

--- a/internal/pipe/nix/testdata/TestRunPipe/zip_publish.nix.golden
+++ b/internal/pipe/nix/testdata/TestRunPipe/zip_publish.nix.golden
@@ -38,8 +38,10 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ installShellFiles unzip ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     cp -vr ./foo $out/bin/foo
+    runHook postInstall
   '';
 
   meta = {

--- a/internal/pipe/nix/tmpl.nix
+++ b/internal/pipe/nix/tmpl.nix
@@ -108,9 +108,11 @@ stdenvNoCC.mkDerivation {
 {{- end }}
 
   installPhase = ''
+    runHook preInstall
     {{- range $index, $element := .Install }}
     {{ . -}}
     {{- end }}
+    runHook postInstall
   '';
 
   {{- with .PostInstall }}


### PR DESCRIPTION
Fixes a group of related bugs in Nix pipe (internal/pipe/nix).

- Closes #7065: format regenerated Nix package content before publishing it.
- Closes #6983: escape Nix package descriptions as Nix string literals.
- Closes #6982: run preInstall and postInstall hooks around generated installPhase bodies.