### PR TITLE
fix(builder/uv,builder/poetry): match built artifact filenames

### DIFF
--- a/internal/builders/poetry/build_test.go
+++ b/internal/builders/poetry/build_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -123,6 +124,82 @@ func TestArtifactNames(t *testing.T) {
 	})
 }
 
+func TestBuildLegacyPoetryProject(t *testing.T) {
+	folder := testlib.Mktmp(t)
+	createFakePoetry(t)
+
+	modTime := time.Now().AddDate(-1, 0, 0).Round(time.Second).UTC()
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Dist:        filepath.Join(folder, "dist"),
+		ProjectName: "testdata",
+		Builds: []config.Build{
+			{
+				ID:           "testdata-wheel",
+				Dir:          poetryTestdataDir(t),
+				ModTimestamp: fmt.Sprintf("%d", modTime.Unix()),
+				Buildmode:    "wheel",
+			},
+			{
+				ID:           "testdata-sdist",
+				Dir:          poetryTestdataDir(t),
+				ModTimestamp: fmt.Sprintf("%d", modTime.Unix()),
+				Buildmode:    "sdist",
+			},
+		},
+	})
+
+	dir := filepath.Join(folder, "dist", "testdata-all-all", "testdata")
+	require.NoError(t, os.MkdirAll(filepath.Dir(dir), 0o755)) // this happens on internal/pipe/build/ when in prod
+	for _, build := range ctx.Config.Builds {
+		build, err := Default.WithDefaults(build)
+		require.NoError(t, err)
+		opts := api.Options{
+			Path:   dir,
+			Target: Target{},
+		}
+		require.NoError(t, Default.Build(ctx, build, opts))
+	}
+
+	builds := ctx.Artifacts.List()
+	require.Len(t, builds, 2)
+	testlib.RequireEqualArtifacts(t, []*artifact.Artifact{
+		{
+			Name:   "testdata-0.1.0-py3-none-any.whl",
+			Path:   filepath.Join("dist", "testdata-all-all", "testdata-0.1.0-py3-none-any.whl"),
+			Goos:   "all",
+			Goarch: "all",
+			Target: "none-any",
+			Type:   artifact.PyWheel,
+			Extra: artifact.Extras{
+				artifact.ExtraBuilder: "poetry",
+				artifact.ExtraExt:     ".whl",
+				artifact.ExtraID:      "testdata-wheel",
+			},
+		},
+		{
+			Name:   "testdata-0.1.0.tar.gz",
+			Path:   filepath.Join("dist", "testdata-all-all", "testdata-0.1.0.tar.gz"),
+			Goos:   "all",
+			Goarch: "all",
+			Target: "none-any",
+			Type:   artifact.PySdist,
+			Extra: artifact.Extras{
+				artifact.ExtraBuilder: "poetry",
+				artifact.ExtraExt:     ".tar.gz",
+				artifact.ExtraID:      "testdata-sdist",
+			},
+		},
+	}, builds)
+
+	for _, art := range builds {
+		_, err := art.Checksum("sha256")
+		require.NoError(t, err)
+		fi, err := os.Stat(art.Path)
+		require.NoError(t, err)
+		require.True(t, modTime.Equal(fi.ModTime()))
+	}
+}
+
 func TestBuild(t *testing.T) {
 	testlib.CheckPath(t, "poetry")
 
@@ -211,4 +288,80 @@ func TestBuild(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, modTime.Equal(fi.ModTime()))
 	}
+}
+
+func createFakePoetry(tb testing.TB) {
+	tb.Helper()
+
+	createFakeExecutable(
+		tb,
+		"poetry",
+		`#!/bin/sh
+output=""
+format=""
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--output)
+			shift
+			output="$1"
+			;;
+		--format)
+			shift
+			format="$1"
+			;;
+	esac
+	shift
+done
+mkdir -p "$output"
+case "$format" in
+	wheel)
+		printf fake > "$output/testdata-0.1.0-py3-none-any.whl"
+		;;
+	sdist)
+		printf fake > "$output/testdata-0.1.0.tar.gz"
+		;;
+esac
+`,
+		`@echo off
+set output=
+set format=
+:parse
+if "%1"=="" goto done
+if "%1"=="--output" (
+	shift
+	set output=%1
+) else if "%1"=="--format" (
+	shift
+	set format=%1
+)
+shift
+goto parse
+:done
+if not exist "%output%" mkdir "%output%"
+if "%format%"=="wheel" (
+	echo fake>"%output%\testdata-0.1.0-py3-none-any.whl"
+) else if "%format%"=="sdist" (
+	echo fake>"%output%\testdata-0.1.0.tar.gz"
+)
+`,
+	)
+}
+
+func poetryTestdataDir(tb testing.TB) string {
+	tb.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	require.True(tb, ok)
+	return filepath.Join(filepath.Dir(file), "testdata")
+}
+
+func createFakeExecutable(tb testing.TB, name, unix, windows string) {
+	tb.Helper()
+
+	dir := tb.TempDir()
+	if runtime.GOOS == "windows" {
+		name += ".bat"
+		unix = windows
+	}
+	require.NoError(tb, os.WriteFile(filepath.Join(dir, name), []byte(unix), 0o755))
+	tb.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }

--- a/internal/builders/poetry/build_test.go
+++ b/internal/builders/poetry/build_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
+	"github.com/goreleaser/goreleaser/v2/internal/pyproject"
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/internal/testlib"
 	api "github.com/goreleaser/goreleaser/v2/pkg/build"
@@ -75,6 +76,50 @@ func TestWithDefaults(t *testing.T) {
 			Main: "something",
 		})
 		require.Error(t, err)
+	})
+}
+
+func TestArtifactNames(t *testing.T) {
+	var proj pyproject.PyProject
+	proj.Project.Name = "My..Pkg"
+	proj.Project.Version = "0.1.0"
+
+	options := api.Options{
+		Path:   filepath.Join("dist", "my-pkg-all-all", "my-pkg"),
+		Target: Target{},
+	}
+	build := config.Build{ID: "my-pkg"}
+
+	testlib.RequireEqualArtifacts(t, []*artifact.Artifact{
+		{
+			Name:   "my_pkg-0.1.0-py3-none-any.whl",
+			Path:   filepath.Join("dist", "my-pkg-all-all", "my_pkg-0.1.0-py3-none-any.whl"),
+			Goos:   "all",
+			Goarch: "all",
+			Target: "none-any",
+			Type:   artifact.PyWheel,
+			Extra: artifact.Extras{
+				artifact.ExtraBuilder: "poetry",
+				artifact.ExtraExt:     ".whl",
+				artifact.ExtraID:      "my-pkg",
+			},
+		},
+		{
+			Name:   "my_pkg-0.1.0.tar.gz",
+			Path:   filepath.Join("dist", "my-pkg-all-all", "my_pkg-0.1.0.tar.gz"),
+			Goos:   "all",
+			Goarch: "all",
+			Target: "none-any",
+			Type:   artifact.PySdist,
+			Extra: artifact.Extras{
+				artifact.ExtraBuilder: "poetry",
+				artifact.ExtraExt:     ".tar.gz",
+				artifact.ExtraID:      "my-pkg",
+			},
+		},
+	}, []*artifact.Artifact{
+		wheel(proj, build, options),
+		sdist(proj, build, options),
 	})
 }
 

--- a/internal/builders/poetry/build_test.go
+++ b/internal/builders/poetry/build_test.go
@@ -165,7 +165,7 @@ func TestBuildLegacyPoetryProject(t *testing.T) {
 	testlib.RequireEqualArtifacts(t, []*artifact.Artifact{
 		{
 			Name:   "testdata-0.1.0-py3-none-any.whl",
-			Path:   filepath.Join("dist", "testdata-all-all", "testdata-0.1.0-py3-none-any.whl"),
+			Path:   filepath.ToSlash(filepath.Join("dist", "testdata-all-all", "testdata-0.1.0-py3-none-any.whl")),
 			Goos:   "all",
 			Goarch: "all",
 			Target: "none-any",
@@ -178,7 +178,7 @@ func TestBuildLegacyPoetryProject(t *testing.T) {
 		},
 		{
 			Name:   "testdata-0.1.0.tar.gz",
-			Path:   filepath.Join("dist", "testdata-all-all", "testdata-0.1.0.tar.gz"),
+			Path:   filepath.ToSlash(filepath.Join("dist", "testdata-all-all", "testdata-0.1.0.tar.gz")),
 			Goos:   "all",
 			Goarch: "all",
 			Target: "none-any",
@@ -328,11 +328,15 @@ set format=
 :parse
 if "%1"=="" goto done
 if "%1"=="--output" (
+	set "output=%~2"
 	shift
-	set output=%1
+	shift
+	goto parse
 ) else if "%1"=="--format" (
+	set "format=%~2"
 	shift
-	set format=%1
+	shift
+	goto parse
 )
 shift
 goto parse

--- a/internal/builders/uv/build_test.go
+++ b/internal/builders/uv/build_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
+	"github.com/goreleaser/goreleaser/v2/internal/pyproject"
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/internal/testlib"
 	api "github.com/goreleaser/goreleaser/v2/pkg/build"
@@ -75,6 +76,50 @@ func TestWithDefaults(t *testing.T) {
 			Main: "something",
 		})
 		require.Error(t, err)
+	})
+}
+
+func TestArtifactNames(t *testing.T) {
+	var proj pyproject.PyProject
+	proj.Project.Name = "My..Pkg"
+	proj.Project.Version = "0.1.0"
+
+	options := api.Options{
+		Path:   filepath.Join("dist", "my-pkg-all-all", "my-pkg"),
+		Target: Target{},
+	}
+	build := config.Build{ID: "my-pkg"}
+
+	testlib.RequireEqualArtifacts(t, []*artifact.Artifact{
+		{
+			Name:   "my_pkg-0.1.0-py3-none-any.whl",
+			Path:   filepath.Join("dist", "my-pkg-all-all", "my_pkg-0.1.0-py3-none-any.whl"),
+			Goos:   "all",
+			Goarch: "all",
+			Target: "none-any",
+			Type:   artifact.PyWheel,
+			Extra: artifact.Extras{
+				artifact.ExtraBuilder: "uv",
+				artifact.ExtraExt:     ".whl",
+				artifact.ExtraID:      "my-pkg",
+			},
+		},
+		{
+			Name:   "my_pkg-0.1.0.tar.gz",
+			Path:   filepath.Join("dist", "my-pkg-all-all", "my_pkg-0.1.0.tar.gz"),
+			Goos:   "all",
+			Goarch: "all",
+			Target: "none-any",
+			Type:   artifact.PySdist,
+			Extra: artifact.Extras{
+				artifact.ExtraBuilder: "uv",
+				artifact.ExtraExt:     ".tar.gz",
+				artifact.ExtraID:      "my-pkg",
+			},
+		},
+	}, []*artifact.Artifact{
+		wheel(proj, build, options),
+		sdist(proj, build, options),
 	})
 }
 

--- a/internal/pyproject/pyproject.go
+++ b/internal/pyproject/pyproject.go
@@ -16,6 +16,8 @@ type PyProject struct {
 	}
 	Tool struct {
 		Poetry struct {
+			Name     string
+			Version  string
 			Packages []any
 		}
 	}
@@ -55,6 +57,14 @@ func Open(name string) (PyProject, error) {
 	if err != nil {
 		return proj, err
 	}
-	err = toml.Unmarshal(data, &proj)
-	return proj, err
+	if err := toml.Unmarshal(data, &proj); err != nil {
+		return proj, err
+	}
+	if proj.Project.Name == "" {
+		proj.Project.Name = proj.Tool.Poetry.Name
+	}
+	if proj.Project.Version == "" {
+		proj.Project.Version = proj.Tool.Poetry.Version
+	}
+	return proj, nil
 }

--- a/internal/pyproject/pyproject.go
+++ b/internal/pyproject/pyproject.go
@@ -27,7 +27,25 @@ func (p PyProject) IsPoetry() bool {
 
 // Name returns the project name.
 func (p PyProject) Name() string {
-	return strings.ReplaceAll(p.Project.Name, "-", "_")
+	return normalizeName(p.Project.Name)
+}
+
+func normalizeName(name string) string {
+	var b strings.Builder
+	previousWasSeparator := false
+	for _, r := range strings.ToLower(name) {
+		switch r {
+		case '-', '_', '.':
+			if !previousWasSeparator {
+				b.WriteRune('_')
+			}
+			previousWasSeparator = true
+		default:
+			b.WriteRune(r)
+			previousWasSeparator = false
+		}
+	}
+	return b.String()
 }
 
 // Open opens and parses a pyproject.toml file.

--- a/internal/pyproject/pyproject_test.go
+++ b/internal/pyproject/pyproject_test.go
@@ -14,6 +14,20 @@ func TestOpen(t *testing.T) {
 	require.False(t, proj.IsPoetry())
 }
 
+func TestOpenLegacyPoetry(t *testing.T) {
+	proj, err := Open("../builders/poetry/testdata/pyproject.toml")
+	require.NoError(t, err)
+	require.Equal(t, "testdata", proj.Project.Name)
+	require.Equal(t, "0.1.0", proj.Project.Version)
+}
+
+func TestOpenProjectMetadataPrecedence(t *testing.T) {
+	proj, err := Open("./testdata/project-and-poetry-pyproject.toml")
+	require.NoError(t, err)
+	require.Equal(t, "project-name", proj.Project.Name)
+	require.Equal(t, "1.2.3", proj.Project.Version)
+}
+
 func TestOpenError(t *testing.T) {
 	_, err := Open("./testdata/nope.toml")
 	require.Error(t, err)

--- a/internal/pyproject/pyproject_test.go
+++ b/internal/pyproject/pyproject_test.go
@@ -25,6 +25,24 @@ func TestName(t *testing.T) {
 	require.Equal(t, "python_test", proj.Name())
 }
 
+func TestNormalizeName(t *testing.T) {
+	for name, expected := range map[string]string{
+		"My..Pkg":          "my_pkg",
+		"my-pkg":           "my_pkg",
+		"my__pkg":          "my_pkg",
+		"my-_.pkg":         "my_pkg",
+		"python-test":      "python_test",
+		"already_normal":   "already_normal",
+		"package.with.dot": "package_with_dot",
+	} {
+		t.Run(name, func(t *testing.T) {
+			var proj PyProject
+			proj.Project.Name = name
+			require.Equal(t, expected, proj.Name())
+		})
+	}
+}
+
 func TestIsPoetry(t *testing.T) {
 	proj, err := Open("./testdata/poetry-pyproject.toml")
 	require.NoError(t, err)

--- a/internal/pyproject/testdata/project-and-poetry-pyproject.toml
+++ b/internal/pyproject/testdata/project-and-poetry-pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "project-name"
+version = "1.2.3"
+
+[tool.poetry]
+name = "poetry-name"
+version = "4.5.6"


### PR DESCRIPTION
Fixes a group of related bugs in the Python builders.

- Closes #6906: Normalize Python package names so uv and poetry artifact paths match built wheel and sdist filenames.
- Closes #6905: Read legacy Poetry name and version metadata so registered artifact paths exist.