### PR TITLE
fix(flatpak,docker): quote install paths and respect project environment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/goreleaser/goreleaser/v2
 go 1.27.1
 
 require (
-	al.essio.dev/pkg/shellescape v1.6.0
 	charm.land/lipgloss/v2 v2.0.6
 	code.gitea.io/sdk/gitea v0.25.1
 	dario.cat/mergo v1.0.2
@@ -64,6 +63,7 @@ require (
 )
 
 require (
+	al.essio.dev/pkg/shellescape v1.6.0 // indirect
 	cel.dev/expr v0.25.2 // indirect
 	cloud.google.com/go v0.123.0 // indirect
 	cloud.google.com/go/auth v0.20.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/goreleaser/goreleaser/v2
 go 1.27.1
 
 require (
+	al.essio.dev/pkg/shellescape v1.6.0
 	charm.land/lipgloss/v2 v2.0.6
 	code.gitea.io/sdk/gitea v0.25.1
 	dario.cat/mergo v1.0.2
@@ -63,7 +64,6 @@ require (
 )
 
 require (
-	al.essio.dev/pkg/shellescape v1.6.0 // indirect
 	cel.dev/expr v0.25.2 // indirect
 	cloud.google.com/go v0.123.0 // indirect
 	cloud.google.com/go/auth v0.20.0 // indirect

--- a/internal/pipe/docker/api.go
+++ b/internal/pipe/docker/api.go
@@ -48,7 +48,7 @@ func runCommand(ctx *context.Context, dir, binary string, args ...string) error 
 	/* #nosec */
 	cmd := exec.CommandContext(ctx, binary, args...)
 	cmd.Dir = dir
-	cmd.Env = append(ctx.Env.Strings(), cmd.Environ()...)
+	cmd.Env = append(cmd.Environ(), ctx.Env.Strings()...)
 
 	var b bytes.Buffer
 	w := gio.Safe(&b)
@@ -70,7 +70,7 @@ func runCommandWithOutput(ctx *context.Context, dir, binary string, args ...stri
 	/* #nosec */
 	cmd := exec.CommandContext(ctx, binary, args...)
 	cmd.Dir = dir
-	cmd.Env = append(ctx.Env.Strings(), cmd.Environ()...)
+	cmd.Env = append(cmd.Environ(), ctx.Env.Strings()...)
 
 	var b bytes.Buffer
 	w := gio.Safe(&b)

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -36,6 +36,90 @@ func start(tb testing.TB) {
 	testlib.StartRegistry(tb, "alt_registry", altRegistryPort)
 }
 
+func TestRunCommandEnvPrecedence(t *testing.T) {
+	for name, tt := range map[string]struct {
+		ambient string
+		project string
+		want    string
+	}{
+		"conflicting": {
+			ambient: "ambient-config",
+			project: "project-config",
+			want:    "project-config",
+		},
+		"configured-only": {
+			project: "project-config",
+			want:    "project-config",
+		},
+		"inherited-only": {
+			ambient: "ambient-config",
+			want:    "ambient-config",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			key := "GORELEASER_TEST_DOCKER_ENV_" + strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
+			unsetEnv(t, key)
+			if tt.ambient != "" {
+				t.Setenv(key, tt.ambient)
+			}
+			t.Setenv("GO_WANT_DOCKER_COMMAND_HELPER", "1")
+			t.Setenv("DOCKER_ENV_HELPER_KEY", key)
+
+			cfg := config.Project{}
+			if tt.project != "" {
+				cfg.Env = []string{key + "=" + tt.project}
+			}
+			ctx := testctx.WrapWithCfg(t.Context(), cfg)
+
+			t.Run("without output", func(t *testing.T) {
+				record := filepath.Join(t.TempDir(), "record")
+				t.Setenv("DOCKER_ENV_HELPER_RECORD", record)
+				require.NoError(t, runCommand(ctx, t.TempDir(), os.Args[0], "-test.run=TestDockerCommandHelper"))
+
+				bts, err := os.ReadFile(record)
+				require.NoError(t, err)
+				require.Equal(t, tt.want, string(bts))
+			})
+
+			t.Run("with output", func(t *testing.T) {
+				t.Setenv("DOCKER_ENV_HELPER_RECORD", "")
+				out, err := runCommandWithOutput(ctx, t.TempDir(), os.Args[0], "-test.run=TestDockerCommandHelper")
+				require.NoError(t, err)
+				require.Equal(t, tt.want, string(out))
+			})
+		})
+	}
+}
+
+func TestDockerCommandHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_DOCKER_COMMAND_HELPER") != "1" {
+		return
+	}
+
+	value := os.Getenv(os.Getenv("DOCKER_ENV_HELPER_KEY"))
+	if record := os.Getenv("DOCKER_ENV_HELPER_RECORD"); record != "" {
+		if err := os.WriteFile(record, []byte(value), 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "write record: %v\n", err)
+			os.Exit(2)
+		}
+	}
+	fmt.Fprint(os.Stdout, value)
+	os.Exit(0)
+}
+
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+	old, ok := os.LookupEnv(key)
+	require.NoError(t, os.Unsetenv(key))
+	t.Cleanup(func() {
+		if ok {
+			require.NoError(t, os.Setenv(key, old))
+			return
+		}
+		require.NoError(t, os.Unsetenv(key))
+	})
+}
+
 // TODO: this test is too big... split in smaller tests? Mainly the manifest ones...
 func TestRunPipe(t *testing.T) {
 	testlib.CheckDocker(t)

--- a/internal/pipe/docker/docker_test.go
+++ b/internal/pipe/docker/docker_test.go
@@ -91,7 +91,7 @@ func TestRunCommandEnvPrecedence(t *testing.T) {
 	}
 }
 
-func TestDockerCommandHelper(t *testing.T) {
+func TestDockerCommandHelper(_ *testing.T) {
 	if os.Getenv("GO_WANT_DOCKER_COMMAND_HELPER") != "1" {
 		return
 	}
@@ -109,15 +109,8 @@ func TestDockerCommandHelper(t *testing.T) {
 
 func unsetEnv(t *testing.T, key string) {
 	t.Helper()
-	old, ok := os.LookupEnv(key)
+	t.Setenv(key, "")
 	require.NoError(t, os.Unsetenv(key))
-	t.Cleanup(func() {
-		if ok {
-			require.NoError(t, os.Setenv(key, old))
-			return
-		}
-		require.NoError(t, os.Unsetenv(key))
-	})
 }
 
 // TODO: this test is too big... split in smaller tests? Mainly the manifest ones...

--- a/internal/pipe/docker/v2/docker.go
+++ b/internal/pipe/docker/v2/docker.go
@@ -287,7 +287,7 @@ func doBuild(ctx *context.Context, d config.DockerV2, wd string, arg []string) (
 				Debug("running docker build")
 			cmd := exec.CommandContext(ctx, "docker", arg...)
 			cmd.Dir = wd
-			cmd.Env = append(ctx.Env.Strings(), cmd.Environ()...)
+			cmd.Env = append(cmd.Environ(), ctx.Env.Strings()...)
 			var b bytes.Buffer
 			w := gio.Safe(&b)
 			cmd.Stderr = redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)

--- a/internal/pipe/docker/v2/docker_test.go
+++ b/internal/pipe/docker/v2/docker_test.go
@@ -2,9 +2,11 @@ package docker
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -370,6 +372,93 @@ func TestDisable(t *testing.T) {
 		require.NoError(t, Base{}.Default(ctx))
 		testlib.RequireTemplateError(t, Snapshot{}.Run(ctx))
 		testlib.RequireTemplateError(t, Publish{}.Publish(ctx))
+	})
+}
+
+func TestDoBuildEnvPrecedence(t *testing.T) {
+	for name, tt := range map[string]struct {
+		ambient string
+		project string
+		want    string
+	}{
+		"conflicting": {
+			ambient: "ambient-config",
+			project: "project-config",
+			want:    "project-config",
+		},
+		"configured-only": {
+			project: "project-config",
+			want:    "project-config",
+		},
+		"inherited-only": {
+			ambient: "ambient-config",
+			want:    "ambient-config",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			binDir := t.TempDir()
+			writeDockerV2TestCommand(t, binDir)
+			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+			key := "GORELEASER_TEST_DOCKER_V2_ENV_" + strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
+			unsetEnv(t, key)
+			if tt.ambient != "" {
+				t.Setenv(key, tt.ambient)
+			}
+			t.Setenv("GO_WANT_DOCKER_V2_COMMAND_HELPER", "1")
+			t.Setenv("DOCKER_V2_ENV_HELPER_KEY", key)
+			record := filepath.Join(t.TempDir(), "record")
+			t.Setenv("DOCKER_V2_ENV_HELPER_RECORD", record)
+
+			cfg := config.Project{}
+			if tt.project != "" {
+				cfg.Env = []string{key + "=" + tt.project}
+			}
+			ctx := testctx.WrapWithCfg(t.Context(), cfg)
+			digest, err := doBuild(ctx, config.DockerV2{}, t.TempDir(), []string{"build"})
+			require.NoError(t, err)
+			require.Equal(t, "sha256:test", digest)
+
+			bts, err := os.ReadFile(record)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, string(bts))
+		})
+	}
+}
+
+func writeDockerV2TestCommand(t *testing.T, dir string) {
+	t.Helper()
+	script := fmt.Sprintf("#!/bin/sh\nexec %q -test.run=TestDockerV2CommandHelper -- \"$@\"\n", os.Args[0])
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "docker"), []byte(script), 0o755))
+}
+
+func TestDockerV2CommandHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_DOCKER_V2_COMMAND_HELPER") != "1" {
+		return
+	}
+
+	if err := os.WriteFile("id.txt", []byte("sha256:test"), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "write id: %v\n", err)
+		os.Exit(2)
+	}
+	value := os.Getenv(os.Getenv("DOCKER_V2_ENV_HELPER_KEY"))
+	if err := os.WriteFile(os.Getenv("DOCKER_V2_ENV_HELPER_RECORD"), []byte(value), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "write record: %v\n", err)
+		os.Exit(2)
+	}
+	os.Exit(0)
+}
+
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+	old, ok := os.LookupEnv(key)
+	require.NoError(t, os.Unsetenv(key))
+	t.Cleanup(func() {
+		if ok {
+			require.NoError(t, os.Setenv(key, old))
+			return
+		}
+		require.NoError(t, os.Unsetenv(key))
 	})
 }
 

--- a/internal/pipe/docker/v2/docker_test.go
+++ b/internal/pipe/docker/v2/docker_test.go
@@ -430,9 +430,13 @@ func writeDockerV2TestCommand(t *testing.T, dir string) {
 	t.Helper()
 	script := fmt.Sprintf("#!/bin/sh\nexec %q -test.run=TestDockerV2CommandHelper -- \"$@\"\n", os.Args[0])
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "docker"), []byte(script), 0o755))
+	if testlib.IsWindows() {
+		script := fmt.Sprintf("@echo off\r\n%q -test.run=TestDockerV2CommandHelper -- %%*\r\n", os.Args[0])
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "docker.bat"), []byte(script), 0o755))
+	}
 }
 
-func TestDockerV2CommandHelper(t *testing.T) {
+func TestDockerV2CommandHelper(_ *testing.T) {
 	if os.Getenv("GO_WANT_DOCKER_V2_COMMAND_HELPER") != "1" {
 		return
 	}
@@ -451,15 +455,8 @@ func TestDockerV2CommandHelper(t *testing.T) {
 
 func unsetEnv(t *testing.T, key string) {
 	t.Helper()
-	old, ok := os.LookupEnv(key)
+	t.Setenv(key, "")
 	require.NoError(t, os.Unsetenv(key))
-	t.Cleanup(func() {
-		if ok {
-			require.NoError(t, os.Setenv(key, old))
-			return
-		}
-		require.NoError(t, os.Unsetenv(key))
-	})
 }
 
 func TestIsDockerDaemonAvailableNoDaemon(t *testing.T) {

--- a/internal/pipe/flatpak/flatpak.go
+++ b/internal/pipe/flatpak/flatpak.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"al.essio.dev/pkg/shellescape"
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/gerrors"
@@ -192,7 +193,11 @@ func create(ctx *context.Context, fp config.Flatpak, arch string, binaries []*ar
 			Path:         binaryName,
 			DestFilename: binaryName,
 		})
-		installCmds = append(installCmds, fmt.Sprintf("install -Dm755 %s /app/bin/%s", binaryName, binaryName))
+		installCmds = append(installCmds, fmt.Sprintf(
+			"install -Dm755 %s %s",
+			shellescape.Quote(binaryName),
+			shellescape.Quote("/app/bin/"+binaryName),
+		))
 	}
 
 	manifest.Modules = []ManifestModule{

--- a/internal/pipe/flatpak/flatpak.go
+++ b/internal/pipe/flatpak/flatpak.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"al.essio.dev/pkg/shellescape"
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/gerrors"
@@ -194,8 +195,8 @@ func create(ctx *context.Context, fp config.Flatpak, arch string, binaries []*ar
 		})
 		installCmds = append(installCmds, fmt.Sprintf(
 			"install -Dm755 %s %s",
-			quoteField(binaryName),
-			quoteField("/app/bin/"+binaryName),
+			shellescape.Quote(binaryName),
+			shellescape.Quote("/app/bin/"+binaryName),
 		))
 	}
 
@@ -271,10 +272,6 @@ func create(ctx *context.Context, fp config.Flatpak, arch string, binaries []*ar
 		},
 	})
 	return nil
-}
-
-func quoteField(value string) string {
-	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
 }
 
 func runCmd(ctx *context.Context, dir, errMsg, bin string, args ...string) error {

--- a/internal/pipe/flatpak/flatpak.go
+++ b/internal/pipe/flatpak/flatpak.go
@@ -14,7 +14,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"al.essio.dev/pkg/shellescape"
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/gerrors"
@@ -195,8 +194,8 @@ func create(ctx *context.Context, fp config.Flatpak, arch string, binaries []*ar
 		})
 		installCmds = append(installCmds, fmt.Sprintf(
 			"install -Dm755 %s %s",
-			shellescape.Quote(binaryName),
-			shellescape.Quote("/app/bin/"+binaryName),
+			quoteField(binaryName),
+			quoteField("/app/bin/"+binaryName),
 		))
 	}
 
@@ -272,6 +271,10 @@ func create(ctx *context.Context, fp config.Flatpak, arch string, binaries []*ar
 		},
 	})
 	return nil
+}
+
+func quoteField(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
 }
 
 func runCmd(ctx *context.Context, dir, errMsg, bin string, args ...string) error {

--- a/internal/pipe/flatpak/flatpak.go
+++ b/internal/pipe/flatpak/flatpak.go
@@ -277,7 +277,7 @@ func create(ctx *context.Context, fp config.Flatpak, arch string, binaries []*ar
 func runCmd(ctx *context.Context, dir, errMsg, bin string, args ...string) error {
 	cmd := exec.CommandContext(ctx, bin, args...)
 	cmd.Dir = dir
-	cmd.Env = append(ctx.Env.Strings(), cmd.Environ()...)
+	cmd.Env = append(cmd.Environ(), ctx.Env.Strings()...)
 	var b bytes.Buffer
 	w := gio.Safe(&b)
 	cmd.Stderr = redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)

--- a/internal/pipe/flatpak/flatpak_test.go
+++ b/internal/pipe/flatpak/flatpak_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
@@ -242,6 +243,59 @@ func TestRunPipeQuotesInstallPaths(t *testing.T) {
 	}
 }
 
+func TestRunCmdEnvPrecedence(t *testing.T) {
+	for name, tt := range map[string]struct {
+		ambient string
+		project string
+		want    string
+	}{
+		"conflicting": {
+			ambient: "ambient-config",
+			project: "project-config",
+			want:    "project-config",
+		},
+		"configured-only": {
+			project: "project-config",
+			want:    "project-config",
+		},
+		"inherited-only": {
+			ambient: "ambient-config",
+			want:    "ambient-config",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			key := "GORELEASER_TEST_FLATPAK_ENV_" + strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
+			unsetEnv(t, key)
+			if tt.ambient != "" {
+				t.Setenv(key, tt.ambient)
+			}
+			t.Setenv("GO_WANT_FLATPAK_COMMAND_HELPER", "1")
+			t.Setenv("FLATPAK_ENV_HELPER_KEY", key)
+			record := filepath.Join(t.TempDir(), "record")
+			t.Setenv("FLATPAK_ENV_HELPER_RECORD", record)
+
+			cfg := config.Project{}
+			if tt.project != "" {
+				cfg.Env = []string{key + "=" + tt.project}
+			}
+			ctx := testctx.WrapWithCfg(t.Context(), cfg)
+			require.NoError(t, runCmd(
+				ctx,
+				t.TempDir(),
+				"failed to run flatpak helper",
+				os.Args[0],
+				"-test.run=TestFlatpakCommandHelper",
+				"--",
+				"env",
+			))
+
+			bts, err := os.ReadFile(record)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, string(bts))
+		})
+	}
+}
+
 func TestDependencies(t *testing.T) {
 	require.Equal(t, []string{"flatpak-builder", "flatpak"}, Pipe{}.Dependencies(nil))
 }
@@ -316,6 +370,8 @@ func TestFlatpakCommandHelper(t *testing.T) {
 		os.Exit(0)
 	case "install":
 		runInstallHelper(args[1:])
+	case "env":
+		runFlatpakEnvHelper()
 	default:
 		fmt.Fprintf(os.Stderr, "unknown helper command: %s\n", args[0])
 		os.Exit(2)
@@ -363,6 +419,15 @@ func runFlatpakBuilderHelper(args []string) {
 	os.Exit(0)
 }
 
+func runFlatpakEnvHelper() {
+	value := os.Getenv(os.Getenv("FLATPAK_ENV_HELPER_KEY"))
+	if err := os.WriteFile(os.Getenv("FLATPAK_ENV_HELPER_RECORD"), []byte(value), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "write record: %v\n", err)
+		os.Exit(2)
+	}
+	os.Exit(0)
+}
+
 func runInstallHelper(args []string) {
 	expected := []string{
 		"-Dm755",
@@ -389,4 +454,17 @@ func runInstallHelper(args []string) {
 		os.Exit(2)
 	}
 	os.Exit(0)
+}
+
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+	old, ok := os.LookupEnv(key)
+	require.NoError(t, os.Unsetenv(key))
+	t.Cleanup(func() {
+		if ok {
+			require.NoError(t, os.Setenv(key, old))
+			return
+		}
+		require.NoError(t, os.Unsetenv(key))
+	})
 }

--- a/internal/pipe/flatpak/flatpak_test.go
+++ b/internal/pipe/flatpak/flatpak_test.go
@@ -207,6 +207,7 @@ func TestRunPipeQuotesInstallPaths(t *testing.T) {
 		"ordinary": "myapp",
 		"spaces":   "my app",
 		"quotes":   `my "app's"`,
+		"hostile":  "my 'app\" with space \\ $HOME `whoami` $(id)\nnext",
 	} {
 		t.Run(name, func(t *testing.T) {
 			binDir := t.TempDir()

--- a/internal/pipe/flatpak/flatpak_test.go
+++ b/internal/pipe/flatpak/flatpak_test.go
@@ -350,9 +350,13 @@ func writeFlatpakTestCommand(t *testing.T, dir, name string) {
 	t.Helper()
 	script := fmt.Sprintf("#!/bin/sh\nexec %q -test.run=TestFlatpakCommandHelper -- %q \"$@\"\n", os.Args[0], name)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(script), 0o755))
+	if testlib.IsWindows() {
+		script := fmt.Sprintf("@echo off\r\n%q -test.run=TestFlatpakCommandHelper -- %q %%*\r\n", os.Args[0], name)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name+".bat"), []byte(script), 0o755))
+	}
 }
 
-func TestFlatpakCommandHelper(t *testing.T) {
+func TestFlatpakCommandHelper(_ *testing.T) {
 	if os.Getenv("GO_WANT_FLATPAK_COMMAND_HELPER") != "1" {
 		return
 	}
@@ -443,14 +447,12 @@ func runInstallHelper(args []string) {
 		fmt.Fprintf(os.Stderr, "open install record: %v\n", err)
 		os.Exit(2)
 	}
-	defer func() {
-		if err := f.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "close install record: %v\n", err)
-			os.Exit(2)
-		}
-	}()
 	if _, err := fmt.Fprintf(f, "%s\n%s\n", args[1], args[2]); err != nil {
 		fmt.Fprintf(os.Stderr, "write install record: %v\n", err)
+		os.Exit(2)
+	}
+	if err := f.Close(); err != nil {
+		fmt.Fprintf(os.Stderr, "close install record: %v\n", err)
 		os.Exit(2)
 	}
 	os.Exit(0)
@@ -458,13 +460,6 @@ func runInstallHelper(args []string) {
 
 func unsetEnv(t *testing.T, key string) {
 	t.Helper()
-	old, ok := os.LookupEnv(key)
+	t.Setenv(key, "")
 	require.NoError(t, os.Unsetenv(key))
-	t.Cleanup(func() {
-		if ok {
-			require.NoError(t, os.Setenv(key, old))
-			return
-		}
-		require.NoError(t, os.Unsetenv(key))
-	})
 }

--- a/internal/pipe/flatpak/flatpak_test.go
+++ b/internal/pipe/flatpak/flatpak_test.go
@@ -3,9 +3,12 @@ package flatpak
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"maps"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
@@ -196,6 +199,49 @@ func TestRunPipe(t *testing.T) {
 	require.Equal(t, "simple", manifest.Modules[0].BuildSystem)
 }
 
+func TestRunPipeQuotesInstallPaths(t *testing.T) {
+	testlib.SkipIfWindows(t, "flatpak build commands are shell commands")
+
+	for name, binaryName := range map[string]string{
+		"ordinary": "myapp",
+		"spaces":   "my app",
+		"quotes":   `my "app's"`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			binDir := t.TempDir()
+			writeFlatpakTestCommand(t, binDir, "flatpak-builder")
+			writeFlatpakTestCommand(t, binDir, "flatpak")
+			writeFlatpakTestCommand(t, binDir, "install")
+			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("GO_WANT_FLATPAK_COMMAND_HELPER", "1")
+			t.Setenv("EXPECTED_INSTALL_SOURCE", binaryName)
+			t.Setenv("EXPECTED_INSTALL_DEST", "/app/bin/"+binaryName)
+			record := filepath.Join(t.TempDir(), "install-record")
+			t.Setenv("INSTALL_RECORD", record)
+
+			dist := filepath.Join(t.TempDir(), "dist")
+			require.NoError(t, os.Mkdir(dist, 0o755))
+			fp := validFlatpak()
+			fp.NameTemplate = "foo_{{.Arch}}"
+			fp.AppID = "org.example.MyBin"
+			fp.IDs = []string{binaryName}
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+				ProjectName: "mybin",
+				Dist:        dist,
+				Flatpaks:    []config.Flatpak{fp},
+			}, testctx.WithCurrentTag("v1.2.3"), testctx.WithVersion("1.2.3"))
+
+			addBinaries(t, ctx, binaryName, dist)
+			requireNoGerror(t, Pipe{}.Run(ctx))
+
+			contents, err := os.ReadFile(record)
+			require.NoError(t, err)
+			require.Contains(t, string(contents), binaryName)
+			require.Contains(t, string(contents), "/app/bin/"+binaryName)
+		})
+	}
+}
+
 func TestDependencies(t *testing.T) {
 	require.Equal(t, []string{"flatpak-builder", "flatpak"}, Pipe{}.Dependencies(nil))
 }
@@ -244,4 +290,103 @@ func addBinaries(t *testing.T, ctx *context.Context, name, dist string) {
 			ctx.Artifacts.Add(a)
 		}
 	}
+}
+
+func writeFlatpakTestCommand(t *testing.T, dir, name string) {
+	t.Helper()
+	script := fmt.Sprintf("#!/bin/sh\nexec %q -test.run=TestFlatpakCommandHelper -- %q \"$@\"\n", os.Args[0], name)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(script), 0o755))
+}
+
+func TestFlatpakCommandHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_FLATPAK_COMMAND_HELPER") != "1" {
+		return
+	}
+
+	args := flatpakCommandHelperArgs()
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "missing helper command")
+		os.Exit(2)
+	}
+
+	switch args[0] {
+	case "flatpak-builder":
+		runFlatpakBuilderHelper(args[1:])
+	case "flatpak":
+		os.Exit(0)
+	case "install":
+		runInstallHelper(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown helper command: %s\n", args[0])
+		os.Exit(2)
+	}
+}
+
+func flatpakCommandHelperArgs() []string {
+	for i, arg := range os.Args {
+		if arg == "--" {
+			return os.Args[i+1:]
+		}
+	}
+	return nil
+}
+
+func runFlatpakBuilderHelper(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "missing manifest path")
+		os.Exit(2)
+	}
+
+	manifestBytes, err := os.ReadFile(args[len(args)-1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read manifest: %v\n", err)
+		os.Exit(2)
+	}
+
+	var manifest Manifest
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		fmt.Fprintf(os.Stderr, "unmarshal manifest: %v\n", err)
+		os.Exit(2)
+	}
+
+	for _, module := range manifest.Modules {
+		for _, buildCommand := range module.BuildCommands {
+			cmd := exec.Command("sh", "-c", buildCommand)
+			cmd.Env = os.Environ()
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "run build command %q: %v\n%s", buildCommand, err, out)
+				os.Exit(1)
+			}
+		}
+	}
+	os.Exit(0)
+}
+
+func runInstallHelper(args []string) {
+	expected := []string{
+		"-Dm755",
+		os.Getenv("EXPECTED_INSTALL_SOURCE"),
+		os.Getenv("EXPECTED_INSTALL_DEST"),
+	}
+	if !slices.Equal(args, expected) {
+		fmt.Fprintf(os.Stderr, "install args: got %#v, want %#v\n", args, expected)
+		os.Exit(64)
+	}
+	f, err := os.OpenFile(os.Getenv("INSTALL_RECORD"), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "open install record: %v\n", err)
+		os.Exit(2)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "close install record: %v\n", err)
+			os.Exit(2)
+		}
+	}()
+	if _, err := fmt.Fprintf(f, "%s\n%s\n", args[1], args[2]); err != nil {
+		fmt.Fprintf(os.Stderr, "write install record: %v\n", err)
+		os.Exit(2)
+	}
+	os.Exit(0)
 }


### PR DESCRIPTION
Fixes a group of related bugs in Flatpak pipe and inherited environment handling.

- Closes #6931: shell-quotes Flatpak install source and destination paths in generated build commands.
- Closes #6924: lets project environment values override inherited environment values for Docker and Flatpak subprocesses.