### PR TITLE
fix(archive,sourcearchive,gio): backups, ZIP metadata, mtime and CPU variants

### DIFF
--- a/internal/archivefiles/archivefiles.go
+++ b/internal/archivefiles/archivefiles.go
@@ -40,7 +40,7 @@ func Eval(template *tmpl.Template, files []config.File) ([]config.File, error) {
 			continue
 		}
 
-		if err := tmplInfo(template, &f.Info); err != nil {
+		if err := EvalInfo(template, &f.Info); err != nil {
 			return result, err
 		}
 
@@ -70,7 +70,8 @@ func Eval(template *tmpl.Template, files []config.File) ([]config.File, error) {
 	return unique(result), nil
 }
 
-func tmplInfo(template *tmpl.Template, info *config.FileInfo) error {
+// EvalInfo applies templates and parses file-info fields.
+func EvalInfo(template *tmpl.Template, info *config.FileInfo) error {
 	if err := template.ApplyAll(
 		&info.Owner,
 		&info.Group,

--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -498,25 +498,37 @@ func (artifacts *Artifacts) GroupByPlatform() map[string][]*Artifact {
 	// gomips, to keep compatibility with previous versions of goreleaser.
 	simpleResult := map[string][]*Artifact{}
 	specificResult := map[string][]*Artifact{}
+	go386s := map[string]struct{}{}
 	goamd64s := map[string]struct{}{}
+	goarm64s := map[string]struct{}{}
 	gomipses := map[string]struct{}{}
 	goarms := map[string]struct{}{}
+	goppc64s := map[string]struct{}{}
+	goriscv64s := map[string]struct{}{}
 	abis := map[string]struct{}{}
 	for _, a := range artifacts.List() {
 		plat := a.Goos + a.Goarch
 		abi := ExtraOr(*a, "Abi", "")
-		fullplat := plat + abi + a.Goarm + a.Gomips + a.Goamd64
+		fullplat := plat + abi + a.Goarm + a.Gomips + a.Goamd64 + a.Go386 + a.Goarm64 + a.Goppc64 + a.Goriscv64
+		go386s[a.Go386] = struct{}{}
 		goamd64s[a.Goamd64] = struct{}{}
+		goarm64s[a.Goarm64] = struct{}{}
 		gomipses[a.Gomips] = struct{}{}
 		goarms[a.Goarm] = struct{}{}
+		goppc64s[a.Goppc64] = struct{}{}
+		goriscv64s[a.Goriscv64] = struct{}{}
 		abis[abi] = struct{}{}
 		simpleResult[plat] = append(simpleResult[plat], a)
 		specificResult[fullplat] = append(specificResult[fullplat], a)
 	}
 
-	if len(nonEmpty(goamd64s)) > 1 ||
+	if len(nonEmpty(go386s)) > 1 ||
+		len(nonEmpty(goamd64s)) > 1 ||
+		len(nonEmpty(goarm64s)) > 1 ||
 		len(nonEmpty(gomipses)) > 1 ||
 		len(nonEmpty(goarms)) > 1 ||
+		len(nonEmpty(goppc64s)) > 1 ||
+		len(nonEmpty(goriscv64s)) > 1 ||
 		len(nonEmpty(abis)) > 1 {
 		return specificResult
 	}

--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -329,6 +329,54 @@ func TestGroupByPlatform(t *testing.T) {
 			Gomips: "hardfloat",
 		},
 		{
+			Name:    "foobar",
+			Goos:    "linux",
+			Goarch:  "arm64",
+			Goarm64: "v8.0",
+		},
+		{
+			Name:    "foobar",
+			Goos:    "linux",
+			Goarch:  "arm64",
+			Goarm64: "v9.0",
+		},
+		{
+			Name:   "foobar",
+			Goos:   "linux",
+			Goarch: "386",
+			Go386:  "sse2",
+		},
+		{
+			Name:   "foobar",
+			Goos:   "linux",
+			Goarch: "386",
+			Go386:  "softfloat",
+		},
+		{
+			Name:    "foobar",
+			Goos:    "linux",
+			Goarch:  "ppc64",
+			Goppc64: "power8",
+		},
+		{
+			Name:    "foobar",
+			Goos:    "linux",
+			Goarch:  "ppc64",
+			Goppc64: "power9",
+		},
+		{
+			Name:      "foobar",
+			Goos:      "linux",
+			Goarch:    "riscv64",
+			Goriscv64: "rva20u64",
+		},
+		{
+			Name:      "foobar",
+			Goos:      "linux",
+			Goarch:    "riscv64",
+			Goriscv64: "rva22u64",
+		},
+		{
 			Name: "check",
 			Type: Checksum,
 		},
@@ -344,6 +392,14 @@ func TestGroupByPlatform(t *testing.T) {
 	require.Len(t, groups["linuxarm6"], 1)
 	require.Len(t, groups["linuxmipssoftfloat"], 1)
 	require.Len(t, groups["linuxmipshardfloat"], 1)
+	require.Len(t, groups["linuxarm64v8.0"], 1)
+	require.Len(t, groups["linuxarm64v9.0"], 1)
+	require.Len(t, groups["linux386sse2"], 1)
+	require.Len(t, groups["linux386softfloat"], 1)
+	require.Len(t, groups["linuxppc64power8"], 1)
+	require.Len(t, groups["linuxppc64power9"], 1)
+	require.Len(t, groups["linuxriscv64rva20u64"], 1)
+	require.Len(t, groups["linuxriscv64rva22u64"], 1)
 }
 
 func TestGroupByPlatform_mixingBuilders(t *testing.T) {
@@ -381,16 +437,64 @@ func TestGroupByPlatform_mixingBuilders(t *testing.T) {
 			Goos:   "linux",
 			Goarch: "arm",
 		},
+		{
+			Name:   "foo",
+			Goos:   "linux",
+			Goarch: "arm64",
+		},
+		{
+			Name:    "bar",
+			Goos:    "linux",
+			Goarch:  "arm64",
+			Goarm64: "v8.0",
+		},
+		{
+			Name:   "foo",
+			Goos:   "linux",
+			Goarch: "386",
+		},
+		{
+			Name:   "bar",
+			Goos:   "linux",
+			Goarch: "386",
+			Go386:  "sse2",
+		},
+		{
+			Name:   "foo",
+			Goos:   "linux",
+			Goarch: "ppc64",
+		},
+		{
+			Name:    "bar",
+			Goos:    "linux",
+			Goarch:  "ppc64",
+			Goppc64: "power8",
+		},
+		{
+			Name:   "foo",
+			Goos:   "linux",
+			Goarch: "riscv64",
+		},
+		{
+			Name:      "bar",
+			Goos:      "linux",
+			Goarch:    "riscv64",
+			Goriscv64: "rva20u64",
+		},
 	}
 	artifacts := New()
 	for _, a := range data {
 		artifacts.Add(a)
 	}
 	groups := artifacts.GroupByPlatform()
-	require.Len(t, groups, 3)
+	require.Len(t, groups, 7)
 	require.Len(t, groups["linuxamd64"], 2)
 	require.Len(t, groups["linuxmips"], 2)
 	require.Len(t, groups["linuxarm"], 2)
+	require.Len(t, groups["linuxarm64"], 2)
+	require.Len(t, groups["linux386"], 2)
+	require.Len(t, groups["linuxppc64"], 2)
+	require.Len(t, groups["linuxriscv64"], 2)
 }
 
 func TestGroupByPlatform_abi(t *testing.T) {

--- a/internal/gio/copy.go
+++ b/internal/gio/copy.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/caarlos0/log"
 )
@@ -18,30 +17,31 @@ func Copy(src, dst string) error {
 // CopyWithMode recursively copies src into dst with the given mode.
 // The given mode applies only to files. Their parent dirs will have the same mode as their src counterparts.
 func CopyWithMode(src, dst string, mode os.FileMode) error {
-	src = filepath.ToSlash(src)
-	dst = filepath.ToSlash(dst)
+	src = filepath.Clean(src)
+	dst = filepath.Clean(dst)
 	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return fmt.Errorf("failed to copy %s to %s: %w", src, dst, err)
 		}
-		path = filepath.ToSlash(path)
-		// We have the following:
-		// - src = "a/b"
-		// - dst = "dist/linuxamd64/b"
-		// - path = "a/b/c.txt"
-		// So we join "a/b" with "c.txt" and use it as the destination.
-		dst := filepath.ToSlash(filepath.Join(dst, strings.Replace(path, src, "", 1)))
-		log.WithField("src", path).WithField("dst", dst).Debug("copying file")
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return fmt.Errorf("failed to copy %s to %s: %w", src, dst, err)
+		}
+		target := dst
+		if rel != "." {
+			target = filepath.Join(dst, rel)
+		}
+		log.WithField("src", filepath.ToSlash(path)).WithField("dst", filepath.ToSlash(target)).Debug("copying file")
 		if info.IsDir() {
-			return os.MkdirAll(dst, info.Mode())
+			return os.MkdirAll(target, info.Mode())
 		}
 		if info.Mode()&os.ModeSymlink != 0 {
-			return copySymlink(path, dst)
+			return copySymlink(path, target)
 		}
 		if mode != 0 {
-			return copyFile(path, dst, mode)
+			return copyFile(path, target, mode)
 		}
-		return copyFile(path, dst, info.Mode())
+		return copyFile(path, target, info.Mode())
 	})
 }
 

--- a/internal/gio/copy_test.go
+++ b/internal/gio/copy_test.go
@@ -108,6 +108,36 @@ func TestCopyTwoLevelDirectory(t *testing.T) {
 	requireEqualFiles(t, filepath.Join(srcLevel2, testFile), filepath.Join(dstDir, "level2", testFile))
 }
 
+func TestCopyDotRelativeDirectory(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+	require.NoError(t, os.MkdirAll(filepath.Join("assets", "css"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join("assets", "index.html"), []byte("index"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join("assets", "css", "style.css"), []byte("style"), 0o644))
+	dstDir := t.TempDir()
+
+	require.NoError(t, Copy("./assets", filepath.Join(dstDir, "assets")))
+
+	requireEqualFiles(t, filepath.Join("assets", "index.html"), filepath.Join(dstDir, "assets", "index.html"))
+	requireEqualFiles(t, filepath.Join("assets", "css", "style.css"), filepath.Join(dstDir, "assets", "css", "style.css"))
+	require.NoFileExists(t, filepath.Join(dstDir, "assets", "assets", "index.html"))
+}
+
+func TestCopyDotDirectory(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+	require.NoError(t, os.WriteFile("config.json", []byte("config"), 0o644))
+	require.NoError(t, os.WriteFile(".dockerignore", []byte("dist"), 0o644))
+	dstDir := t.TempDir()
+
+	require.NoError(t, Copy(".", dstDir))
+
+	requireEqualFiles(t, "config.json", filepath.Join(dstDir, "config.json"))
+	requireEqualFiles(t, ".dockerignore", filepath.Join(dstDir, ".dockerignore"))
+	require.NoFileExists(t, filepath.Join(dstDir, "configjson"))
+	require.NoFileExists(t, filepath.Join(dstDir, "dockerignore"))
+}
+
 func requireEqualFiles(tb testing.TB, a, b string) {
 	tb.Helper()
 	eq, err := EqualFiles(a, b)

--- a/internal/pipe/archive/archive.go
+++ b/internal/pipe/archive/archive.go
@@ -230,6 +230,12 @@ func create(ctx *context.Context, arch config.Archive, binaries []*artifact.Arti
 			return fmt.Errorf("failed to add: '%s' -> '%s': %w", f.Source, f.Destination, err)
 		}
 	}
+	buildsInfo := arch.BuildsInfo
+	if len(binaries) > 0 {
+		if err := archivefiles.EvalInfo(template, &buildsInfo); err != nil {
+			return err
+		}
+	}
 	bins := []string{}
 	for _, binary := range binaries {
 		dst := binary.Name
@@ -239,7 +245,7 @@ func create(ctx *context.Context, arch config.Archive, binaries []*artifact.Arti
 		if err := a.Add(config.File{
 			Source:      binary.Path,
 			Destination: dst,
-			Info:        arch.BuildsInfo,
+			Info:        buildsInfo,
 		}); err != nil {
 			return fmt.Errorf("failed to add: '%s' -> '%s': %w", binary.Path, dst, err)
 		}

--- a/internal/pipe/archive/archive_test.go
+++ b/internal/pipe/archive/archive_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/skips"
@@ -365,6 +366,119 @@ func TestRunPipeDifferentBinaryCount(t *testing.T) {
 	})
 }
 
+func TestRunPipeBuildsInfoMTime(t *testing.T) {
+	for _, format := range []string{"tar.gz", "zip"} {
+		t.Run(format, func(t *testing.T) {
+			for name, tt := range map[string]struct {
+				mtime   string
+				want    time.Time
+				commit  time.Time
+				noMTime bool
+			}{
+				"configured": {
+					mtime: "2008-01-02T15:04:06Z",
+					want:  time.Date(2008, 1, 2, 15, 4, 6, 0, time.UTC),
+				},
+				"templated": {
+					mtime:  "{{ .CommitDate }}",
+					want:   time.Date(2009, 2, 4, 6, 8, 10, 0, time.UTC),
+					commit: time.Date(2009, 2, 4, 6, 8, 10, 0, time.UTC),
+				},
+				"unset": {
+					want:    time.Date(2020, 3, 4, 5, 6, 8, 0, time.UTC),
+					noMTime: true,
+				},
+			} {
+				t.Run(name, func(t *testing.T) {
+					dist := t.TempDir()
+					binPath := filepath.Join(dist, "linuxamd64", "mybin")
+					require.NoError(t, os.MkdirAll(filepath.Dir(binPath), 0o755))
+					require.NoError(t, os.WriteFile(binPath, []byte("binary"), 0o755))
+					sourceMTime := time.Date(2020, 3, 4, 5, 6, 8, 0, time.UTC)
+					require.NoError(t, os.Chtimes(binPath, sourceMTime, sourceMTime))
+
+					buildsInfo := config.FileInfo{Mode: 0o755, MTime: tt.mtime}
+					if tt.noMTime {
+						buildsInfo.MTime = ""
+					}
+					ctx := testctx.WrapWithCfg(t.Context(),
+						config.Project{
+							Dist: dist,
+							Archives: []config.Archive{
+								{
+									ID:           "default",
+									IDs:          []string{"default"},
+									NameTemplate: "archive",
+									Formats:      []string{format},
+									Files:        []config.File{{Source: "missing*", Default: true}},
+									BuildsInfo:   buildsInfo,
+								},
+							},
+						},
+						testctx.WithVersion("0.0.1"),
+						testctx.WithCurrentTag("v0.0.1"))
+					if !tt.commit.IsZero() {
+						ctx.Git.CommitDate = tt.commit
+					}
+					ctx.Artifacts.Add(&artifact.Artifact{
+						Goos:    "linux",
+						Goarch:  "amd64",
+						Goamd64: "v1",
+						Name:    "mybin",
+						Path:    binPath,
+						Type:    artifact.Binary,
+						Extra: map[string]any{
+							artifact.ExtraBinary: "mybin",
+							artifact.ExtraID:     "default",
+						},
+					})
+
+					require.NoError(t, Pipe{}.Default(ctx))
+					require.NoError(t, Pipe{}.Run(ctx))
+					got := archiveBinaryModTime(t, filepath.Join(dist, "archive."+format), format, "mybin")
+					require.Equal(t, tt.want.Unix(), got.Unix())
+				})
+			}
+		})
+	}
+}
+
+func TestRunPipeInvalidBuildsInfoMTime(t *testing.T) {
+	dist := t.TempDir()
+	binPath := filepath.Join(dist, "linuxamd64", "mybin")
+	require.NoError(t, os.MkdirAll(filepath.Dir(binPath), 0o755))
+	require.NoError(t, os.WriteFile(binPath, []byte("binary"), 0o755))
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Dist: dist,
+		Archives: []config.Archive{
+			{
+				ID:           "default",
+				IDs:          []string{"default"},
+				NameTemplate: "archive",
+				Formats:      []string{"zip"},
+				Files:        []config.File{{Source: "missing*", Default: true}},
+				BuildsInfo: config.FileInfo{
+					MTime: "not-a-date",
+				},
+			},
+		},
+	})
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Goos:   "linux",
+		Goarch: "amd64",
+		Name:   "mybin",
+		Path:   binPath,
+		Type:   artifact.Binary,
+		Extra: map[string]any{
+			artifact.ExtraBinary: "mybin",
+			artifact.ExtraID:     "default",
+		},
+	})
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.ErrorContains(t, Pipe{}.Run(ctx), "failed to parse not-a-date")
+}
+
 func TestRunPipeNoBinaries(t *testing.T) {
 	t.Parallel()
 	folder := t.TempDir()
@@ -394,6 +508,11 @@ func TestRunPipeNoBinaries(t *testing.T) {
 
 func zipInfo(t *testing.T, path, name string) fs.FileInfo {
 	t.Helper()
+	return zipFile(t, path, name).FileInfo()
+}
+
+func zipFile(t *testing.T, path, name string) *zip.File {
+	t.Helper()
 	f, err := os.Open(path)
 	require.NoError(t, err)
 	defer f.Close()
@@ -403,11 +522,23 @@ func zipInfo(t *testing.T, path, name string) fs.FileInfo {
 	require.NoError(t, err)
 	for _, next := range r.File {
 		if next.Name == name {
-			return next.FileInfo()
+			return next
 		}
 	}
 	t.Fatalf("could not find %q in %q", name, path)
 	return nil
+}
+
+func archiveBinaryModTime(t *testing.T, path, format, name string) time.Time {
+	t.Helper()
+	switch format {
+	case "tar.gz":
+		return tarInfo(t, path, name).ModTime
+	case "zip":
+		return zipFile(t, path, name).Modified
+	}
+	t.Fatalf("unsupported format %q", format)
+	return time.Time{}
 }
 
 func tarInfo(t *testing.T, path, name string) *tar.Header {

--- a/internal/pipe/archive/archive_test.go
+++ b/internal/pipe/archive/archive_test.go
@@ -479,6 +479,55 @@ func TestRunPipeInvalidBuildsInfoMTime(t *testing.T) {
 	require.ErrorContains(t, Pipe{}.Run(ctx), "failed to parse not-a-date")
 }
 
+func TestRunPipeDistinctCPUVariants(t *testing.T) {
+	dist := t.TempDir()
+	for _, variant := range []string{"v8.0", "v9.0"} {
+		binPath := filepath.Join(dist, "linuxarm64"+variant, "mybin")
+		require.NoError(t, os.MkdirAll(filepath.Dir(binPath), 0o755))
+		require.NoError(t, os.WriteFile(binPath, []byte(variant), 0o755))
+	}
+	ctx := testctx.WrapWithCfg(t.Context(),
+		config.Project{
+			Dist: dist,
+			Archives: []config.Archive{
+				{
+					ID:           "default",
+					IDs:          []string{"default"},
+					NameTemplate: "archive_{{ .Os }}_{{ .Arch }}_{{ .Arm64 }}",
+					Formats:      []string{"tar.gz"},
+					Files:        []config.File{{Source: "missing*", Default: true}},
+				},
+			},
+		},
+		testctx.WithVersion("0.0.1"),
+		testctx.WithCurrentTag("v0.0.1"))
+	for _, variant := range []string{"v8.0", "v9.0"} {
+		ctx.Artifacts.Add(&artifact.Artifact{
+			Goos:    "linux",
+			Goarch:  "arm64",
+			Goarm64: variant,
+			Name:    "mybin",
+			Path:    filepath.Join(dist, "linuxarm64"+variant, "mybin"),
+			Type:    artifact.Binary,
+			Extra: map[string]any{
+				artifact.ExtraBinary: "mybin",
+				artifact.ExtraID:     "default",
+			},
+		})
+	}
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Run(ctx))
+
+	archives := ctx.Artifacts.Filter(artifact.ByType(artifact.UploadableArchive)).List()
+	require.Len(t, archives, 2)
+	for _, variant := range []string{"v8.0", "v9.0"} {
+		path := filepath.Join(dist, "archive_linux_arm64_"+variant+".tar.gz")
+		require.Equal(t, []string{"mybin"}, testlib.LsArchive(t, path, "tar.gz"))
+		require.Equal(t, variant, string(testlib.GetFileFromArchive(t, path, "tar.gz", "mybin")))
+	}
+}
+
 func TestRunPipeNoBinaries(t *testing.T) {
 	t.Parallel()
 	folder := t.TempDir()

--- a/internal/pipe/sourcearchive/source.go
+++ b/internal/pipe/sourcearchive/source.go
@@ -120,6 +120,12 @@ func appendExtraFilesToArchive(ctx *context.Context, prefix, name, format string
 	if err := af.Close(); err != nil {
 		return fmt.Errorf("could not close archive file: %w", err)
 	}
+	if err := of.Close(); err != nil {
+		return fmt.Errorf("could not close archive backup: %w", err)
+	}
+	if err := os.Remove(oldPath); err != nil {
+		return fmt.Errorf("could not remove archive backup: %w", err)
+	}
 	return nil
 }
 

--- a/internal/pipe/sourcearchive/source_test.go
+++ b/internal/pipe/sourcearchive/source_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestArchive(t *testing.T) {
-	for _, format := range []string{"tar.gz", "tar", "zip"} {
+	for _, format := range []string{"tar.gz", "tar", "zip", "tgz"} {
 		t.Run(format, func(t *testing.T) {
 			tmp := testlib.Mktmp(t)
 			require.NoError(t, os.Mkdir("dist", 0o744))
@@ -143,6 +143,7 @@ func doVerifyTestArchive(tb testing.TB, ctx *context.Context, tmp, format string
 	stat, err := os.Stat(path)
 	require.NoError(tb, err)
 	require.Greater(tb, stat.Size(), int64(100))
+	require.NoFileExists(tb, path+".bkp")
 
 	require.ElementsMatch(tb, expected, testlib.LsArchive(tb, path, format))
 

--- a/pkg/archive/zip/zip.go
+++ b/pkg/archive/zip/zip.go
@@ -44,29 +44,9 @@ func Copy(source *os.File, target io.Writer) (Archive, error) {
 	w := New(target)
 	for _, zf := range r.File {
 		w.files[zf.Name] = true
-		hdr := zip.FileHeader{
-			Name:               zf.Name,
-			UncompressedSize64: zf.UncompressedSize64,
-			UncompressedSize:   zf.UncompressedSize,
-			CreatorVersion:     zf.CreatorVersion,
-			ExternalAttrs:      zf.ExternalAttrs,
+		if err := w.z.Copy(zf); err != nil {
+			return Archive{}, fmt.Errorf("copying %q to target: %w", zf.Name, err)
 		}
-		ww, err := w.z.CreateHeader(&hdr)
-		if err != nil {
-			return Archive{}, fmt.Errorf("creating %q header in target: %w", zf.Name, err)
-		}
-		if zf.Mode().IsDir() {
-			continue
-		}
-		rr, err := zf.Open()
-		if err != nil {
-			return Archive{}, fmt.Errorf("opening %q from source: %w", zf.Name, err)
-		}
-		defer rr.Close()
-		if _, err = io.Copy(ww, rr); err != nil {
-			return Archive{}, fmt.Errorf("copy from %q source to target: %w", zf.Name, err)
-		}
-		_ = rr.Close()
 	}
 	return w, nil
 }

--- a/pkg/archive/zip/zip_test.go
+++ b/pkg/archive/zip/zip_test.go
@@ -166,4 +166,77 @@ func TestTarInvalidLink(t *testing.T) {
 	}))
 }
 
-// TODO: add copying test
+func TestCopyPreservesMetadataAndRejectsDuplicates(t *testing.T) {
+	tmp := t.TempDir()
+	sourcePath := filepath.Join(tmp, "source.zip")
+	source, err := os.Create(sourcePath)
+	require.NoError(t, err)
+
+	modified := time.Date(2024, 2, 3, 4, 5, 6, 0, time.UTC)
+	extra := []byte{0xfe, 0xca, 0x04, 0x00, 'm', 'e', 't', 'a'}
+	header := &zip.FileHeader{
+		Name:    "foo.txt",
+		Method:  zip.Deflate,
+		Comment: "entry comment",
+		Extra:   extra,
+	}
+	header.SetModTime(modified)
+	header.SetMode(0o755)
+
+	writer := zip.NewWriter(source)
+	entry, err := writer.CreateHeader(header)
+	require.NoError(t, err)
+	_, err = entry.Write([]byte("hello world\n"))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	require.NoError(t, source.Close())
+
+	source, err = os.Open(sourcePath)
+	require.NoError(t, err)
+	defer source.Close()
+
+	info, err := source.Stat()
+	require.NoError(t, err)
+	sourceReader, err := zip.NewReader(source, info.Size())
+	require.NoError(t, err)
+	require.Len(t, sourceReader.File, 1)
+	expectedExtra := append([]byte(nil), sourceReader.File[0].Extra...)
+
+	var target bytes.Buffer
+	archive, err := Copy(source, &target)
+	require.NoError(t, err)
+
+	duplicate := filepath.Join(tmp, "duplicate.txt")
+	require.NoError(t, os.WriteFile(duplicate, []byte("duplicate"), 0o644))
+	require.ErrorIs(t, archive.Add(config.File{
+		Source:      duplicate,
+		Destination: "foo.txt",
+	}), fs.ErrExist)
+
+	notice := filepath.Join(tmp, "NOTICE.txt")
+	require.NoError(t, os.WriteFile(notice, []byte("notice"), 0o644))
+	require.NoError(t, archive.Add(config.File{
+		Source:      notice,
+		Destination: "NOTICE.txt",
+	}))
+	require.NoError(t, archive.Close())
+
+	reader, err := zip.NewReader(bytes.NewReader(target.Bytes()), int64(target.Len()))
+	require.NoError(t, err)
+	require.Len(t, reader.File, 2)
+
+	copied := reader.File[0]
+	require.Equal(t, "foo.txt", copied.Name)
+	require.Equal(t, zip.Deflate, copied.Method)
+	require.Equal(t, modified.Unix(), copied.Modified.Unix())
+	require.Equal(t, "entry comment", copied.Comment)
+	require.Equal(t, expectedExtra, copied.Extra)
+	require.Equal(t, fs.FileMode(0o755), copied.FileInfo().Mode())
+
+	rc, err := copied.Open()
+	require.NoError(t, err)
+	content, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.NoError(t, rc.Close())
+	require.Equal(t, "hello world\n", string(content))
+}


### PR DESCRIPTION
Fixes a group of related bugs in archive, sourcearchive and gio.

- Closes #6989: removes successful sourcearchive extra-file backups after the final archive is closed.
- Closes #6886: preserves existing ZIP entry compression and metadata when appending source archive files.
- Closes #6885: applies archives.builds_info.mtime to binary entries in TAR.GZ and ZIP archives.
- Closes #6884: keeps distinct CPU variants in separate archive groups and variant-aware archives.
- Closes #6883: preserves destination paths for dot-relative directory copies.