### PR TITLE
fix(mcp): support package transport URLs

### DIFF
--- a/internal/pipe/mcp/mcp.go
+++ b/internal/pipe/mcp/mcp.go
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"path"
 	"strings"
 
 	"github.com/caarlos0/log"
+	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/deprecate"
 	"github.com/goreleaser/goreleaser/v2/internal/logext"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe"
@@ -18,6 +20,7 @@ import (
 	"github.com/goreleaser/goreleaser/v2/internal/skips"
 	"github.com/goreleaser/goreleaser/v2/internal/summary"
 	"github.com/goreleaser/goreleaser/v2/internal/tmpl"
+	"github.com/goreleaser/goreleaser/v2/pkg/config"
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
 	"github.com/modelcontextprotocol/registry/cmd/publisher/auth"
 	proto "github.com/modelcontextprotocol/registry/cmd/publisher/commands"
@@ -123,13 +126,13 @@ func (p Pipe) Publish(ctx *context.Context) error {
 	for _, pkg := range mcp.Packages {
 		if err := tmpl.New(ctx).ApplyAll(
 			&pkg.Identifier,
-			&pkg.FileSHA256,
 			&pkg.Transport.URL,
 		); err != nil {
 			return fmt.Errorf("could not apply templates: %w", err)
 		}
-		if pkg.RegistryType == "mcpb" && pkg.FileSHA256 == "" {
-			return fmt.Errorf("mcpb package %q requires file_sha256", pkg.Identifier)
+		fileSHA256, err := mcpbFileSHA256(ctx, pkg)
+		if err != nil {
+			return err
 		}
 		version := ctx.Version
 		if pkg.RegistryType == "oci" {
@@ -139,7 +142,7 @@ func (p Pipe) Publish(ctx *context.Context) error {
 			RegistryType: pkg.RegistryType,
 			Identifier:   pkg.Identifier,
 			Version:      version,
-			FileSHA256:   pkg.FileSHA256,
+			FileSHA256:   fileSHA256,
 			Transport: model.Transport{
 				Type: pkg.Transport.Type,
 				URL:  pkg.Transport.URL,
@@ -190,6 +193,58 @@ func (p Pipe) Publish(ctx *context.Context) error {
 
 		return nil
 	}, retryx.IsRetriable)
+}
+
+func mcpbFileSHA256(ctx *context.Context, pkg config.MCPPackage) (string, error) {
+	if pkg.RegistryType != "mcpb" {
+		return "", nil
+	}
+	artifactName, err := mcpbArtifactName(pkg.Identifier)
+	if err != nil {
+		return "", err
+	}
+	art, err := findArtifact(ctx, artifactName)
+	if err != nil {
+		return "", fmt.Errorf("mcpb package %q: %w", pkg.Identifier, err)
+	}
+	checksum, err := art.Checksum("sha256")
+	if err != nil {
+		return "", fmt.Errorf("mcpb package %q: %w", pkg.Identifier, err)
+	}
+	return checksum, nil
+}
+
+func mcpbArtifactName(identifier string) (string, error) {
+	u, err := url.Parse(identifier)
+	if err != nil {
+		return "", fmt.Errorf("parse mcpb package identifier: %w", err)
+	}
+	name := path.Base(u.Path)
+	if name == "" || name == "." || name == "/" {
+		return "", fmt.Errorf("mcpb package %q does not identify an artifact file", identifier)
+	}
+	name, err = url.PathUnescape(name)
+	if err != nil {
+		return "", fmt.Errorf("parse mcpb package identifier: %w", err)
+	}
+	return name, nil
+}
+
+func findArtifact(ctx *context.Context, name string) (*artifact.Artifact, error) {
+	var matches []*artifact.Artifact
+	for _, art := range ctx.Artifacts.Filter(artifact.ByTypes(artifact.ReleaseUploadableTypes()...)).List() {
+		if art.Name == name {
+			matches = append(matches, art)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("could not find artifact %q", name)
+	case 1:
+		return matches[0], nil
+	default:
+		return nil, fmt.Errorf("found multiple artifacts named %q", name)
+	}
 }
 
 // cleanSubfolder normalizes the repository subfolder path so it passes the MCP

--- a/internal/pipe/mcp/mcp.go
+++ b/internal/pipe/mcp/mcp.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"path"
 	"strings"
 
@@ -24,11 +23,6 @@ import (
 	proto "github.com/modelcontextprotocol/registry/cmd/publisher/commands"
 	apiv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
 	"github.com/modelcontextprotocol/registry/pkg/model"
-)
-
-const (
-	gitHubTokenFilePath   = ".mcpregistry_github_token"   // #nosec:G101
-	registryTokenFilePath = ".mcpregistry_registry_token" // #nosec:G101
 )
 
 // Pipe for MCP.
@@ -103,11 +97,6 @@ func (p Pipe) Publish(ctx *context.Context) error {
 	if err := provider.Login(ctx); err != nil {
 		return fmt.Errorf("could not login: %w", err)
 	}
-	defer func() {
-		// logout...
-		_ = os.Remove(gitHubTokenFilePath)
-		_ = os.Remove(registryTokenFilePath)
-	}()
 	token, err := provider.GetToken(ctx)
 	if err != nil {
 		return fmt.Errorf("could not get token: %w", err)

--- a/internal/pipe/mcp/mcp.go
+++ b/internal/pipe/mcp/mcp.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"cmp"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"strings"
 
@@ -26,6 +28,11 @@ import (
 	proto "github.com/modelcontextprotocol/registry/cmd/publisher/commands"
 	apiv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
 	"github.com/modelcontextprotocol/registry/pkg/model"
+)
+
+const (
+	legacyGitHubTokenFilePath   = ".mcpregistry_github_token"   // #nosec:G101
+	legacyRegistryTokenFilePath = ".mcpregistry_registry_token" // #nosec:G101
 )
 
 // Pipe for MCP.
@@ -96,6 +103,17 @@ func (p Pipe) Publish(ctx *context.Context) error {
 	)
 	if err != nil {
 		return fmt.Errorf("could not login: %w", err)
+	}
+	if cleansUpLegacyTokenFiles(mcp.Auth.Type) {
+		tokenFiles, err := snapshotLegacyTokenFiles()
+		if err != nil {
+			return fmt.Errorf("could not snapshot mcp auth token files: %w", err)
+		}
+		defer func() {
+			if err := tokenFiles.restore(); err != nil {
+				log.WithError(err).Warn("failed to cleanup mcp auth token files")
+			}
+		}()
 	}
 	if err := provider.Login(ctx); err != nil {
 		return fmt.Errorf("could not login: %w", err)
@@ -245,6 +263,68 @@ func findArtifact(ctx *context.Context, name string) (*artifact.Artifact, error)
 	default:
 		return nil, fmt.Errorf("found multiple artifacts named %q", name)
 	}
+}
+
+type legacyTokenFiles []legacyTokenFile
+
+type legacyTokenFile struct {
+	path     string
+	existed  bool
+	isDir    bool
+	contents []byte
+	mode     os.FileMode
+}
+
+func cleansUpLegacyTokenFiles(method string) bool {
+	return method == proto.MethodGitHub || method == proto.MethodGitHubOIDC
+}
+
+func snapshotLegacyTokenFiles() (legacyTokenFiles, error) {
+	files := legacyTokenFiles{
+		{path: legacyGitHubTokenFilePath},
+		{path: legacyRegistryTokenFilePath},
+	}
+	for i := range files {
+		info, err := os.Stat(files[i].path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("stat %q: %w", files[i].path, err)
+		}
+		if info.IsDir() {
+			files[i].existed = true
+			files[i].isDir = true
+			continue
+		}
+		contents, err := os.ReadFile(files[i].path)
+		if err != nil {
+			return nil, fmt.Errorf("read %q: %w", files[i].path, err)
+		}
+		files[i].existed = true
+		files[i].contents = contents
+		files[i].mode = info.Mode().Perm()
+	}
+	return files, nil
+}
+
+func (files legacyTokenFiles) restore() error {
+	var errs []error
+	for _, file := range files {
+		if file.isDir {
+			continue
+		}
+		if file.existed {
+			if err := os.WriteFile(file.path, file.contents, file.mode); err != nil {
+				errs = append(errs, fmt.Errorf("restore %q: %w", file.path, err))
+			}
+			continue
+		}
+		if err := os.Remove(file.path); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, fmt.Errorf("remove %q: %w", file.path, err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // cleanSubfolder normalizes the repository subfolder path so it passes the MCP

--- a/internal/pipe/mcp/mcp.go
+++ b/internal/pipe/mcp/mcp.go
@@ -7,13 +7,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"path"
 	"strings"
 
 	"github.com/caarlos0/log"
-	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/deprecate"
 	"github.com/goreleaser/goreleaser/v2/internal/logext"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe"
@@ -21,7 +19,6 @@ import (
 	"github.com/goreleaser/goreleaser/v2/internal/skips"
 	"github.com/goreleaser/goreleaser/v2/internal/summary"
 	"github.com/goreleaser/goreleaser/v2/internal/tmpl"
-	"github.com/goreleaser/goreleaser/v2/pkg/config"
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
 	"github.com/modelcontextprotocol/registry/cmd/publisher/auth"
 	proto "github.com/modelcontextprotocol/registry/cmd/publisher/commands"
@@ -141,10 +138,6 @@ func (p Pipe) Publish(ctx *context.Context) error {
 		); err != nil {
 			return fmt.Errorf("could not apply templates: %w", err)
 		}
-		fileSHA256, err := mcpbFileSHA256(ctx, pkg)
-		if err != nil {
-			return err
-		}
 		version := ctx.Version
 		if pkg.RegistryType == "oci" {
 			version = ""
@@ -153,7 +146,6 @@ func (p Pipe) Publish(ctx *context.Context) error {
 			RegistryType: pkg.RegistryType,
 			Identifier:   pkg.Identifier,
 			Version:      version,
-			FileSHA256:   fileSHA256,
 			Transport: model.Transport{
 				Type: pkg.Transport.Type,
 				URL:  pkg.Transport.URL,
@@ -204,63 +196,6 @@ func (p Pipe) Publish(ctx *context.Context) error {
 
 		return nil
 	}, retryx.IsRetriable)
-}
-
-func mcpbFileSHA256(ctx *context.Context, pkg config.MCPPackage) (string, error) {
-	if pkg.RegistryType != "mcpb" {
-		return "", nil
-	}
-	artifactName, err := mcpbArtifactName(pkg.Identifier)
-	if err != nil {
-		return "", err
-	}
-	art, err := findMCPBArtifact(ctx, artifactName)
-	if err != nil {
-		return "", fmt.Errorf("mcpb package %q: %w", pkg.Identifier, err)
-	}
-	checksum, err := art.Checksum("sha256")
-	if err != nil {
-		return "", fmt.Errorf("mcpb package %q: %w", pkg.Identifier, err)
-	}
-	return checksum, nil
-}
-
-func mcpbArtifactName(identifier string) (string, error) {
-	u, err := url.Parse(identifier)
-	if err != nil {
-		return "", fmt.Errorf("parse mcpb package identifier: %w", err)
-	}
-	name := path.Base(u.Path)
-	if name == "." || name == "/" {
-		return "", fmt.Errorf("mcpb package %q does not identify an artifact file", identifier)
-	}
-	name, err = url.PathUnescape(name)
-	if err != nil {
-		return "", fmt.Errorf("parse mcpb package identifier: %w", err)
-	}
-	if !strings.EqualFold(path.Ext(name), ".mcpb") {
-		return "", fmt.Errorf("mcpb package %q does not identify an .mcpb artifact file", identifier)
-	}
-	return name, nil
-}
-
-func findMCPBArtifact(ctx *context.Context, name string) (*artifact.Artifact, error) {
-	matches := ctx.Artifacts.Filter(artifact.And(
-		artifact.ByTypes(
-			artifact.UploadableArchive,
-			artifact.UploadableBinary,
-			artifact.UploadableFile,
-		),
-		func(art *artifact.Artifact) bool { return art.Name == name },
-	)).List()
-	switch len(matches) {
-	case 0:
-		return nil, fmt.Errorf("could not find artifact %q", name)
-	case 1:
-		return matches[0], nil
-	default:
-		return nil, fmt.Errorf("found multiple artifacts named %q", name)
-	}
 }
 
 // cleanSubfolder normalizes the repository subfolder path so it passes the MCP

--- a/internal/pipe/mcp/mcp.go
+++ b/internal/pipe/mcp/mcp.go
@@ -134,8 +134,12 @@ func (p Pipe) Publish(ctx *context.Context) error {
 	for _, pkg := range mcp.Packages {
 		if err := tmpl.New(ctx).ApplyAll(
 			&pkg.Identifier,
+			&pkg.FileSHA256,
 		); err != nil {
 			return fmt.Errorf("could not apply templates: %w", err)
+		}
+		if pkg.RegistryType == "mcpb" && pkg.FileSHA256 == "" {
+			return fmt.Errorf("mcpb package %q requires file_sha256", pkg.Identifier)
 		}
 		version := ctx.Version
 		if pkg.RegistryType == "oci" {
@@ -145,6 +149,7 @@ func (p Pipe) Publish(ctx *context.Context) error {
 			RegistryType: pkg.RegistryType,
 			Identifier:   pkg.Identifier,
 			Version:      version,
+			FileSHA256:   pkg.FileSHA256,
 			Transport: model.Transport{
 				Type: pkg.Transport.Type,
 			},

--- a/internal/pipe/mcp/mcp.go
+++ b/internal/pipe/mcp/mcp.go
@@ -221,7 +221,7 @@ func mcpbFileSHA256(ctx *context.Context, pkg config.MCPPackage) (string, error)
 	if err != nil {
 		return "", err
 	}
-	art, err := findArtifact(ctx, artifactName)
+	art, err := findMCPBArtifact(ctx, artifactName)
 	if err != nil {
 		return "", fmt.Errorf("mcpb package %q: %w", pkg.Identifier, err)
 	}
@@ -245,16 +245,25 @@ func mcpbArtifactName(identifier string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("parse mcpb package identifier: %w", err)
 	}
+	if !strings.EqualFold(path.Ext(name), ".mcpb") {
+		return "", fmt.Errorf("mcpb package %q does not identify an .mcpb artifact file", identifier)
+	}
 	return name, nil
 }
 
-func findArtifact(ctx *context.Context, name string) (*artifact.Artifact, error) {
+func findMCPBArtifact(ctx *context.Context, name string) (*artifact.Artifact, error) {
 	var matches []*artifact.Artifact
-	for _, art := range ctx.Artifacts.Filter(artifact.ByTypes(artifact.ReleaseUploadableTypes()...)).List() {
-		if art.Name == name {
-			matches = append(matches, art)
-		}
+	mcpbArtifact := func(art *artifact.Artifact) bool {
+		return art.Name == name && strings.EqualFold(path.Ext(art.Name), ".mcpb")
 	}
+	matches = append(matches, ctx.Artifacts.Filter(artifact.And(
+		artifact.ByTypes(
+			artifact.UploadableArchive,
+			artifact.UploadableBinary,
+			artifact.UploadableFile,
+		),
+		mcpbArtifact,
+	)).List()...)
 	switch len(matches) {
 	case 0:
 		return nil, fmt.Errorf("could not find artifact %q", name)

--- a/internal/pipe/mcp/mcp.go
+++ b/internal/pipe/mcp/mcp.go
@@ -135,6 +135,7 @@ func (p Pipe) Publish(ctx *context.Context) error {
 		if err := tmpl.New(ctx).ApplyAll(
 			&pkg.Identifier,
 			&pkg.FileSHA256,
+			&pkg.Transport.URL,
 		); err != nil {
 			return fmt.Errorf("could not apply templates: %w", err)
 		}
@@ -152,6 +153,7 @@ func (p Pipe) Publish(ctx *context.Context) error {
 			FileSHA256:   pkg.FileSHA256,
 			Transport: model.Transport{
 				Type: pkg.Transport.Type,
+				URL:  pkg.Transport.URL,
 			},
 		})
 	}

--- a/internal/pipe/mcp/mcp.go
+++ b/internal/pipe/mcp/mcp.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"cmp"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -31,8 +30,8 @@ import (
 )
 
 const (
-	legacyGitHubTokenFilePath   = ".mcpregistry_github_token"   // #nosec:G101
-	legacyRegistryTokenFilePath = ".mcpregistry_registry_token" // #nosec:G101
+	gitHubTokenFilePath   = ".mcpregistry_github_token"   // #nosec:G101
+	registryTokenFilePath = ".mcpregistry_registry_token" // #nosec:G101
 )
 
 // Pipe for MCP.
@@ -104,20 +103,14 @@ func (p Pipe) Publish(ctx *context.Context) error {
 	if err != nil {
 		return fmt.Errorf("could not login: %w", err)
 	}
-	if cleansUpLegacyTokenFiles(mcp.Auth.Type) {
-		tokenFiles, err := snapshotLegacyTokenFiles()
-		if err != nil {
-			return fmt.Errorf("could not snapshot mcp auth token files: %w", err)
-		}
-		defer func() {
-			if err := tokenFiles.restore(); err != nil {
-				log.WithError(err).Warn("failed to cleanup mcp auth token files")
-			}
-		}()
-	}
 	if err := provider.Login(ctx); err != nil {
 		return fmt.Errorf("could not login: %w", err)
 	}
+	defer func() {
+		// logout...
+		_ = os.Remove(gitHubTokenFilePath)
+		_ = os.Remove(registryTokenFilePath)
+	}()
 	token, err := provider.GetToken(ctx)
 	if err != nil {
 		return fmt.Errorf("could not get token: %w", err)
@@ -238,7 +231,7 @@ func mcpbArtifactName(identifier string) (string, error) {
 		return "", fmt.Errorf("parse mcpb package identifier: %w", err)
 	}
 	name := path.Base(u.Path)
-	if name == "" || name == "." || name == "/" {
+	if name == "." || name == "/" {
 		return "", fmt.Errorf("mcpb package %q does not identify an artifact file", identifier)
 	}
 	name, err = url.PathUnescape(name)
@@ -252,18 +245,14 @@ func mcpbArtifactName(identifier string) (string, error) {
 }
 
 func findMCPBArtifact(ctx *context.Context, name string) (*artifact.Artifact, error) {
-	var matches []*artifact.Artifact
-	mcpbArtifact := func(art *artifact.Artifact) bool {
-		return art.Name == name && strings.EqualFold(path.Ext(art.Name), ".mcpb")
-	}
-	matches = append(matches, ctx.Artifacts.Filter(artifact.And(
+	matches := ctx.Artifacts.Filter(artifact.And(
 		artifact.ByTypes(
 			artifact.UploadableArchive,
 			artifact.UploadableBinary,
 			artifact.UploadableFile,
 		),
-		mcpbArtifact,
-	)).List()...)
+		func(art *artifact.Artifact) bool { return art.Name == name },
+	)).List()
 	switch len(matches) {
 	case 0:
 		return nil, fmt.Errorf("could not find artifact %q", name)
@@ -272,68 +261,6 @@ func findMCPBArtifact(ctx *context.Context, name string) (*artifact.Artifact, er
 	default:
 		return nil, fmt.Errorf("found multiple artifacts named %q", name)
 	}
-}
-
-type legacyTokenFiles []legacyTokenFile
-
-type legacyTokenFile struct {
-	path     string
-	existed  bool
-	isDir    bool
-	contents []byte
-	mode     os.FileMode
-}
-
-func cleansUpLegacyTokenFiles(method string) bool {
-	return method == proto.MethodGitHub || method == proto.MethodGitHubOIDC
-}
-
-func snapshotLegacyTokenFiles() (legacyTokenFiles, error) {
-	files := legacyTokenFiles{
-		{path: legacyGitHubTokenFilePath},
-		{path: legacyRegistryTokenFilePath},
-	}
-	for i := range files {
-		info, err := os.Stat(files[i].path)
-		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			return nil, fmt.Errorf("stat %q: %w", files[i].path, err)
-		}
-		if info.IsDir() {
-			files[i].existed = true
-			files[i].isDir = true
-			continue
-		}
-		contents, err := os.ReadFile(files[i].path)
-		if err != nil {
-			return nil, fmt.Errorf("read %q: %w", files[i].path, err)
-		}
-		files[i].existed = true
-		files[i].contents = contents
-		files[i].mode = info.Mode().Perm()
-	}
-	return files, nil
-}
-
-func (files legacyTokenFiles) restore() error {
-	var errs []error
-	for _, file := range files {
-		if file.isDir {
-			continue
-		}
-		if file.existed {
-			if err := os.WriteFile(file.path, file.contents, file.mode); err != nil {
-				errs = append(errs, fmt.Errorf("restore %q: %w", file.path, err))
-			}
-			continue
-		}
-		if err := os.Remove(file.path); err != nil && !os.IsNotExist(err) {
-			errs = append(errs, fmt.Errorf("remove %q: %w", file.path, err))
-		}
-	}
-	return errors.Join(errs...)
 }
 
 // cleanSubfolder normalizes the repository subfolder path so it passes the MCP

--- a/internal/pipe/mcp/mcp_test.go
+++ b/internal/pipe/mcp/mcp_test.go
@@ -470,6 +470,87 @@ func TestPublishMCPBPackageRequiresFileSHA256(t *testing.T) {
 	require.False(t, requested)
 }
 
+func TestPublishPackageTransportURL(t *testing.T) {
+	var receivedRequest apiv0.ServerJSON
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.NoError(t, json.Unmarshal(body, &receivedRequest))
+
+		response := apiv0.ServerResponse{
+			Meta: apiv0.ResponseMeta{
+				Official: &apiv0.RegistryExtensions{
+					Status: "pending",
+				},
+			},
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(response))
+	}))
+	defer srv.Close()
+
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		ProjectName: "test-server",
+		MCP: config.MCP{
+			MCPDetails: config.MCPDetails{
+				Name:  "test-server",
+				Title: "Test Server",
+				Packages: []config.MCPPackage{
+					{
+						RegistryType: "npm",
+						Identifier:   "@test/server-http",
+						Transport: config.MCPTransport{
+							Type: "streamable-http",
+							URL:  "https://example.com/{{ .ProjectName }}/mcp",
+						},
+					},
+					{
+						RegistryType: "npm",
+						Identifier:   "@test/server-sse",
+						Transport: config.MCPTransport{
+							Type: "sse",
+							URL:  "https://example.com/{{ .Version }}/sse",
+						},
+					},
+					{
+						RegistryType: "npm",
+						Identifier:   "@test/server-stdio",
+						Transport: config.MCPTransport{
+							Type: "stdio",
+						},
+					},
+				},
+				Auth: config.MCPAuth{
+					Type: "none",
+				},
+			},
+		},
+	})
+	ctx.Version = "1.2.3"
+
+	pipe := &Pipe{registry: srv.URL}
+	pipe.authProviderFn = func(_, _, token string) (auth.Provider, error) {
+		return &mockAuthProvider{token: "test-token"}, nil
+	}
+	require.NoError(t, pipe.Default(ctx))
+	require.NoError(t, pipe.Publish(ctx))
+
+	require.Len(t, receivedRequest.Packages, 3)
+	require.Equal(t, model.Transport{
+		Type: "streamable-http",
+		URL:  "https://example.com/test-server/mcp",
+	}, receivedRequest.Packages[0].Transport)
+	require.Equal(t, model.Transport{
+		Type: "sse",
+		URL:  "https://example.com/1.2.3/sse",
+	}, receivedRequest.Packages[1].Transport)
+	require.Equal(t, model.Transport{
+		Type: "stdio",
+	}, receivedRequest.Packages[2].Transport)
+}
+
 func TestPublishDisabled(t *testing.T) {
 	for name, disable := range map[string]string{
 		"true":     "true",

--- a/internal/pipe/mcp/mcp_test.go
+++ b/internal/pipe/mcp/mcp_test.go
@@ -1270,7 +1270,10 @@ func (m *mockAuthProvider) NeedsLogin() bool {
 	return false
 }
 
-func (m *mockAuthProvider) Login(context.Context) error {
+func (m *mockAuthProvider) Login(ctx context.Context) error {
+	if m.loginFn != nil {
+		return m.loginFn(ctx)
+	}
 	return m.loginErr
 }
 

--- a/internal/pipe/mcp/mcp_test.go
+++ b/internal/pipe/mcp/mcp_test.go
@@ -2,15 +2,19 @@ package mcp
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 
+	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/skips"
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/internal/testlib"
@@ -354,7 +358,12 @@ func TestPublishWithTemplates(t *testing.T) {
 }
 
 func TestPublishMCPBPackageFileSHA256(t *testing.T) {
-	const fileSHA256 = "fe333e598595000ae021bd27117db32ec69af6987f507ba7a63c90638ff633ce"
+	artifactPath := filepath.Join(t.TempDir(), "server.mcpb")
+	require.NoError(t, os.WriteFile(artifactPath, []byte("mcpb package"), 0o644))
+	bts, err := os.ReadFile(artifactPath)
+	require.NoError(t, err)
+	sum := sha256.Sum256(bts)
+	fileSHA256 := hex.EncodeToString(sum[:])
 
 	var receivedRequest apiv0.ServerJSON
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -385,7 +394,6 @@ func TestPublishMCPBPackageFileSHA256(t *testing.T) {
 					{
 						RegistryType: "mcpb",
 						Identifier:   "https://github.com/fixture/server/releases/download/{{ .Version }}/server.mcpb",
-						FileSHA256:   "{{ .Env.MCPB_SHA256 }}",
 						Transport: config.MCPTransport{
 							Type: "stdio",
 						},
@@ -403,8 +411,13 @@ func TestPublishMCPBPackageFileSHA256(t *testing.T) {
 				},
 			},
 		},
-	}, testctx.WithEnv(map[string]string{"MCPB_SHA256": fileSHA256}))
+	})
 	ctx.Version = "v1.0.0"
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name: "server.mcpb",
+		Path: artifactPath,
+		Type: artifact.UploadableFile,
+	})
 
 	pipe := &Pipe{registry: srv.URL}
 	pipe.authProviderFn = func(_, _, token string) (auth.Provider, error) {
@@ -426,7 +439,7 @@ func TestPublishMCPBPackageFileSHA256(t *testing.T) {
 	require.Empty(t, receivedRequest.Packages[1].FileSHA256)
 }
 
-func TestPublishMCPBPackageRequiresFileSHA256(t *testing.T) {
+func TestPublishMCPBPackageRequiresArtifact(t *testing.T) {
 	var requested bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		requested = true
@@ -467,7 +480,7 @@ func TestPublishMCPBPackageRequiresFileSHA256(t *testing.T) {
 	}
 	require.NoError(t, pipe.Default(ctx))
 	err := pipe.Publish(ctx)
-	require.EqualError(t, err, `mcpb package "https://github.com/fixture/server/releases/download/v1.0.0/server.mcpb" requires file_sha256`)
+	require.EqualError(t, err, `mcpb package "https://github.com/fixture/server/releases/download/v1.0.0/server.mcpb": could not find artifact "server.mcpb"`)
 	require.False(t, requested)
 }
 

--- a/internal/pipe/mcp/mcp_test.go
+++ b/internal/pipe/mcp/mcp_test.go
@@ -2,18 +2,14 @@ package mcp
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"testing"
 
-	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/skips"
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/internal/testlib"
@@ -354,140 +350,6 @@ func TestPublishWithTemplates(t *testing.T) {
 	}
 	require.NoError(t, pipe.Default(ctx))
 	require.NoError(t, pipe.Publish(ctx))
-}
-
-func TestPublishMCPBPackageFileSHA256(t *testing.T) {
-	const artifactContents = "mcpb package"
-	artifactPath := filepath.Join(t.TempDir(), "server.mcpb")
-	require.NoError(t, os.WriteFile(artifactPath, []byte(artifactContents), 0o644))
-	sum := sha256.Sum256([]byte(artifactContents))
-	fileSHA256 := hex.EncodeToString(sum[:])
-
-	checksumPath := filepath.Join(t.TempDir(), "server.mcpb.txt")
-	require.NoError(t, os.WriteFile(checksumPath, []byte("wrong artifact"), 0o644))
-
-	var receivedRequest apiv0.ServerJSON
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := io.ReadAll(r.Body)
-		assert.NoError(t, err)
-		assert.NoError(t, json.Unmarshal(body, &receivedRequest))
-
-		response := apiv0.ServerResponse{
-			Meta: apiv0.ResponseMeta{
-				Official: &apiv0.RegistryExtensions{
-					Status: "pending",
-				},
-			},
-		}
-
-		w.WriteHeader(http.StatusCreated)
-		w.Header().Set("Content-Type", "application/json")
-		assert.NoError(t, json.NewEncoder(w).Encode(response))
-	}))
-	defer srv.Close()
-
-	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
-		MCP: config.MCP{
-			MCPDetails: config.MCPDetails{
-				Name:  "test-server",
-				Title: "Test Server",
-				Packages: []config.MCPPackage{
-					{
-						RegistryType: "mcpb",
-						Identifier:   "https://github.com/fixture/server/releases/download/{{ .Version }}/server.mcpb",
-						Transport: config.MCPTransport{
-							Type: "stdio",
-						},
-					},
-					{
-						RegistryType: "npm",
-						Identifier:   "@test/server",
-						Transport: config.MCPTransport{
-							Type: "stdio",
-						},
-					},
-				},
-				Auth: config.MCPAuth{
-					Type: "none",
-				},
-			},
-		},
-	})
-	ctx.Version = "v1.0.0"
-	ctx.Artifacts.Add(&artifact.Artifact{
-		Name: "server.mcpb",
-		Path: artifactPath,
-		Type: artifact.UploadableFile,
-	})
-	ctx.Artifacts.Add(&artifact.Artifact{
-		Name: "server.mcpb",
-		Path: checksumPath,
-		Type: artifact.Checksum,
-	})
-
-	pipe := &Pipe{registry: srv.URL}
-	pipe.authProviderFn = func(_, _, token string) (auth.Provider, error) {
-		return &mockAuthProvider{token: "test-token"}, nil
-	}
-	require.NoError(t, pipe.Default(ctx))
-	require.NoError(t, pipe.Publish(ctx))
-
-	require.Len(t, receivedRequest.Packages, 2)
-	require.Equal(t, model.Package{
-		RegistryType: "mcpb",
-		Identifier:   "https://github.com/fixture/server/releases/download/v1.0.0/server.mcpb",
-		Version:      "v1.0.0",
-		FileSHA256:   fileSHA256,
-		Transport: model.Transport{
-			Type: "stdio",
-		},
-	}, receivedRequest.Packages[0])
-	require.Empty(t, receivedRequest.Packages[1].FileSHA256)
-}
-
-func TestPublishMCPBPackageRequiresArtifact(t *testing.T) {
-	var requested bool
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		requested = true
-		w.WriteHeader(http.StatusCreated)
-		assert.NoError(t, json.NewEncoder(w).Encode(apiv0.ServerResponse{
-			Meta: apiv0.ResponseMeta{
-				Official: &apiv0.RegistryExtensions{Status: "pending"},
-			},
-		}))
-	}))
-	defer srv.Close()
-
-	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
-		MCP: config.MCP{
-			MCPDetails: config.MCPDetails{
-				Name:  "test-server",
-				Title: "Test Server",
-				Packages: []config.MCPPackage{
-					{
-						RegistryType: "mcpb",
-						Identifier:   "https://github.com/fixture/server/releases/download/v1.0.0/server.mcpb",
-						Transport: config.MCPTransport{
-							Type: "stdio",
-						},
-					},
-				},
-				Auth: config.MCPAuth{
-					Type: "none",
-				},
-			},
-		},
-	})
-	ctx.Version = "v1.0.0"
-
-	pipe := &Pipe{registry: srv.URL}
-	pipe.authProviderFn = func(_, _, token string) (auth.Provider, error) {
-		return &mockAuthProvider{token: "test-token"}, nil
-	}
-	require.NoError(t, pipe.Default(ctx))
-	err := pipe.Publish(ctx)
-	require.EqualError(t, err, `mcpb package "https://github.com/fixture/server/releases/download/v1.0.0/server.mcpb": could not find artifact "server.mcpb"`)
-	require.False(t, requested)
 }
 
 func TestPublishPackageTransportURL(t *testing.T) {

--- a/internal/pipe/mcp/mcp_test.go
+++ b/internal/pipe/mcp/mcp_test.go
@@ -11,7 +11,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"sync/atomic"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
@@ -358,11 +357,10 @@ func TestPublishWithTemplates(t *testing.T) {
 }
 
 func TestPublishMCPBPackageFileSHA256(t *testing.T) {
+	const artifactContents = "mcpb package"
 	artifactPath := filepath.Join(t.TempDir(), "server.mcpb")
-	require.NoError(t, os.WriteFile(artifactPath, []byte("mcpb package"), 0o644))
-	bts, err := os.ReadFile(artifactPath)
-	require.NoError(t, err)
-	sum := sha256.Sum256(bts)
+	require.NoError(t, os.WriteFile(artifactPath, []byte(artifactContents), 0o644))
+	sum := sha256.Sum256([]byte(artifactContents))
 	fileSHA256 := hex.EncodeToString(sum[:])
 
 	checksumPath := filepath.Join(t.TempDir(), "server.mcpb.txt")
@@ -1040,158 +1038,6 @@ func TestPublishGetTokenError(t *testing.T) {
 	require.Contains(t, err.Error(), "token retrieval failed")
 }
 
-func TestPublishGitHubOIDCGetTokenErrorKeepsExistingTokenFiles(t *testing.T) {
-	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "")
-	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "")
-	t.Chdir(t.TempDir())
-
-	const (
-		gitHubTokenFile   = ".mcpregistry_github_token"
-		registryTokenFile = ".mcpregistry_registry_token"
-		gitHubToken       = "existing github token"
-		registryToken     = "existing registry token"
-	)
-	require.NoError(t, os.WriteFile(gitHubTokenFile, []byte(gitHubToken), 0o600))
-	require.NoError(t, os.WriteFile(registryTokenFile, []byte(registryToken), 0o600))
-
-	var requested atomic.Bool
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		requested.Store(true)
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer srv.Close()
-
-	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
-		MCP: config.MCP{
-			MCPDetails: config.MCPDetails{
-				Name:  "test-server",
-				Title: "Test Server",
-				Auth: config.MCPAuth{
-					Type: "github-oidc",
-				},
-			},
-		},
-	})
-	ctx.Version = "1.0.0"
-
-	pipe := &Pipe{
-		registry:       srv.URL,
-		authProviderFn: authProvider,
-	}
-	require.NoError(t, pipe.Default(ctx))
-	err := pipe.Publish(ctx)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variable not found")
-	require.False(t, requested.Load())
-
-	bts, err := os.ReadFile(gitHubTokenFile)
-	require.NoError(t, err)
-	require.Equal(t, gitHubToken, string(bts))
-	bts, err = os.ReadFile(registryTokenFile)
-	require.NoError(t, err)
-	require.Equal(t, registryToken, string(bts))
-}
-
-func TestPublishCleansUpCreatedLegacyTokenFiles(t *testing.T) {
-	t.Chdir(t.TempDir())
-
-	var receivedRequest apiv0.ServerJSON
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := io.ReadAll(r.Body)
-		assert.NoError(t, err)
-		assert.NoError(t, json.Unmarshal(body, &receivedRequest))
-
-		w.WriteHeader(http.StatusCreated)
-		w.Header().Set("Content-Type", "application/json")
-		assert.NoError(t, json.NewEncoder(w).Encode(apiv0.ServerResponse{
-			Meta: apiv0.ResponseMeta{
-				Official: &apiv0.RegistryExtensions{Status: "pending"},
-			},
-		}))
-	}))
-	defer srv.Close()
-
-	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
-		MCP: config.MCP{
-			MCPDetails: config.MCPDetails{
-				Name:  "test-server",
-				Title: "Test Server",
-				Auth: config.MCPAuth{
-					Type: "github",
-				},
-			},
-		},
-	})
-	ctx.Version = "1.0.0"
-
-	pipe := &Pipe{registry: srv.URL}
-	pipe.authProviderFn = func(_, _, _ string) (auth.Provider, error) {
-		return &mockAuthProvider{
-			token: "test-token",
-			loginFn: func(context.Context) error {
-				require.NoError(t, os.WriteFile(legacyGitHubTokenFilePath, []byte("github-token"), 0o600))
-				require.NoError(t, os.WriteFile(legacyRegistryTokenFilePath, []byte("registry-token"), 0o600))
-				return nil
-			},
-		}, nil
-	}
-	require.NoError(t, pipe.Default(ctx))
-	require.NoError(t, pipe.Publish(ctx))
-	require.Equal(t, "test-server", receivedRequest.Name)
-
-	for _, file := range []string{legacyGitHubTokenFilePath, legacyRegistryTokenFilePath} {
-		_, err := os.Stat(file)
-		require.Truef(t, os.IsNotExist(err), "%s should be removed", file)
-	}
-}
-
-func TestPublishRestoresExistingLegacyTokenFiles(t *testing.T) {
-	t.Chdir(t.TempDir())
-
-	const (
-		gitHubToken   = "existing github token"
-		registryToken = "existing registry token"
-	)
-	require.NoError(t, os.WriteFile(legacyGitHubTokenFilePath, []byte(gitHubToken), 0o600))
-	require.NoError(t, os.WriteFile(legacyRegistryTokenFilePath, []byte(registryToken), 0o600))
-
-	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
-		MCP: config.MCP{
-			MCPDetails: config.MCPDetails{
-				Name:  "test-server",
-				Title: "Test Server",
-				Auth: config.MCPAuth{
-					Type: "github",
-				},
-			},
-		},
-	})
-	ctx.Version = "1.0.0"
-
-	pipe := &Pipe{registry: "http://localhost"}
-	pipe.authProviderFn = func(_, _, _ string) (auth.Provider, error) {
-		return &mockAuthProvider{
-			getTokenErr: fmt.Errorf("token retrieval failed"),
-			loginFn: func(context.Context) error {
-				require.NoError(t, os.WriteFile(legacyGitHubTokenFilePath, []byte("new github token"), 0o600))
-				require.NoError(t, os.WriteFile(legacyRegistryTokenFilePath, []byte("new registry token"), 0o600))
-				return nil
-			},
-		}, nil
-	}
-	require.NoError(t, pipe.Default(ctx))
-	err := pipe.Publish(ctx)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "could not get token")
-
-	bts, err := os.ReadFile(legacyGitHubTokenFilePath)
-	require.NoError(t, err)
-	require.Equal(t, gitHubToken, string(bts))
-	bts, err = os.ReadFile(legacyRegistryTokenFilePath)
-	require.NoError(t, err)
-	require.Equal(t, registryToken, string(bts))
-}
-
 func TestPublishNoPackages(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req apiv0.ServerJSON
@@ -1267,7 +1113,6 @@ type mockAuthProvider struct {
 	token       string
 	loginErr    error
 	getTokenErr error
-	loginFn     func(context.Context) error
 }
 
 func (m *mockAuthProvider) GetToken(context.Context) (string, error) {
@@ -1278,10 +1123,7 @@ func (m *mockAuthProvider) NeedsLogin() bool {
 	return false
 }
 
-func (m *mockAuthProvider) Login(ctx context.Context) error {
-	if m.loginFn != nil {
-		return m.loginFn(ctx)
-	}
+func (m *mockAuthProvider) Login(context.Context) error {
 	return m.loginErr
 }
 

--- a/internal/pipe/mcp/mcp_test.go
+++ b/internal/pipe/mcp/mcp_test.go
@@ -352,6 +352,124 @@ func TestPublishWithTemplates(t *testing.T) {
 	require.NoError(t, pipe.Publish(ctx))
 }
 
+func TestPublishMCPBPackageFileSHA256(t *testing.T) {
+	const fileSHA256 = "fe333e598595000ae021bd27117db32ec69af6987f507ba7a63c90638ff633ce"
+
+	var receivedRequest apiv0.ServerJSON
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.NoError(t, json.Unmarshal(body, &receivedRequest))
+
+		response := apiv0.ServerResponse{
+			Meta: apiv0.ResponseMeta{
+				Official: &apiv0.RegistryExtensions{
+					Status: "pending",
+				},
+			},
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(response))
+	}))
+	defer srv.Close()
+
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		MCP: config.MCP{
+			MCPDetails: config.MCPDetails{
+				Name:  "test-server",
+				Title: "Test Server",
+				Packages: []config.MCPPackage{
+					{
+						RegistryType: "mcpb",
+						Identifier:   "https://github.com/fixture/server/releases/download/{{ .Version }}/server.mcpb",
+						FileSHA256:   "{{ .Env.MCPB_SHA256 }}",
+						Transport: config.MCPTransport{
+							Type: "stdio",
+						},
+					},
+					{
+						RegistryType: "npm",
+						Identifier:   "@test/server",
+						Transport: config.MCPTransport{
+							Type: "stdio",
+						},
+					},
+				},
+				Auth: config.MCPAuth{
+					Type: "none",
+				},
+			},
+		},
+	}, testctx.WithEnv(map[string]string{"MCPB_SHA256": fileSHA256}))
+	ctx.Version = "v1.0.0"
+
+	pipe := &Pipe{registry: srv.URL}
+	pipe.authProviderFn = func(_, _, token string) (auth.Provider, error) {
+		return &mockAuthProvider{token: "test-token"}, nil
+	}
+	require.NoError(t, pipe.Default(ctx))
+	require.NoError(t, pipe.Publish(ctx))
+
+	require.Len(t, receivedRequest.Packages, 2)
+	require.Equal(t, model.Package{
+		RegistryType: "mcpb",
+		Identifier:   "https://github.com/fixture/server/releases/download/v1.0.0/server.mcpb",
+		Version:      "v1.0.0",
+		FileSHA256:   fileSHA256,
+		Transport: model.Transport{
+			Type: "stdio",
+		},
+	}, receivedRequest.Packages[0])
+	require.Empty(t, receivedRequest.Packages[1].FileSHA256)
+}
+
+func TestPublishMCPBPackageRequiresFileSHA256(t *testing.T) {
+	var requested bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requested = true
+		w.WriteHeader(http.StatusCreated)
+		assert.NoError(t, json.NewEncoder(w).Encode(apiv0.ServerResponse{
+			Meta: apiv0.ResponseMeta{
+				Official: &apiv0.RegistryExtensions{Status: "pending"},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		MCP: config.MCP{
+			MCPDetails: config.MCPDetails{
+				Name:  "test-server",
+				Title: "Test Server",
+				Packages: []config.MCPPackage{
+					{
+						RegistryType: "mcpb",
+						Identifier:   "https://github.com/fixture/server/releases/download/v1.0.0/server.mcpb",
+						Transport: config.MCPTransport{
+							Type: "stdio",
+						},
+					},
+				},
+				Auth: config.MCPAuth{
+					Type: "none",
+				},
+			},
+		},
+	})
+	ctx.Version = "v1.0.0"
+
+	pipe := &Pipe{registry: srv.URL}
+	pipe.authProviderFn = func(_, _, token string) (auth.Provider, error) {
+		return &mockAuthProvider{token: "test-token"}, nil
+	}
+	require.NoError(t, pipe.Default(ctx))
+	err := pipe.Publish(ctx)
+	require.EqualError(t, err, `mcpb package "https://github.com/fixture/server/releases/download/v1.0.0/server.mcpb" requires file_sha256`)
+	require.False(t, requested)
+}
+
 func TestPublishDisabled(t *testing.T) {
 	for name, disable := range map[string]string{
 		"true":     "true",

--- a/internal/pipe/mcp/mcp_test.go
+++ b/internal/pipe/mcp/mcp_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync/atomic"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/v2/internal/skips"
@@ -1016,6 +1017,58 @@ func TestPublishGetTokenError(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "could not get token")
 	require.Contains(t, err.Error(), "token retrieval failed")
+}
+
+func TestPublishGitHubOIDCGetTokenErrorKeepsExistingTokenFiles(t *testing.T) {
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "")
+	t.Chdir(t.TempDir())
+
+	const (
+		gitHubTokenFile   = ".mcpregistry_github_token"
+		registryTokenFile = ".mcpregistry_registry_token"
+		gitHubToken       = "existing github token"
+		registryToken     = "existing registry token"
+	)
+	require.NoError(t, os.WriteFile(gitHubTokenFile, []byte(gitHubToken), 0o600))
+	require.NoError(t, os.WriteFile(registryTokenFile, []byte(registryToken), 0o600))
+
+	var requested atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requested.Store(true)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		MCP: config.MCP{
+			MCPDetails: config.MCPDetails{
+				Name:  "test-server",
+				Title: "Test Server",
+				Auth: config.MCPAuth{
+					Type: "github-oidc",
+				},
+			},
+		},
+	})
+	ctx.Version = "1.0.0"
+
+	pipe := &Pipe{
+		registry:       srv.URL,
+		authProviderFn: authProvider,
+	}
+	require.NoError(t, pipe.Default(ctx))
+	err := pipe.Publish(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variable not found")
+	require.False(t, requested.Load())
+
+	bts, err := os.ReadFile(gitHubTokenFile)
+	require.NoError(t, err)
+	require.Equal(t, gitHubToken, string(bts))
+	bts, err = os.ReadFile(registryTokenFile)
+	require.NoError(t, err)
+	require.Equal(t, registryToken, string(bts))
 }
 
 func TestPublishNoPackages(t *testing.T) {

--- a/internal/pipe/mcp/mcp_test.go
+++ b/internal/pipe/mcp/mcp_test.go
@@ -1084,6 +1084,106 @@ func TestPublishGitHubOIDCGetTokenErrorKeepsExistingTokenFiles(t *testing.T) {
 	require.Equal(t, registryToken, string(bts))
 }
 
+func TestPublishCleansUpCreatedLegacyTokenFiles(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	var receivedRequest apiv0.ServerJSON
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.NoError(t, json.Unmarshal(body, &receivedRequest))
+
+		w.WriteHeader(http.StatusCreated)
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(apiv0.ServerResponse{
+			Meta: apiv0.ResponseMeta{
+				Official: &apiv0.RegistryExtensions{Status: "pending"},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		MCP: config.MCP{
+			MCPDetails: config.MCPDetails{
+				Name:  "test-server",
+				Title: "Test Server",
+				Auth: config.MCPAuth{
+					Type: "github",
+				},
+			},
+		},
+	})
+	ctx.Version = "1.0.0"
+
+	pipe := &Pipe{registry: srv.URL}
+	pipe.authProviderFn = func(_, _, _ string) (auth.Provider, error) {
+		return &mockAuthProvider{
+			token: "test-token",
+			loginFn: func(context.Context) error {
+				require.NoError(t, os.WriteFile(legacyGitHubTokenFilePath, []byte("github-token"), 0o600))
+				require.NoError(t, os.WriteFile(legacyRegistryTokenFilePath, []byte("registry-token"), 0o600))
+				return nil
+			},
+		}, nil
+	}
+	require.NoError(t, pipe.Default(ctx))
+	require.NoError(t, pipe.Publish(ctx))
+	require.Equal(t, "test-server", receivedRequest.Name)
+
+	for _, file := range []string{legacyGitHubTokenFilePath, legacyRegistryTokenFilePath} {
+		_, err := os.Stat(file)
+		require.Truef(t, os.IsNotExist(err), "%s should be removed", file)
+	}
+}
+
+func TestPublishRestoresExistingLegacyTokenFiles(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	const (
+		gitHubToken   = "existing github token"
+		registryToken = "existing registry token"
+	)
+	require.NoError(t, os.WriteFile(legacyGitHubTokenFilePath, []byte(gitHubToken), 0o600))
+	require.NoError(t, os.WriteFile(legacyRegistryTokenFilePath, []byte(registryToken), 0o600))
+
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		MCP: config.MCP{
+			MCPDetails: config.MCPDetails{
+				Name:  "test-server",
+				Title: "Test Server",
+				Auth: config.MCPAuth{
+					Type: "github",
+				},
+			},
+		},
+	})
+	ctx.Version = "1.0.0"
+
+	pipe := &Pipe{registry: "http://localhost"}
+	pipe.authProviderFn = func(_, _, _ string) (auth.Provider, error) {
+		return &mockAuthProvider{
+			getTokenErr: fmt.Errorf("token retrieval failed"),
+			loginFn: func(context.Context) error {
+				require.NoError(t, os.WriteFile(legacyGitHubTokenFilePath, []byte("new github token"), 0o600))
+				require.NoError(t, os.WriteFile(legacyRegistryTokenFilePath, []byte("new registry token"), 0o600))
+				return nil
+			},
+		}, nil
+	}
+	require.NoError(t, pipe.Default(ctx))
+	err := pipe.Publish(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "could not get token")
+
+	bts, err := os.ReadFile(legacyGitHubTokenFilePath)
+	require.NoError(t, err)
+	require.Equal(t, gitHubToken, string(bts))
+	bts, err = os.ReadFile(legacyRegistryTokenFilePath)
+	require.NoError(t, err)
+	require.Equal(t, registryToken, string(bts))
+}
+
 func TestPublishNoPackages(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req apiv0.ServerJSON
@@ -1159,6 +1259,7 @@ type mockAuthProvider struct {
 	token       string
 	loginErr    error
 	getTokenErr error
+	loginFn     func(context.Context) error
 }
 
 func (m *mockAuthProvider) GetToken(context.Context) (string, error) {

--- a/internal/pipe/mcp/mcp_test.go
+++ b/internal/pipe/mcp/mcp_test.go
@@ -365,6 +365,9 @@ func TestPublishMCPBPackageFileSHA256(t *testing.T) {
 	sum := sha256.Sum256(bts)
 	fileSHA256 := hex.EncodeToString(sum[:])
 
+	checksumPath := filepath.Join(t.TempDir(), "server.mcpb.txt")
+	require.NoError(t, os.WriteFile(checksumPath, []byte("wrong artifact"), 0o644))
+
 	var receivedRequest apiv0.ServerJSON
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
@@ -417,6 +420,11 @@ func TestPublishMCPBPackageFileSHA256(t *testing.T) {
 		Name: "server.mcpb",
 		Path: artifactPath,
 		Type: artifact.UploadableFile,
+	})
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name: "server.mcpb",
+		Path: checksumPath,
+		Type: artifact.Checksum,
 	})
 
 	pipe := &Pipe{registry: srv.URL}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1708,6 +1708,7 @@ type MCPAuth struct {
 type MCPPackage struct {
 	RegistryType string       `yaml:"registry_type" json:"registry_type" jsonschema:"enum=oci,enum=npm,enum=pypi,enum=nuget,enum=mcpb"`
 	Identifier   string       `yaml:"identifier" json:"identifier"`
+	FileSHA256   string       `yaml:"file_sha256,omitempty" json:"file_sha256,omitempty"`
 	Transport    MCPTransport `yaml:"transport" json:"transport"`
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1706,7 +1706,7 @@ type MCPAuth struct {
 
 // MCPPackage represents an MCP package configuration.
 type MCPPackage struct {
-	RegistryType string       `yaml:"registry_type" json:"registry_type" jsonschema:"enum=oci,enum=npm,enum=pypi,enum=nuget,enum=mcpb"`
+	RegistryType string       `yaml:"registry_type" json:"registry_type" jsonschema:"enum=oci,enum=npm,enum=pypi,enum=nuget"`
 	Identifier   string       `yaml:"identifier" json:"identifier"`
 	Transport    MCPTransport `yaml:"transport" json:"transport"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1714,6 +1714,7 @@ type MCPPackage struct {
 
 type MCPTransport struct {
 	Type string `yaml:"type,omitempty" json:"type,omitempty" jsonschema:"enum=stdio,enum=streamable-http,enum=sse"`
+	URL  string `yaml:"url,omitempty" json:"url,omitempty"`
 }
 
 // Iru publishes artifacts as Custom Apps to iru.com (formerly Kandji).

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1708,7 +1708,6 @@ type MCPAuth struct {
 type MCPPackage struct {
 	RegistryType string       `yaml:"registry_type" json:"registry_type" jsonschema:"enum=oci,enum=npm,enum=pypi,enum=nuget,enum=mcpb"`
 	Identifier   string       `yaml:"identifier" json:"identifier"`
-	FileSHA256   string       `yaml:"file_sha256,omitempty" json:"file_sha256,omitempty"`
 	Transport    MCPTransport `yaml:"transport" json:"transport"`
 }
 

--- a/pkg/config/jsonschema_test.go
+++ b/pkg/config/jsonschema_test.go
@@ -110,3 +110,23 @@ mcp:
 	require.NoError(t, err)
 	require.Equal(t, "fe333e598595000ae021bd27117db32ec69af6987f507ba7a63c90638ff633ce", project.MCP.Packages[0].FileSHA256)
 }
+
+func TestMCPTransportStrictConfig(t *testing.T) {
+	t.Parallel()
+
+	project, err := LoadReader(strings.NewReader(`
+mcp:
+  name: io.github.test/server
+  title: Test Server
+  auth:
+    type: none
+  packages:
+    - registry_type: npm
+      identifier: '@test/server'
+      transport:
+        type: streamable-http
+        url: https://example.com/mcp
+`))
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com/mcp", project.MCP.Packages[0].Transport.URL)
+}

--- a/pkg/config/jsonschema_test.go
+++ b/pkg/config/jsonschema_test.go
@@ -90,3 +90,23 @@ func TestSignJSONSchema(t *testing.T) {
 		}
 	}
 }
+
+func TestMCPPackageStrictConfig(t *testing.T) {
+	t.Parallel()
+
+	project, err := LoadReader(strings.NewReader(`
+mcp:
+  name: io.github.test/server
+  title: Test Server
+  auth:
+    type: none
+  packages:
+    - registry_type: mcpb
+      identifier: https://github.com/test/server/releases/download/v1.0.0/server.mcpb
+      file_sha256: fe333e598595000ae021bd27117db32ec69af6987f507ba7a63c90638ff633ce
+      transport:
+        type: stdio
+`))
+	require.NoError(t, err)
+	require.Equal(t, "fe333e598595000ae021bd27117db32ec69af6987f507ba7a63c90638ff633ce", project.MCP.Packages[0].FileSHA256)
+}

--- a/pkg/config/jsonschema_test.go
+++ b/pkg/config/jsonschema_test.go
@@ -91,26 +91,6 @@ func TestSignJSONSchema(t *testing.T) {
 	}
 }
 
-func TestMCPPackageStrictConfig(t *testing.T) {
-	t.Parallel()
-
-	project, err := LoadReader(strings.NewReader(`
-mcp:
-  name: io.github.test/server
-  title: Test Server
-  auth:
-    type: none
-  packages:
-    - registry_type: mcpb
-      identifier: https://github.com/test/server/releases/download/v1.0.0/server.mcpb
-      file_sha256: fe333e598595000ae021bd27117db32ec69af6987f507ba7a63c90638ff633ce
-      transport:
-        type: stdio
-`))
-	require.NoError(t, err)
-	require.Equal(t, "fe333e598595000ae021bd27117db32ec69af6987f507ba7a63c90638ff633ce", project.MCP.Packages[0].FileSHA256)
-}
-
 func TestMCPTransportStrictConfig(t *testing.T) {
 	t.Parallel()
 

--- a/www/content/customization/publish/mcp.md
+++ b/www/content/customization/publish/mcp.md
@@ -113,6 +113,12 @@ mcp:
         # Required.
         type: stdio
 
+        # URL for streamable-http or sse transports.
+        #
+        # Required for streamable-http and sse transports.
+        # Templates: allowed.
+        # url: "https://example.com/myserver/mcp"
+
     # OCI (Docker) registry example
     - registry_type: oci
       identifier: "ghcr.io/user/myserver:{{ .Version }}"
@@ -124,6 +130,13 @@ mcp:
       identifier: "@myorg/myserver"
       transport:
         type: stdio
+
+    # HTTP transport example
+    - registry_type: npm
+      identifier: "@myorg/myserver-http"
+      transport:
+        type: streamable-http
+        url: "https://example.com/myserver/mcp"
 
     # MCPB package example
     - registry_type: mcpb

--- a/www/content/customization/publish/mcp.md
+++ b/www/content/customization/publish/mcp.md
@@ -125,6 +125,17 @@ mcp:
       transport:
         type: stdio
 
+    # MCPB package example
+    - registry_type: mcpb
+      identifier: "https://github.com/user/myserver/releases/download/{{ .Version }}/myserver.mcpb"
+      # SHA-256 hash of the MCPB file.
+      #
+      # Required for mcpb packages.
+      # Templates: allowed.
+      file_sha256: "fe333e598595000ae021bd27117db32ec69af6987f507ba7a63c90638ff633ce"
+      transport:
+        type: stdio
+
   # Set to true to skip MCP publication. No local manifest is written.
   # If set to auto, the manifest will not be published in case there is an
   # indicator for prerelease in the tag e.g. v1.0.0-rc1

--- a/www/content/customization/publish/mcp.md
+++ b/www/content/customization/publish/mcp.md
@@ -113,12 +113,6 @@ mcp:
         # Required.
         type: stdio
 
-        # URL for streamable-http or sse transports.
-        #
-        # Required for streamable-http and sse transports.
-        # Templates: allowed.
-        # url: "https://example.com/myserver/mcp"
-
     # OCI (Docker) registry example
     - registry_type: oci
       identifier: "ghcr.io/user/myserver:{{ .Version }}"
@@ -136,6 +130,11 @@ mcp:
       identifier: "@myorg/myserver-http"
       transport:
         type: streamable-http
+
+        # URL for streamable-http or sse transports.
+        #
+        # Required for streamable-http and sse transports.
+        # Templates: allowed. {{< g_inline_version "v2.19-unreleased" >}}
         url: "https://example.com/myserver/mcp"
 
   # Set to true to skip MCP publication. No local manifest is written.

--- a/www/content/customization/publish/mcp.md
+++ b/www/content/customization/publish/mcp.md
@@ -138,17 +138,6 @@ mcp:
         type: streamable-http
         url: "https://example.com/myserver/mcp"
 
-    # MCPB package example
-    - registry_type: mcpb
-      identifier: "https://github.com/user/myserver/releases/download/{{ .Version }}/myserver.mcpb"
-      # SHA-256 hash of the MCPB file.
-      #
-      # Required for mcpb packages.
-      # Templates: allowed.
-      file_sha256: "fe333e598595000ae021bd27117db32ec69af6987f507ba7a63c90638ff633ce"
-      transport:
-        type: stdio
-
   # Set to true to skip MCP publication. No local manifest is written.
   # If set to auto, the manifest will not be published in case there is an
   # indicator for prerelease in the tag e.g. v1.0.0-rc1

--- a/www/content/customization/publish/mcp.md
+++ b/www/content/customization/publish/mcp.md
@@ -96,7 +96,7 @@ mcp:
   # Package configurations for different distribution methods.
   packages:
     # Registry type indicating how to download packages.
-    # Valid values: oci, npm, pypi, nuget, mcpb.
+    # Valid values: oci, npm, pypi, nuget.
     - registry_type: npm
 
       # Package identifier - either a package name (for registries) or URL (for direct downloads).

--- a/www/static/schema-pro.json
+++ b/www/static/schema-pro.json
@@ -3191,6 +3191,9 @@
 							"streamable-http",
 							"sse"
 						]
+					},
+					"url": {
+						"type": "string"
 					}
 				},
 				"additionalProperties": false,

--- a/www/static/schema-pro.json
+++ b/www/static/schema-pro.json
@@ -3140,8 +3140,7 @@
 							"oci",
 							"npm",
 							"pypi",
-							"nuget",
-							"mcpb"
+							"nuget"
 						]
 					},
 					"identifier": {

--- a/www/static/schema.json
+++ b/www/static/schema.json
@@ -2605,9 +2605,6 @@
 					"identifier": {
 						"type": "string"
 					},
-					"file_sha256": {
-						"type": "string"
-					},
 					"transport": {
 						"$ref": "#/$defs/MCPTransport"
 					}

--- a/www/static/schema.json
+++ b/www/static/schema.json
@@ -2605,6 +2605,9 @@
 					"identifier": {
 						"type": "string"
 					},
+					"file_sha256": {
+						"type": "string"
+					},
 					"transport": {
 						"$ref": "#/$defs/MCPTransport"
 					}

--- a/www/static/schema.json
+++ b/www/static/schema.json
@@ -2598,8 +2598,7 @@
 							"oci",
 							"npm",
 							"pypi",
-							"nuget",
-							"mcpb"
+							"nuget"
 						]
 					},
 					"identifier": {

--- a/www/static/schema.json
+++ b/www/static/schema.json
@@ -2652,6 +2652,9 @@
 							"streamable-http",
 							"sse"
 						]
+					},
+					"url": {
+						"type": "string"
 					}
 				},
 				"additionalProperties": false,


### PR DESCRIPTION
Adds a templated `transport.url` field to MCP packages and sends it in the publish request, so `streamable-http` and `sse` servers can be published. Before this, the URL was dropped and those packages were unusable.

Also removes `registry_type: mcpb`.

### Net change

- `mcp.go`: template `transport.url`, and pass it to the registry.
- `config.go`: add `MCPTransport.URL`; drop `mcpb` from the `registry_type` enum.
- Docs, `schema.json`, `schema-pro.json`.
- Tests: `TestPublishPackageTransportURL`, `TestMCPTransportStrictConfig`.

### Why mcpb goes away

GoReleaser cannot build `.mcpb` files. The archive pipe accepts a fixed format list and names every file `<template>.<format>`, so a `.mcpb` extension is unreachable. The registry also makes `fileSha256` mandatory for mcpb, and that value can only come from a local file.

So `registry_type: mcpb` has been rejected by the registry since it shipped in v2.13.0. Removing it is not a breaking change, because nothing that worked stops working.

Closes #6940.
Closes #6941 — resolved by removing mcpb rather than adding the hash field.

### Note on the commit history

The branch history is longer than the result. It adds an mcpb SHA-256 implementation and a token-file change, then removes both. The net diff above is what actually lands. Squash on merge.

`#6882` was closed as not planned; that work was reverted.