### PR TITLE
fix(slack,smtp,config): cancellation, message escaping and block round-trips

### DIFF
--- a/internal/pipe/effectiveconfig/config_test.go
+++ b/internal/pipe/effectiveconfig/config_test.go
@@ -1,10 +1,16 @@
 package effectiveconfig
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 
+	slackpipe "github.com/goreleaser/goreleaser/v2/internal/pipe/slack"
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/pkg/config"
 	"github.com/stretchr/testify/require"
@@ -27,4 +33,73 @@ func TestRun(t *testing.T) {
 	bts, err := os.ReadFile(filepath.Join(dist, "config.yaml"))
 	require.NoError(t, err)
 	require.NotEmpty(t, string(bts))
+}
+
+func TestRunPreservesSlackBlocksAndAttachments(t *testing.T) {
+	const conf = `
+version: 2
+project_name: schema-audit
+announce:
+  slack:
+    enabled: true
+    message_template: fallback
+    blocks:
+      - type: divider
+    attachments:
+      - text: hello
+`
+	project, err := config.LoadReader(strings.NewReader(conf))
+	require.NoError(t, err)
+
+	folder := t.TempDir()
+	dist := filepath.Join(folder, "dist")
+	require.NoError(t, os.Mkdir(dist, 0o755))
+	project.Dist = dist
+
+	var payloads []slackWebhookPayload
+	var payloadsMu sync.Mutex
+	decodeErrs := make(chan error, 2)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload slackWebhookPayload
+		err := json.NewDecoder(r.Body).Decode(&payload)
+		decodeErrs <- err
+		payloadsMu.Lock()
+		payloads = append(payloads, payload)
+		payloadsMu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("SLACK_WEBHOOK", srv.URL)
+
+	require.NoError(t, slackpipe.Pipe{}.Announce(testctx.WrapWithCfg(t.Context(), project)))
+	require.NoError(t, Pipe{}.Run(testctx.WrapWithCfg(t.Context(), project)))
+
+	bts, err := os.ReadFile(filepath.Join(dist, "config.yaml"))
+	require.NoError(t, err)
+	require.NotContains(t, string(bts), "internal:")
+
+	reloaded, err := config.Load(filepath.Join(dist, "config.yaml"))
+	require.NoError(t, err)
+	require.NoError(t, slackpipe.Pipe{}.Announce(testctx.WrapWithCfg(t.Context(), reloaded)))
+
+	require.NoError(t, <-decodeErrs)
+	require.NoError(t, <-decodeErrs)
+
+	payloadsMu.Lock()
+	got := append([]slackWebhookPayload(nil), payloads...)
+	payloadsMu.Unlock()
+	require.Len(t, got, 2)
+	for _, payload := range got {
+		require.Len(t, payload.Blocks, 1)
+		require.Equal(t, "divider", payload.Blocks[0]["type"])
+		require.NotContains(t, payload.Blocks[0], "internal")
+		require.Len(t, payload.Attachments, 1)
+		require.Equal(t, "hello", payload.Attachments[0]["text"])
+		require.NotContains(t, payload.Attachments[0], "internal")
+	}
+}
+
+type slackWebhookPayload struct {
+	Blocks      []map[string]any `json:"blocks"`
+	Attachments []map[string]any `json:"attachments"`
 }

--- a/internal/pipe/slack/slack.go
+++ b/internal/pipe/slack/slack.go
@@ -4,7 +4,6 @@ package slack
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/caarlos0/env/v11"
 	"github.com/caarlos0/log"
@@ -105,18 +104,53 @@ func unmarshal(ctx *context.Context, in any, target any) error {
 		return fmt.Errorf("failed to marshal input as JSON: %w", err)
 	}
 
-	body := string(jazon)
-	// ensure that double quotes that are inside the string get un-escaped so they can be interpreted for templates
-	body = strings.ReplaceAll(body, "\\\"", "\"")
+	var raw any
+	if err := json.Unmarshal(jazon, &raw); err != nil {
+		return fmt.Errorf("failed to unmarshal input as JSON: %w", err)
+	}
 
-	tplApplied, err := tmpl.New(ctx).Apply(body)
+	tplApplied, err := applyTemplates(tmpl.New(ctx), raw)
 	if err != nil {
 		return fmt.Errorf("failed to evaluate template: %w", err)
 	}
 
-	if err = json.Unmarshal([]byte(tplApplied), target); err != nil {
+	jazon, err = json.Marshal(tplApplied)
+	if err != nil {
+		return fmt.Errorf("failed to marshal rendered input as JSON: %w", err)
+	}
+
+	if err = json.Unmarshal(jazon, target); err != nil {
 		return fmt.Errorf("failed to unmarshal into target: %w", err)
 	}
 
 	return nil
+}
+
+func applyTemplates(tpl *tmpl.Template, in any) (any, error) {
+	switch v := in.(type) {
+	case string:
+		return tpl.Apply(v)
+	case []any:
+		out := make([]any, len(v))
+		for i, item := range v {
+			applied, err := applyTemplates(tpl, item)
+			if err != nil {
+				return nil, err
+			}
+			out[i] = applied
+		}
+		return out, nil
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for key, value := range v {
+			applied, err := applyTemplates(tpl, value)
+			if err != nil {
+				return nil, err
+			}
+			out[key] = applied
+		}
+		return out, nil
+	default:
+		return v, nil
+	}
 }

--- a/internal/pipe/slack/slack.go
+++ b/internal/pipe/slack/slack.go
@@ -73,7 +73,7 @@ func (p Pipe) Announce(ctx *context.Context) error {
 	}
 
 	return retryx.Do(ctx, ctx.Config.Retry, func() error {
-		return slack.PostWebhook(cfg.Webhook, wm)
+		return slack.PostWebhookContext(ctx, cfg.Webhook, wm)
 	}, retryx.IsNetworkError)
 }
 

--- a/internal/pipe/slack/slack_test.go
+++ b/internal/pipe/slack/slack_test.go
@@ -202,6 +202,50 @@ func TestParseRichText(t *testing.T) {
 	})
 }
 
+func TestParseRichTextPreservesQuotesAndRenderedNewlines(t *testing.T) {
+	t.Parallel()
+
+	const conf = `
+version: 2
+announce:
+  slack:
+    enabled: true
+    message_template: fallback
+    blocks:
+      - type: section
+        text:
+          type: plain_text
+          text: 'Release "stable"'
+      - type: section
+        text:
+          type: plain_text
+          text: '{{ .ReleaseNotes }}'
+    attachments:
+      - text: 'Release "stable"'
+      - text: '{{ .ReleaseNotes }}'
+`
+	project, err := config.LoadReader(bytes.NewBufferString(conf))
+	require.NoError(t, err)
+	ctx := testctx.WrapWithCfg(t.Context(), project)
+	ctx.ReleaseNotes = "line \"one\"\nline two"
+
+	blocks, attachments, err := parseAdvancedFormatting(ctx)
+	require.NoError(t, err)
+	require.Len(t, blocks.BlockSet, 2)
+	require.Len(t, attachments, 2)
+
+	section, ok := blocks.BlockSet[0].(*slack.SectionBlock)
+	require.True(t, ok)
+	require.Equal(t, `Release "stable"`, section.Text.Text)
+
+	section, ok = blocks.BlockSet[1].(*slack.SectionBlock)
+	require.True(t, ok)
+	require.Equal(t, "line \"one\"\nline two", section.Text.Text)
+
+	require.Equal(t, `Release "stable"`, attachments[0].Text)
+	require.Equal(t, "line \"one\"\nline two", attachments[1].Text)
+}
+
 func TestRichText(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/internal/pipe/slack/slack_test.go
+++ b/internal/pipe/slack/slack_test.go
@@ -2,10 +2,13 @@ package slack
 
 import (
 	"bytes"
+	stdctx "context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/internal/testlib"
@@ -77,6 +80,57 @@ func TestAnnounceWithQuotes(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, string(attachmentsBody), `The current user is bot-mc-botyson\n\nIncluding newlines\n`)
 	})
+}
+
+func TestAnnounceCancelsPendingWebhook(t *testing.T) {
+	releaseResponse := make(chan struct{})
+	requestReceived := make(chan struct{})
+	var receivedOnce sync.Once
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedOnce.Do(func() {
+			close(requestReceived)
+		})
+		select {
+		case <-releaseResponse:
+			w.WriteHeader(http.StatusOK)
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(func() {
+		close(releaseResponse)
+		srv.Close()
+	})
+	t.Setenv("SLACK_WEBHOOK", srv.URL)
+
+	parent, cancel := stdctx.WithCancel(t.Context())
+	ctx := testctx.WrapWithCfg(parent, config.Project{
+		Announce: config.Announce{
+			Slack: config.Slack{
+				MessageTemplate: "hello",
+			},
+		},
+	})
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- Pipe{}.Announce(ctx)
+	}()
+
+	select {
+	case <-requestReceived:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for Slack webhook request")
+	}
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, stdctx.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for Slack webhook cancellation")
+	}
 }
 
 func TestAnnounceMissingEnv(t *testing.T) {

--- a/internal/pipe/smtp/smtp.go
+++ b/internal/pipe/smtp/smtp.go
@@ -82,7 +82,10 @@ func (p Pipe) Announce(ctx *context.Context) error {
 
 	// This is only needed when SSL/TLS certificate is not valid on server.
 	// In production this should be set to false.
-	d.TLSConfig = &tls.Config{InsecureSkipVerify: ctx.Config.Announce.SMTP.InsecureSkipVerify}
+	d.TLSConfig = &tls.Config{
+		ServerName:         cfg.Host,
+		InsecureSkipVerify: ctx.Config.Announce.SMTP.InsecureSkipVerify,
+	}
 
 	// Now send E-Mail
 	if err := d.DialAndSend(m); err != nil {

--- a/internal/pipe/smtp/smtp_test.go
+++ b/internal/pipe/smtp/smtp_test.go
@@ -1,12 +1,21 @@
 package smtp
 
 import (
+	"bufio"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/pkg/config"
 	"github.com/stretchr/testify/require"
+	gomail "gopkg.in/mail.v2"
 )
 
 func TestStringer(t *testing.T) {
@@ -47,6 +56,147 @@ func TestDefault(t *testing.T) {
 	require.NoError(t, Pipe{}.Default(ctx))
 	require.Equal(t, defaultBodyTemplate, ctx.Config.Announce.SMTP.BodyTemplate)
 	require.Equal(t, defaultSubjectTemplate, ctx.Config.Announce.SMTP.SubjectTemplate)
+}
+
+func TestAnnounceTLSConfigUsesServerName(t *testing.T) {
+	t.Run("starttls", func(t *testing.T) {
+		requireTLSValidationError(t, 587, serveSMTPStartTLS)
+	})
+
+	t.Run("implicit tls", func(t *testing.T) {
+		requireTLSValidationError(t, 465, serveImplicitSMTPTLS)
+	})
+}
+
+func requireTLSValidationError(t *testing.T, port int, serve func(net.Listener, tls.Certificate, chan<- error)) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = ln.Close()
+	})
+
+	previousDial := gomail.NetDialTimeout
+	gomail.NetDialTimeout = func(network, _ string, timeout time.Duration) (net.Conn, error) {
+		return net.DialTimeout(network, ln.Addr().String(), timeout)
+	}
+	t.Cleanup(func() {
+		gomail.NetDialTimeout = previousDial
+	})
+
+	serverErr := make(chan error, 1)
+	go serve(ln, smtpTestCertificate(t), serverErr)
+
+	t.Setenv("SMTP_PASSWORD", "secret")
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Announce: config.Announce{
+			SMTP: config.SMTP{
+				Enabled:         "true",
+				Host:            "smtp.example.test",
+				Port:            port,
+				Username:        "user",
+				From:            "from@example.com",
+				To:              []string{"to@example.com"},
+				SubjectTemplate: "subject",
+				BodyTemplate:    "body",
+			},
+		},
+	})
+
+	err = Pipe{}.Announce(ctx)
+	require.Error(t, err)
+
+	select {
+	case <-serverErr:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for SMTP TLS handshake")
+	}
+
+	require.NotContains(t, err.Error(), "either ServerName or InsecureSkipVerify")
+	require.Contains(t, err.Error(), "certificate")
+}
+
+func smtpTestCertificate(t *testing.T) tls.Certificate {
+	t.Helper()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	t.Cleanup(srv.Close)
+	require.NotEmpty(t, srv.TLS.Certificates)
+	return srv.TLS.Certificates[0]
+}
+
+func serveImplicitSMTPTLS(ln net.Listener, cert tls.Certificate, errCh chan<- error) {
+	conn, err := ln.Accept()
+	if err != nil {
+		errCh <- err
+		return
+	}
+	defer conn.Close()
+	if err := conn.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		errCh <- err
+		return
+	}
+
+	errCh <- tls.Server(conn, &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}).Handshake()
+}
+
+func serveSMTPStartTLS(ln net.Listener, cert tls.Certificate, errCh chan<- error) {
+	conn, err := ln.Accept()
+	if err != nil {
+		errCh <- err
+		return
+	}
+	defer conn.Close()
+	if err := conn.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		errCh <- err
+		return
+	}
+
+	rw := bufio.NewReadWriter(bufio.NewReader(conn), bufio.NewWriter(conn))
+	if err := writeSMTP(rw, "220 smtp.example.test ESMTP"); err != nil {
+		errCh <- err
+		return
+	}
+	line, err := rw.ReadString('\n')
+	if err != nil {
+		errCh <- err
+		return
+	}
+	if !strings.HasPrefix(line, "EHLO ") && !strings.HasPrefix(line, "HELO ") {
+		errCh <- fmt.Errorf("expected EHLO or HELO, got %q", line)
+		return
+	}
+	if err := writeSMTP(rw, "250-smtp.example.test\r\n250-STARTTLS\r\n250 AUTH PLAIN"); err != nil {
+		errCh <- err
+		return
+	}
+	line, err = rw.ReadString('\n')
+	if err != nil {
+		errCh <- err
+		return
+	}
+	if !strings.HasPrefix(line, "STARTTLS") {
+		errCh <- fmt.Errorf("expected STARTTLS, got %q", line)
+		return
+	}
+	if err := writeSMTP(rw, "220 ready"); err != nil {
+		errCh <- err
+		return
+	}
+
+	errCh <- tls.Server(conn, &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}).Handshake()
+}
+
+func writeSMTP(rw *bufio.ReadWriter, msg string) error {
+	if _, err := rw.WriteString(msg + "\r\n"); err != nil {
+		return err
+	}
+	return rw.Flush()
 }
 
 func TestGetConfig(t *testing.T) {

--- a/pkg/config/marshaler.go
+++ b/pkg/config/marshaler.go
@@ -10,6 +10,11 @@ func (a SlackBlock) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a.Internal)
 }
 
+// MarshalYAML marshals a slack block as YAML.
+func (a SlackBlock) MarshalYAML() (any, error) {
+	return a.Internal, nil
+}
+
 // UnmarshalYAML is a custom unmarshaler that unmarshals a YAML slack attachment as untyped interface{}.
 func (a *SlackAttachment) UnmarshalYAML(unmarshal func(any) error) error {
 	var yamlv2 any
@@ -25,6 +30,11 @@ func (a *SlackAttachment) UnmarshalYAML(unmarshal func(any) error) error {
 // MarshalJSON marshals a slack attachment as JSON.
 func (a SlackAttachment) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a.Internal)
+}
+
+// MarshalYAML marshals a slack attachment as YAML.
+func (a SlackAttachment) MarshalYAML() (any, error) {
+	return a.Internal, nil
 }
 
 // UnmarshalYAML is a custom unmarshaler that allows simplified declarations of commands as strings.


### PR DESCRIPTION
Fixes a group of related bugs in Slack and SMTP announcers plus effective configuration marshalling.

- Closes #6933: Slack webhook requests now use the release context so cancellation aborts pending posts.
- Closes #6932: Slack block and attachment templates now preserve literal quotes and rendered newlines.
- Closes #6881: SMTP TLS now sets ServerName while preserving certificate verification settings.
- Closes #6954: effective YAML now preserves Slack blocks and attachment text across reloads.