### PR TITLE
fix(github): UTF-8 safe truncation, draft reuse, asset replacement and token override

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -5,6 +5,7 @@ import (
 	"cmp"
 	"errors"
 	"fmt"
+	"unicode/utf8"
 
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
@@ -15,7 +16,7 @@ import (
 )
 
 const (
-	// maxReleaseBodyLength defines the max characters size of the body
+	// maxReleaseBodyLength defines the max byte size of the body
 	maxReleaseBodyLength = 125000
 	// ellipsis to be used when release notes body is too long
 	ellipsis = "..."
@@ -178,7 +179,11 @@ func NewIfToken(ctx *context.Context, cli Client, token string) (Client, error) 
 
 func truncateReleaseBody(body string) string {
 	if len(body) > maxReleaseBodyLength {
-		body = body[:(maxReleaseBodyLength-len(ellipsis))] + ellipsis
+		cutoff := maxReleaseBodyLength - len(ellipsis)
+		for !utf8.RuneStart(body[cutoff]) {
+			cutoff--
+		}
+		body = body[:cutoff] + ellipsis
 	}
 	return body
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"math/rand/v2"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/internal/testlib"
@@ -139,6 +141,29 @@ func TestTruncateReleaseBodyNoTruncation(t *testing.T) {
 	body := "short body"
 	out := truncateReleaseBody(body)
 	require.Equal(t, body, out)
+}
+
+func TestTruncateReleaseBodyPreservesUTF8(t *testing.T) {
+	t.Parallel()
+	body := strings.Repeat("a", maxReleaseBodyLength-len(ellipsis)-1) + "ééé"
+	out := truncateReleaseBody(body)
+	require.LessOrEqual(t, len(out), maxReleaseBodyLength)
+	require.True(t, strings.HasSuffix(out, ellipsis), "truncated body should end with ellipsis")
+	require.True(t, utf8.ValidString(out), "truncated body should be valid UTF-8")
+
+	bts, err := json.Marshal(out)
+	require.NoError(t, err)
+	var roundtrip string
+	require.NoError(t, json.Unmarshal(bts, &roundtrip))
+	require.Equal(t, out, roundtrip)
+}
+
+func TestTruncateReleaseBodyDoesNotTruncateUTF8AtLimit(t *testing.T) {
+	t.Parallel()
+	body := strings.Repeat("a", maxReleaseBodyLength-len("é")) + "é"
+	out := truncateReleaseBody(body)
+	require.Equal(t, body, out)
+	require.True(t, utf8.ValidString(out))
 }
 
 func TestNewIfToken(t *testing.T) {

--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -805,16 +805,21 @@ func (c *githubClient) Upload(
 		}
 		defer file.Close()
 
-		_, resp, err := c.client.Repositories.UploadReleaseAsset(
-			ctx,
-			ctx.Config.Release.GitHub.Owner,
-			ctx.Config.Release.GitHub.Name,
-			githubReleaseID,
-			&github.UploadOptions{
-				Name: artifact.Name,
-			},
-			file,
-		)
+		upload := func() (*github.Response, error) {
+			_, resp, err := c.client.Repositories.UploadReleaseAsset(
+				ctx,
+				ctx.Config.Release.GitHub.Owner,
+				ctx.Config.Release.GitHub.Name,
+				githubReleaseID,
+				&github.UploadOptions{
+					Name: artifact.Name,
+				},
+				file,
+			)
+			return resp, err
+		}
+
+		resp, err := upload()
 		if err == nil {
 			return nil
 		}
@@ -829,12 +834,20 @@ func (c *githubClient) Upload(
 			if !ctx.Config.Release.ReplaceExistingArtifacts {
 				return retryx.Unrecoverable(err)
 			}
-			// if the user allowed to delete assets, we delete it, and return
-			// a retriable error so we try again.
 			if delErr := c.deleteReleaseArtifact(ctx, githubReleaseID, artifact.Name, 1); delErr != nil {
 				return retryx.Unrecoverable(delErr)
 			}
-			return retryx.Retriable(err)
+			if _, err := file.Seek(0, io.SeekStart); err != nil {
+				return retryx.Unrecoverable(fmt.Errorf("could not rewind artifact %q: %w", artifact.Path, err))
+			}
+			resp, err = upload()
+			if err == nil {
+				return nil
+			}
+			githubErrLogger(resp, err).
+				WithField("name", artifact.Name).
+				WithField("release-id", releaseID).
+				Warn("upload failed")
 		}
 		return githubError(err, resp)
 	}, retryx.IsRetriable)

--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -604,7 +604,7 @@ func (c *githubClient) PublishRelease(ctx *context.Context, releaseID string) er
 
 func (c *githubClient) createOrUpdateRelease(ctx *context.Context, data github.UpdateReleaseRequest, body string) (*github.RepositoryRelease, error) {
 	c.checkRateLimit(ctx)
-	release, err := c.findRelease(ctx, data.GetTagName())
+	release, err := c.findRelease(ctx, data.GetTagName(), data.GetName())
 	if err != nil || release == nil {
 		release, resp, err := githubDo(ctx, func() (*github.RepositoryRelease, *github.Response, error) {
 			return c.client.Repositories.CreateRelease(
@@ -655,14 +655,14 @@ func (c *githubClient) createOrUpdateRelease(ctx *context.Context, data github.U
 	return c.updateRelease(ctx, release.GetID(), data)
 }
 
-func (c *githubClient) findRelease(ctx *context.Context, name string) (*github.RepositoryRelease, error) {
+func (c *githubClient) findRelease(ctx *context.Context, tag, name string) (*github.RepositoryRelease, error) {
 	if !ctx.Config.Release.UseExistingDraft {
 		release, _, err := githubDo(ctx, func() (*github.RepositoryRelease, *github.Response, error) {
 			return c.client.Repositories.GetReleaseByTag(
 				ctx,
 				ctx.Config.Release.GitHub.Owner,
 				ctx.Config.Release.GitHub.Name,
-				name,
+				tag,
 			)
 		})
 		return release, err

--- a/internal/client/github_test.go
+++ b/internal/client/github_test.go
@@ -1879,19 +1879,33 @@ func TestGitHubCloseMilestoneNotFound(t *testing.T) {
 
 func TestGitHubUploadReplaceExisting(t *testing.T) {
 	t.Parallel()
+	var assetID atomic.Int64
+	assetID.Store(456)
+	var uploads atomic.Int64
 	srv := githubTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		if strings.HasSuffix(r.URL.Path, "/releases/123/assets") && r.Method == http.MethodPost {
-			w.WriteHeader(http.StatusUnprocessableEntity)
-			fmt.Fprint(w, `{"message":"already exists"}`)
+			if uploads.Add(1) == 1 {
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				fmt.Fprint(w, `{"message":"already exists"}`)
+				return
+			}
+			assetID.Store(789)
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"id":789,"name":"test-file.txt"}`)
 			return
 		}
 		if r.URL.Path == "/api/v3/repos/owner/name/releases/123/assets" && r.Method == http.MethodGet {
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, `[{"id":456,"name":"test-file.txt"}]`)
+			if id := assetID.Load(); id != 0 {
+				fmt.Fprintf(w, `[{"id":%d,"name":"test-file.txt"}]`, id)
+				return
+			}
+			fmt.Fprint(w, `[]`)
 			return
 		}
 		if r.URL.Path == "/api/v3/repos/owner/name/releases/assets/456" && r.Method == http.MethodDelete {
+			assetID.Store(0)
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
@@ -1914,17 +1928,87 @@ func TestGitHubUploadReplaceExisting(t *testing.T) {
 	fmt.Fprint(f, "test content")
 	require.NoError(t, f.Close())
 	err = client.Upload(ctx, "123", &artifact.Artifact{Name: "test-file.txt", Path: f.Name()})
-	require.Error(t, err)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, uploads.Load())
+	require.EqualValues(t, 789, assetID.Load())
+}
+
+func TestGitHubUploadReplaceExistingAfterRetry(t *testing.T) {
+	t.Parallel()
+	var assetID atomic.Int64
+	assetID.Store(456)
+	var uploads atomic.Int64
+	srv := githubTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		if strings.HasSuffix(r.URL.Path, "/releases/123/assets") && r.Method == http.MethodPost {
+			switch uploads.Add(1) {
+			case 1:
+				w.WriteHeader(http.StatusInternalServerError)
+				fmt.Fprint(w, `{"message":"try again"}`)
+			case 2:
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				fmt.Fprint(w, `{"message":"already exists"}`)
+			default:
+				assetID.Store(789)
+				w.WriteHeader(http.StatusCreated)
+				fmt.Fprint(w, `{"id":789,"name":"test-file.txt"}`)
+			}
+			return
+		}
+		if r.URL.Path == "/api/v3/repos/owner/name/releases/123/assets" && r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusOK)
+			if id := assetID.Load(); id != 0 {
+				fmt.Fprintf(w, `[{"id":%d,"name":"test-file.txt"}]`, id)
+				return
+			}
+			fmt.Fprint(w, `[]`)
+			return
+		}
+		if r.URL.Path == "/api/v3/repos/owner/name/releases/assets/456" && r.Method == http.MethodDelete {
+			assetID.Store(0)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		t.Error("unhandled request: " + r.Method + " " + r.URL.Path)
+	})
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		GitHubURLs: config.GitHubURLs{
+			API:    srv.URL,
+			Upload: srv.URL,
+		},
+		Release: config.Release{
+			GitHub:                   config.Repo{Owner: "owner", Name: "name"},
+			ReplaceExistingArtifacts: true,
+		},
+		Retry: config.Retry{Attempts: 2},
+	})
+	client, err := newGitHub(ctx, "test-token")
+	require.NoError(t, err)
+	f, err := os.CreateTemp(t.TempDir(), "upload-test")
+	require.NoError(t, err)
+	fmt.Fprint(f, "test content")
+	require.NoError(t, f.Close())
+	err = client.Upload(ctx, "123", &artifact.Artifact{Name: "test-file.txt", Path: f.Name()})
+	require.NoError(t, err)
+	require.EqualValues(t, 3, uploads.Load())
+	require.EqualValues(t, 789, assetID.Load())
 }
 
 func TestGitHubUploadNoReplace(t *testing.T) {
 	t.Parallel()
+	var assetID atomic.Int64
+	assetID.Store(456)
+	var uploads atomic.Int64
 	srv := githubTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		if strings.HasSuffix(r.URL.Path, "/releases/123/assets") && r.Method == http.MethodPost {
+			uploads.Add(1)
 			w.WriteHeader(http.StatusUnprocessableEntity)
 			fmt.Fprint(w, `{"message":"already exists"}`)
 			return
+		}
+		if r.Method == http.MethodDelete {
+			t.Error("delete should not be called when replacement is disabled")
 		}
 		t.Error("unhandled request: " + r.Method + " " + r.URL.Path)
 	})
@@ -1946,6 +2030,8 @@ func TestGitHubUploadNoReplace(t *testing.T) {
 	require.NoError(t, f.Close())
 	err = client.Upload(ctx, "123", &artifact.Artifact{Name: "test-file.txt", Path: f.Name()})
 	require.Error(t, err)
+	require.EqualValues(t, 1, uploads.Load())
+	require.EqualValues(t, 456, assetID.Load())
 }
 
 func TestHeadString(t *testing.T) {

--- a/internal/client/github_test.go
+++ b/internal/client/github_test.go
@@ -1317,6 +1317,64 @@ func TestGitHubCreateReleaseUseExistingDraft(t *testing.T) {
 	require.Equal(t, "1", release)
 }
 
+func TestGitHubCreateReleaseUseExistingDraftCustomTitle(t *testing.T) {
+	t.Parallel()
+	srv := githubTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		if r.URL.Path == "/api/v3/repos/goreleaser/test/releases" && r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `[{"id":1,"name":"Release v1.0.0","tag_name":"v1.0.0","draft":true,"body":"Existing draft release"}]`)
+			return
+		}
+
+		if r.URL.Path == "/api/v3/repos/goreleaser/test/releases/1" && r.Method == http.MethodPatch {
+			got, err := io.ReadAll(r.Body)
+			assert.NoError(t, err)
+			assert.JSONEq(t, `{"name": "Release v1.0.0", "tag_name": "v1.0.0", "body": "Existing draft release", "draft": true, "prerelease": false}`, string(got))
+
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"id": 1, "name": "Release v1.0.0"}`)
+			return
+		}
+
+		if r.URL.Path == "/api/v3/repos/goreleaser/test/releases" && r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			fmt.Fprint(w, `{"message":"release already exists"}`)
+			return
+		}
+
+		t.Error("unhandled request: " + r.Method + " " + r.URL.Path)
+	})
+
+	ctx := testctx.WrapWithCfg(
+		t.Context(),
+		config.Project{
+			GitHubURLs: config.GitHubURLs{
+				API: srv.URL,
+			},
+			Release: config.Release{
+				NameTemplate: "Release {{ .Tag }}",
+				GitHub: config.Repo{
+					Owner: "goreleaser",
+					Name:  "test",
+				},
+				UseExistingDraft: true,
+			},
+		},
+		testctx.WithGitInfo(context.GitInfo{
+			CurrentTag: "v1.0.0",
+		}),
+	)
+
+	client, err := newGitHub(ctx, "test-token")
+	require.NoError(t, err)
+
+	release, err := client.CreateRelease(ctx, "test update draft release")
+	require.NoError(t, err)
+	require.Equal(t, "1", release)
+}
+
 func TestGitHubCreateFileWithGitHubAppToken(t *testing.T) {
 	t.Parallel()
 	srv := githubTestServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/internal/pipe/release/scm.go
+++ b/internal/pipe/release/scm.go
@@ -13,6 +13,7 @@ func setupGitHub(ctx *context.Context) error {
 		if err != nil && !ctx.Snapshot {
 			return err
 		}
+		repo.Token = ctx.Config.Release.GitHub.Token
 		ctx.Config.Release.GitHub = repo
 	}
 
@@ -40,6 +41,7 @@ func setupGitLab(ctx *context.Context) error {
 		if err != nil {
 			return err
 		}
+		repo.Token = ctx.Config.Release.GitLab.Token
 		ctx.Config.Release.GitLab = repo
 	}
 
@@ -67,6 +69,7 @@ func setupGitea(ctx *context.Context) error {
 		if err != nil {
 			return err
 		}
+		repo.Token = ctx.Config.Release.Gitea.Token
 		ctx.Config.Release.Gitea = repo
 	}
 

--- a/internal/pipe/release/scm_test.go
+++ b/internal/pipe/release/scm_test.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/goreleaser/goreleaser/v2/internal/git"
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
+	"github.com/goreleaser/goreleaser/v2/internal/testlib"
 	"github.com/goreleaser/goreleaser/v2/pkg/config"
+	"github.com/goreleaser/goreleaser/v2/pkg/context"
 	"github.com/stretchr/testify/require"
 )
 
@@ -175,4 +177,100 @@ func TestSetupGitHub(t *testing.T) {
 			require.Error(t, setupGitHub(ctx))
 		})
 	})
+}
+
+func TestSetupPreservesToken(t *testing.T) {
+	for name, tt := range map[string]struct {
+		remote string
+		cfg    config.Project
+		setup  func(*context.Context) error
+		repo   func(*context.Context) config.Repo
+	}{
+		"github": {
+			remote: "git@github.com:goreleaser/goreleaser.git",
+			cfg: config.Project{
+				Release: config.Release{
+					GitHub: config.Repo{Token: "{{ .Env.RELEASE_TOKEN }}"},
+				},
+			},
+			setup: setupGitHub,
+			repo:  func(ctx *context.Context) config.Repo { return ctx.Config.Release.GitHub },
+		},
+		"gitlab": {
+			remote: "git@gitlab.com:goreleaser/goreleaser.git",
+			cfg: config.Project{
+				Release: config.Release{
+					GitLab: config.Repo{Token: "{{ .Env.RELEASE_TOKEN }}"},
+				},
+			},
+			setup: setupGitLab,
+			repo:  func(ctx *context.Context) config.Repo { return ctx.Config.Release.GitLab },
+		},
+		"gitea": {
+			remote: "git@gitea.example.com:goreleaser/goreleaser.git",
+			cfg: config.Project{
+				Release: config.Release{
+					Gitea: config.Repo{Token: "{{ .Env.RELEASE_TOKEN }}"},
+				},
+			},
+			setup: setupGitea,
+			repo:  func(ctx *context.Context) config.Repo { return ctx.Config.Release.Gitea },
+		},
+	} {
+		t.Run(name+"/inferred", func(t *testing.T) {
+			testlib.Mktmp(t)
+			testlib.GitInit(t)
+			testlib.GitRemoteAdd(t, tt.remote)
+
+			ctx := testctx.WrapWithCfg(t.Context(), tt.cfg)
+			require.NoError(t, tt.setup(ctx))
+			repo := tt.repo(ctx)
+			require.Equal(t, "goreleaser", repo.Owner)
+			require.Equal(t, "goreleaser", repo.Name)
+			require.Equal(t, "{{ .Env.RELEASE_TOKEN }}", repo.Token)
+		})
+	}
+
+	for name, tt := range map[string]struct {
+		cfg   config.Project
+		setup func(*context.Context) error
+		repo  func(*context.Context) config.Repo
+	}{
+		"github": {
+			cfg: config.Project{
+				Release: config.Release{
+					GitHub: config.Repo{Owner: "owner", Name: "name", Token: "{{ .Env.RELEASE_TOKEN }}"},
+				},
+			},
+			setup: setupGitHub,
+			repo:  func(ctx *context.Context) config.Repo { return ctx.Config.Release.GitHub },
+		},
+		"gitlab": {
+			cfg: config.Project{
+				Release: config.Release{
+					GitLab: config.Repo{Owner: "owner", Name: "name", Token: "{{ .Env.RELEASE_TOKEN }}"},
+				},
+			},
+			setup: setupGitLab,
+			repo:  func(ctx *context.Context) config.Repo { return ctx.Config.Release.GitLab },
+		},
+		"gitea": {
+			cfg: config.Project{
+				Release: config.Release{
+					Gitea: config.Repo{Owner: "owner", Name: "name", Token: "{{ .Env.RELEASE_TOKEN }}"},
+				},
+			},
+			setup: setupGitea,
+			repo:  func(ctx *context.Context) config.Repo { return ctx.Config.Release.Gitea },
+		},
+	} {
+		t.Run(name+"/explicit", func(t *testing.T) {
+			ctx := testctx.WrapWithCfg(t.Context(), tt.cfg)
+			require.NoError(t, tt.setup(ctx))
+			repo := tt.repo(ctx)
+			require.Equal(t, "owner", repo.Owner)
+			require.Equal(t, "name", repo.Name)
+			require.Equal(t, "{{ .Env.RELEASE_TOKEN }}", repo.Token)
+		})
+	}
 }


### PR DESCRIPTION
Fixes a group of related bugs in GitHub client and release pipe.

- Closes #6917: truncates release notes on UTF-8 rune boundaries before adding the ellipsis.
- Closes #6916: reuses existing GitHub drafts by rendered release title while keeping tag lookup separate.
- Closes #6878: deletes and re-uploads conflicting GitHub release assets within the same retry attempt.
- Closes #6910: preserves repository token overrides when release setup infers repository owner/name.