### PR TITLE
fix(docker): v2 build context, annotations and ARM64 handling

### DIFF
--- a/internal/pipe/docker/v2/baseimage.go
+++ b/internal/pipe/docker/v2/baseimage.go
@@ -33,12 +33,12 @@ type dockerImage struct{ name, digest string }
 // getBaseImage returns the base image of dockerfile and its manifest digest.
 // Returns errNoBaseImage when there's no usable FROM. Returns (base, "", err)
 // on digest resolution failure, so callers can still use the image name.
-func getBaseImage(ctx *context.Context, dockerfile string) (dockerImage, error) {
+func getBaseImage(ctx *context.Context, dockerfile string, buildArgs ...map[string]string) (dockerImage, error) {
 	content, err := os.ReadFile(dockerfile)
 	if err != nil {
 		return dockerImage{}, err
 	}
-	base := parseBaseImage(string(content))
+	base := parseBaseImage(string(content), buildArgs...)
 	if base == "" || strings.EqualFold(base, "scratch") {
 		return dockerImage{}, errNoBaseImage
 	}
@@ -58,17 +58,20 @@ var (
 	fromRe         = regexp.MustCompile(`(?i)^FROM(?:\s+--\S+)*\s+(\S+)(?:\s+AS\s+(\S+))?\s*$`)
 )
 
-// parseBaseImage returns the final stage's base image, following AS
-// aliases and substituting global ARG defaults. Returns "" if no FROM
-// is found. Doesn't try to be a full Dockerfile parser — only enough
-// to fill the BaseImage/BaseImageDigest template vars. If it gets it
-// wrong the user just won't get the annotation; the real `docker
-// build` is the source of truth.
-func parseBaseImage(content string) string {
+// parseBaseImage returns the final stage's base image, following AS aliases and
+// substituting effective global ARG values. Returns "" if no FROM is found.
+// Doesn't try to be a full Dockerfile parser — only enough to fill the
+// BaseImage/BaseImageDigest template vars. The real `docker build` is the
+// source of truth.
+func parseBaseImage(content string, buildArgs ...map[string]string) string {
 	content = continuationRe.ReplaceAllString(content, " ")
 
 	args := map[string]string{}
 	aliases := map[string]string{}
+	overrides := map[string]string{}
+	if len(buildArgs) > 0 {
+		overrides = buildArgs[0]
+	}
 	var base string
 
 	for line := range strings.SplitSeq(content, "\n") {
@@ -80,6 +83,9 @@ func parseBaseImage(content string) string {
 		if m := argRe.FindStringSubmatch(line); m != nil && base == "" {
 			// Only global ARGs (before any FROM) are usable in FROM lines.
 			args[m[1]] = strings.Trim(m[2], `"'`)
+			if override := overrides[m[1]]; override != "" {
+				args[m[1]] = override
+			}
 			continue
 		}
 

--- a/internal/pipe/docker/v2/baseimage_test.go
+++ b/internal/pipe/docker/v2/baseimage_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/pkg/config"
+	"github.com/goreleaser/goreleaser/v2/pkg/context"
 	"github.com/stretchr/testify/require"
 )
 
@@ -89,4 +90,51 @@ func TestMakeArgsWithBaseImage(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, da.args, "org.opencontainers.image.base.name="+ref)
 	require.Contains(t, da.args, "org.opencontainers.image.base.digest="+digest)
+}
+
+func TestMakeArgsWithBaseImageBuildArgOverride(t *testing.T) {
+	const defaultRef = "alpine@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	const overrideRef = "busybox@sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	const overrideDigest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+
+	dir := t.TempDir()
+	dockerfile := filepath.Join(dir, "Dockerfile")
+	require.NoError(t, os.WriteFile(dockerfile, []byte("ARG BASE="+defaultRef+"\nFROM ${BASE}\n"), 0o644))
+
+	for name, tt := range map[string]struct {
+		ctx      *context.Context
+		buildArg string
+	}{
+		"literal": {
+			ctx:      testctx.Wrap(t.Context()),
+			buildArg: overrideRef,
+		},
+		"templated": {
+			ctx:      testctx.Wrap(t.Context(), testctx.WithEnv(map[string]string{"BASE": overrideRef})),
+			buildArg: "{{ .Env.BASE }}",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			da, err := makeArgs(
+				tt.ctx,
+				config.DockerV2{
+					Dockerfile: dockerfile,
+					Images:     []string{"ghcr.io/foo/bar"},
+					Tags:       []string{"latest"},
+					Platforms:  []string{"linux/amd64"},
+					BuildArgs: map[string]string{
+						"BASE": tt.buildArg,
+					},
+					Annotations: map[string]string{
+						"org.opencontainers.image.base.name":   "{{.BaseImage}}",
+						"org.opencontainers.image.base.digest": "{{.BaseImageDigest}}",
+					},
+				},
+				nil,
+			)
+			require.NoError(t, err)
+			require.Contains(t, annotationsOf(da.args), "org.opencontainers.image.base.name="+overrideRef)
+			require.Contains(t, annotationsOf(da.args), "org.opencontainers.image.base.digest="+overrideDigest)
+		})
+	}
 }

--- a/internal/pipe/docker/v2/docker.go
+++ b/internal/pipe/docker/v2/docker.go
@@ -459,6 +459,12 @@ func makeContext(d config.DockerV2, artifacts []*artifact.Artifact, dockerfile s
 	if err != nil {
 		return "", fmt.Errorf("failed to create temporary dir: %w", err)
 	}
+	ok := false
+	defer func() {
+		if !ok {
+			_ = os.RemoveAll(tmp)
+		}
+	}()
 
 	if err := gio.Copy(dockerfile, filepath.Join(tmp, "Dockerfile")); err != nil {
 		return "", fmt.Errorf("failed to copy dockerfile: %w: %s", err, d.ID)
@@ -500,6 +506,7 @@ func makeContext(d config.DockerV2, artifacts []*artifact.Artifact, dockerfile s
 		}
 	}
 
+	ok = true
 	return tmp, nil
 }
 

--- a/internal/pipe/docker/v2/docker.go
+++ b/internal/pipe/docker/v2/docker.go
@@ -346,7 +346,12 @@ func makeArgs(ctx *context.Context, d config.DockerV2, extraArgs []string) (dock
 		return dockerArgs{}, fmt.Errorf("invalid dockerfile: %w", err)
 	}
 
-	baseImg, err := getBaseImage(ctx, dockerfile)
+	buildArgEntries, err := tplMapEntries(tpl, d.BuildArgs)
+	if err != nil {
+		return dockerArgs{}, fmt.Errorf("invalid build args: %w", err)
+	}
+
+	baseImg, err := getBaseImage(ctx, dockerfile, mapEntriesMap(buildArgEntries))
 	if err != nil && !errors.Is(err, errNoBaseImage) {
 		log.WithField("dockerfile", d.Dockerfile).
 			WithError(err).
@@ -398,10 +403,7 @@ func makeArgs(ctx *context.Context, d config.DockerV2, extraArgs []string) (dock
 		}
 	}
 
-	buildFlags, err := tplMapFlags(tpl, "--build-arg", d.BuildArgs)
-	if err != nil {
-		return dockerArgs{}, fmt.Errorf("invalid build args: %w", err)
-	}
+	buildFlags := mapEntriesFlags("--build-arg", buildArgEntries)
 
 	flags, err := tpl.Slice(d.Flags, tmpl.NonEmpty())
 	if err != nil {
@@ -645,7 +647,20 @@ func hasAnnotationScope(annotation string) bool {
 // It'll also sort keys so the resulting slice is always in the same order.
 // Finally, it will also skip entries with either an empty key or value.
 func tplMapFlags(tpl *tmpl.Template, flag string, m map[string]string) ([]string, error) {
-	var result []string
+	entries, err := tplMapEntries(tpl, m)
+	if err != nil {
+		return nil, err
+	}
+	return mapEntriesFlags(flag, entries), nil
+}
+
+type mapEntry struct {
+	key   string
+	value string
+}
+
+func tplMapEntries(tpl *tmpl.Template, m map[string]string) ([]mapEntry, error) {
+	var result []mapEntry
 	keys := slices.Collect(maps.Keys(m))
 	slices.Sort(keys)
 	for _, k := range keys {
@@ -656,9 +671,25 @@ func tplMapFlags(tpl *tmpl.Template, flag string, m map[string]string) ([]string
 		if strings.TrimSpace(k) == "" || strings.TrimSpace(v) == "" {
 			continue
 		}
-		result = append(result, flag, k+"="+v)
+		result = append(result, mapEntry{key: k, value: v})
 	}
 	return result, nil
+}
+
+func mapEntriesFlags(flag string, entries []mapEntry) []string {
+	var result []string
+	for _, entry := range entries {
+		result = append(result, flag, entry.key+"="+entry.value)
+	}
+	return result
+}
+
+func mapEntriesMap(entries []mapEntry) map[string]string {
+	result := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		result[entry.key] = entry.value
+	}
+	return result
 }
 
 // IsRetriableBuild reports whether a failed docker build is worth retrying.

--- a/internal/pipe/docker/v2/docker.go
+++ b/internal/pipe/docker/v2/docker.go
@@ -537,6 +537,9 @@ func contextArtifacts(ctx *context.Context, d config.DockerV2) []*artifact.Artif
 		if plat.arm64 != "" {
 			filters = append(filters, byGoarm64(plat.arm64))
 		}
+		if plat.amd64 != "" {
+			filters = append(filters, artifact.ByGoamd64(plat.amd64))
+		}
 		platFilters = append(platFilters, artifact.And(filters...))
 	}
 
@@ -579,8 +582,13 @@ func toPlatform(a *artifact.Artifact) (string, error) {
 		return "", fmt.Errorf("unsupported OS: %q", a.Goos)
 	}
 	switch a.Goarch {
-	case "amd64", "arm64", "386", "ppc64le", "s390x", "riscv64":
+	case "arm64", "386", "ppc64le", "s390x", "riscv64":
 		parts = append(parts, a.Goarch)
+	case "amd64":
+		parts = append(parts, a.Goarch)
+		if a.Goamd64 != "" && a.Goamd64 != "v1" {
+			parts = append(parts, a.Goamd64)
+		}
 	case "arm":
 		parts = append(parts, a.Goarch)
 		switch a.Goarm {
@@ -599,6 +607,7 @@ type platform struct {
 	os, arch string
 	arm      string
 	arm64    string
+	amd64    string
 }
 
 func parsePlatform(p string) platform {
@@ -608,9 +617,14 @@ func parsePlatform(p string) platform {
 	}
 	if len(parts) >= 2 {
 		result.arch = parts[1]
+		if result.arch == "amd64" {
+			result.amd64 = "v1"
+		}
 	}
 	if len(parts) >= 3 {
 		switch result.arch {
+		case "amd64":
+			result.amd64 = toGoamd64(parts[2])
 		case "arm":
 			result.arm = strings.TrimPrefix(parts[2], "v")
 		case "arm64":
@@ -618,6 +632,14 @@ func parsePlatform(p string) platform {
 		}
 	}
 	return result
+}
+
+func toGoamd64(variant string) string {
+	variant = strings.TrimPrefix(variant, "v")
+	if variant == "" {
+		return ""
+	}
+	return "v" + variant
 }
 
 func toGoarm64(variant string) string {

--- a/internal/pipe/docker/v2/docker.go
+++ b/internal/pipe/docker/v2/docker.go
@@ -534,6 +534,9 @@ func contextArtifacts(ctx *context.Context, d config.DockerV2) []*artifact.Artif
 		if plat.arm != "" {
 			filters = append(filters, artifact.ByGoarm(plat.arm))
 		}
+		if plat.arm64 != "" {
+			filters = append(filters, byGoarm64(plat.arm64))
+		}
 		platFilters = append(platFilters, artifact.And(filters...))
 	}
 
@@ -595,6 +598,7 @@ func toPlatform(a *artifact.Artifact) (string, error) {
 type platform struct {
 	os, arch string
 	arm      string
+	arm64    string
 }
 
 func parsePlatform(p string) platform {
@@ -606,9 +610,32 @@ func parsePlatform(p string) platform {
 		result.arch = parts[1]
 	}
 	if len(parts) >= 3 {
-		result.arm = strings.TrimPrefix(parts[2], "v")
+		switch result.arch {
+		case "arm":
+			result.arm = strings.TrimPrefix(parts[2], "v")
+		case "arm64":
+			result.arm64 = toGoarm64(parts[2])
+		}
 	}
 	return result
+}
+
+func toGoarm64(variant string) string {
+	variant = strings.TrimPrefix(variant, "v")
+	if variant == "" {
+		return ""
+	}
+	if !strings.Contains(variant, ".") {
+		variant += ".0"
+	}
+	return "v" + variant
+}
+
+func byGoarm64(s string) artifact.Filter {
+	return func(a *artifact.Artifact) bool {
+		return s == a.Goarm64 ||
+			(a.Goarch == "arm64" && a.Goarm64 == "" && s == "v8.0")
+	}
 }
 
 // annotationScopes are the annotation types buildx accepts, optionally

--- a/internal/pipe/docker/v2/docker_test.go
+++ b/internal/pipe/docker/v2/docker_test.go
@@ -572,9 +572,10 @@ func TestToPlatform(t *testing.T) {
 
 func TestParsePlatform(t *testing.T) {
 	for input, output := range map[string]platform{
-		"linux/amd64":  {os: "linux", arch: "amd64"},
-		"linux/arm/v6": {os: "linux", arch: "arm", arm: "6"},
-		"linux":        {os: "linux"},
+		"linux/amd64":    {os: "linux", arch: "amd64"},
+		"linux/arm/v6":   {os: "linux", arch: "arm", arm: "6"},
+		"linux/arm64/v8": {os: "linux", arch: "arm64", arm64: "v8.0"},
+		"linux":          {os: "linux"},
 	} {
 		t.Run(input, func(t *testing.T) {
 			require.Equal(t, output, parsePlatform(input))
@@ -632,6 +633,48 @@ func TestContextArtifacts(t *testing.T) {
 			Platforms: []string{"linux/arm/v7", "linux/amd64", "linux/arm64"},
 		})
 		require.Len(t, arts, 5)
+	})
+
+	t.Run("arm64 variant", func(t *testing.T) {
+		ctx := testctx.Wrap(t.Context())
+		ctx.Artifacts.Add(&artifact.Artifact{
+			Name:    "mybin",
+			Goos:    "linux",
+			Goarch:  "arm64",
+			Goarm64: "v8.0",
+			Type:    artifact.Binary,
+			Extra: artifact.Extras{
+				artifact.ExtraID: "id1",
+			},
+		})
+
+		arts := contextArtifacts(ctx, config.DockerV2{
+			Platforms: []string{"linux/arm64/v8"},
+			IDs:       []string{"id1"},
+		})
+		require.Len(t, arts, 1)
+	})
+
+	t.Run("arm variants", func(t *testing.T) {
+		ctx := testctx.Wrap(t.Context())
+		for _, goarm := range []string{"5", "6", "7"} {
+			ctx.Artifacts.Add(&artifact.Artifact{
+				Name:   "mybin",
+				Goos:   "linux",
+				Goarch: "arm",
+				Goarm:  goarm,
+				Type:   artifact.Binary,
+				Extra: artifact.Extras{
+					artifact.ExtraID: "id1",
+				},
+			})
+		}
+
+		arts := contextArtifacts(ctx, config.DockerV2{
+			Platforms: []string{"linux/arm/v5", "linux/arm/v6", "linux/arm/v7"},
+			IDs:       []string{"id1"},
+		})
+		require.Len(t, arts, 3)
 	})
 }
 

--- a/internal/pipe/docker/v2/docker_test.go
+++ b/internal/pipe/docker/v2/docker_test.go
@@ -187,6 +187,51 @@ func TestBuildImageRemovesTemporaryDirOnSuccess(t *testing.T) {
 	require.Empty(t, dockerContextDirs(t, tmp))
 }
 
+func TestMakeContextUsesStableAmd64Variant(t *testing.T) {
+	for name, order := range map[string][]string{
+		"v1 then v3": {"v1", "v3"},
+		"v3 then v1": {"v3", "v1"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir, _ := isolatedDockerContextTemp(t)
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644))
+			for _, goamd64 := range []string{"v1", "v3"} {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "mybin-"+goamd64), []byte(goamd64), 0o644))
+			}
+
+			ctx := testctx.Wrap(t.Context())
+			for _, goamd64 := range order {
+				ctx.Artifacts.Add(&artifact.Artifact{
+					Name:    "mybin",
+					Path:    "mybin-" + goamd64,
+					Goos:    "linux",
+					Goarch:  "amd64",
+					Goamd64: goamd64,
+					Type:    artifact.Binary,
+					Extra: artifact.Extras{
+						artifact.ExtraID: "cli",
+					},
+				})
+			}
+
+			d := config.DockerV2{
+				ID:        "test",
+				IDs:       []string{"cli"},
+				Platforms: []string{"linux/amd64"},
+			}
+			wd, err := makeContext(d, contextArtifacts(ctx, d), "Dockerfile")
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = os.RemoveAll(wd)
+			})
+
+			content, err := os.ReadFile(filepath.Join(wd, "linux/amd64/mybin"))
+			require.NoError(t, err)
+			require.Equal(t, "v1", string(content))
+		})
+	}
+}
+
 func isolatedDockerContextTemp(t *testing.T) (string, string) {
 	t.Helper()
 	root := t.TempDir()
@@ -502,6 +547,11 @@ func TestToPlatform(t *testing.T) {
 			Goos:   "linux",
 			Goarch: "amd64",
 		},
+		"linux/amd64/v3": {
+			Goos:    "linux",
+			Goarch:  "amd64",
+			Goamd64: "v3",
+		},
 		"linux/arm64": {
 			Goos:   "linux",
 			Goarch: "arm64",
@@ -572,7 +622,8 @@ func TestToPlatform(t *testing.T) {
 
 func TestParsePlatform(t *testing.T) {
 	for input, output := range map[string]platform{
-		"linux/amd64":    {os: "linux", arch: "amd64"},
+		"linux/amd64":    {os: "linux", arch: "amd64", amd64: "v1"},
+		"linux/amd64/v3": {os: "linux", arch: "amd64", amd64: "v3"},
 		"linux/arm/v6":   {os: "linux", arch: "arm", arm: "6"},
 		"linux/arm64/v8": {os: "linux", arch: "arm64", arm64: "v8.0"},
 		"linux":          {os: "linux"},
@@ -633,6 +684,29 @@ func TestContextArtifacts(t *testing.T) {
 			Platforms: []string{"linux/arm/v7", "linux/amd64", "linux/arm64"},
 		})
 		require.Len(t, arts, 5)
+	})
+
+	t.Run("amd64 variant", func(t *testing.T) {
+		ctx := testctx.Wrap(t.Context())
+		for _, goamd64 := range []string{"v1", "v3"} {
+			ctx.Artifacts.Add(&artifact.Artifact{
+				Name:    "mybin",
+				Goos:    "linux",
+				Goarch:  "amd64",
+				Goamd64: goamd64,
+				Type:    artifact.Binary,
+				Extra: artifact.Extras{
+					artifact.ExtraID: "id1",
+				},
+			})
+		}
+
+		arts := contextArtifacts(ctx, config.DockerV2{
+			Platforms: []string{"linux/amd64/v3"},
+			IDs:       []string{"id1"},
+		})
+		require.Len(t, arts, 1)
+		require.Equal(t, "v3", arts[0].Goamd64)
 	})
 
 	t.Run("arm64 variant", func(t *testing.T) {

--- a/internal/pipe/docker/v2/docker_test.go
+++ b/internal/pipe/docker/v2/docker_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -115,6 +116,113 @@ func TestMakeContext(t *testing.T) {
 		require.FileExists(t, filepath.Join(dir, "linux/arm/v7/mybin"))
 		require.FileExists(t, filepath.Join(dir, "testdata/foo.conf"))
 	})
+}
+
+func TestMakeContextRemovesTemporaryDirOnCopyError(t *testing.T) {
+	for name, setup := range map[string]func(t *testing.T, dir string) (config.DockerV2, []*artifact.Artifact){
+		"extra file": func(t *testing.T, dir string) (config.DockerV2, []*artifact.Artifact) {
+			t.Helper()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "assets.bin"), []byte(strings.Repeat("a", 8192)), 0o644))
+			return config.DockerV2{
+				ID:         "test",
+				ExtraFiles: []string{"assets.bin", "missing.txt"},
+			}, nil
+		},
+		"artifact": func(t *testing.T, dir string) (config.DockerV2, []*artifact.Artifact) {
+			t.Helper()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "mybin"), []byte("binary"), 0o644))
+			return config.DockerV2{ID: "test"}, []*artifact.Artifact{
+				{
+					Name:   "mybin",
+					Path:   "mybin",
+					Goos:   "linux",
+					Goarch: "amd64",
+				},
+				{
+					Name:   "missing",
+					Path:   "missing",
+					Goos:   "linux",
+					Goarch: "amd64",
+				},
+			}
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir, tmp := isolatedDockerContextTemp(t)
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644))
+			d, artifacts := setup(t, dir)
+
+			wd, err := makeContext(d, artifacts, "Dockerfile")
+
+			require.Error(t, err)
+			require.Empty(t, wd)
+			require.Empty(t, dockerContextDirs(t, tmp))
+		})
+	}
+}
+
+func TestBuildImageRemovesTemporaryDirOnSuccess(t *testing.T) {
+	dir, tmp := isolatedDockerContextTemp(t)
+	fakeDockerBuildxBuild(t)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "mybin"), []byte("binary"), 0o644))
+
+	ctx := testctx.Wrap(t.Context())
+	ctx.Artifacts.Add(&artifact.Artifact{
+		Name:   "mybin",
+		Path:   "mybin",
+		Goos:   "linux",
+		Goarch: "amd64",
+		Type:   artifact.Binary,
+	})
+
+	require.NoError(t, buildImage(ctx, config.DockerV2{
+		ID:         "test",
+		Dockerfile: "Dockerfile",
+		Images:     []string{"ghcr.io/foo/bar"},
+		Tags:       []string{"latest"},
+		Platforms:  []string{"linux/amd64"},
+	}, "--load"))
+
+	require.Empty(t, dockerContextDirs(t, tmp))
+}
+
+func isolatedDockerContextTemp(t *testing.T) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, "work")
+	tmp := filepath.Join(root, "tmp")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.MkdirAll(tmp, 0o755))
+	t.Setenv("TMPDIR", tmp)
+	t.Chdir(dir)
+	return dir, tmp
+}
+
+func dockerContextDirs(t *testing.T, tmp string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(tmp)
+	require.NoError(t, err)
+	var dirs []string
+	for _, entry := range entries {
+		if entry.IsDir() && strings.HasPrefix(entry.Name(), "goreleaserdocker") {
+			dirs = append(dirs, entry.Name())
+		}
+	}
+	return dirs
+}
+
+func fakeDockerBuildxBuild(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	name := "docker"
+	script := "#!/bin/sh\nprintf 'sha256:test' > id.txt\n"
+	if testlib.IsWindows() {
+		name = "docker.bat"
+		script = "@echo off\r\necho sha256:test> id.txt\r\n"
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(script), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
 func TestPublishExtraArgs(t *testing.T) {


### PR DESCRIPTION
Fixes a group of related bugs in Docker v2.

- Closes #7046: remove temporary build contexts when Docker v2 context construction fails during copies.
- Closes #6923: resolve base image annotations from effective build-argument overrides.
- Closes #6922: keep linux/arm64/v8 from filtering out matching ARM64 binaries.
- Closes #6880: select the default AMD64 v1 artifact for unqualified linux/amd64 contexts.