### PR TITLE
fix(gomod): scope proxying to Go builds and validate the right module

### DIFF
--- a/internal/pipe/gomod/gomod_proxy.go
+++ b/internal/pipe/gomod/gomod_proxy.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/caarlos0/log"
@@ -17,6 +16,7 @@ import (
 	"github.com/goreleaser/goreleaser/v2/internal/tmpl"
 	"github.com/goreleaser/goreleaser/v2/pkg/config"
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
+	"golang.org/x/mod/modfile"
 )
 
 // ErrReplaceWithProxy happens when the configuration has gomod.proxy enabled,
@@ -33,8 +33,6 @@ func (CheckGoModPipe) Skip(ctx *context.Context) bool {
 	return ctx.ModulePath == "" || !ctx.Config.GoMod.Proxy
 }
 
-var replaceRe = regexp.MustCompile("^replace .* => .*$")
-
 // Run the ReplaceCheckPipe.
 func (CheckGoModPipe) Run(ctx *context.Context) error {
 	for i := range ctx.Config.Builds {
@@ -47,17 +45,18 @@ func (CheckGoModPipe) Run(ctx *context.Context) error {
 			}
 			return fmt.Errorf("could not check %q: %w", path, err)
 		}
-		for line := range strings.SplitSeq(string(mod), "\n") {
-			if !replaceRe.MatchString(line) {
-				continue
-			}
+		file, err := modfile.Parse(path, mod, nil)
+		if err != nil {
+			return fmt.Errorf("could not parse %q: %w", path, err)
+		}
+		for _, replace := range file.Replace {
 			log.Warnf(
 				"your %[2]s file has %[1]s directive in it, and go mod proxying is enabled - "+
 					"this does not work, and you need to either disable it or remove the %[1]s directive",
 				logext.Keyword("replace"),
 				logext.Keyword("go.mod"),
 			)
-			log.Warnf("the offending line is %s", logext.Keyword(strings.TrimSpace(line)))
+			log.Warnf("the offending line is %s", logext.Keyword(formatReplace(replace)))
 			if ctx.Snapshot {
 				// only warn on snapshots
 				break
@@ -67,6 +66,18 @@ func (CheckGoModPipe) Run(ctx *context.Context) error {
 	}
 
 	return nil
+}
+
+func formatReplace(replace *modfile.Replace) string {
+	old := replace.Old.Path
+	if replace.Old.Version != "" {
+		old += " " + replace.Old.Version
+	}
+	new := replace.New.Path
+	if replace.New.Version != "" {
+		new += " " + replace.New.Version
+	}
+	return strings.TrimSpace(fmt.Sprintf("replace %s => %s", old, new))
 }
 
 // ProxyPipe for gomod proxy.

--- a/internal/pipe/gomod/gomod_proxy.go
+++ b/internal/pipe/gomod/gomod_proxy.go
@@ -37,7 +37,10 @@ func (CheckGoModPipe) Skip(ctx *context.Context) bool {
 func (CheckGoModPipe) Run(ctx *context.Context) error {
 	for i := range ctx.Config.Builds {
 		build := &ctx.Config.Builds[i]
-		path := filepath.Join(build.UnproxiedDir, "go.mod")
+		if build.Builder != "" && build.Builder != "go" {
+			continue
+		}
+		path := goModPath(ctx, build)
 		mod, err := os.ReadFile(path)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
@@ -66,6 +69,31 @@ func (CheckGoModPipe) Run(ctx *context.Context) error {
 	}
 
 	return nil
+}
+
+func goModPath(ctx *context.Context, build *config.Build) string {
+	dir := build.UnproxiedDir
+	if dir == "" {
+		dir = ctx.Config.GoMod.Dir
+	}
+	if dir == "" {
+		dir = build.Dir
+	}
+	if dir == "" {
+		dir = "."
+	}
+
+	for {
+		path := filepath.Join(dir, "go.mod")
+		if _, err := os.Stat(path); err == nil || !errors.Is(err, os.ErrNotExist) {
+			return path
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return path
+		}
+		dir = parent
+	}
 }
 
 func formatReplace(replace *modfile.Replace) string {

--- a/internal/pipe/gomod/gomod_proxy.go
+++ b/internal/pipe/gomod/gomod_proxy.go
@@ -82,6 +82,9 @@ func (ProxyPipe) Skip(ctx *context.Context) bool {
 func (ProxyPipe) Run(ctx *context.Context) error {
 	for i := range ctx.Config.Builds {
 		build := &ctx.Config.Builds[i]
+		if build.Builder != "" && build.Builder != "go" {
+			continue
+		}
 		if err := proxyBuild(ctx, build); err != nil {
 			return err
 		}

--- a/internal/pipe/gomod/gomod_proxy.go
+++ b/internal/pipe/gomod/gomod_proxy.go
@@ -166,7 +166,7 @@ func proxyBuild(ctx *context.Context, build *config.Build) error {
 		func() error {
 			cmd := exec.CommandContext(ctx, ctx.Config.GoMod.GoBinary, "get", ctx.ModulePath+"@"+ctx.Git.CurrentTag)
 			cmd.Dir = dir
-			cmd.Env = append(ctx.Config.GoMod.Env, os.Environ()...)
+			cmd.Env = append(ctx.Env.Strings(), ctx.Config.GoMod.Env...)
 			if out, err := cmd.CombinedOutput(); err != nil {
 				return newDetailedErrProxy(err, string(out))
 			}

--- a/internal/pipe/gomod/gomod_proxy_test.go
+++ b/internal/pipe/gomod/gomod_proxy_test.go
@@ -148,6 +148,66 @@ replace (
 		require.NoError(t, exec.CommandContext(t.Context(), "go", "mod", "edit", "-replace", "foo=../bar").Run())
 		require.ErrorIs(t, CheckGoModPipe{}.Run(ctx), ErrReplaceWithProxy)
 	})
+	t.Run("replace in configured module dir", func(t *testing.T) {
+		dir := testlib.Mktmp(t)
+		dist := filepath.Join(dir, "dist")
+		require.NoError(t, os.Mkdir("src", 0o755))
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			Dist: dist,
+			GoMod: config.GoMod{
+				Proxy:    true,
+				GoBinary: "go",
+				Dir:      "src",
+			},
+			Builds: []config.Build{
+				{
+					ID:      "foo",
+					Builder: "go",
+					Goos:    []string{runtime.GOOS},
+					Goarch:  []string{runtime.GOARCH},
+					Main:    ".",
+					Dir:     "src",
+				},
+			},
+		}, withTestModulePath)
+
+		require.NoError(t, os.WriteFile(filepath.Join("src", "go.mod"), fmt.Appendf(nil, `module %s
+
+replace example.invalid/dependency => example.invalid/fork v1.0.0
+`, ctx.ModulePath), 0o666))
+		require.ErrorIs(t, CheckGoModPipe{}.Run(ctx), ErrReplaceWithProxy)
+	})
+	t.Run("clean configured module dir ignores root replacement", func(t *testing.T) {
+		dir := testlib.Mktmp(t)
+		dist := filepath.Join(dir, "dist")
+		require.NoError(t, os.Mkdir("src", 0o755))
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			Dist: dist,
+			GoMod: config.GoMod{
+				Proxy:    true,
+				GoBinary: "go",
+				Dir:      "src",
+			},
+			Builds: []config.Build{
+				{
+					ID:      "foo",
+					Builder: "go",
+					Goos:    []string{runtime.GOOS},
+					Goarch:  []string{runtime.GOARCH},
+					Main:    ".",
+					Dir:     "src",
+				},
+			},
+		}, withTestModulePath)
+
+		require.NoError(t, os.WriteFile("go.mod", []byte(`module example.invalid/root
+
+replace example.invalid/dependency => example.invalid/fork v1.0.0
+`), 0o666))
+		require.NoError(t, os.WriteFile(filepath.Join("src", "go.mod"), fmt.Appendf(nil, `module %s
+`, ctx.ModulePath), 0o666))
+		require.NoError(t, CheckGoModPipe{}.Run(ctx))
+	})
 	t.Run("replace block", func(t *testing.T) {
 		dir := testlib.Mktmp(t)
 		dist := filepath.Join(dir, "dist")

--- a/internal/pipe/gomod/gomod_proxy_test.go
+++ b/internal/pipe/gomod/gomod_proxy_test.go
@@ -47,6 +47,35 @@ func TestCheckGoMod(t *testing.T) {
 		require.NoError(t, exec.CommandContext(t.Context(), "go", "mod", "edit", "-replace", "foo=../bar").Run())
 		require.NoError(t, CheckGoModPipe{}.Run(ctx))
 	})
+	t.Run("replace block on snapshot", func(t *testing.T) {
+		dir := testlib.Mktmp(t)
+		dist := filepath.Join(dir, "dist")
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			Dist: dist,
+			GoMod: config.GoMod{
+				Proxy:    true,
+				GoBinary: "go",
+			},
+			Builds: []config.Build{
+				{
+					ID:     "foo",
+					Goos:   []string{runtime.GOOS},
+					Goarch: []string{runtime.GOARCH},
+					Main:   ".",
+					Dir:    ".",
+				},
+			},
+		}, testctx.Snapshot, withTestModulePath)
+
+		require.NoError(t, os.WriteFile("go.mod", fmt.Appendf(nil, `module %s
+
+replace (
+	example.invalid/dependency => example.invalid/fork v1.0.0
+	example.invalid/other => ../other
+)
+`, ctx.ModulePath), 0o666))
+		require.NoError(t, CheckGoModPipe{}.Run(ctx))
+	})
 	t.Run("no go mod", func(t *testing.T) {
 		dir := testlib.Mktmp(t)
 		dist := filepath.Join(dir, "dist")
@@ -117,6 +146,35 @@ func TestCheckGoMod(t *testing.T) {
 
 		fakeGoModAndSum(t, ctx.ModulePath)
 		require.NoError(t, exec.CommandContext(t.Context(), "go", "mod", "edit", "-replace", "foo=../bar").Run())
+		require.ErrorIs(t, CheckGoModPipe{}.Run(ctx), ErrReplaceWithProxy)
+	})
+	t.Run("replace block", func(t *testing.T) {
+		dir := testlib.Mktmp(t)
+		dist := filepath.Join(dir, "dist")
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			Dist: dist,
+			GoMod: config.GoMod{
+				Proxy:    true,
+				GoBinary: "go",
+			},
+			Builds: []config.Build{
+				{
+					ID:     "foo",
+					Goos:   []string{runtime.GOOS},
+					Goarch: []string{runtime.GOARCH},
+					Main:   ".",
+					Dir:    ".",
+				},
+			},
+		}, withTestModulePath)
+
+		require.NoError(t, os.WriteFile("go.mod", fmt.Appendf(nil, `module %s
+
+replace (
+	example.invalid/dependency => example.invalid/fork v1.0.0
+	example.invalid/other => ../other
+)
+`, ctx.ModulePath), 0o666))
 		require.ErrorIs(t, CheckGoModPipe{}.Run(ctx), ErrReplaceWithProxy)
 	})
 }

--- a/internal/pipe/gomod/gomod_proxy_test.go
+++ b/internal/pipe/gomod/gomod_proxy_test.go
@@ -269,6 +269,40 @@ func TestGoModProxy(t *testing.T) {
 		require.Empty(t, ctx.Config.Builds[1].UnproxiedDir)
 		require.Empty(t, ctx.Config.Builds[1].UnproxiedMain)
 	})
+
+	t.Run("uses configured env precedence", func(t *testing.T) {
+		t.Setenv("GOPROXY", "off")
+		dir := testlib.Mktmp(t)
+		dist := filepath.Join(dir, "dist")
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			Dist: dist,
+			Env: []string{
+				"GOPROXY=https://root.example",
+				"VERIFY_ROOT=from-root",
+				"VERIFY_OVERRIDE=root",
+			},
+			GoMod: config.GoMod{
+				Proxy:    true,
+				GoBinary: fakeGoBinaryExpectingEnv(t),
+				Env: []string{
+					"GOPROXY=https://gomod.example",
+					"VERIFY_OVERRIDE=gomod",
+				},
+			},
+			Builds: []config.Build{
+				{
+					ID:      "foo",
+					Builder: "go",
+					Goos:    []string{runtime.GOOS},
+					Goarch:  []string{runtime.GOARCH},
+					Main:    ".",
+				},
+			},
+		}, withTestModulePath, testctx.WithCurrentTag("v0.1.1"))
+
+		fakeGoModAndSum(t, ctx.ModulePath)
+		require.NoError(t, ProxyPipe{}.Run(ctx))
+	})
 }
 
 func TestProxyDescription(t *testing.T) {
@@ -384,6 +418,39 @@ func fakeGoBinary(tb testing.TB) string {
 	if testlib.IsWindows() {
 		bin = strings.Replace(bin, ".bin", ".bat", 1)
 		content = []byte("@echo off\r\nexit /b 0")
+	}
+	require.NoError(tb, os.WriteFile(bin, content, 0o755))
+	return bin
+}
+
+func fakeGoBinaryExpectingEnv(tb testing.TB) string {
+	tb.Helper()
+	bin := filepath.Join(tb.TempDir(), "go.bin")
+	content := []byte(strings.Join([]string{
+		"#!/bin/sh",
+		`[ "$GOPROXY" = "https://gomod.example" ] || { echo "GOPROXY=$GOPROXY"; exit 1; }`,
+		`[ "$VERIFY_ROOT" = "from-root" ] || { echo "VERIFY_ROOT=$VERIFY_ROOT"; exit 1; }`,
+		`[ "$VERIFY_OVERRIDE" = "gomod" ] || { echo "VERIFY_OVERRIDE=$VERIFY_OVERRIDE"; exit 1; }`,
+		"exit 0",
+	}, "\n"))
+	if testlib.IsWindows() {
+		bin = strings.Replace(bin, ".bin", ".bat", 1)
+		content = []byte(strings.Join([]string{
+			"@echo off",
+			`if not "%GOPROXY%"=="https://gomod.example" (`,
+			`  echo GOPROXY=%GOPROXY%`,
+			`  exit /b 1`,
+			`)`,
+			`if not "%VERIFY_ROOT%"=="from-root" (`,
+			`  echo VERIFY_ROOT=%VERIFY_ROOT%`,
+			`  exit /b 1`,
+			`)`,
+			`if not "%VERIFY_OVERRIDE%"=="gomod" (`,
+			`  echo VERIFY_OVERRIDE=%VERIFY_OVERRIDE%`,
+			`  exit /b 1`,
+			`)`,
+			"exit /b 0",
+		}, "\r\n"))
 	}
 	require.NoError(tb, os.WriteFile(bin, content, 0o755))
 	return bin

--- a/internal/pipe/gomod/gomod_proxy_test.go
+++ b/internal/pipe/gomod/gomod_proxy_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
@@ -230,6 +231,44 @@ func TestGoModProxy(t *testing.T) {
 		require.Equal(t, ctx.ModulePath, ctx.Config.Builds[0].Main)
 		require.Equal(t, filepath.Join(dist, "proxy", "foo"), ctx.Config.Builds[0].Dir)
 	})
+
+	t.Run("mixed builders", func(t *testing.T) {
+		dir := testlib.Mktmp(t)
+		dist := filepath.Join(dir, "dist")
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			Dist: dist,
+			GoMod: config.GoMod{
+				Proxy:    true,
+				GoBinary: fakeGoBinary(t),
+			},
+			Builds: []config.Build{
+				{
+					ID:      "go-app",
+					Builder: "go",
+					Goos:    []string{runtime.GOOS},
+					Goarch:  []string{runtime.GOARCH},
+					Main:    "./cmd/fake",
+				},
+				{
+					ID:      "rust-app",
+					Builder: "rust",
+					Dir:     "rust",
+					Main:    ".",
+				},
+			},
+		}, withTestModulePath, testctx.WithCurrentTag("v0.1.1"))
+
+		fakeGoModAndSum(t, ctx.ModulePath)
+		require.NoError(t, ProxyPipe{}.Run(ctx))
+		require.Equal(t, ctx.ModulePath+"/cmd/fake", ctx.Config.Builds[0].Main)
+		require.Equal(t, filepath.Join(dist, "proxy", "go-app"), ctx.Config.Builds[0].Dir)
+		require.Equal(t, "./cmd/fake", ctx.Config.Builds[0].UnproxiedMain)
+		require.Empty(t, ctx.Config.Builds[0].UnproxiedDir)
+		require.Equal(t, "rust", ctx.Config.Builds[1].Dir)
+		require.Equal(t, ".", ctx.Config.Builds[1].Main)
+		require.Empty(t, ctx.Config.Builds[1].UnproxiedDir)
+		require.Empty(t, ctx.Config.Builds[1].UnproxiedMain)
+	})
 }
 
 func TestProxyDescription(t *testing.T) {
@@ -336,6 +375,18 @@ func fakeGoModAndSum(tb testing.TB, module string) {
 func fakeGoMod(tb testing.TB, module string) {
 	tb.Helper()
 	require.NoError(tb, os.WriteFile("go.mod", fmt.Appendf(nil, "module %s\n", module), 0o666))
+}
+
+func fakeGoBinary(tb testing.TB) string {
+	tb.Helper()
+	bin := filepath.Join(tb.TempDir(), "go.bin")
+	content := []byte("#!/bin/sh\nexit 0")
+	if testlib.IsWindows() {
+		bin = strings.Replace(bin, ".bin", ".bat", 1)
+		content = []byte("@echo off\r\nexit /b 0")
+	}
+	require.NoError(tb, os.WriteFile(bin, content, 0o755))
+	return bin
 }
 
 func withTestModulePath(ctx *context.Context) {


### PR DESCRIPTION
Fixes a group of related bugs in the gomod pipe and proxying.

- Closes #6894: only Go builds are proxied, leaving non-Go build directories and mains unchanged.
- Closes #6893: proxy downloads now use the same context-plus-gomod environment precedence as module loading.
- Closes #6892: replacement blocks are parsed and rejected the same as single-line replacements.
- Closes #6891: replacement validation now reads the configured module's go.mod instead of unrelated root/proxy state.