### PR TITLE
fix(gitea,gitlab): pagination, subpath URLs, default branch, links and cancellation

### DIFF
--- a/internal/client/gitea.go
+++ b/internal/client/gitea.go
@@ -53,9 +53,9 @@ func getInstanceURL(ctx *context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	u.Path = ""
+	u.Path = strings.TrimSuffix(strings.TrimSuffix(u.Path, "/"), "/api/v1")
 	rawurl := u.String()
-	if rawurl == "" {
+	if u.Scheme == "" || u.Host == "" || rawurl == "" {
 		return "", fmt.Errorf("invalid URL: %q", ctx.Config.GiteaURLs.API)
 	}
 	return rawurl, nil

--- a/internal/client/gitea.go
+++ b/internal/client/gitea.go
@@ -77,6 +77,7 @@ func newGitea(ctx *context.Context, token string) (*giteaClient, error) {
 	httpClient := &http.Client{Transport: transport}
 	options := []gitea.ClientOption{
 		gitea.SetHTTPClient(httpClient),
+		gitea.SetContext(ctx),
 	}
 	if token != "giteatoken" { // token used in tests
 		options = append(options, gitea.SetToken(token))
@@ -84,11 +85,6 @@ func newGitea(ctx *context.Context, token string) (*giteaClient, error) {
 	client, err := gitea.NewClient(instanceURL, options...)
 	if err != nil {
 		return nil, err
-	}
-	if ctx != nil {
-		if err := gitea.SetContext(ctx)(client); err != nil {
-			return nil, err
-		}
 	}
 	return &giteaClient{client: client}, nil
 }

--- a/internal/client/gitea.go
+++ b/internal/client/gitea.go
@@ -257,20 +257,16 @@ func (c *giteaClient) createRelease(ctx *context.Context, title, body string) (*
 }
 
 func (c *giteaClient) getExistingRelease(ctx *context.Context, owner, repoName, tagName string) (*gitea.Release, error) {
-	releases, _, err := giteaDo(ctx, func() ([]*gitea.Release, *gitea.Response, error) {
-		return c.client.ListReleases(owner, repoName, gitea.ListReleasesOptions{})
+	release, resp, err := giteaDo(ctx, func() (*gitea.Release, *gitea.Response, error) {
+		return c.client.GetReleaseByTag(owner, repoName, tagName)
 	})
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil, nil
+		}
 		return nil, err
 	}
-
-	for _, release := range releases {
-		if release.TagName == tagName {
-			return release, nil
-		}
-	}
-
-	return nil, nil
+	return release, nil
 }
 
 func (c *giteaClient) updateRelease(ctx *context.Context, title, body string, id int64) (*gitea.Release, error) {

--- a/internal/client/gitea_test.go
+++ b/internal/client/gitea_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	stdctx "context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -8,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"code.gitea.io/sdk/gitea"
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
@@ -863,6 +865,107 @@ func TestGiteaNewGiteaPreservesSubpath(t *testing.T) {
 	})
 	_, err := newGitea(ctx, "giteatoken")
 	require.NoError(t, err)
+}
+
+func TestGiteaVersionRequestUsesReleaseContext(t *testing.T) {
+	entered := make(chan struct{}, 1)
+	releaseResponse := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		if r.URL.Path != "/api/v1/version" {
+			http.Error(w, "unexpected "+r.URL.Path, http.StatusInternalServerError)
+			return
+		}
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
+		<-releaseResponse
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	baseCtx, cancel := stdctx.WithCancel(t.Context())
+	ctx := testctx.WrapWithCfg(baseCtx, config.Project{
+		GiteaURLs: config.GiteaURLs{API: srv.URL},
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := newGitea(ctx, "giteatoken")
+		done <- err
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		close(releaseResponse)
+		t.Fatal("timed out waiting for Gitea version request")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		require.Error(t, err)
+	case <-time.After(time.Second):
+		close(releaseResponse)
+		<-done
+		t.Fatal("Gitea version request did not return after cancellation")
+	}
+	close(releaseResponse)
+}
+
+func TestGiteaChangelogRequestUsesReleaseContext(t *testing.T) {
+	entered := make(chan struct{}, 1)
+	releaseResponse := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		switch {
+		case r.URL.Path == "/api/v1/version":
+			fmt.Fprint(w, `{"version":"1.22.0"}`)
+		case r.URL.Path == "/api/v1/repos/someone/something/compare/v1.0.0...v1.1.0":
+			select {
+			case entered <- struct{}{}:
+			default:
+			}
+			<-releaseResponse
+			fmt.Fprint(w, `{"commits":[]}`)
+		default:
+			http.Error(w, "unexpected "+r.URL.Path, http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	baseCtx, cancel := stdctx.WithCancel(t.Context())
+	ctx := testctx.WrapWithCfg(baseCtx, config.Project{
+		GiteaURLs: config.GiteaURLs{API: srv.URL},
+	})
+	client, err := newGitea(ctx, "giteatoken")
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.Changelog(ctx, Repo{Owner: "someone", Name: "something"}, "v1.0.0", "v1.1.0")
+		done <- err
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		close(releaseResponse)
+		t.Fatal("timed out waiting for Gitea compare request")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		require.Error(t, err)
+	case <-time.After(time.Second):
+		close(releaseResponse)
+		<-done
+		t.Fatal("Gitea compare request did not return after cancellation")
+	}
+	close(releaseResponse)
 }
 
 func TestGiteaCreateFileNewFile(t *testing.T) {

--- a/internal/client/gitea_test.go
+++ b/internal/client/gitea_test.go
@@ -214,7 +214,7 @@ func (s *GetExistingReleaseSuite) TestNoReleases() {
 
 func (s *GetExistingReleaseSuite) TestNoRepo() {
 	t := s.T()
-	httpmock.RegisterResponder("GET", s.releasesURL, httpmock.NewStringResponder(404, ""))
+	httpmock.RegisterResponder("GET", s.releasesURL, httpmock.NewStringResponder(500, ""))
 
 	release, err := s.client.getExistingRelease(s.ctx, s.owner, s.repoName, s.tag)
 	require.Nil(t, release)
@@ -234,8 +234,60 @@ func (s *GetExistingReleaseSuite) TestReleaseExists() {
 	require.NoError(t, err)
 }
 
+func (s *GetExistingReleaseSuite) TestReleaseExistsOnFallbackSecondPage() {
+	t := s.T()
+	release := gitea.Release{TagName: s.tag}
+	responder := func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Query().Get("page") {
+		case "", "1":
+			return httpmock.NewJsonResponse(200, []gitea.Release{{TagName: "older-tag"}})
+		case "2":
+			return httpmock.NewJsonResponse(200, []gitea.Release{release})
+		default:
+			return httpmock.NewJsonResponse(200, []gitea.Release{})
+		}
+	}
+	httpmock.RegisterResponder("GET", s.releasesURL, responder)
+
+	result, err := s.client.getExistingRelease(s.ctx, s.owner, s.repoName, s.tag)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, release, *result)
+}
+
 func TestGiteaGetExistingReleaseSuite(t *testing.T) {
 	suite.Run(t, new(GetExistingReleaseSuite))
+}
+
+func TestGiteaGetExistingReleaseByTag(t *testing.T) {
+	listed := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		switch {
+		case r.URL.Path == "/api/v1/version":
+			fmt.Fprint(w, `{"version":"1.22.0"}`)
+		case r.URL.Path == "/api/v1/repos/owner/repo/releases/tags/v1.0.0":
+			fmt.Fprint(w, `{"id":123,"tag_name":"v1.0.0"}`)
+		case r.URL.Path == "/api/v1/repos/owner/repo/releases":
+			listed = true
+			http.Error(w, "unexpected release list", http.StatusInternalServerError)
+		default:
+			http.Error(w, "unexpected "+r.URL.Path, http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		GiteaURLs: config.GiteaURLs{API: srv.URL},
+	})
+	client, err := newGitea(ctx, "giteatoken")
+	require.NoError(t, err)
+
+	release, err := client.getExistingRelease(ctx, "owner", "repo", "v1.0.0")
+	require.NoError(t, err)
+	require.False(t, listed)
+	require.NotNil(t, release)
+	require.EqualValues(t, 123, release.ID)
 }
 
 type GiteacreateReleaseSuite struct {

--- a/internal/client/gitea_test.go
+++ b/internal/client/gitea_test.go
@@ -39,6 +39,34 @@ func (s *GetInstanceURLSuite) TestWithScheme() {
 	require.Equal(t, rootURL, result)
 }
 
+func (s *GetInstanceURLSuite) TestWithSubpath() {
+	t := s.T()
+	rootURL := "https://gitea.com/forge"
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		GiteaURLs: config.GiteaURLs{
+			API: rootURL + "/api/v1",
+		},
+	})
+
+	result, err := getInstanceURL(ctx)
+	require.NoError(t, err)
+	require.Equal(t, rootURL, result)
+}
+
+func (s *GetInstanceURLSuite) TestWithSubpathTrailingSlash() {
+	t := s.T()
+	rootURL := "https://gitea.com/forge"
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		GiteaURLs: config.GiteaURLs{
+			API: rootURL + "/api/v1/",
+		},
+	})
+
+	result, err := getInstanceURL(ctx)
+	require.NoError(t, err)
+	require.Equal(t, rootURL, result)
+}
+
 func (s *GetInstanceURLSuite) TestParseError() {
 	t := s.T()
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
@@ -816,6 +844,25 @@ func TestGiteaNewGiteaInstanceURLError(t *testing.T) {
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{GiteaURLs: config.GiteaURLs{API: "{{ .NoKeyLikeThat }}"}})
 	_, err := newGitea(ctx, "giteatoken")
 	require.Error(t, err)
+}
+
+func TestGiteaNewGiteaPreservesSubpath(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		if r.URL.Path != "/forge/api/v1/version" {
+			http.Error(w, "unexpected "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		GiteaURLs: config.GiteaURLs{API: srv.URL + "/forge/api/v1"},
+	})
+	_, err := newGitea(ctx, "giteatoken")
+	require.NoError(t, err)
 }
 
 func TestGiteaCreateFileNewFile(t *testing.T) {

--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -205,13 +205,13 @@ func (c *gitlabClient) Changelog(ctx *context.Context, repo Repo, prev, current 
 
 // getDefaultBranch get the default branch
 func (c *gitlabClient) getDefaultBranch(ctx *context.Context, repo Repo) (string, error) {
-	if branch := os.Getenv("CI_DEFAULT_BRANCH"); branch != "" {
+	if branch := gitlabCIDefaultBranch(repo); branch != "" {
 		return branch, nil
 	}
 	if err := c.checkIsPrivateToken(); err != nil {
 		return "", fmt.Errorf("get default branch: %w", err)
 	}
-	projectID := repo.String()
+	projectID := gitlabProjectID(repo)
 	p, res, err := gitlabDo(ctx, func() (*gitlab.Project, *gitlab.Response, error) {
 		return c.client.Projects.GetProject(projectID, nil)
 	})
@@ -226,12 +226,33 @@ func (c *gitlabClient) getDefaultBranch(ctx *context.Context, repo Repo) (string
 	return p.DefaultBranch, nil
 }
 
-// checkBranchExists checks if a branch exists
-func (c *gitlabClient) checkBranchExists(ctx *context.Context, repo Repo, branch string) (bool, error) {
+func gitlabCIDefaultBranch(repo Repo) string {
+	branch := os.Getenv("CI_DEFAULT_BRANCH")
+	if branch == "" {
+		return ""
+	}
+
+	projectID := gitlabProjectID(repo)
+	if projectID == "" {
+		return ""
+	}
+	if os.Getenv("CI_PROJECT_PATH") == projectID || os.Getenv("CI_PROJECT_ID") == projectID {
+		return branch
+	}
+	return ""
+}
+
+func gitlabProjectID(repo Repo) string {
 	projectID := repo.Name
 	if repo.Owner != "" {
 		projectID = repo.Owner + "/" + projectID
 	}
+	return projectID
+}
+
+// checkBranchExists checks if a branch exists
+func (c *gitlabClient) checkBranchExists(ctx *context.Context, repo Repo, branch string) (bool, error) {
+	projectID := gitlabProjectID(repo)
 
 	_, res, err := gitlabDo(ctx, func() (*gitlab.Branch, *gitlab.Response, error) {
 		return c.client.Branches.GetBranch(projectID, branch)
@@ -291,10 +312,7 @@ func (c *gitlabClient) CreateFile(
 		return fmt.Errorf("create file: %w", err)
 	}
 
-	projectID := repo.Name
-	if repo.Owner != "" {
-		projectID = repo.Owner + "/" + projectID
-	}
+	projectID := gitlabProjectID(repo)
 
 	log.
 		WithField("projectID", projectID).

--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -96,6 +96,7 @@ func newGitLab(ctx *context.Context, token string, opts ...gitlab.ClientOptionFu
 		gitlab.WithHTTPClient(&http.Client{
 			Transport: transport,
 		}),
+		gitlab.WithRequestOptions(gitlab.WithContext(ctx)),
 		// the SDK retries 429s and 5xx on its own, with its own budget and
 		// backoff. retryx does that too, honoring the user configuration, so
 		// let it own the retries.

--- a/internal/client/gitlab.go
+++ b/internal/client/gitlab.go
@@ -723,9 +723,13 @@ func (c *gitlabClient) Upload(
 		)
 		if err != nil {
 			if resp != nil && resp.StatusCode == http.StatusBadRequest {
-				return c.replaceReleaseLink(ctx, projectID, releaseID, name, err)
+				releaseLink, err = c.replaceReleaseLink(ctx, projectID, releaseID, name, opt, err)
+				if err != nil {
+					return err
+				}
+			} else {
+				return gitlabError(err, resp)
 			}
-			return gitlabError(err, resp)
 		}
 
 		log.WithField("id", releaseLink.ID).
@@ -743,27 +747,27 @@ func (c *gitlabClient) Upload(
 
 // replaceReleaseLink handles a failed release link creation that is likely
 // caused by a link with the same name already existing: it deletes the existing
-// link, if the user allowed it, and returns a retriable error so the upload
-// happens again.
+// link, if the user allowed it, and recreates it with the already uploaded URL.
 //
 // The failed creation does not return the ID of the existing link, so it has to
 // be found in the release link list first.
 func (c *gitlabClient) replaceReleaseLink(
 	ctx *context.Context,
 	projectID, releaseID, name string,
+	opt *gitlab.CreateReleaseLinkOptions,
 	createErr error,
-) error {
+) (*gitlab.ReleaseLink, error) {
 	if !ctx.Config.Release.ReplaceExistingArtifacts {
-		return retryx.Unrecoverable(createErr)
+		return nil, retryx.Unrecoverable(createErr)
 	}
 
 	link, err := c.getReleaseLinkByName(projectID, releaseID, name)
 	if err != nil {
-		return errors.Join(createErr, err)
+		return nil, errors.Join(createErr, err)
 	}
 	if link == nil {
 		// the creation failed for some other reason.
-		return retryx.Unrecoverable(createErr)
+		return nil, retryx.Unrecoverable(createErr)
 	}
 
 	if _, resp, err := c.client.ReleaseLinks.DeleteReleaseLink(
@@ -771,14 +775,18 @@ func (c *gitlabClient) replaceReleaseLink(
 		releaseID,
 		link.ID,
 	); err != nil {
-		return errors.Join(createErr, gitlabError(err, resp))
+		return nil, errors.Join(createErr, gitlabError(err, resp))
 	}
 
 	log.WithField("id", link.ID).
 		WithField("name", name).
 		Debug("deleted existing release link")
 
-	return retryx.Retriable(createErr)
+	releaseLink, resp, err := c.client.ReleaseLinks.CreateReleaseLink(projectID, releaseID, opt)
+	if err != nil {
+		return nil, errors.Join(createErr, gitlabError(err, resp))
+	}
+	return releaseLink, nil
 }
 
 // getReleaseLinkByName returns the release link with the given name, or nil if

--- a/internal/client/gitlab_test.go
+++ b/internal/client/gitlab_test.go
@@ -613,9 +613,133 @@ func TestGitLabGetDefaultBranchEnv(t *testing.T) {
 	}
 
 	t.Setenv("CI_DEFAULT_BRANCH", "foo")
+	t.Setenv("CI_PROJECT_PATH", "someone/something")
 	b, err := client.getDefaultBranch(ctx, repo)
 	require.NoError(t, err)
 	require.Equal(t, "foo", b)
+}
+
+func TestGitLabGetDefaultBranchEnvProjectID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if serveGitLabVersion(w, r) {
+			return
+		}
+		t.Error("shouldn't have made any calls to the API")
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		GitLabURLs: config.GitLabURLs{
+			API: srv.URL,
+		},
+	})
+	client, err := newGitLab(ctx, "test-token")
+	require.NoError(t, err)
+
+	t.Setenv("CI_DEFAULT_BRANCH", "main")
+	t.Setenv("CI_PROJECT_ID", "123456789")
+	b, err := client.getDefaultBranch(ctx, Repo{Name: "123456789"})
+	require.NoError(t, err)
+	require.Equal(t, "main", b)
+}
+
+func TestGitLabCreateFileUsesTargetDefaultBranch(t *testing.T) {
+	var gotRef string
+	var gotBranch string
+	var decodeErr error
+	var projectLookups int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		switch {
+		case serveGitLabVersion(w, r):
+		case r.URL.Path == "/api/v4/projects/target/project":
+			projectLookups++
+			fmt.Fprint(w, `{"default_branch":"trunk"}`)
+		case strings.Contains(r.URL.Path, "/repository/files/test.rb") && r.Method == http.MethodGet:
+			gotRef = r.URL.Query().Get("ref")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"message":"404 File Not Found"}`)
+		case strings.Contains(r.URL.Path, "/repository/files/test.rb") && r.Method == http.MethodPost:
+			var req map[string]string
+			decodeErr = json.NewDecoder(r.Body).Decode(&req)
+			gotBranch = req["branch"]
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"file_path":"test.rb","branch":"trunk"}`)
+		default:
+			http.Error(w, "unexpected "+r.URL.Path, http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv("CI_DEFAULT_BRANCH", "main")
+	t.Setenv("CI_PROJECT_PATH", "source/project")
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		GitLabURLs: config.GitLabURLs{API: srv.URL},
+	})
+	client, err := newGitLab(ctx, "test-token")
+	require.NoError(t, err)
+
+	err = client.CreateFile(
+		ctx,
+		config.CommitAuthor{Name: "user", Email: "u@e.com"},
+		Repo{Owner: "target", Name: "project"},
+		[]byte("content"),
+		"test.rb",
+		"add test",
+	)
+	require.NoError(t, err)
+	require.NoError(t, decodeErr)
+	require.Equal(t, 1, projectLookups)
+	require.Equal(t, "trunk", gotRef)
+	require.Equal(t, "trunk", gotBranch)
+}
+
+func TestGitLabCreateFileExplicitBranchIgnoresCIDefaultBranch(t *testing.T) {
+	var gotRef string
+	var gotBranch string
+	var decodeErr error
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		switch {
+		case serveGitLabVersion(w, r):
+		case strings.HasSuffix(r.URL.Path, "/repository/branches/trunk"):
+			fmt.Fprint(w, `{"name":"trunk"}`)
+		case strings.Contains(r.URL.Path, "/repository/files/test.rb") && r.Method == http.MethodGet:
+			gotRef = r.URL.Query().Get("ref")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"message":"404 File Not Found"}`)
+		case strings.Contains(r.URL.Path, "/repository/files/test.rb") && r.Method == http.MethodPost:
+			var req map[string]string
+			decodeErr = json.NewDecoder(r.Body).Decode(&req)
+			gotBranch = req["branch"]
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"file_path":"test.rb","branch":"trunk"}`)
+		default:
+			http.Error(w, "unexpected "+r.URL.Path, http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv("CI_DEFAULT_BRANCH", "main")
+	t.Setenv("CI_PROJECT_PATH", "source/project")
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		GitLabURLs: config.GitLabURLs{API: srv.URL},
+	})
+	client, err := newGitLab(ctx, "test-token")
+	require.NoError(t, err)
+
+	err = client.CreateFile(
+		ctx,
+		config.CommitAuthor{Name: "user", Email: "u@e.com"},
+		Repo{Owner: "target", Name: "project", Branch: "trunk"},
+		[]byte("content"),
+		"test.rb",
+		"add test",
+	)
+	require.NoError(t, err)
+	require.NoError(t, decodeErr)
+	require.Equal(t, "trunk", gotRef)
+	require.Equal(t, "trunk", gotBranch)
 }
 
 func TestGitLabGetDefaultBranchErr(t *testing.T) {

--- a/internal/client/gitlab_test.go
+++ b/internal/client/gitlab_test.go
@@ -1835,30 +1835,49 @@ func TestGitLabPublishRelease(t *testing.T) {
 func TestGitLabUploadReleaseLinkExists(t *testing.T) {
 	t.Parallel()
 	for name, tt := range map[string]struct {
-		links       string
-		linksStatus int
-		replace     bool
-		wantDeletes int64
-		wantErrs    []string
+		links           string
+		linksStatus     int
+		replace         bool
+		failFirstCreate bool
+		retryAttempts   uint
+		wantCreates     int64
+		wantDeletes     int64
+		wantErrs        []string
 	}{
-		"replaces it": {
-			links:       `[{"id":1,"name":"other"},{"id":2,"name":"test.tar.gz"}]`,
-			replace:     true,
-			wantDeletes: 1,
+		"replaces it without another retry": {
+			links:         `[{"id":1,"name":"other"},{"id":2,"name":"test.tar.gz"}]`,
+			replace:       true,
+			retryAttempts: 1,
+			wantCreates:   2,
+			wantDeletes:   1,
+		},
+		"replaces it after an earlier transient failure": {
+			links:           `[{"id":1,"name":"other"},{"id":2,"name":"test.tar.gz"}]`,
+			replace:         true,
+			failFirstCreate: true,
+			retryAttempts:   2,
+			wantCreates:     3,
+			wantDeletes:     1,
 		},
 		"replace disabled": {
-			links:    `[{"id":2,"name":"test.tar.gz"}]`,
-			wantErrs: []string{"has already been taken"},
+			links:         `[{"id":2,"name":"test.tar.gz"}]`,
+			retryAttempts: 2,
+			wantCreates:   1,
+			wantErrs:      []string{"has already been taken"},
 		},
 		"no link with that name": {
-			links:    `[{"id":1,"name":"other"}]`,
-			replace:  true,
-			wantErrs: []string{"has already been taken"},
+			links:         `[{"id":1,"name":"other"}]`,
+			replace:       true,
+			retryAttempts: 2,
+			wantCreates:   1,
+			wantErrs:      []string{"has already been taken"},
 		},
 		"listing the links fails": {
-			links:       `{"message":"404 Project Not Found"}`,
-			linksStatus: http.StatusNotFound,
-			replace:     true,
+			links:         `{"message":"404 Project Not Found"}`,
+			linksStatus:   http.StatusNotFound,
+			replace:       true,
+			retryAttempts: 2,
+			wantCreates:   1,
 			// the create error must survive: it names the real problem.
 			wantErrs: []string{"has already been taken", "404"},
 		},
@@ -1866,7 +1885,8 @@ func TestGitLabUploadReleaseLinkExists(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			var deletes atomic.Int64
-			var created atomic.Bool
+			var createAttempts atomic.Int64
+			var duplicateReturned atomic.Bool
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				defer r.Body.Close()
 				_, _ = io.Copy(io.Discard, r.Body)
@@ -1886,14 +1906,19 @@ func TestGitLabUploadReleaseLinkExists(t *testing.T) {
 				case r.Method == http.MethodDelete:
 					deletes.Add(1)
 					fmt.Fprint(w, `{"id":2,"name":"test.tar.gz"}`)
-				case !created.Swap(true):
+				case tt.failFirstCreate && createAttempts.Load() == 0:
+					createAttempts.Add(1)
+					http.Error(w, `{"error":"service unavailable"}`, http.StatusServiceUnavailable)
+				case !duplicateReturned.Swap(true):
 					// the link already exists, so the first create fails.
+					createAttempts.Add(1)
 					http.Error(
 						w,
 						`{"message":{"name":["has already been taken"]}}`,
 						http.StatusBadRequest,
 					)
 				default:
+					createAttempts.Add(1)
 					fmt.Fprint(w, `{"id":3,"name":"test.tar.gz"}`)
 				}
 			}))
@@ -1911,7 +1936,7 @@ func TestGitLabUploadReleaseLinkExists(t *testing.T) {
 					},
 					ReplaceExistingArtifacts: tt.replace,
 				},
-				Retry: config.Retry{Attempts: 2},
+				Retry: config.Retry{Attempts: tt.retryAttempts},
 			}, testctx.WithVersion("1.0.0"), testctx.WithCurrentTag("v1.0.0"))
 			client, err := newGitLab(ctx, "test-token")
 			require.NoError(t, err)
@@ -1924,6 +1949,7 @@ func TestGitLabUploadReleaseLinkExists(t *testing.T) {
 			for _, want := range tt.wantErrs {
 				require.ErrorContains(t, err, want)
 			}
+			require.Equal(t, tt.wantCreates, createAttempts.Load())
 			require.Equal(t, tt.wantDeletes, deletes.Load())
 		})
 	}

--- a/internal/client/gitlab_test.go
+++ b/internal/client/gitlab_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	stdctx "context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1304,6 +1305,106 @@ func TestGitLabVersionProbeIsBounded(t *testing.T) {
 	require.False(t, client.isV17OrLater)
 	require.EqualValues(t, versionRetry.Attempts, probes.Load())
 	require.Less(t, time.Since(start), 10*time.Second)
+}
+
+func TestGitLabVersionRequestUsesReleaseContext(t *testing.T) {
+	entered := make(chan struct{}, 1)
+	releaseResponse := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		if !strings.HasPrefix(r.URL.Path, "/api/v4/version") {
+			http.Error(w, "unexpected "+r.URL.Path, http.StatusInternalServerError)
+			return
+		}
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
+		<-releaseResponse
+		fmt.Fprint(w, `{"version":"18.0.0"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	baseCtx, cancel := stdctx.WithCancel(t.Context())
+	ctx := testctx.WrapWithCfg(baseCtx, config.Project{
+		GitLabURLs: config.GitLabURLs{API: srv.URL},
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := newGitLab(ctx, "test-token", gitlab.WithoutRetries())
+		done <- err
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		close(releaseResponse)
+		t.Fatal("timed out waiting for GitLab version request")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		close(releaseResponse)
+		<-done
+		t.Fatal("GitLab version request did not return after cancellation")
+	}
+	close(releaseResponse)
+}
+
+func TestGitLabChangelogRequestUsesReleaseContext(t *testing.T) {
+	entered := make(chan struct{}, 1)
+	releaseResponse := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		switch {
+		case serveGitLabVersion(w, r):
+		case strings.Contains(r.URL.Path, "/repository/compare"):
+			select {
+			case entered <- struct{}{}:
+			default:
+			}
+			<-releaseResponse
+			fmt.Fprint(w, `{"commits":[]}`)
+		default:
+			http.Error(w, "unexpected "+r.URL.Path, http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	baseCtx, cancel := stdctx.WithCancel(t.Context())
+	ctx := testctx.WrapWithCfg(baseCtx, config.Project{
+		GitLabURLs: config.GitLabURLs{API: srv.URL},
+	})
+	client, err := newGitLab(ctx, "test-token")
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.Changelog(ctx, Repo{Owner: "someone", Name: "something"}, "v1.0.0", "v1.1.0")
+		done <- err
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		close(releaseResponse)
+		t.Fatal("timed out waiting for GitLab compare request")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		require.Error(t, err)
+	case <-time.After(time.Second):
+		close(releaseResponse)
+		<-done
+		t.Fatal("GitLab compare request did not return after cancellation")
+	}
+	close(releaseResponse)
 }
 
 func TestGitLabRateLimitRetryAfter(t *testing.T) {


### PR DESCRIPTION
Fixes a group of related bugs in Gitea and GitLab clients.

- Closes #6913: Gitea now finds existing releases by tag, including older-server paginated fallback results.
- Closes #6912: Gitea API initialization preserves deployment subpaths while trimming the terminal /api/v1 suffix.
- Closes #6911: GitLab only uses CI default-branch metadata for the matching target project.
- Closes #6879: GitLab release-link replacement recreates the link in the same logical upload attempt.
- Closes #6877: GitLab SDK requests inherit the release context and cancel in-flight requests.
- Closes #6876: Gitea SDK initialization receives the release context before the version probe.