### PR TITLE
fix(git,changelog): metadata quoting, dirty detection, key cleanup and mailmap

### DIFF
--- a/internal/client/git.go
+++ b/internal/client/git.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"cmp"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -83,7 +84,7 @@ func (g *gitClient) CreateFiles(
 	}
 
 	parent := filepath.Join(ctx.Config.Dist, "git")
-	name := repo.Name + "-" + g.branch
+	name := checkoutDirName(repo.Name, url, g.branch)
 	cwd := filepath.Join(parent, name)
 	env := []string{fmt.Sprintf("GIT_SSH_COMMAND=%s", sshcmd)}
 
@@ -250,6 +251,11 @@ func pushRepo(ctx *context.Context, cwd string, env []string) error {
 		},
 		retryx.IsNetworkError,
 	)
+}
+
+func checkoutDirName(name, url, branch string) string {
+	sum := sha256.Sum256([]byte(url + "\x00" + branch))
+	return fmt.Sprintf("%s-%s-%x", name, branch, sum[:8])
 }
 
 func runGitCmd(ctx *context.Context, cwd string, env []string, cmd ...string) error {

--- a/internal/client/git.go
+++ b/internal/client/git.go
@@ -65,9 +65,14 @@ func (g *gitClient) CreateFiles(
 		return fmt.Errorf("git: failed to template private key: %w", err)
 	}
 
-	key, err = keyPath(key)
+	key, cleanupKey, err := keyPath(key)
 	if err != nil {
 		return err
+	}
+	if cleanupKey != nil {
+		defer func() {
+			err = errors.Join(err, cleanupKey())
+		}()
 	}
 
 	sshcmd, err := tmpl.New(ctx).WithExtraFields(tmpl.Fields{
@@ -141,26 +146,38 @@ func (g *gitClient) CreateFile(ctx *context.Context, commitAuthor config.CommitA
 	}})
 }
 
-func keyPath(key string) (string, error) {
+func keyPath(key string) (path string, cleanup func() error, err error) {
 	if key == "" {
-		return "", pipe.Skip("private_key is empty")
+		return "", nil, pipe.Skip("private_key is empty")
 	}
 
-	path := key
+	path = key
 
-	_, err := ssh.ParsePrivateKey([]byte(key))
+	_, err = ssh.ParsePrivateKey([]byte(key))
 	if isPasswordError(err) {
-		return "", errors.New("git: key is password-protected")
+		return "", nil, errors.New("git: key is password-protected")
 	}
 
 	if err == nil {
 		// if it can be parsed as a valid private key, we write it to a
 		// temp file and use that path on GIT_SSH_COMMAND.
-		f, err := os.CreateTemp("", "id_*")
-		if err != nil {
-			return "", fmt.Errorf("git: failed to store private key: %w", err)
+		f, createErr := os.CreateTemp("", "id_*")
+		if createErr != nil {
+			return "", nil, fmt.Errorf("git: failed to store private key: %w", createErr)
 		}
-		defer f.Close()
+		generatedPath := f.Name()
+		path = generatedPath
+		cleanup = func() error {
+			if err := os.Remove(generatedPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("git: failed to remove private_key: %w", err)
+			}
+			return nil
+		}
+		defer func() {
+			if err != nil {
+				err = errors.Join(err, cleanup())
+			}
+		}()
 
 		// the key needs to EOF at an empty line, seems like github actions
 		// is somehow removing them.
@@ -168,25 +185,32 @@ func keyPath(key string) (string, error) {
 			key += "\n"
 		}
 
-		if _, err := io.WriteString(f, key); err != nil {
-			return "", fmt.Errorf("git: failed to store private key: %w", err)
+		if _, err = io.WriteString(f, key); err != nil {
+			err = errors.Join(fmt.Errorf("git: failed to store private key: %w", err), f.Close())
+			path = ""
+			return
 		}
-		if err := f.Close(); err != nil {
-			return "", fmt.Errorf("git: failed to store private key: %w", err)
+		if err = f.Close(); err != nil {
+			err = fmt.Errorf("git: failed to store private key: %w", err)
+			path = ""
+			return
 		}
-		path = f.Name()
 	}
 
-	if _, err := os.Stat(path); err != nil {
-		return "", fmt.Errorf("git: could not stat private_key: %w", err)
+	if _, err = os.Stat(path); err != nil {
+		err = fmt.Errorf("git: could not stat private_key: %w", err)
+		path = ""
+		return
 	}
 
 	// in any case, ensure the key has the correct permissions.
-	if err := os.Chmod(path, 0o600); err != nil {
-		return "", fmt.Errorf("git: failed to ensure private_key permissions: %w", err)
+	if err = os.Chmod(path, 0o600); err != nil {
+		err = fmt.Errorf("git: failed to ensure private_key permissions: %w", err)
+		path = ""
+		return
 	}
 
-	return path, nil
+	return path, cleanup, nil
 }
 
 func isPasswordError(err error) bool {

--- a/internal/client/git_test.go
+++ b/internal/client/git_test.go
@@ -260,14 +260,16 @@ func TestKeyPath(t *testing.T) {
 
 	t.Run("with valid path", func(t *testing.T) {
 		t.Parallel()
-		result, err := keyPath(sshKey)
+		result, cleanup, err := keyPath(sshKey)
 		require.NoError(t, err)
+		require.Nil(t, cleanup)
 		require.Equal(t, sshKey, result)
 	})
 	t.Run("with invalid path", func(t *testing.T) {
 		t.Parallel()
-		result, err := keyPath("testdata/nope")
+		result, cleanup, err := keyPath("testdata/nope")
 		require.ErrorIs(t, err, os.ErrNotExist)
+		require.Nil(t, cleanup)
 		require.Empty(t, result)
 	})
 
@@ -277,22 +279,25 @@ func TestKeyPath(t *testing.T) {
 		bts, err := os.ReadFile(path)
 		require.NoError(t, err)
 
-		result, err := keyPath(string(bts))
+		result, cleanup, err := keyPath(string(bts))
 		require.EqualError(t, err, "git: key is password-protected")
+		require.Nil(t, cleanup)
 		require.Empty(t, result)
 	})
 
 	t.Run("with key", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := keyPath(sshKey)
+		_, cleanup, err := keyPath(sshKey)
 		require.NoError(t, err)
+		require.Nil(t, cleanup)
 	})
 
 	t.Run("empty", func(t *testing.T) {
 		t.Parallel()
-		result, err := keyPath("")
+		result, cleanup, err := keyPath("")
 		require.EqualError(t, err, `private_key is empty`)
+		require.Nil(t, cleanup)
 		require.Empty(t, result)
 	})
 
@@ -301,12 +306,104 @@ func TestKeyPath(t *testing.T) {
 		bts, err := os.ReadFile(sshKey)
 		require.NoError(t, err)
 
-		result, err := keyPath(strings.TrimSpace(string(bts)))
+		result, cleanup, err := keyPath(strings.TrimSpace(string(bts)))
 		require.NoError(t, err)
+		require.NotNil(t, cleanup)
 
 		resultbts, err := os.ReadFile(result)
 		require.NoError(t, err)
 		require.Equal(t, string(bts), string(resultbts))
+		require.NoError(t, cleanup())
+		require.NoFileExists(t, result)
+	})
+}
+
+func TestGitClientRemovesInlinePrivateKey(t *testing.T) {
+	author := config.CommitAuthor{
+		Name:  "Foo",
+		Email: "foo@bar.com",
+	}
+	sshKey := testlib.MakeNewSSHKey(t, "")
+	bts, err := os.ReadFile(sshKey)
+	require.NoError(t, err)
+	inlineKey := string(bts)
+
+	temp := t.TempDir()
+	t.Setenv("TMPDIR", temp)
+	t.Setenv("TMP", temp)
+	t.Setenv("TEMP", temp)
+
+	requireNoGeneratedKeys := func(tb testing.TB) {
+		tb.Helper()
+		entries, err := os.ReadDir(temp)
+		require.NoError(tb, err)
+		for _, entry := range entries {
+			require.False(tb, strings.HasPrefix(entry.Name(), "id_"), "generated key %q was not removed", entry.Name())
+		}
+	}
+
+	t.Run("success", func(t *testing.T) {
+		url := testlib.GitMakeBareRepository(t)
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			Dist: t.TempDir(),
+		})
+
+		repo := Repo{
+			GitURL:     url,
+			PrivateKey: inlineKey,
+			Name:       "inline-key-success",
+		}
+		cli := NewGitUploadClient(repo.Branch)
+		require.NoError(t, cli.CreateFile(ctx, author, repo, []byte("content"), "file.txt", "add file"))
+		requireNoGeneratedKeys(t)
+	})
+
+	t.Run("clone failure", func(t *testing.T) {
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			Dist: t.TempDir(),
+		})
+
+		repo := Repo{
+			GitURL:        "git@localhost:nope/nopenopenopenope",
+			PrivateKey:    inlineKey,
+			GitSSHCommand: `ssh -i "{{ .KeyPath }}" -o StrictHostKeyChecking=accept-new -o ConnectTimeout=1 -o BatchMode=yes -F /dev/null`,
+		}
+		cli := NewGitUploadClient(repo.Branch)
+		err := cli.CreateFile(ctx, author, repo, []byte{}, "filename", "msg")
+		require.ErrorContains(t, err, "failed to clone")
+		requireNoGeneratedKeys(t)
+	})
+
+	t.Run("ssh command template failure", func(t *testing.T) {
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			Dist: t.TempDir(),
+		})
+
+		repo := Repo{
+			GitURL:        testlib.GitMakeBareRepository(t),
+			PrivateKey:    inlineKey,
+			GitSSHCommand: "{{.Foo}}",
+		}
+		cli := NewGitUploadClient(repo.Branch)
+		testlib.RequireTemplateError(t, cli.CreateFile(ctx, author, repo, []byte{}, "filename", "msg"))
+		requireNoGeneratedKeys(t)
+	})
+
+	t.Run("caller-owned path", func(t *testing.T) {
+		url := testlib.GitMakeBareRepository(t)
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			Dist: t.TempDir(),
+		})
+
+		repo := Repo{
+			GitURL:     url,
+			PrivateKey: sshKey,
+			Name:       "caller-owned-key",
+		}
+		cli := NewGitUploadClient(repo.Branch)
+		require.NoError(t, cli.CreateFile(ctx, author, repo, []byte("content"), "file.txt", "add file"))
+		require.FileExists(t, sshKey)
+		requireNoGeneratedKeys(t)
 	})
 }
 

--- a/internal/client/git_test.go
+++ b/internal/client/git_test.go
@@ -407,6 +407,35 @@ func TestGitClientRemovesInlinePrivateKey(t *testing.T) {
 	})
 }
 
+func TestGitClientUsesRepositorySpecificCheckout(t *testing.T) {
+	sshKey := testlib.MakeNewSSHKey(t, "")
+	author := config.CommitAuthor{
+		Name:  "Foo",
+		Email: "foo@bar.com",
+	}
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Dist: t.TempDir(),
+	})
+	cli := NewGitUploadClient("main")
+
+	first := testlib.GitMakeBareRepository(t)
+	second := testlib.GitMakeBareRepository(t)
+	repo := Repo{
+		PrivateKey: sshKey,
+		Name:       "homebrew-tap",
+		Branch:     "main",
+	}
+
+	repo.GitURL = first
+	require.NoError(t, cli.CreateFile(ctx, author, repo, []byte("first"), "first.rb", "add first"))
+
+	repo.GitURL = second
+	require.NoError(t, cli.CreateFile(ctx, author, repo, []byte("second"), "second.rb", "add second"))
+
+	require.Equal(t, "first.rb", gitInBare(t, first, "ls-tree", "--name-only", "-r", "main"))
+	require.Equal(t, "second.rb", gitInBare(t, second, "ls-tree", "--name-only", "-r", "main"))
+}
+
 func TestGitClientWithSigning(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pipe/changelog/changelog.go
+++ b/internal/pipe/changelog/changelog.go
@@ -546,7 +546,7 @@ const (
 	gitLogFormat = shaOpen + "%H" + shaClose +
 		messageOpen + "%s" + messageClose +
 		messageBodyOpen + "%b" + messageBodyClose +
-		authorOpen + "%an" + authorClose +
+		authorOpen + "%aN" + authorClose +
 		emailOpen + "%aE" + emailClose +
 		commitDivider
 )

--- a/internal/pipe/changelog/changelog_test.go
+++ b/internal/pipe/changelog/changelog_test.go
@@ -178,6 +178,37 @@ func TestChangelog(t *testing.T) {
 	require.NotEmpty(t, string(bts))
 }
 
+func TestChangelogHonorsMailmapAuthors(t *testing.T) {
+	folder := testlib.Mktmp(t)
+	testlib.GitInit(t)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(folder, ".mailmap"),
+		[]byte("Canonical Author <canonical@example.invalid> Old Author <old@example.invalid>\n"),
+		0o644,
+	))
+	testlib.GitAdd(t)
+	testlib.GitCommit(t, "mailmap")
+	testlib.GitTag(t, "v0.0.1")
+	gitCommitWithAuthor(t, "Old Author", "old@example.invalid", "feat: mapped author")
+	gitCommitWithAuthor(t, "Ordinary Author", "ordinary@example.invalid", "feat: ordinary author")
+	testlib.GitTag(t, "v0.0.2")
+
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Dist: folder,
+		Changelog: config.Changelog{
+			Use:    "git",
+			Sort:   "asc",
+			Format: `{{ .AuthorName }} <{{ .AuthorEmail }}> / {{ range .Authors }}{{ .Name }} <{{ .Email }}>{{ end }}: {{ .Message }}`,
+		},
+	}, testctx.WithCurrentTag("v0.0.2"), testctx.WithPreviousTag("v0.0.1"))
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Contains(t, ctx.ReleaseNotes, "Canonical Author <canonical@example.invalid> / Canonical Author <canonical@example.invalid>: feat: mapped author")
+	require.NotContains(t, ctx.ReleaseNotes, "Old Author <canonical@example.invalid>")
+	require.Contains(t, ctx.ReleaseNotes, "Ordinary Author <ordinary@example.invalid> / Ordinary Author <ordinary@example.invalid>: feat: ordinary author")
+}
+
 func TestChangelogInclude(t *testing.T) {
 	folder := testlib.Mktmp(t)
 	testlib.GitInit(t)
@@ -1469,4 +1500,17 @@ func withFirstCommit(tb testing.TB) testctx.Opt {
 		require.NoError(tb, err)
 		ctx.Git.FirstCommit = s
 	}
+}
+
+func gitCommitWithAuthor(tb testing.TB, name, email, msg string) {
+	tb.Helper()
+	out, err := git.Run(
+		tb.Context(),
+		"-c", "user.name="+name,
+		"-c", "user.email="+email,
+		"-c", "commit.gpgSign=false",
+		"commit", "--allow-empty", "-m", msg,
+	)
+	require.NoError(tb, err)
+	require.Contains(tb, out, "main", msg)
 }

--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"cmp"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -206,7 +207,11 @@ func CheckDirty(ctx *context.Context) error {
 }
 
 func getBranch(ctx *context.Context) (string, error) {
-	return git.Clean(git.Run(ctx, "rev-parse", "--abbrev-ref", "HEAD", "--quiet"))
+	out, err := git.Run(ctx, "rev-parse", "--abbrev-ref", "HEAD", "--quiet")
+	if err != nil {
+		return "", errors.New(strings.TrimSuffix(err.Error(), "\n"))
+	}
+	return strings.TrimRight(out, "\r\n"), nil
 }
 
 // getCommit returns the short hash, full hash and committer date of HEAD.

--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -142,6 +142,7 @@ func getGitInfo(ctx *context.Context) (context.GitInfo, error) {
 			URL:         gitURL,
 			CurrentTag:  "v0.0.0",
 			Summary:     summary,
+			Dirty:       CheckDirty(ctx) != nil,
 		}, ErrNoTag
 	}
 

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/goreleaser/goreleaser/v2/internal/skips"
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/internal/testlib"
+	"github.com/goreleaser/goreleaser/v2/internal/tmpl"
 	"github.com/goreleaser/goreleaser/v2/pkg/config"
 	"github.com/stretchr/testify/require"
 )
@@ -121,16 +122,23 @@ func TestAnnotatedTagsWithApostrophes(t *testing.T) {
 }
 
 func TestBranch(t *testing.T) {
-	testlib.Mktmp(t)
-	testlib.GitInit(t)
-	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
-	testlib.GitCommit(t, "test-branch-commit")
-	testlib.GitTag(t, "test-branch-tag")
-	testlib.GitCheckoutBranch(t, "test-branch")
-	ctx := testctx.Wrap(t.Context())
-	require.NoError(t, Pipe{}.Run(ctx))
-	require.Equal(t, "test-branch", ctx.Git.Branch)
-	require.Equal(t, "test-branch-tag", ctx.Git.Summary)
+	for _, branch := range []string{"test-branch", "feature/o'brien"} {
+		t.Run(branch, func(t *testing.T) {
+			testlib.Mktmp(t)
+			testlib.GitInit(t)
+			testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
+			testlib.GitCommit(t, "test-branch-commit")
+			testlib.GitTag(t, "test-branch-tag")
+			testlib.GitCheckoutBranch(t, branch)
+			ctx := testctx.Wrap(t.Context())
+			require.NoError(t, Pipe{}.Run(ctx))
+			require.Equal(t, branch, ctx.Git.Branch)
+			rendered, err := tmpl.New(ctx).Apply("{{ .Branch }}")
+			require.NoError(t, err)
+			require.Equal(t, branch, rendered)
+			require.Equal(t, "test-branch-tag", ctx.Git.Summary)
+		})
+	}
 }
 
 func TestNoRemote(t *testing.T) {

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -329,16 +329,43 @@ func TestValidState(t *testing.T) {
 }
 
 func TestSnapshotNoTags(t *testing.T) {
-	testlib.Mktmp(t)
-	testlib.GitInit(t)
-	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
-	testlib.GitAdd(t)
-	testlib.GitCommit(t, "whatever")
-	ctx := testctx.Wrap(t.Context(), testctx.Snapshot)
-	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
-	require.Equal(t, fakeInfo.CurrentTag, ctx.Git.CurrentTag)
-	require.Empty(t, ctx.Git.PreviousTag)
-	require.NotEmpty(t, ctx.Git.FirstCommit)
+	for _, tt := range []struct {
+		name     string
+		dirty    bool
+		rendered string
+	}{
+		{
+			name:     "clean",
+			rendered: "false/true/clean",
+		},
+		{
+			name:     "dirty",
+			dirty:    true,
+			rendered: "true/false/dirty",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			folder := testlib.Mktmp(t)
+			testlib.GitInit(t)
+			testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
+			path := filepath.Join(folder, "foo")
+			require.NoError(t, os.WriteFile(path, []byte("initial"), 0o644))
+			testlib.GitAdd(t)
+			testlib.GitCommit(t, "whatever")
+			if tt.dirty {
+				require.NoError(t, os.WriteFile(path, []byte("dirty"), 0o644))
+			}
+			ctx := testctx.Wrap(t.Context(), testctx.Snapshot)
+			testlib.AssertSkipped(t, Pipe{}.Run(ctx))
+			require.Equal(t, fakeInfo.CurrentTag, ctx.Git.CurrentTag)
+			require.Empty(t, ctx.Git.PreviousTag)
+			require.NotEmpty(t, ctx.Git.FirstCommit)
+			require.Equal(t, tt.dirty, ctx.Git.Dirty)
+			rendered, err := tmpl.New(ctx).Apply("{{ .IsGitDirty }}/{{ .IsGitClean }}/{{ .GitTreeState }}")
+			require.NoError(t, err)
+			require.Equal(t, tt.rendered, rendered)
+		})
+	}
 }
 
 func TestSnapshotNoCommits(t *testing.T) {
@@ -376,6 +403,10 @@ func TestSnapshotDirty(t *testing.T) {
 	ctx := testctx.Wrap(t.Context(), testctx.Snapshot)
 	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
 	require.Equal(t, "v0.0.1", ctx.Git.Summary)
+	require.True(t, ctx.Git.Dirty)
+	rendered, err := tmpl.New(ctx).Apply("{{ .IsGitDirty }}/{{ .IsGitClean }}/{{ .GitTreeState }}")
+	require.NoError(t, err)
+	require.Equal(t, "true/false/dirty", rendered)
 }
 
 func TestGitNotInPath(t *testing.T) {


### PR DESCRIPTION
Fixes a group of related bugs in git helpers, git publishing, and changelog.

- Closes #6991: preserve apostrophes in branch metadata and templates.
- Closes #6990: carry dirty state into untagged snapshot metadata.
- Closes #6914: remove generated inline private-key files after git publication exits.
- Closes #6875: isolate reusable publishing checkouts by rendered repository URL and branch.
- Closes #6915: use mailmap-aware author names in git changelog entries.