### PR TITLE
fix(cmd): auto-snapshot ordering, schema error reporting and --output selection

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -149,7 +149,11 @@ func impliedSnapshot(parent stdctx.Context, snapshot, autoSnapshot bool) bool {
 	if snapshot || !autoSnapshot {
 		return snapshot
 	}
-	return git.CheckDirty(context.Wrap(parent, config.Project{})) != nil
+	if git.CheckDirty(context.Wrap(parent, config.Project{})) != nil {
+		log.Info("git repository is dirty and --auto-snapshot is set, implying --snapshot")
+		return true
+	}
+	return false
 }
 
 func setupPipeline(ctx *context.Context, options buildOpts) []pipeline.Piper {
@@ -168,11 +172,6 @@ func setupBuildContext(ctx *context.Context, options buildOpts) error {
 	}
 	log.Debugf("parallelism: %v", ctx.Parallelism)
 	ctx.Snapshot = options.snapshot
-
-	if options.autoSnapshot && git.CheckDirty(ctx) != nil {
-		log.Info("git repository is dirty and --auto-snapshot is set, implying --snapshot")
-		ctx.Snapshot = true
-	}
 
 	if err := skips.SetBuild(ctx, options.skips...); err != nil {
 		return err
@@ -196,7 +195,7 @@ func setupBuildContext(ctx *context.Context, options buildOpts) error {
 		}
 	}
 	if options.output != "" && options.singleTarget && len(options.ids) > 0 && len(ctx.Config.Builds) > 1 {
-		return errors.New(outputRequiresSingleBuildError)
+		return errOutputSingleBuild
 	}
 
 	if skips.Any(ctx, skips.Build...) {
@@ -230,7 +229,7 @@ func setupBuildID(ctx *context.Context, ids []string) error {
 	return nil
 }
 
-const outputRequiresSingleBuildError = "--output requires a single build"
+var errOutputSingleBuild = errors.New("--output requires a single build")
 
 // withOutputPipe copies the binary from dist to the specified output path.
 type withOutputPipe struct {
@@ -247,7 +246,7 @@ func (w withOutputPipe) Run(ctx *context.Context) error {
 		return errors.New("no binary found")
 	}
 	if len(bins) > 1 {
-		return fmt.Errorf("multiple binaries found: %s", outputRequiresSingleBuildError)
+		return fmt.Errorf("multiple binaries found: %w", errOutputSingleBuild)
 	}
 	path := bins[0].Path
 	out := w.output

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -116,6 +116,7 @@ When using ` + "`--single-target`" + `, you use the ` + "`TARGET`, or `GOOS`, `G
 
 func buildProject(parent stdctx.Context, options buildOpts) error {
 	start := time.Now()
+	options.snapshot = impliedSnapshot(parent, options.snapshot, options.autoSnapshot)
 	cfg, err := loadConfig(!options.snapshot, options.config)
 	if err != nil {
 		return decorateWithCtxErr(parent, err, "build", after(start))
@@ -142,6 +143,13 @@ func buildProject(parent stdctx.Context, options buildOpts) error {
 	deprecateWarn(ctx)
 	log.Infof(boldStyle.Render(fmt.Sprintf("build succeeded after %s", after(start).String())))
 	return nil
+}
+
+func impliedSnapshot(parent stdctx.Context, snapshot, autoSnapshot bool) bool {
+	if snapshot || !autoSnapshot {
+		return snapshot
+	}
+	return git.CheckDirty(context.Wrap(parent, config.Project{})) != nil
 }
 
 func setupPipeline(ctx *context.Context, options buildOpts) []pipeline.Piper {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -153,7 +153,7 @@ func impliedSnapshot(parent stdctx.Context, snapshot, autoSnapshot bool) bool {
 }
 
 func setupPipeline(ctx *context.Context, options buildOpts) []pipeline.Piper {
-	if options.output != "" && options.singleTarget && (len(options.ids) > 0 || len(ctx.Config.Builds) == 1) {
+	if options.output != "" && options.singleTarget && len(ctx.Config.Builds) == 1 {
 		return append(pipeline.BuildCmdPipeline, withOutputPipe{options.output})
 	}
 	return pipeline.BuildCmdPipeline
@@ -195,6 +195,9 @@ func setupBuildContext(ctx *context.Context, options buildOpts) error {
 			return err
 		}
 	}
+	if options.output != "" && options.singleTarget && len(options.ids) > 0 && len(ctx.Config.Builds) > 1 {
+		return errors.New(outputRequiresSingleBuildError)
+	}
 
 	if skips.Any(ctx, skips.Build...) {
 		log.Warnf(
@@ -227,6 +230,8 @@ func setupBuildID(ctx *context.Context, ids []string) error {
 	return nil
 }
 
+const outputRequiresSingleBuildError = "--output requires a single build"
+
 // withOutputPipe copies the binary from dist to the specified output path.
 type withOutputPipe struct {
 	output string
@@ -240,6 +245,9 @@ func (w withOutputPipe) Run(ctx *context.Context) error {
 	bins := ctx.Artifacts.Filter(artifact.ByType(artifact.Binary)).List()
 	if len(bins) == 0 {
 		return errors.New("no binary found")
+	}
+	if len(bins) > 1 {
+		return fmt.Errorf("multiple binaries found: %s", outputRequiresSingleBuildError)
 	}
 	path := bins[0].Path
 	out := w.output

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -38,6 +38,36 @@ func TestBuildAutoSnapshot(t *testing.T) {
 	})
 }
 
+func TestBuildAutoSnapshotWithProConfig(t *testing.T) {
+	t.Run("explicit snapshot", func(t *testing.T) {
+		setupPro(t)
+		cmd := newBuildCmd()
+		cmd.cmd.SetArgs([]string{"--snapshot", "--timeout=1m", "--parallelism=2", "--deprecated"})
+		require.NoError(t, cmd.cmd.Execute())
+		matches, err := filepath.Glob("./dist/fake_*/fake_snapshot")
+		require.NoError(t, err)
+		require.Len(t, matches, 1)
+	})
+
+	t.Run("dirty automatic snapshot", func(t *testing.T) {
+		setupPro(t)
+		createFile(t, "foo", "force dirty tree")
+		cmd := newBuildCmd()
+		cmd.cmd.SetArgs([]string{"--auto-snapshot", "--timeout=1m", "--parallelism=2", "--deprecated"})
+		require.NoError(t, cmd.cmd.Execute())
+		matches, err := filepath.Glob("./dist/fake_*/fake_snapshot")
+		require.NoError(t, err)
+		require.Len(t, matches, 1)
+	})
+
+	t.Run("clean automatic snapshot", func(t *testing.T) {
+		setupPro(t)
+		cmd := newBuildCmd()
+		cmd.cmd.SetArgs([]string{"--auto-snapshot", "--timeout=1m", "--parallelism=2", "--deprecated"})
+		require.ErrorIs(t, cmd.cmd.Execute(), config.ErrProConfig)
+	})
+}
+
 func TestBuildSingleTarget(t *testing.T) {
 	setup(t)
 	cmd := newBuildCmd()

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"os"
 	"path/filepath"
 	"slices"
 	"testing"
 
+	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/pipeline"
 	"github.com/goreleaser/goreleaser/v2/internal/skips"
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
@@ -125,11 +127,16 @@ func TestSetupPipeline(t *testing.T) {
 		require.Equal(
 			t,
 			append(slices.Clone(pipeline.BuildCmdPipeline), withOutputPipe{"."}),
-			setupPipeline(testctx.Wrap(t.Context()), buildOpts{
-				singleTarget: true,
-				ids:          []string{"foo"},
-				output:       ".",
-			}),
+			setupPipeline(
+				testctx.WrapWithCfg(t.Context(), config.Project{
+					Builds: []config.Build{{}},
+				}),
+				buildOpts{
+					singleTarget: true,
+					ids:          []string{"foo"},
+					output:       ".",
+				},
+			),
 		)
 	})
 
@@ -154,7 +161,9 @@ func TestSetupPipeline(t *testing.T) {
 			t,
 			append(slices.Clone(pipeline.BuildCmdPipeline), withOutputPipe{"foobar"}),
 			setupPipeline(
-				testctx.Wrap(t.Context()),
+				testctx.WrapWithCfg(t.Context(), config.Project{
+					Builds: []config.Build{{}},
+				}),
 				buildOpts{
 					singleTarget: true,
 					ids:          []string{"foo"},
@@ -180,6 +189,46 @@ func TestSetupPipeline(t *testing.T) {
 			),
 		)
 	})
+}
+
+func TestWithOutputPipe(t *testing.T) {
+	t.Run("single binary", func(t *testing.T) {
+		mktmp(t)
+		createFile(t, "a", "A")
+		ctx := testctx.Wrap(t.Context())
+		ctx.Artifacts.Add(&artifact.Artifact{
+			Name: "a",
+			Path: "a",
+			Type: artifact.Binary,
+		})
+
+		require.NoError(t, (withOutputPipe{"picked"}).Run(ctx))
+		bts, err := os.ReadFile("picked")
+		require.NoError(t, err)
+		require.Equal(t, "A", string(bts))
+	})
+
+	for name, binaries := range map[string][]string{
+		"a first": {"a", "b"},
+		"b first": {"b", "a"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			mktmp(t)
+			createFile(t, "a", "A")
+			createFile(t, "b", "B")
+			ctx := testctx.Wrap(t.Context())
+			for _, binary := range binaries {
+				ctx.Artifacts.Add(&artifact.Artifact{
+					Name: binary,
+					Path: binary,
+					Type: artifact.Binary,
+				})
+			}
+
+			require.ErrorContains(t, (withOutputPipe{"picked"}).Run(ctx), "--output requires a single build")
+			require.NoFileExists(t, "picked")
+		})
+	}
 }
 
 func TestBuildFlags(t *testing.T) {
@@ -259,6 +308,25 @@ func TestBuildFlags(t *testing.T) {
 			require.NoError(t, setupBuildContext(ctx, buildOpts{
 				ids: []string{"foo", "default"},
 			}))
+		})
+
+		t.Run("match-multiple with output", func(t *testing.T) {
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+				Builds: []config.Build{
+					{
+						ID: "default",
+					},
+					{
+						ID: "foo",
+					},
+				},
+			})
+
+			require.ErrorContains(t, setupBuildContext(ctx, buildOpts{
+				singleTarget: true,
+				ids:          []string{"foo", "default"},
+				output:       "picked",
+			}), "--output requires a single build")
 		})
 
 		t.Run("match-partial", func(t *testing.T) {

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -100,6 +100,7 @@ func newReleaseCmd() *releaseCmd {
 func releaseProject(parent stdctx.Context, options releaseOpts) error {
 	start := time.Now()
 	log.Infof(boldStyle.Render("starting release"))
+	options.snapshot = impliedSnapshot(parent, options.snapshot, options.autoSnapshot)
 	cfg, err := loadConfig(!options.snapshot, options.config)
 	if err != nil {
 		return decorateWithCtxErr(parent, err, "release", after(start))

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -11,7 +11,6 @@ import (
 	"github.com/goreleaser/goreleaser/v2/internal/middleware/errhandler"
 	"github.com/goreleaser/goreleaser/v2/internal/middleware/logging"
 	"github.com/goreleaser/goreleaser/v2/internal/middleware/skip"
-	"github.com/goreleaser/goreleaser/v2/internal/pipe/git"
 	"github.com/goreleaser/goreleaser/v2/internal/pipeline"
 	"github.com/goreleaser/goreleaser/v2/internal/skips"
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
@@ -146,10 +145,6 @@ func setupReleaseContext(ctx *context.Context, options releaseOpts) error {
 	ctx.Snapshot = options.snapshot
 	ctx.FailFast = options.failFast
 	ctx.Clean = options.clean
-	if options.autoSnapshot && git.CheckDirty(ctx) != nil {
-		log.Info("git repository is dirty and --auto-snapshot is set, implying --snapshot")
-		ctx.Snapshot = true
-	}
 
 	if options.draft {
 		ctx.Config.Release.Draft = true

--- a/cmd/release_test.go
+++ b/cmd/release_test.go
@@ -34,6 +34,36 @@ func TestReleaseAutoSnapshot(t *testing.T) {
 	})
 }
 
+func TestReleaseAutoSnapshotWithProConfig(t *testing.T) {
+	t.Run("explicit snapshot", func(t *testing.T) {
+		setupPro(t)
+		cmd := newReleaseCmd()
+		cmd.cmd.SetArgs([]string{"--snapshot", "--skip=publish", "--timeout=1m", "--parallelism=2", "--deprecated"})
+		require.NoError(t, cmd.cmd.Execute())
+		matches, err := filepath.Glob("./dist/fake_0.0.2-SNAPSHOT-*_checksums.txt")
+		require.NoError(t, err)
+		require.Len(t, matches, 1)
+	})
+
+	t.Run("dirty automatic snapshot", func(t *testing.T) {
+		setupPro(t)
+		createFile(t, "foo", "force dirty tree")
+		cmd := newReleaseCmd()
+		cmd.cmd.SetArgs([]string{"--auto-snapshot", "--skip=publish", "--timeout=1m", "--parallelism=2", "--deprecated"})
+		require.NoError(t, cmd.cmd.Execute())
+		matches, err := filepath.Glob("./dist/fake_0.0.2-SNAPSHOT-*_checksums.txt")
+		require.NoError(t, err)
+		require.Len(t, matches, 1)
+	})
+
+	t.Run("clean automatic snapshot", func(t *testing.T) {
+		setupPro(t)
+		cmd := newReleaseCmd()
+		cmd.cmd.SetArgs([]string{"--auto-snapshot", "--skip=publish", "--timeout=1m", "--parallelism=2", "--deprecated"})
+		require.ErrorIs(t, cmd.cmd.Execute(), config.ErrProConfig)
+	})
+}
+
 func TestReleaseInvalidConfig(t *testing.T) {
 	mktmp(t)
 	createFile(t, "goreleaser.yml", "foo: bar\nversion: 2")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,7 +37,7 @@ func (cmd *rootCmd) Execute(args []string) {
 	}
 
 	if shouldDisableLogs(args) {
-		log.SetLevel(log.FatalLevel)
+		log.SetLevel(log.ErrorLevel)
 	}
 
 	if err := fang.Execute(

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,7 +37,7 @@ func (cmd *rootCmd) Execute(args []string) {
 	}
 
 	if shouldDisableLogs(args) {
-		log.SetLevel(log.ErrorLevel)
+		log.SetLevel(log.FatalLevel)
 	}
 
 	if err := fang.Execute(
@@ -57,6 +57,10 @@ func (cmd *rootCmd) Execute(args []string) {
 }
 
 func errorHandler(_ io.Writer, _ fang.Styles, err error) {
+	// commands that disable logs still need to report their errors.
+	if logger, ok := log.Log.(*log.Logger); ok && logger.Level > log.ErrorLevel {
+		logger.Level = log.ErrorLevel
+	}
 	log := log.WithError(err)
 	var message string
 	if de, ok := errors.AsType[gerrors.ErrDetailed](err); ok {

--- a/cmd/schema_test.go
+++ b/cmd/schema_test.go
@@ -1,9 +1,14 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
+	"os/exec"
 	"path"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -25,4 +30,60 @@ func TestGenerateSchema(t *testing.T) {
 	schema := map[string]any{}
 	require.NoError(t, json.NewDecoder(outFile).Decode(&schema))
 	require.Equal(t, "https://json-schema.org/draft/2020-12/schema", schema["$schema"].(string))
+}
+
+func TestSchemaCommandErrors(t *testing.T) {
+	binary := buildGoReleaserBinary(t)
+	for _, name := range []string{"jsonschema", "schema"} {
+		t.Run(name, func(t *testing.T) {
+			stdout, stderr, err := runSchemaCommand(t, binary, name, "--not-a-flag")
+			require.Error(t, err)
+			require.Empty(t, stdout)
+			require.Contains(t, stderr, "unknown flag: --not-a-flag")
+
+			var exitErr *exec.ExitError
+			require.True(t, errors.As(err, &exitErr))
+			require.Equal(t, 1, exitErr.ExitCode())
+		})
+	}
+}
+
+func TestSchemaCommandSuccessWritesJSONToStdout(t *testing.T) {
+	binary := buildGoReleaserBinary(t)
+	for _, name := range []string{"jsonschema", "schema"} {
+		t.Run(name, func(t *testing.T) {
+			stdout, _, err := runSchemaCommand(t, binary, name)
+			require.NoError(t, err)
+
+			schema := map[string]any{}
+			require.NoError(t, json.Unmarshal([]byte(stdout), &schema))
+			require.Equal(t, "https://json-schema.org/draft/2020-12/schema", schema["$schema"].(string))
+		})
+	}
+}
+
+func buildGoReleaserBinary(tb testing.TB) string {
+	tb.Helper()
+
+	binary := filepath.Join(tb.TempDir(), "goreleaser")
+	if runtime.GOOS == "windows" {
+		binary += ".exe"
+	}
+	cmd := exec.Command("go", "build", "-o", binary, "..")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	require.NoError(tb, cmd.Run(), stderr.String())
+	return binary
+}
+
+func runSchemaCommand(tb testing.TB, binary string, args ...string) (string, string, error) {
+	tb.Helper()
+
+	cmd := exec.Command(binary, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	return stdout.String(), stderr.String(), err
 }

--- a/cmd/schema_test.go
+++ b/cmd/schema_test.go
@@ -3,14 +3,11 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"os"
-	"os/exec"
 	"path"
-	"path/filepath"
-	"runtime"
 	"testing"
 
+	"github.com/caarlos0/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,57 +30,50 @@ func TestGenerateSchema(t *testing.T) {
 }
 
 func TestSchemaCommandErrors(t *testing.T) {
-	binary := buildGoReleaserBinary(t)
 	for _, name := range []string{"jsonschema", "schema"} {
 		t.Run(name, func(t *testing.T) {
-			stdout, stderr, err := runSchemaCommand(t, binary, name, "--not-a-flag")
-			require.Error(t, err)
-			require.Empty(t, stdout)
-			require.Contains(t, stderr, "unknown flag: --not-a-flag")
+			var stderr bytes.Buffer
+			previousLog := log.Log
+			log.Log = log.New(&stderr)
+			log.SetLevel(log.InfoLevel)
+			t.Cleanup(func() {
+				log.Log = previousLog
+			})
 
-			var exitErr *exec.ExitError
-			require.True(t, errors.As(err, &exitErr))
-			require.Equal(t, 1, exitErr.ExitCode())
+			mem := &exitMemento{}
+			cmd := newRootCmd(testversion, mem.Exit)
+			cmd.Execute([]string{name, "--not-a-flag"})
+
+			require.Equal(t, 1, mem.code)
+			require.Contains(t, stderr.String(), "unknown flag: --not-a-flag")
 		})
 	}
 }
 
 func TestSchemaCommandSuccessWritesJSONToStdout(t *testing.T) {
-	binary := buildGoReleaserBinary(t)
 	for _, name := range []string{"jsonschema", "schema"} {
 		t.Run(name, func(t *testing.T) {
-			stdout, _, err := runSchemaCommand(t, binary, name)
+			file, err := os.CreateTemp(t.TempDir(), "schema-stdout")
 			require.NoError(t, err)
 
+			stdout := os.Stdout
+			os.Stdout = file
+			t.Cleanup(func() {
+				os.Stdout = stdout
+			})
+
+			mem := &exitMemento{}
+			cmd := newRootCmd(testversion, mem.Exit)
+			cmd.Execute([]string{name})
+
+			require.NoError(t, file.Close())
+			out, err := os.ReadFile(file.Name())
+			require.NoError(t, err)
+			require.Equal(t, 0, mem.code)
+
 			schema := map[string]any{}
-			require.NoError(t, json.Unmarshal([]byte(stdout), &schema))
+			require.NoError(t, json.Unmarshal(out, &schema))
 			require.Equal(t, "https://json-schema.org/draft/2020-12/schema", schema["$schema"].(string))
 		})
 	}
-}
-
-func buildGoReleaserBinary(tb testing.TB) string {
-	tb.Helper()
-
-	binary := filepath.Join(tb.TempDir(), "goreleaser")
-	if runtime.GOOS == "windows" {
-		binary += ".exe"
-	}
-	cmd := exec.Command("go", "build", "-o", binary, "..")
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	require.NoError(tb, cmd.Run(), stderr.String())
-	return binary
-}
-
-func runSchemaCommand(tb testing.TB, binary string, args ...string) (string, string, error) {
-	tb.Helper()
-
-	cmd := exec.Command(binary, args...)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-	return stdout.String(), stderr.String(), err
 }

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -86,3 +86,41 @@ release:
 `
 	createFile(tb, "goreleaser.yml", yaml)
 }
+
+func setupPro(tb testing.TB) {
+	tb.Helper()
+
+	mktmp(tb)
+
+	createProGoReleaserYaml(tb)
+	createMainGo(tb)
+	goModInit(tb)
+	testlib.GitInit(tb)
+	testlib.GitAdd(tb)
+	testlib.GitCommit(tb, "asdf")
+	testlib.GitTag(tb, "v0.0.1")
+	testlib.GitCommit(tb, "asas89d")
+	testlib.GitCommit(tb, "assssf")
+	testlib.GitCommit(tb, "assd")
+	testlib.GitTag(tb, "v0.0.2")
+	testlib.GitRemoteAdd(tb, "git@github.com:goreleaser/fake.git")
+}
+
+func createProGoReleaserYaml(tb testing.TB) {
+	tb.Helper()
+	yaml := `version: 2
+pro: true
+includes: []
+builds:
+- binary: 'fake{{if .IsSnapshot}}_snapshot{{end}}'
+  goos:
+    - linux
+  goarch:
+    - amd64
+release:
+  github:
+    owner: goreleaser
+    name: fake
+`
+	createFile(tb, "goreleaser.yml", yaml)
+}


### PR DESCRIPTION
Fixes a group of related bugs in the build, release and schema commands.

- Closes #6953: load dirty --auto-snapshot build and release runs as snapshots before strict Pro config validation.
- Closes #6952: keep jsonschema command errors visible while still keeping generated JSON on stdout.
- Closes #6949: reject ambiguous build --output selections instead of copying the first binary.