### PR TITLE
fix(env,log): redact secrets across writes and honour force_token

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,1 @@
+81250ee7b98829704f7e44d53ee3631d08f4cf64:internal/redact/redact_test.go:generic-api-key:211

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -92,10 +92,6 @@ func executePublisher(ctx *context.Context, publisher config.Publisher) error {
 }
 
 func executeCommand(c *command, artifact *artifact.Artifact) error {
-	log.WithField("args", c.Args).
-		WithField("artifact", artifact.Name).
-		Debug("executing command")
-
 	//nolint:gosec
 	cmd := exec.CommandContext(c.Ctx, c.Args[0], c.Args[1:]...)
 	cmd.Env = []string{}
@@ -109,6 +105,10 @@ func executeCommand(c *command, artifact *artifact.Artifact) error {
 	if c.Dir != "" {
 		cmd.Dir = c.Dir
 	}
+
+	log.WithField("args", redactArgs(c.Args, cmd.Env)).
+		WithField("artifact", artifact.Name).
+		Debug("executing command")
 
 	var b bytes.Buffer
 	w := gio.Safe(&b)
@@ -141,6 +141,14 @@ func executeCommand(c *command, artifact *artifact.Artifact) error {
 
 	log.Debug("command finished successfully")
 	return nil
+}
+
+func redactArgs(args, env []string) []string {
+	redacted := make([]string, len(args))
+	for i, arg := range args {
+		redacted[i] = redact.String(arg, env)
+	}
+	return redacted
 }
 
 func filterArtifacts(ctx *context.Context, publisher config.Publisher) []*artifact.Artifact {

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -112,20 +112,31 @@ func executeCommand(c *command, artifact *artifact.Artifact) error {
 
 	var b bytes.Buffer
 	w := gio.Safe(&b)
-	cmd.Stderr = redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
-	cmd.Stdout = redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
+	stderr := redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
+	stdout := redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
+	cmd.Stderr = stderr
+	cmd.Stdout = stdout
 
 	log := log.WithField("cmd", c.Args[0]).
 		WithField("artifact", artifact.Name)
 
 	log.Info("publishing")
-	if err := cmd.Run(); err != nil {
+	runErr := cmd.Run()
+	stderrErr := stderr.Close()
+	stdoutErr := stdout.Close()
+	if runErr != nil {
 		return gerrors.Wrap(
-			err,
+			runErr,
 			gerrors.WithMessage("publishing failed"),
 			gerrors.WithDetails("cmd", cmd.Args[0]),
 			gerrors.WithOutput(b.String()),
 		)
+	}
+	if stderrErr != nil {
+		return stderrErr
+	}
+	if stdoutErr != nil {
+		return stdoutErr
 	}
 
 	log.Debug("command finished successfully")

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path"
@@ -9,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/pipe"
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
@@ -308,6 +310,30 @@ func TestExecute(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExecuteCommandRedactsDebugArgs(t *testing.T) {
+	testlib.SkipIfWindows(t, "uses sh")
+
+	var logs bytes.Buffer
+	previousLog := log.Log
+	log.Log = log.New(&logs)
+	log.SetLevel(log.DebugLevel)
+	t.Cleanup(func() { log.Log = previousLog })
+
+	const secret = "key123key123"
+	err := executeCommand(&command{
+		Ctx: testctx.Wrap(t.Context()),
+		Env: []string{"API_KEY=" + secret},
+		Args: []string{
+			"sh",
+			"-c",
+			`test "$API_KEY" = "key123key123" && echo "$API_KEY"`,
+		},
+	}, &artifact.Artifact{Name: "artifact"})
+	require.NoError(t, err)
+	require.NotContains(t, logs.String(), secret)
+	require.Contains(t, logs.String(), "$API_KEY")
 }
 
 func assertEnv(kvs map[string]string) string {

--- a/internal/pipe/docker/api.go
+++ b/internal/pipe/docker/api.go
@@ -52,16 +52,27 @@ func runCommand(ctx *context.Context, dir, binary string, args ...string) error 
 
 	var b bytes.Buffer
 	w := gio.Safe(&b)
-	cmd.Stderr = redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
-	cmd.Stdout = redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
+	stderr := redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
+	stdout := redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
+	cmd.Stderr = stderr
+	cmd.Stdout = stdout
 
 	log.
 		WithField("cmd", append([]string{binary}, args[0])).
 		WithField("cwd", dir).
 		WithField("args", args[1:]).
 		Debug("running")
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("%w: %s", err, b.String())
+	runErr := cmd.Run()
+	stderrErr := stderr.Close()
+	stdoutErr := stdout.Close()
+	if runErr != nil {
+		return fmt.Errorf("%w: %s", runErr, b.String())
+	}
+	if stderrErr != nil {
+		return stderrErr
+	}
+	if stdoutErr != nil {
+		return stdoutErr
 	}
 	return nil
 }
@@ -74,7 +85,8 @@ func runCommandWithOutput(ctx *context.Context, dir, binary string, args ...stri
 
 	var b bytes.Buffer
 	w := gio.Safe(&b)
-	cmd.Stderr = redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
+	stderr := redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
+	cmd.Stderr = stderr
 
 	log.
 		WithField("cmd", append([]string{binary}, args[0])).
@@ -84,7 +96,12 @@ func runCommandWithOutput(ctx *context.Context, dir, binary string, args ...stri
 	out, err := cmd.Output()
 	if out != nil {
 		// regardless of command success, always print stdout for backward-compatibility with runCommand()
-		_, _ = redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env).Write(out)
+		stdout := redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
+		_, _ = stdout.Write(out)
+		_ = stdout.Close()
+	}
+	if closeErr := stderr.Close(); closeErr != nil && err == nil {
+		return nil, closeErr
 	}
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", err, b.String())

--- a/internal/pipe/docker/v2/docker.go
+++ b/internal/pipe/docker/v2/docker.go
@@ -290,12 +290,17 @@ func doBuild(ctx *context.Context, d config.DockerV2, wd string, arg []string) (
 			cmd.Env = append(ctx.Env.Strings(), cmd.Environ()...)
 			var b bytes.Buffer
 			w := gio.Safe(&b)
-			cmd.Stderr = redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
-			cmd.Stdout = redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
-			if err := cmd.Run(); err != nil {
+			stderr := redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
+			stdout := redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
+			cmd.Stderr = stderr
+			cmd.Stdout = stdout
+			runErr := cmd.Run()
+			stderrErr := stderr.Close()
+			stdoutErr := stdout.Close()
+			if runErr != nil {
 				if isFileNotFoundError(b.String()) {
 					return gerrors.Wrap(
-						err,
+						runErr,
 						gerrors.WithMessage("could not build docker image"),
 						gerrors.WithOutput(b.String()),
 						gerrors.WithDetails(
@@ -305,7 +310,7 @@ func doBuild(ctx *context.Context, d config.DockerV2, wd string, arg []string) (
 					)
 				}
 				return gerrors.Wrap(
-					err,
+					runErr,
 					gerrors.WithMessage("could not build docker image"),
 					gerrors.WithOutput(b.String()),
 					gerrors.WithDetails(
@@ -313,6 +318,12 @@ func doBuild(ctx *context.Context, d config.DockerV2, wd string, arg []string) (
 						"id", d.ID,
 					),
 				)
+			}
+			if stderrErr != nil {
+				return stderrErr
+			}
+			if stdoutErr != nil {
+				return stdoutErr
 			}
 			return nil
 		},

--- a/internal/pipe/env/env.go
+++ b/internal/pipe/env/env.go
@@ -77,13 +77,19 @@ func (Pipe) Run(ctx *context.Context) error {
 	switch strings.ToLower(forceToken) {
 	case "github":
 		gitlabToken = ""
+		gitlabTokenErr = nil
 		giteaToken = ""
+		giteaTokenErr = nil
 	case "gitlab":
 		githubToken = ""
+		githubTokenErr = nil
 		giteaToken = ""
+		giteaTokenErr = nil
 	case "gitea":
 		githubToken = ""
+		githubTokenErr = nil
 		gitlabToken = ""
+		gitlabTokenErr = nil
 	default:
 		var tokens []string
 		if githubToken != "" {

--- a/internal/pipe/env/env_test.go
+++ b/internal/pipe/env/env_test.go
@@ -110,6 +110,51 @@ func TestForceToken(t *testing.T) {
 	})
 }
 
+func TestForceTokenIgnoresExcludedTokenFileErrors(t *testing.T) {
+	t.Run("config selector", func(t *testing.T) {
+		isolateEnv(t)
+		t.Setenv("GITHUB_TOKEN", "fake")
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			ForceToken: "github",
+			EnvFiles: config.EnvFiles{
+				GitLabToken: t.TempDir(),
+			},
+		})
+
+		require.NoError(t, Pipe{}.Run(ctx))
+		require.Equal(t, context.TokenTypeGitHub, ctx.TokenType)
+		require.Equal(t, "fake", ctx.Token)
+	})
+
+	t.Run("environment selector", func(t *testing.T) {
+		isolateEnv(t)
+		t.Setenv("GITHUB_TOKEN", "fake")
+		t.Setenv("GORELEASER_FORCE_TOKEN", "github")
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			EnvFiles: config.EnvFiles{
+				GitLabToken: t.TempDir(),
+			},
+		})
+
+		require.NoError(t, Pipe{}.Run(ctx))
+		require.Equal(t, context.TokenTypeGitHub, ctx.TokenType)
+		require.Equal(t, "fake", ctx.Token)
+	})
+
+	t.Run("selected provider error is returned", func(t *testing.T) {
+		isolateEnv(t)
+		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+			ForceToken: "github",
+			EnvFiles: config.EnvFiles{
+				GitHubToken: t.TempDir(),
+			},
+		})
+
+		err := Pipe{}.Run(ctx)
+		require.ErrorContains(t, err, "failed to load github token")
+	})
+}
+
 func TestValidGithubEnv(t *testing.T) {
 	isolateEnv(t)
 	t.Setenv("GITHUB_TOKEN", "asdf")

--- a/internal/pipe/flatpak/flatpak.go
+++ b/internal/pipe/flatpak/flatpak.go
@@ -275,15 +275,26 @@ func runCmd(ctx *context.Context, dir, errMsg, bin string, args ...string) error
 	cmd.Env = append(ctx.Env.Strings(), cmd.Environ()...)
 	var b bytes.Buffer
 	w := gio.Safe(&b)
-	cmd.Stderr = redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
-	cmd.Stdout = redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
-	if err := cmd.Run(); err != nil {
+	stderr := redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
+	stdout := redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
+	cmd.Stderr = stderr
+	cmd.Stdout = stdout
+	runErr := cmd.Run()
+	stderrErr := stderr.Close()
+	stdoutErr := stdout.Close()
+	if runErr != nil {
 		return gerrors.Wrap(
-			err,
+			runErr,
 			gerrors.WithMessage(errMsg),
 			gerrors.WithDetails("args", strings.Join(cmd.Args, " ")),
 			gerrors.WithOutput(b.String()),
 		)
+	}
+	if stderrErr != nil {
+		return stderrErr
+	}
+	if stdoutErr != nil {
+		return stdoutErr
 	}
 	return nil
 }

--- a/internal/pipe/makeself/makeself.go
+++ b/internal/pipe/makeself/makeself.go
@@ -202,11 +202,16 @@ func create(ctx *context.Context, cfg config.Makeself, plat string, binaries []*
 	cmd.Env = append(ctx.Env.Strings(), cmd.Environ()...)
 	var b bytes.Buffer
 	w := gio.Safe(&b)
-	cmd.Stderr = redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
-	cmd.Stdout = redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
-	if err := cmd.Run(); err != nil {
+	stderr := redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
+	stdout := redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
+	cmd.Stderr = stderr
+	cmd.Stdout = stdout
+	runErr := cmd.Run()
+	stderrErr := stderr.Close()
+	stdoutErr := stdout.Close()
+	if runErr != nil {
 		return gerrors.Wrap(
-			err,
+			runErr,
 			gerrors.WithMessage("could not create makeself package"),
 			gerrors.WithDetails(
 				"args", strings.Join(cmd.Args, " "),
@@ -214,6 +219,12 @@ func create(ctx *context.Context, cfg config.Makeself, plat string, binaries []*
 			),
 			gerrors.WithOutput(b.String()),
 		)
+	}
+	if stderrErr != nil {
+		return stderrErr
+	}
+	if stdoutErr != nil {
+		return stdoutErr
 	}
 
 	path := filepath.Join(dir, filename)

--- a/internal/pipe/sbom/sbom.go
+++ b/internal/pipe/sbom/sbom.go
@@ -216,15 +216,20 @@ func catalogArtifact(ctx *context.Context, cfg config.SBOM, a *artifact.Artifact
 
 	var b bytes.Buffer
 	w := gio.Safe(&b)
-	cmd.Stderr = redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
-	cmd.Stdout = redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
+	stderr := redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
+	stdout := redact.Writer(io.MultiWriter(logext.NewWriter(), w), cmd.Env)
+	cmd.Stderr = stderr
+	cmd.Stdout = stdout
 
 	log.WithField("cmd", cfg.Cmd).
 		WithField("sbom", strings.Join(names, "\n")).
 		Info("cataloging")
-	if err := cmd.Run(); err != nil {
+	runErr := cmd.Run()
+	stderrErr := stderr.Close()
+	stdoutErr := stdout.Close()
+	if runErr != nil {
 		return nil, gerrors.Wrap(
-			err,
+			runErr,
 			gerrors.WithMessage("could not catalog artifact"),
 			gerrors.WithDetails(
 				"cmd", cfg.Cmd,
@@ -233,6 +238,12 @@ func catalogArtifact(ctx *context.Context, cfg config.SBOM, a *artifact.Artifact
 			),
 			gerrors.WithOutput(b.String()),
 		)
+	}
+	if stderrErr != nil {
+		return nil, stderrErr
+	}
+	if stdoutErr != nil {
+		return nil, stdoutErr
 	}
 
 	var artifacts []*artifact.Artifact

--- a/internal/pipe/sign/sign.go
+++ b/internal/pipe/sign/sign.go
@@ -259,15 +259,20 @@ func signone(ctx *context.Context, cfg config.Sign, art *artifact.Artifact) ([]*
 
 	var b bytes.Buffer
 	w := gio.Safe(&b)
-	cmd.Stderr = redact.Writer(io.MultiWriter(logext.NewConditionalWriter(output), w), cmd.Env)
-	cmd.Stdout = redact.Writer(io.MultiWriter(logext.NewConditionalWriter(output), w), cmd.Env)
+	stderr := redact.Writer(io.MultiWriter(logext.NewConditionalWriter(output), w), cmd.Env)
+	stdout := redact.Writer(io.MultiWriter(logext.NewConditionalWriter(output), w), cmd.Env)
+	cmd.Stderr = stderr
+	cmd.Stdout = stdout
 	if stdin != nil {
 		cmd.Stdin = stdin
 	}
 	log.Info("signing")
-	if err := cmd.Run(); err != nil {
+	runErr := cmd.Run()
+	stderrErr := stderr.Close()
+	stdoutErr := stdout.Close()
+	if runErr != nil {
 		return nil, gerrors.Wrap(
-			err,
+			runErr,
 			gerrors.WithMessage("could not sign artifact"),
 			gerrors.WithDetails(
 				"cmd", cfg.Cmd,
@@ -275,6 +280,12 @@ func signone(ctx *context.Context, cfg config.Sign, art *artifact.Artifact) ([]*
 			),
 			gerrors.WithOutput(b.String()),
 		)
+	}
+	if stderrErr != nil {
+		return nil, stderrErr
+	}
+	if stdoutErr != nil {
+		return nil, stdoutErr
 	}
 
 	var result []*artifact.Artifact

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -12,7 +12,7 @@ import (
 // variable values in the written data with their "$NAME" counterparts.
 //
 // Each entry in env should be in "KEY=VALUE" format.
-func Writer(w io.Writer, env []string) io.Writer {
+func Writer(w io.Writer, env []string) io.WriteCloser {
 	return &redactWriter{
 		re: redact(env),
 		w:  w,
@@ -20,37 +20,50 @@ func Writer(w io.Writer, env []string) io.Writer {
 }
 
 type redactWriter struct {
-	re *strings.Replacer
-	w  io.Writer
+	re      *redacter
+	w       io.Writer
+	pending string
 }
 
 // Write implements [io.Writer].
 func (w *redactWriter) Write(p []byte) (int, error) {
-	_, err := io.WriteString(w.w, w.re.Replace(string(p)))
+	s := w.pending + string(p)
+	redacted, pending := w.re.replacePartial(s)
+	_, err := io.WriteString(w.w, redacted)
 	if err != nil {
 		return 0, err
 	}
+	w.pending = pending
 	return len(p), nil
 }
 
-// redact returns a strings.Replacer that replaces all occurrences of
+// Close flushes any pending data that may have been a secret prefix.
+func (w *redactWriter) Close() error {
+	if w.pending == "" {
+		return nil
+	}
+	_, err := io.WriteString(w.w, w.re.Replace(w.pending))
+	w.pending = ""
+	return err
+}
+
+// redact returns a redacter that replaces all occurrences of
 // secret-looking environment variable values in s with their "$NAME"
 // counterparts.
 //
 // Each entry in env should be in "KEY=VALUE" format.
-func redact(env []string) *strings.Replacer {
-	type kv struct{ k, v string }
-	var secrets []kv
+func redact(env []string) *redacter {
+	var secrets []secret
 	for _, e := range env {
 		k, v, ok := strings.Cut(e, "=")
 		if !ok || v == "" {
 			continue
 		}
 		if looksSecret(k, v) {
-			secrets = append(secrets, kv{k, v})
+			secrets = append(secrets, secret{k, v})
 		}
 	}
-	slices.SortFunc(secrets, func(a, b kv) int {
+	slices.SortFunc(secrets, func(a, b secret) int {
 		if c := cmp.Compare(len(b.v), len(a.v)); c != 0 {
 			return c
 		}
@@ -60,7 +73,74 @@ func redact(env []string) *strings.Replacer {
 	for _, e := range secrets {
 		oldnew = append(oldnew, e.v, "$"+e.k)
 	}
-	return strings.NewReplacer(oldnew...)
+	return &redacter{
+		secrets:  secrets,
+		maxLen:   maxSecretLen(secrets),
+		replacer: strings.NewReplacer(oldnew...),
+	}
+}
+
+type redacter struct {
+	secrets  []secret
+	maxLen   int
+	replacer *strings.Replacer
+}
+
+type secret struct{ k, v string }
+
+func (r *redacter) Replace(s string) string {
+	return r.replacer.Replace(s)
+}
+
+func (r *redacter) replacePartial(s string) (redacted, pending string) {
+	if len(r.secrets) == 0 {
+		return s, ""
+	}
+
+	var b strings.Builder
+	for i := 0; i < len(s); {
+		rest := s[i:]
+		if r.isIncompleteSecret(rest) {
+			return b.String(), rest
+		}
+		if secret, ok := r.match(rest); ok {
+			b.WriteString("$" + secret.k)
+			i += len(secret.v)
+			continue
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String(), ""
+}
+
+func (r *redacter) isIncompleteSecret(s string) bool {
+	if len(s) >= r.maxLen {
+		return false
+	}
+	for _, secret := range r.secrets {
+		if len(secret.v) > len(s) && strings.HasPrefix(secret.v, s) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *redacter) match(s string) (secret, bool) {
+	for _, secret := range r.secrets {
+		if strings.HasPrefix(s, secret.v) {
+			return secret, true
+		}
+	}
+	return secret{}, false
+}
+
+func maxSecretLen(secrets []secret) int {
+	var maxLen int
+	for _, secret := range secrets {
+		maxLen = max(maxLen, len(secret.v))
+	}
+	return maxLen
 }
 
 var keySuffixes = []string{

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -208,12 +208,12 @@ func TestRedactWriter(t *testing.T) {
 		t.Parallel()
 		var buf bytes.Buffer
 		w := Writer(&buf, []string{
-			"SHORT_TOKEN=key123",
-			"API_KEY=key123key123",
+			"SHORT_TOKEN=redacted-test",
+			"API_KEY=redacted-test-value",
 		})
-		_, err := io.WriteString(w, "key123")
+		_, err := io.WriteString(w, "redacted-test")
 		require.NoError(t, err)
-		_, err = io.WriteString(w, "key123")
+		_, err = io.WriteString(w, "-value")
 		require.NoError(t, err)
 		require.Equal(t, "$API_KEY", buf.String())
 	})

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -2,6 +2,7 @@ package redact
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"testing"
 
@@ -184,6 +185,50 @@ func TestRedactWriter(t *testing.T) {
 		require.Equal(t, "nothing secret here\n", buf.String())
 	})
 
+	t.Run("redacts secrets split across every write boundary", func(t *testing.T) {
+		t.Parallel()
+		const secret = "key123key123"
+		for i := 1; i < len(secret); i++ {
+			t.Run(fmt.Sprintf("split at %d", i), func(t *testing.T) {
+				t.Parallel()
+				var buf bytes.Buffer
+				w := Writer(&buf, env)
+				n, err := io.WriteString(w, secret[:i])
+				require.NoError(t, err)
+				require.Equal(t, i, n)
+				n, err = io.WriteString(w, secret[i:])
+				require.NoError(t, err)
+				require.Equal(t, len(secret)-i, n)
+				require.Equal(t, "$API_KEY", buf.String())
+			})
+		}
+	})
+
+	t.Run("prefers longer overlapping secrets across writes", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := Writer(&buf, []string{
+			"SHORT_TOKEN=key123",
+			"API_KEY=key123key123",
+		})
+		_, err := io.WriteString(w, "key123")
+		require.NoError(t, err)
+		_, err = io.WriteString(w, "key123")
+		require.NoError(t, err)
+		require.Equal(t, "$API_KEY", buf.String())
+	})
+
+	t.Run("flushes incomplete secret prefix on close", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := Writer(&buf, env)
+		_, err := io.WriteString(w, "key123")
+		require.NoError(t, err)
+		require.Empty(t, buf.String())
+		closeWriter(t, w)
+		require.Equal(t, "key123", buf.String())
+	})
+
 	t.Run("returns zero bytes on write error", func(t *testing.T) {
 		t.Parallel()
 		w := Writer(&errWriter{err: io.ErrShortWrite}, env)
@@ -214,3 +259,10 @@ func TestRedactString(t *testing.T) {
 type errWriter struct{ err error }
 
 func (e *errWriter) Write([]byte) (int, error) { return 0, e.err }
+
+func closeWriter(tb testing.TB, w io.Writer) {
+	tb.Helper()
+	closer, ok := w.(io.Closer)
+	require.True(tb, ok)
+	require.NoError(tb, closer.Close())
+}

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -30,8 +30,10 @@ func Run(ctx *context.Context, dir string, command, env []string, output bool) e
 	var b bytes.Buffer
 	w := gio.Safe(&b)
 
-	cmd.Stderr = redact.Writer(io.MultiWriter(logext.NewConditionalWriter(output), w), env)
-	cmd.Stdout = redact.Writer(io.MultiWriter(logext.NewConditionalWriter(output), w), env)
+	stderr := redact.Writer(io.MultiWriter(logext.NewConditionalWriter(output), w), env)
+	stdout := redact.Writer(io.MultiWriter(logext.NewConditionalWriter(output), w), env)
+	cmd.Stderr = stderr
+	cmd.Stdout = stdout
 
 	if dir != "" {
 		cmd.Dir = dir
@@ -44,13 +46,22 @@ func Run(ctx *context.Context, dir string, command, env []string, output bool) e
 	start := time.Now()
 	defer logext.Duration(start, time.Second*5)
 
-	if err := cmd.Run(); err != nil {
+	runErr := cmd.Run()
+	stderrErr := stderr.Close()
+	stdoutErr := stdout.Close()
+	if runErr != nil {
 		return gerrors.Wrap(
-			err,
+			runErr,
 			gerrors.WithMessage("command failed"),
 			gerrors.WithDetails("cmd", command[0]),
 			gerrors.WithOutput(strings.TrimSpace(b.String())),
 		)
+	}
+	if stderrErr != nil {
+		return stderrErr
+	}
+	if stdoutErr != nil {
+		return stdoutErr
 	}
 
 	return nil

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -39,7 +39,7 @@ func Run(ctx *context.Context, dir string, command, env []string, output bool) e
 		cmd.Dir = dir
 	}
 
-	log.WithField("cmd", command).
+	log.WithField("cmd", redactArgs(command, cmd.Env)).
 		WithField("dir", dir).
 		Debug("running")
 
@@ -65,4 +65,12 @@ func Run(ctx *context.Context, dir string, command, env []string, output bool) e
 	}
 
 	return nil
+}
+
+func redactArgs(args, env []string) []string {
+	redacted := make([]string, len(args))
+	for i, arg := range args {
+		redacted[i] = redact.String(arg, env)
+	}
+	return redacted
 }

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -1,11 +1,13 @@
 package shell_test
 
 import (
+	"bytes"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/internal/shell"
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/internal/testlib"
@@ -73,4 +75,32 @@ func TestRunCommand(t *testing.T) {
 		require.NoError(t, err)
 		require.FileExists(t, filepath.Join(dir, "bar"))
 	})
+}
+
+func TestRunRedactsDebugCommand(t *testing.T) {
+	testlib.SkipIfWindows(t, "uses sh")
+
+	var logs bytes.Buffer
+	previousLog := log.Log
+	log.Log = log.New(&logs)
+	log.SetLevel(log.DebugLevel)
+	t.Cleanup(func() {
+		log.Log = previousLog
+	})
+
+	const secret = "key123key123"
+	err := shell.Run(
+		testctx.Wrap(t.Context()),
+		"",
+		[]string{
+			"sh",
+			"-c",
+			`test "$API_KEY" = "key123key123" && echo "$API_KEY"`,
+		},
+		[]string{"API_KEY=" + secret},
+		true,
+	)
+	require.NoError(t, err)
+	require.NotContains(t, logs.String(), secret)
+	require.Contains(t, logs.String(), "$API_KEY")
 }


### PR DESCRIPTION
Fixes a group of related bugs in secret redaction and the env pipe.

- Closes #6938: secret redaction now spans process output write boundaries and flushes possible prefixes at completion.
- Closes #6937: command debug fields are redacted with the command effective environment while preserving executed arguments.
- Closes #6903: forced token selection ignores excluded provider token-file errors while preserving selected-provider errors.