### PR TITLE
chore: fix lint on main

### DIFF
--- a/internal/pipe/blob/blob_test.go
+++ b/internal/pipe/blob/blob_test.go
@@ -311,7 +311,7 @@ func TestGetDataAWSKMSPlaintextLimit(t *testing.T) {
 				w.Header().Set("Content-Type", "application/x-amz-json-1.1")
 
 				var input struct {
-					Plaintext []byte `json:"Plaintext"`
+					Plaintext []byte `json:"Plaintext"` //nolint:tagliatelle // AWS KMS Encrypt wire format uses Plaintext.
 				}
 				if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
 					http.Error(w, err.Error(), http.StatusBadRequest)

--- a/internal/pipe/gomod/gomod_proxy.go
+++ b/internal/pipe/gomod/gomod_proxy.go
@@ -97,15 +97,15 @@ func goModPath(ctx *context.Context, build *config.Build) string {
 }
 
 func formatReplace(replace *modfile.Replace) string {
-	old := replace.Old.Path
+	oldPath := replace.Old.Path
 	if replace.Old.Version != "" {
-		old += " " + replace.Old.Version
+		oldPath += " " + replace.Old.Version
 	}
-	new := replace.New.Path
+	newPath := replace.New.Path
 	if replace.New.Version != "" {
-		new += " " + replace.New.Version
+		newPath += " " + replace.New.Version
 	}
-	return strings.TrimSpace(fmt.Sprintf("replace %s => %s", old, new))
+	return strings.TrimSpace(fmt.Sprintf("replace %s => %s", oldPath, newPath))
 }
 
 // ProxyPipe for gomod proxy.

--- a/internal/pipe/smtp/smtp_test.go
+++ b/internal/pipe/smtp/smtp_test.go
@@ -86,7 +86,8 @@ func requireTLSValidationError(t *testing.T, port int, serve func(net.Listener, 
 	})
 
 	serverErr := make(chan error, 1)
-	go serve(ln, smtpTestCertificate(t), serverErr)
+	cert := smtpTestCertificate(t)
+	go serve(ln, cert, serverErr)
 
 	t.Setenv("SMTP_PASSWORD", "secret")
 	ctx := testctx.WrapWithCfg(t.Context(), config.Project{


### PR DESCRIPTION
main is currently lint-red, which makes the `lint` check fail on every open pull request. This makes main lint-clean again and unblocks the shared `lint` check.

- `internal/pipe/gomod/gomod_proxy.go`: rename the `new` local in `formatReplace` to `newPath` and pair it with `oldPath`, avoiding the revive builtin shadow warning without changing behavior.
- `internal/pipe/blob/blob_test.go`: keep `json:"Plaintext"` because AWS KMS Encrypt request syntax requires the capitalized `Plaintext` field, and add a narrow `tagliatelle` exception on that field only.
- `internal/pipe/smtp/smtp_test.go`: build the SMTP test certificate on the test goroutine before passing it into the server goroutine, satisfying testifylint without disabling it.

Validation:
- `golangci-lint run --tests --timeout 10m --config ./.golangci.yaml ./...`
- `go build ./...`
- `go test ./internal/pipe/gomod/... ./internal/pipe/blob/... ./internal/pipe/smtp/... -count=1`
- `go test ./internal/pipe/blob/... ./internal/pipe/smtp/... -count=3`