### PR TITLE
fix(healthcheck): panic on dependency commands that are only shell syntax

### DIFF
--- a/cmd/healthcheck.go
+++ b/cmd/healthcheck.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"cmp"
 	stdctx "context"
 	"errors"
 	"io"
@@ -104,33 +105,34 @@ func check(name string, err error) error {
 	return err
 }
 
+// warn reports tool as unusable because of reason, and gives err back so the
+// caller can propagate it.
+func warn(tool, reason string, err error) error {
+	st := log.Styles[log.ErrorLevel]
+	log.Warnf("%s %s - %s", st.Render("⚠"), codeStyle.Render(tool), st.Render(reason))
+	return err
+}
+
 // checkPath reports whether tool is usable. checked dedupes tools listed by
 // more than one pipe within a single healthcheck run.
 func checkPath(ctx stdctx.Context, checked map[string]bool, tool string) error {
 	tool = strings.TrimSpace(tool)
-	if len(tool) == 0 {
-		return nil
-	}
-	if checked[tool] {
+	if tool == "" || checked[tool] {
 		return nil
 	}
 	checked[tool] = true
+	// Parse gives no arguments back when it fails, and also for a line that is
+	// only shell syntax, such as `|`.
 	args, err := shellwords.Parse(tool)
-	if err != nil {
-		st := log.Styles[log.ErrorLevel]
-		log.Warnf("%s %s - %s", st.Render("⚠"), codeStyle.Render(tool), st.Render("is not a valid command"))
-		return err
+	if len(args) == 0 {
+		return warn(tool, "is not a valid command", cmp.Or(err, exec.ErrNotFound))
 	}
 	if _, err := exec.LookPath(args[0]); err != nil {
-		st := log.Styles[log.ErrorLevel]
-		log.Warnf("%s %s - %s", st.Render("⚠"), codeStyle.Render(tool), st.Render("not present in path"))
-		return err
+		return warn(tool, "not present in path", err)
 	}
 	if len(args) > 1 {
 		if err := exec.CommandContext(ctx, args[0], args[1:]...).Run(); err != nil {
-			st := log.Styles[log.ErrorLevel]
-			log.Warnf("%s %s - %s", st.Render("⚠"), codeStyle.Render(tool), st.Render("command failed"))
-			return err
+			return warn(tool, "command failed", err)
 		}
 	}
 	st := lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Bold(true)

--- a/cmd/healthcheck_test.go
+++ b/cmd/healthcheck_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -49,6 +50,8 @@ func TestCheckPath(t *testing.T) {
 	require.Error(t, checkPath(t.Context(), checked, "some invalid command"))
 	require.NoError(t, checkPath(t.Context(), checked, " \t "))
 	require.Error(t, checkPath(t.Context(), checked, `"unterminated`))
+	// shell syntax alone parses to no arguments at all.
+	require.ErrorIs(t, checkPath(t.Context(), checked, "|"), exec.ErrNotFound)
 }
 
 func TestCheckPathChecksEachToolOnce(t *testing.T) {


### PR DESCRIPTION
Fix a panic in `healthcheck` and simplify `checkPath`.

## What

- Stop `goreleaser healthcheck` from panicking when a dependency command contains only shell syntax, such as `|`, `;` or `&`.
- Deduplicate the three identical warning blocks in `checkPath` into a small `warn` helper.

## Why

#7076 replaced `strings.Fields` with `shellwords.Parse`. `Parse` returns **no arguments and no error** for a line that contains only shell syntax, so `args[0]` reads past the end of the slice:

```
panic: runtime error: index out of range [0] with length 0
```

With `signs: [{cmd: "|"}]`, `goreleaser healthcheck` crashes instead of reporting a failed check. I found this with a fuzz probe over shell metacharacters, then confirmed the inputs: `|`, `;`, `&` and `|&` all parse to zero arguments.

The guard now tests `len(args) == 0`, which covers the parse failure and the empty result together, because every error path in `Parse` returns nil arguments. `cmp.Or` supplies `exec.ErrNotFound` when there is no parse error, so the caller still receives an error and the output stays the same as before.

The `warn` helper removes three copies of the same three-line log block. Behavior, messages and returned errors do not change.

## Tests

`TestCheckPath` gets the `|` case. It is a true regression test: with the guard removed, the test panics; with the guard, it passes.

```
go test ./cmd/ -run 'TestHealthcheck|TestCheckPath'
ok  github.com/goreleaser/goreleaser/v2/cmd
```

`gofmt`, `go build ./...` and `go vet ./cmd/` are clean.

## Links

Follow-up to #7076.
