### PR TITLE
fix: address regressions since v2.18.1

### DIFF
--- a/cmd/healthcheck.go
+++ b/cmd/healthcheck.go
@@ -121,14 +121,17 @@ func checkPath(ctx stdctx.Context, checked map[string]bool, tool string) error {
 		return nil
 	}
 	checked[tool] = true
-	// Parse gives no arguments back when it fails, and also for a line that is
-	// only shell syntax, such as `|`.
-	args, err := shellwords.Parse(tool)
-	if len(args) == 0 {
-		return warn(tool, "is not a valid command", cmp.Or(err, exec.ErrNotFound))
-	}
-	if _, err := exec.LookPath(args[0]); err != nil {
-		return warn(tool, "not present in path", err)
+	args := []string{tool}
+	if _, err := exec.LookPath(tool); err != nil {
+		// Dependencies can be either literal executable paths or commands.
+		// Parse also returns no arguments for bare shell syntax such as `|`.
+		args, err = shellwords.Parse(tool)
+		if len(args) == 0 {
+			return warn(tool, "is not a valid command", cmp.Or(err, exec.ErrNotFound))
+		}
+		if _, err := exec.LookPath(args[0]); err != nil {
+			return warn(tool, "not present in path", err)
+		}
 	}
 	if len(args) > 1 {
 		if err := exec.CommandContext(ctx, args[0], args[1:]...).Run(); err != nil {

--- a/cmd/healthcheck_test.go
+++ b/cmd/healthcheck_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -68,7 +69,7 @@ func TestCheckPathChecksEachToolOnce(t *testing.T) {
 
 func TestCheckPathLiteralExecutable(t *testing.T) {
 	for _, name := range []string{"signer's-tool", "signer's tool"} {
-		if os.PathSeparator == '\\' {
+		if runtime.GOOS == "windows" {
 			name += ".exe"
 		}
 		path := filepath.Join(t.TempDir(), name)

--- a/cmd/healthcheck_test.go
+++ b/cmd/healthcheck_test.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -62,4 +64,19 @@ func TestCheckPathChecksEachToolOnce(t *testing.T) {
 	require.NoError(t, checkPath(t.Context(), checked, "some invalid command"))
 	// a cache of its own sees the failure again.
 	require.Error(t, checkPath(t.Context(), map[string]bool{}, "some invalid command"))
+}
+
+func TestCheckPathLiteralExecutable(t *testing.T) {
+	for _, name := range []string{"signer's-tool", "signer's tool"} {
+		if os.PathSeparator == '\\' {
+			name += ".exe"
+		}
+		path := filepath.Join(t.TempDir(), name)
+		require.NoError(t, os.WriteFile(path, nil, 0o755))
+		for _, tool := range []string{path, fmt.Sprintf("%q", path)} {
+			t.Run(tool, func(t *testing.T) {
+				require.NoError(t, checkPath(t.Context(), map[string]bool{}, tool))
+			})
+		}
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.5
 	gocloud.dev v0.46.0
 	golang.org/x/crypto v0.56.0
+	golang.org/x/mod v0.40.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/text v0.41.0
@@ -358,7 +359,6 @@ require (
 	go.uber.org/zap v1.28.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.6 // indirect
-	golang.org/x/mod v0.40.0 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect

--- a/internal/builders/base/options.go
+++ b/internal/builders/base/options.go
@@ -1,0 +1,35 @@
+package base
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/goreleaser/goreleaser/v2/internal/tmpl"
+	"github.com/goreleaser/goreleaser/v2/pkg/build"
+	"github.com/goreleaser/goreleaser/v2/pkg/config"
+	"github.com/goreleaser/goreleaser/v2/pkg/context"
+)
+
+// OptionsForTarget resolves the binary name and output path for a parsed target.
+func OptionsForTarget(ctx *context.Context, cfg config.Build, target build.Target, ext string) (*build.Options, error) {
+	opts := build.Options{Target: target, Ext: ext}
+	bin, err := tmpl.New(ctx).WithBuildOptions(opts).Apply(cfg.Binary)
+	if err != nil {
+		return nil, err
+	}
+
+	opts.Name = bin + ext
+	dir := fmt.Sprintf("%s_%s", cfg.ID, target)
+	noUnique, err := tmpl.New(ctx).Bool(cfg.NoUniqueDistDir)
+	if err != nil {
+		return nil, err
+	}
+	if noUnique {
+		dir = ""
+	}
+	opts.Path, err = filepath.Abs(filepath.Join(ctx.Config.Dist, dir, opts.Name))
+	if err != nil {
+		return nil, err
+	}
+	return &opts, nil
+}

--- a/internal/builders/rust/build.go
+++ b/internal/builders/rust/build.go
@@ -52,18 +52,34 @@ func (b *Builder) AllowConcurrentBuilds() bool { return false }
 // Prepare implements build.PreparedBuilder.
 func (b *Builder) Prepare(ctx *context.Context, build config.Build) error {
 	for _, target := range build.Targets {
+		parsed, err := b.Parse(target)
+		if err != nil {
+			return err
+		}
+		t := parsed.(Target)
+		var ext string
+		switch {
+		case t.Arch == "wasm":
+			ext = ".wasm"
+		case t.Os == "windows":
+			ext = ".exe"
+		}
+		opts, err := base.OptionsForTarget(ctx, build, t, ext)
+		if err != nil {
+			return err
+		}
 		env := ctx.Env.Strings()
-		tpl := tmpl.New(ctx).WithEnvS(env)
+		tpl := tmpl.New(ctx).
+			WithBuildOptions(*opts).
+			WithEnvS(env).
+			WithArtifact(makeArtifact(build, *opts))
 		tenv, err := base.TemplateEnv(build.Env, tpl)
 		if err != nil {
 			return err
 		}
 		env = append(env, tenv...)
 
-		rustTarget := target
-		if clean, ok := stripGlibcVersion(rustTarget); ok {
-			rustTarget = clean
-		}
+		rustTarget := t.clean()
 		if err := base.Exec(ctx, []string{"rustup", "target", "add", rustTarget}, env, build.Dir); err != nil {
 			return fmt.Errorf("could not add target %s: %w", rustTarget, err)
 		}
@@ -163,25 +179,7 @@ func (b *Builder) Build(ctx *context.Context, build config.Build, options api.Op
 		)
 	}
 	t := options.Target.(Target)
-	a := &artifact.Artifact{
-		Type:   artifact.Binary,
-		Path:   options.Path,
-		Name:   options.Name,
-		Goos:   t.Os,
-		Goarch: t.Arch,
-		Goarm:  t.Arm,
-		Target: t.Target,
-		Extra: map[string]any{
-			artifact.ExtraBinary:  strings.TrimSuffix(filepath.Base(options.Path), options.Ext),
-			artifact.ExtraExt:     options.Ext,
-			artifact.ExtraID:      build.ID,
-			artifact.ExtraBuilder: "rust",
-			keyAbi:                t.Abi,
-		},
-	}
-	if t.Libc != "" {
-		a.Extra[keyLibc] = t.Libc
-	}
+	a := makeArtifact(build, options)
 
 	env := []string{}
 	env = append(env, ctx.Env.Strings()...)
@@ -236,6 +234,30 @@ func (b *Builder) Build(ctx *context.Context, build config.Build, options api.Op
 
 	ctx.Artifacts.Add(a)
 	return nil
+}
+
+func makeArtifact(build config.Build, options api.Options) *artifact.Artifact {
+	t := options.Target.(Target)
+	a := &artifact.Artifact{
+		Type:   artifact.Binary,
+		Path:   options.Path,
+		Name:   options.Name,
+		Goos:   t.Os,
+		Goarch: t.Arch,
+		Goarm:  t.Arm,
+		Target: t.Target,
+		Extra: map[string]any{
+			artifact.ExtraBinary:  strings.TrimSuffix(filepath.Base(options.Path), options.Ext),
+			artifact.ExtraExt:     options.Ext,
+			artifact.ExtraID:      build.ID,
+			artifact.ExtraBuilder: "rust",
+			keyAbi:                t.Abi,
+		},
+	}
+	if t.Libc != "" {
+		a.Extra[keyLibc] = t.Libc
+	}
+	return a
 }
 
 func isSettingPackage(flags []string) bool {

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -107,6 +107,10 @@ func TestPrepareUsesBuildContext(t *testing.T) {
 			buildEnv:      []string{"RUSTUP_TOOLCHAIN={{.Env.TOOLCHAIN}}"},
 			wantToolchain: "1.95.0",
 		},
+		"target environment": {
+			buildEnv:      []string{"RUSTUP_TOOLCHAIN={{ .Target }}|{{ .Os }}|{{ .Arch }}|{{ .Abi }}|{{ .Libc }}"},
+			wantToolchain: "aarch64-unknown-linux-gnu.2.17|linux|arm64|gnu|2.17",
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Setenv("RUSTUP_TOOLCHAIN", "")
@@ -138,6 +142,53 @@ func TestPrepareUsesBuildContext(t *testing.T) {
 			require.Contains(t, gotLog, "cwd="+wantDir+"\n")
 			require.Contains(t, gotLog, "toolchain="+tt.wantToolchain+"\n")
 			require.Contains(t, gotLog, "args=target add aarch64-unknown-linux-gnu\n")
+		})
+	}
+}
+
+func TestPrepareUsesArtifactContext(t *testing.T) {
+	for _, tc := range []struct {
+		target   string
+		arch     string
+		os       string
+		ext      string
+		noUnique string
+	}{
+		{target: "aarch64-unknown-linux-gnu.2.17", arch: "arm64", os: "linux"},
+		{target: "x86_64-pc-windows-gnu", arch: "amd64", os: "windows", ext: ".exe", noUnique: "true"},
+	} {
+		t.Run(tc.target, func(t *testing.T) {
+			log := filepath.Join(t.TempDir(), "rustup.log")
+			createFakeRustup(t, log)
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+				ProjectName: "app",
+				Dist:        t.TempDir(),
+			})
+			build := config.Build{
+				ID:              "app",
+				Dir:             t.TempDir(),
+				Binary:          "bin/app-{{ .Arch }}",
+				Targets:         []string{tc.target},
+				NoUniqueDistDir: tc.noUnique,
+				Env: []string{
+					"RUSTUP_TOOLCHAIN={{ .Target }}|{{ .Os }}|{{ .Arch }}|{{ .Name }}|{{ .Path }}|{{ .Ext }}|{{ .Binary }}|{{ .ArtifactName }}|{{ .ArtifactPath }}",
+				},
+			}
+
+			require.NoError(t, Default.Prepare(ctx, build))
+			got, err := os.ReadFile(log)
+			require.NoError(t, err)
+			name := "bin/app-" + tc.arch + tc.ext
+			dir := ctx.Config.Dist
+			if tc.noUnique == "" {
+				dir = filepath.Join(dir, "app_"+tc.target)
+			}
+			path := filepath.Join(dir, name)
+			expected := strings.Join([]string{
+				tc.target, tc.os, tc.arch, name, path, tc.ext,
+				"app-" + tc.arch, name, path,
+			}, "|")
+			require.Contains(t, strings.ReplaceAll(string(got), "\r\n", "\n"), "toolchain="+expected+"\n")
 		})
 	}
 }

--- a/internal/builders/rust/build_test.go
+++ b/internal/builders/rust/build_test.go
@@ -287,9 +287,11 @@ func createFakeRustup(tb testing.TB, log string) {
 	if runtime.GOOS == "windows" {
 		name += ".bat"
 		log = filepath.ToSlash(log)
+		// Expand after parsing so environment values cannot become batch operators.
 		script = fmt.Sprintf(`@echo off
-> "%s" echo cwd=%%CD%%
->> "%s" echo toolchain=%%RUSTUP_TOOLCHAIN%%
+setlocal EnableDelayedExpansion
+> "%s" echo cwd=!CD!
+>> "%s" echo toolchain=!RUSTUP_TOOLCHAIN!
 >> "%s" echo args=%%*
 `, log, log, log)
 	}

--- a/internal/gio/copy.go
+++ b/internal/gio/copy.go
@@ -17,7 +17,6 @@ func Copy(src, dst string) error {
 // CopyWithMode recursively copies src into dst with the given mode.
 // The given mode applies only to files. Their parent dirs will have the same mode as their src counterparts.
 func CopyWithMode(src, dst string, mode os.FileMode) error {
-	src = filepath.Clean(src)
 	dst = filepath.Clean(dst)
 	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/internal/gio/copy_test.go
+++ b/internal/gio/copy_test.go
@@ -34,6 +34,24 @@ func TestCopySymlink(t *testing.T) {
 	require.Equal(t, a, filepath.ToSlash(l))
 }
 
+func TestCopyDirectorySymlinkWithTrailingSeparator(t *testing.T) {
+	testlib.SkipIfWindows(t, "trailing slash follows directory symlinks on Unix")
+	t.Parallel()
+	src := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src, "asset.txt"), []byte("asset"), 0o644))
+	link := filepath.Join(t.TempDir(), "assets")
+	require.NoError(t, os.Symlink(src, link))
+	dst := t.TempDir()
+
+	require.NoError(t, Copy(link+string(os.PathSeparator), dst))
+	data, err := os.ReadFile(filepath.Join(dst, "asset.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "asset", string(data))
+	info, err := os.Lstat(dst)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+}
+
 func TestEqualFilesModeChanged(t *testing.T) {
 	testlib.SkipIfWindows(t)
 	tmp := t.TempDir()

--- a/internal/pipe/blob/blob_test.go
+++ b/internal/pipe/blob/blob_test.go
@@ -11,11 +11,11 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
@@ -347,41 +347,35 @@ func TestGetDataAWSKMSPlaintextLimit(t *testing.T) {
 }
 
 func TestDoUploadDoesNotStartArtifactWorkersWhenExtraFilesFail(t *testing.T) {
-	errExtraFiles := errors.New("extra files failed")
-	uploader := newRecordingUploader()
-	uploader.block = make(chan struct{})
-	defer close(uploader.block)
+	synctest.Test(t, func(t *testing.T) {
+		errExtraFiles := errors.New("extra files failed")
+		uploader := &recordingUploader{block: make(chan struct{})}
+		defer close(uploader.block)
 
-	replaceBlobUploader(t, uploader)
-	previousFindExtraFiles := findExtraFiles
-	findExtraFiles = func(*context.Context, []config.ExtraFile) (map[string]string, error) {
-		for range 1000 {
-			runtime.Gosched()
-			select {
-			case <-uploader.started:
-				return nil, errors.New("artifact upload started before extra files were resolved")
-			default:
-			}
+		replaceBlobUploader(t, uploader)
+		previousFindExtraFiles := findExtraFiles
+		findExtraFiles = func(*context.Context, []config.ExtraFile) (map[string]string, error) {
+			synctest.Wait()
+			return nil, errExtraFiles
 		}
-		return nil, errExtraFiles
-	}
-	t.Cleanup(func() { findExtraFiles = previousFindExtraFiles })
+		t.Cleanup(func() { findExtraFiles = previousFindExtraFiles })
 
-	ctx, conf := blobUploadContext(t, []string{"one.txt", "two.txt"}, nil)
-	conf.ExtraFiles = []config.ExtraFile{{Glob: filepath.Join(t.TempDir(), "missing.txt")}}
+		ctx, conf := blobUploadContext(t, []string{"one.txt", "two.txt"}, nil)
+		conf.ExtraFiles = []config.ExtraFile{{Glob: filepath.Join(t.TempDir(), "missing.txt")}}
 
-	err := doUpload(ctx, conf)
+		err := doUpload(ctx, conf)
 
-	require.ErrorIs(t, err, errExtraFiles)
-	require.Equal(t, int64(1), uploader.opens.Load())
-	require.Equal(t, int64(1), uploader.closes.Load())
-	require.Zero(t, uploader.active.Load())
-	require.False(t, uploader.closedWithActive.Load())
-	require.Empty(t, uploader.uploaded())
+		require.ErrorIs(t, err, errExtraFiles)
+		require.Equal(t, int64(1), uploader.opens.Load())
+		require.Equal(t, int64(1), uploader.closes.Load())
+		require.Zero(t, uploader.active.Load())
+		require.False(t, uploader.closedWithActive.Load())
+		require.Empty(t, uploader.uploaded())
+	})
 }
 
 func TestDoUploadUploadsArtifactsAndExtraFiles(t *testing.T) {
-	uploader := newRecordingUploader()
+	uploader := &recordingUploader{}
 	replaceBlobUploader(t, uploader)
 
 	ctx, conf := blobUploadContext(t, []string{"one.txt", "two.txt"}, []config.ExtraFile{{Glob: "./testdata/file.golden"}})
@@ -431,21 +425,13 @@ func replaceBlobUploader(tb testing.TB, rec *recordingUploader) {
 	tb.Cleanup(func() { newUploader = previous })
 }
 
-func newRecordingUploader() *recordingUploader {
-	return &recordingUploader{
-		started: make(chan struct{}),
-	}
-}
-
 type recordingUploader struct {
 	opens            atomic.Int64
 	closes           atomic.Int64
 	active           atomic.Int64
 	closedWithActive atomic.Bool
 
-	startOnce sync.Once
-	started   chan struct{}
-	block     chan struct{}
+	block chan struct{}
 
 	mu    sync.Mutex
 	files []string
@@ -458,7 +444,6 @@ func (u *recordingUploader) Open(*context.Context, string) error {
 
 func (u *recordingUploader) Upload(_ *context.Context, path string, _ []byte) error {
 	u.active.Add(1)
-	u.startOnce.Do(func() { close(u.started) })
 	if u.block != nil {
 		<-u.block
 	}

--- a/internal/pipe/brew/brew_test.go
+++ b/internal/pipe/brew/brew_test.go
@@ -171,6 +171,24 @@ func TestFormulaDescriptionEscapesRubyString(t *testing.T) {
 	}
 }
 
+func TestFormulaDescriptionIsTemplatedOnce(t *testing.T) {
+	for _, description := range []string{
+		`Render {{ "{{example}}" }} templates`,
+		`{{ .Env.DESCRIPTION }}`,
+	} {
+		t.Run(description, func(t *testing.T) {
+			data := defaultTemplateData
+			data.Desc = description
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+				Env: []string{"DESCRIPTION=Render {{example}} templates"},
+			})
+			out, err := doBuildFormula(ctx, data)
+			require.NoError(t, err)
+			require.Contains(t, out, "  desc \"Render {{example}} templates\"\n")
+		})
+	}
+}
+
 func TestFullFormulaeMacOSOnly(t *testing.T) {
 	data := defaultTemplateData
 	data.LinuxPackages = []releasePackage{}

--- a/internal/pipe/brew/templates/formula.rb
+++ b/internal/pipe/brew/templates/formula.rb
@@ -6,7 +6,8 @@
 require_relative "{{ .CustomRequire }}"
 {{ end -}}
 class {{ .Name }} < Formula
-  desc {{ .Desc | rubyString }}
+  {{- /* Preserve the rendered description as a literal through the final template pass. */}}
+  desc {{ .Desc | rubyString | printf "{{ %q }}" }}
   homepage "{{ .Homepage }}"
   version "{{ .Version }}"
   {{- if .License }}

--- a/internal/pipe/build/build.go
+++ b/internal/pipe/build/build.go
@@ -219,40 +219,11 @@ func doBuild(ctx *context.Context, build config.Build, opts builders.Options) er
 }
 
 func buildOptionsForTarget(ctx *context.Context, build config.Build, target string) (*builders.Options, error) {
-	ext := extFor(target, build.BuildDetails)
-	buildOpts := builders.Options{
-		Ext: ext,
-	}
-
 	t, err := builders.For(build.Builder).Parse(target)
 	if err != nil {
 		return nil, err
 	}
-	buildOpts.Target = t
-
-	bin, err := tmpl.New(ctx).WithBuildOptions(buildOpts).Apply(build.Binary)
-	if err != nil {
-		return nil, err
-	}
-
-	name := bin + ext
-	dir := fmt.Sprintf("%s_%s", build.ID, t)
-	noUnique, err := tmpl.New(ctx).Bool(build.NoUniqueDistDir)
-	if err != nil {
-		return nil, err
-	}
-	if noUnique {
-		dir = ""
-	}
-	relpath := filepath.Join(ctx.Config.Dist, dir, name)
-	path, err := filepath.Abs(relpath)
-	if err != nil {
-		return nil, err
-	}
-	buildOpts.Path = path
-	buildOpts.Name = name
-
-	return &buildOpts, nil
+	return base.OptionsForTarget(ctx, build, t, extFor(target, build.BuildDetails))
 }
 
 // TODO: this should probably be the responsibility of each builder.

--- a/internal/pipe/cask/cask_test.go
+++ b/internal/pipe/cask/cask_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
@@ -1673,6 +1674,59 @@ func TestRunPipeUniversalBinaryWrappedIn(t *testing.T) {
 			golden.RequireEqualRb(t, golden.RequireReadFile(t, casks[0].Path))
 		})
 	}
+}
+
+func TestRunPipeUniversalArchiveWithLinuxBinary(t *testing.T) {
+	t.Parallel()
+	folder := t.TempDir()
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Dist:        folder,
+		ProjectName: "foo",
+		Casks: []config.HomebrewCask{{
+			Name:     "foo",
+			Binaries: []string{"foo"},
+			Repository: config.RepoRef{
+				Owner: "foo",
+				Name:  "bar",
+			},
+		}},
+	}, testctx.WithCurrentTag("v1.0.0"), testctx.WithVersion("1.0.0"))
+	for _, art := range []*artifact.Artifact{
+		{
+			Name:   "foo_darwin_all.tar.gz",
+			Goos:   "darwin",
+			Goarch: "all",
+			Type:   artifact.UploadableArchive,
+			Extra: artifact.Extras{
+				artifact.ExtraFormat:   "tar.gz",
+				artifact.ExtraBinaries: []string{"foo"},
+				artifact.ExtraReplaces: true,
+			},
+		},
+		{
+			Name:   "foo_linux_amd64",
+			Goos:   "linux",
+			Goarch: "amd64",
+			Type:   artifact.UploadableBinary,
+			Extra: artifact.Extras{
+				artifact.ExtraFormat: "binary",
+				artifact.ExtraBinary: "foo",
+			},
+		},
+	} {
+		art.Path = filepath.Join(folder, art.Name)
+		require.NoError(t, os.WriteFile(art.Path, []byte("foo"), 0o644))
+		ctx.Artifacts.Add(art)
+	}
+
+	require.NoError(t, runAll(ctx, client.NewMock()))
+	casks := ctx.Artifacts.Filter(artifact.ByType(artifact.BrewCask)).List()
+	require.Len(t, casks, 1)
+	content := string(golden.RequireReadFile(t, casks[0].Path))
+	macos, linux, ok := strings.Cut(content, "  on_linux do\n")
+	require.True(t, ok, content)
+	require.Contains(t, macos, "    binary \"foo\"\n")
+	require.Contains(t, linux, "      binary \"foo_linux_amd64\", target: \"foo\"\n")
 }
 
 func TestRunPipeUniversalBinaryNotReplacing(t *testing.T) {

--- a/internal/pipe/cask/cask_test.go
+++ b/internal/pipe/cask/cask_test.go
@@ -244,6 +244,24 @@ func TestCaskDescriptionEscapesRubyString(t *testing.T) {
 	}
 }
 
+func TestCaskDescriptionIsTemplatedOnce(t *testing.T) {
+	for _, description := range []string{
+		`Render {{ "{{example}}" }} templates`,
+		`{{ .Env.DESCRIPTION }}`,
+	} {
+		t.Run(description, func(t *testing.T) {
+			data := defaultTemplateData
+			data.Description = description
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+				Env: []string{"DESCRIPTION=Render {{example}} templates"},
+			})
+			out, err := doBuildCask(ctx, data)
+			require.NoError(t, err)
+			require.Contains(t, out, "  desc \"Render {{example}} templates\"\n")
+		})
+	}
+}
+
 func TestCaskSimple(t *testing.T) {
 	cask, err := doBuildCask(testctx.WrapWithCfg(t.Context(), config.Project{}), defaultTemplateData)
 	require.NoError(t, err)

--- a/internal/pipe/cask/templates/cask.rb
+++ b/internal/pipe/cask/templates/cask.rb
@@ -21,7 +21,8 @@ cask "{{ .Name }}" do
   {{- end }}
 
   name "{{ .Name }}"
-  desc {{ .Description | rubyString }}
+  {{- /* Preserve the rendered description as a literal through the final template pass. */}}
+  desc {{ .Description | rubyString | printf "{{ %q }}" }}
   homepage "{{ .Homepage }}"
 
   livecheck do

--- a/internal/pipe/cask/templates/macos_packages.rb
+++ b/internal/pipe/cask/templates/macos_packages.rb
@@ -12,6 +12,11 @@
   rename "{{ $wrap }}/{{ . }}", "{{ . }}"
   {{- end }}
   {{- end }}
+  {{- if $.HasMixedPackageTypes }}
+  {{- range .CaskBins }}
+  binary "{{ . }}"
+  {{- end }}
+  {{- end }}
 
   {{- else }}
   {{- if eq $element.Arch "amd64" }}

--- a/internal/pipe/docker/v2/baseimage.go
+++ b/internal/pipe/docker/v2/baseimage.go
@@ -4,11 +4,14 @@ import (
 	stdctx "context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"regexp"
+	"slices"
 	"strings"
 
+	"github.com/goreleaser/goreleaser/v2/internal/tmpl"
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
 )
 
@@ -33,12 +36,16 @@ type dockerImage struct{ name, digest string }
 // getBaseImage returns the base image of dockerfile and its manifest digest.
 // Returns errNoBaseImage when there's no usable FROM. Returns (base, "", err)
 // on digest resolution failure, so callers can still use the image name.
-func getBaseImage(ctx *context.Context, dockerfile string, buildArgs ...map[string]string) (dockerImage, error) {
+func getBaseImage(ctx *context.Context, dockerfile string, buildArgs map[string]string) (dockerImage, error) {
 	content, err := os.ReadFile(dockerfile)
 	if err != nil {
 		return dockerImage{}, err
 	}
-	base := parseBaseImage(string(content), buildArgs...)
+	overrides, err := baseImageBuildArgs(ctx, string(content), buildArgs)
+	if err != nil {
+		return dockerImage{}, err
+	}
+	base := parseBaseImage(string(content), overrides)
 	if base == "" || strings.EqualFold(base, "scratch") {
 		return dockerImage{}, errNoBaseImage
 	}
@@ -52,6 +59,43 @@ func getBaseImage(ctx *context.Context, dockerfile string, buildArgs ...map[stri
 	return dockerImage{base, digest}, nil
 }
 
+// Other build arguments can depend on the resolved base image and are rendered later.
+func baseImageBuildArgs(ctx *context.Context, content string, args map[string]string) (map[string]string, error) {
+	used := map[string]bool{}
+	for line := range strings.SplitSeq(continuationRe.ReplaceAllString(content, " "), "\n") {
+		if m := fromRe.FindStringSubmatch(strings.TrimSpace(line)); m != nil {
+			os.Expand(m[1], func(name string) string {
+				key, _, _ := strings.Cut(name, ":-")
+				used[key] = true
+				return ""
+			})
+		}
+	}
+	if len(used) == 0 {
+		return nil, nil
+	}
+
+	tpl := tmpl.New(ctx)
+	result := map[string]string{}
+	for _, key := range slices.Sorted(maps.Keys(args)) {
+		k, err := tpl.Apply(key)
+		if err != nil {
+			return nil, err
+		}
+		if !used[k] {
+			continue
+		}
+		v, err := tpl.Apply(args[key])
+		if err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(v) != "" {
+			result[k] = v
+		}
+	}
+	return result, nil
+}
+
 var (
 	continuationRe = regexp.MustCompile(`\\\s*\n`)
 	argRe          = regexp.MustCompile(`(?i)^ARG\s+([A-Za-z_][A-Za-z0-9_]*)(?:=(.*))?$`)
@@ -63,15 +107,11 @@ var (
 // Doesn't try to be a full Dockerfile parser — only enough to fill the
 // BaseImage/BaseImageDigest template vars. The real `docker build` is the
 // source of truth.
-func parseBaseImage(content string, buildArgs ...map[string]string) string {
+func parseBaseImage(content string, overrides map[string]string) string {
 	content = continuationRe.ReplaceAllString(content, " ")
 
 	args := map[string]string{}
 	aliases := map[string]string{}
-	overrides := map[string]string{}
-	if len(buildArgs) > 0 {
-		overrides = buildArgs[0]
-	}
 	var base string
 
 	for line := range strings.SplitSeq(content, "\n") {

--- a/internal/pipe/docker/v2/baseimage_test.go
+++ b/internal/pipe/docker/v2/baseimage_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
+	"github.com/goreleaser/goreleaser/v2/internal/testlib"
 	"github.com/goreleaser/goreleaser/v2/pkg/config"
 	"github.com/goreleaser/goreleaser/v2/pkg/context"
 	"github.com/stretchr/testify/require"
@@ -36,19 +37,19 @@ func TestParseBaseImage(t *testing.T) {
 		t.Run(file, func(t *testing.T) {
 			content, err := os.ReadFile(filepath.Join("testdata", "dockerfiles", file))
 			require.NoError(t, err)
-			require.Equal(t, want, parseBaseImage(string(content)))
+			require.Equal(t, want, parseBaseImage(string(content), nil))
 		})
 	}
 }
 
 func TestGetBaseImage(t *testing.T) {
 	t.Run("missing file", func(t *testing.T) {
-		_, err := getBaseImage(testctx.Wrap(t.Context()), "nope.Dockerfile")
+		_, err := getBaseImage(testctx.Wrap(t.Context()), "nope.Dockerfile", nil)
 		require.Error(t, err)
 	})
 
 	t.Run("scratch", func(t *testing.T) {
-		img, err := getBaseImage(testctx.Wrap(t.Context()), filepath.Join("testdata", "dockerfiles", "scratch"))
+		img, err := getBaseImage(testctx.Wrap(t.Context()), filepath.Join("testdata", "dockerfiles", "scratch"), nil)
 		require.ErrorIs(t, err, errNoBaseImage)
 		require.Empty(t, img.name)
 		require.Empty(t, img.digest)
@@ -56,14 +57,14 @@ func TestGetBaseImage(t *testing.T) {
 
 	t.Run("digest pinned in FROM", func(t *testing.T) {
 		const ref = "alpine@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1"
-		img, err := getBaseImage(testctx.Wrap(t.Context()), filepath.Join("testdata", "dockerfiles", "pinned-digest"))
+		img, err := getBaseImage(testctx.Wrap(t.Context()), filepath.Join("testdata", "dockerfiles", "pinned-digest"), nil)
 		require.NoError(t, err)
 		require.Equal(t, ref, img.name)
 		require.Equal(t, "sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1", img.digest)
 	})
 
 	t.Run("digest resolution error returns base", func(t *testing.T) {
-		img, err := getBaseImage(testctx.Wrap(t.Context()), filepath.Join("testdata", "dockerfiles", "unknown-image"))
+		img, err := getBaseImage(testctx.Wrap(t.Context()), filepath.Join("testdata", "dockerfiles", "unknown-image"), nil)
 		require.Error(t, err)
 		require.Equal(t, "goreleaser-nonexistent-image:nope", img.name)
 		require.Empty(t, img.digest)
@@ -80,6 +81,10 @@ func TestMakeArgsWithBaseImage(t *testing.T) {
 			Images:     []string{"ghcr.io/foo/bar"},
 			Tags:       []string{"latest"},
 			Platforms:  []string{"linux/amd64"},
+			BuildArgs: map[string]string{
+				"BASE_NAME":   "{{ .BaseImage }}",
+				"BASE_DIGEST": "{{ .BaseImageDigest }}",
+			},
 			Annotations: map[string]string{
 				"org.opencontainers.image.base.name":   "{{.BaseImage}}",
 				"org.opencontainers.image.base.digest": "{{.BaseImageDigest}}",
@@ -90,6 +95,8 @@ func TestMakeArgsWithBaseImage(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, da.args, "org.opencontainers.image.base.name="+ref)
 	require.Contains(t, da.args, "org.opencontainers.image.base.digest="+digest)
+	require.Contains(t, da.args, "BASE_NAME="+ref)
+	require.Contains(t, da.args, "BASE_DIGEST="+digest)
 }
 
 func TestMakeArgsWithBaseImageBuildArgOverride(t *testing.T) {
@@ -99,19 +106,42 @@ func TestMakeArgsWithBaseImageBuildArgOverride(t *testing.T) {
 
 	dir := t.TempDir()
 	dockerfile := filepath.Join(dir, "Dockerfile")
-	require.NoError(t, os.WriteFile(dockerfile, []byte("ARG BASE="+defaultRef+"\nFROM ${BASE}\n"), 0o644))
+	require.NoError(t, os.WriteFile(dockerfile, []byte("ARG BASE="+defaultRef+"\nARG BASE_DIGEST\nFROM ${BASE}\n"), 0o644))
 
 	for name, tt := range map[string]struct {
-		ctx      *context.Context
-		buildArg string
+		ctx        *context.Context
+		key        string
+		buildArg   string
+		wantRef    string
+		wantDigest string
 	}{
 		"literal": {
-			ctx:      testctx.Wrap(t.Context()),
-			buildArg: overrideRef,
+			ctx:        testctx.Wrap(t.Context()),
+			key:        "BASE",
+			buildArg:   overrideRef,
+			wantRef:    overrideRef,
+			wantDigest: overrideDigest,
 		},
 		"templated": {
-			ctx:      testctx.Wrap(t.Context(), testctx.WithEnv(map[string]string{"BASE": overrideRef})),
-			buildArg: "{{ .Env.BASE }}",
+			ctx:        testctx.Wrap(t.Context(), testctx.WithEnv(map[string]string{"BASE": overrideRef})),
+			key:        "BASE",
+			buildArg:   "{{ .Env.BASE }}",
+			wantRef:    overrideRef,
+			wantDigest: overrideDigest,
+		},
+		"templated key": {
+			ctx:        testctx.Wrap(t.Context(), testctx.WithEnv(map[string]string{"KEY": "BASE", "BASE": overrideRef})),
+			key:        "{{ .Env.KEY }}",
+			buildArg:   "{{ .Env.BASE }}",
+			wantRef:    overrideRef,
+			wantDigest: overrideDigest,
+		},
+		"empty override": {
+			ctx:        testctx.Wrap(t.Context(), testctx.WithEnv(map[string]string{"BASE": ""})),
+			key:        "BASE",
+			buildArg:   "{{ .Env.BASE }}",
+			wantRef:    defaultRef,
+			wantDigest: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -123,7 +153,8 @@ func TestMakeArgsWithBaseImageBuildArgOverride(t *testing.T) {
 					Tags:       []string{"latest"},
 					Platforms:  []string{"linux/amd64"},
 					BuildArgs: map[string]string{
-						"BASE": tt.buildArg,
+						tt.key:        tt.buildArg,
+						"BASE_DIGEST": "{{ .BaseImageDigest }}",
 					},
 					Annotations: map[string]string{
 						"org.opencontainers.image.base.name":   "{{.BaseImage}}",
@@ -133,8 +164,21 @@ func TestMakeArgsWithBaseImageBuildArgOverride(t *testing.T) {
 				nil,
 			)
 			require.NoError(t, err)
-			require.Contains(t, annotationsOf(da.args), "org.opencontainers.image.base.name="+overrideRef)
-			require.Contains(t, annotationsOf(da.args), "org.opencontainers.image.base.digest="+overrideDigest)
+			require.Contains(t, annotationsOf(da.args), "org.opencontainers.image.base.name="+tt.wantRef)
+			require.Contains(t, annotationsOf(da.args), "org.opencontainers.image.base.digest="+tt.wantDigest)
+			require.Contains(t, da.args, "BASE_DIGEST="+tt.wantDigest)
 		})
 	}
+}
+
+func TestMakeArgsDoesNotDiscardBaseImageArgumentError(t *testing.T) {
+	dockerfile := filepath.Join(t.TempDir(), "Dockerfile")
+	require.NoError(t, os.WriteFile(dockerfile, []byte("ARG BASE=alpine\nFROM ${BASE}\n"), 0o644))
+	_, err := makeArgs(testctx.Wrap(t.Context()), config.DockerV2{
+		Dockerfile: dockerfile,
+		Images:     []string{"ghcr.io/foo/bar"},
+		Tags:       []string{"latest"},
+		BuildArgs:  map[string]string{"BASE": "{{ .BaseImage }}"},
+	}, nil)
+	testlib.RequireTemplateError(t, err)
 }

--- a/internal/pipe/docker/v2/docker.go
+++ b/internal/pipe/docker/v2/docker.go
@@ -357,15 +357,10 @@ func makeArgs(ctx *context.Context, d config.DockerV2, extraArgs []string) (dock
 		return dockerArgs{}, fmt.Errorf("invalid dockerfile: %w", err)
 	}
 
-	buildArgEntries, err := tplMapEntries(tpl, d.BuildArgs)
-	if err != nil {
-		return dockerArgs{}, fmt.Errorf("invalid build args: %w", err)
-	}
-
-	baseImg, err := getBaseImage(ctx, dockerfile, mapEntriesMap(buildArgEntries))
-	if err != nil && !errors.Is(err, errNoBaseImage) {
+	baseImg, baseErr := getBaseImage(ctx, dockerfile, d.BuildArgs)
+	if baseErr != nil && !errors.Is(baseErr, errNoBaseImage) {
 		log.WithField("dockerfile", d.Dockerfile).
-			WithError(err).
+			WithError(baseErr).
 			Debug("could not resolve base image")
 	}
 
@@ -380,6 +375,9 @@ func makeArgs(ctx *context.Context, d config.DockerV2, extraArgs []string) (dock
 	}
 	if len(images) == 0 {
 		return dockerArgs{}, pipe.Skip("no images")
+	}
+	if _, ok := errors.AsType[tmpl.Error](baseErr); ok {
+		return dockerArgs{}, fmt.Errorf("invalid build args: %w", baseErr)
 	}
 	tags, err := tpl.Slice(d.Tags, tmpl.NonEmpty())
 	if err != nil {
@@ -414,7 +412,10 @@ func makeArgs(ctx *context.Context, d config.DockerV2, extraArgs []string) (dock
 		}
 	}
 
-	buildFlags := mapEntriesFlags("--build-arg", buildArgEntries)
+	buildFlags, err := tplMapFlags(tpl, "--build-arg", d.BuildArgs)
+	if err != nil {
+		return dockerArgs{}, fmt.Errorf("invalid build args: %w", err)
+	}
 
 	flags, err := tpl.Slice(d.Flags, tmpl.NonEmpty())
 	if err != nil {
@@ -707,20 +708,7 @@ func hasAnnotationScope(annotation string) bool {
 // It'll also sort keys so the resulting slice is always in the same order.
 // Finally, it will also skip entries with either an empty key or value.
 func tplMapFlags(tpl *tmpl.Template, flag string, m map[string]string) ([]string, error) {
-	entries, err := tplMapEntries(tpl, m)
-	if err != nil {
-		return nil, err
-	}
-	return mapEntriesFlags(flag, entries), nil
-}
-
-type mapEntry struct {
-	key   string
-	value string
-}
-
-func tplMapEntries(tpl *tmpl.Template, m map[string]string) ([]mapEntry, error) {
-	var result []mapEntry
+	var result []string
 	keys := slices.Collect(maps.Keys(m))
 	slices.Sort(keys)
 	for _, k := range keys {
@@ -731,25 +719,9 @@ func tplMapEntries(tpl *tmpl.Template, m map[string]string) ([]mapEntry, error) 
 		if strings.TrimSpace(k) == "" || strings.TrimSpace(v) == "" {
 			continue
 		}
-		result = append(result, mapEntry{key: k, value: v})
+		result = append(result, flag, k+"="+v)
 	}
 	return result, nil
-}
-
-func mapEntriesFlags(flag string, entries []mapEntry) []string {
-	var result []string
-	for _, entry := range entries {
-		result = append(result, flag, entry.key+"="+entry.value)
-	}
-	return result
-}
-
-func mapEntriesMap(entries []mapEntry) map[string]string {
-	result := make(map[string]string, len(entries))
-	for _, entry := range entries {
-		result[entry.key] = entry.value
-	}
-	return result
 }
 
 // IsRetriableBuild reports whether a failed docker build is worth retrying.

--- a/internal/pipe/docker/v2/docker_test.go
+++ b/internal/pipe/docker/v2/docker_test.go
@@ -326,6 +326,16 @@ func TestMakeArgs(t *testing.T) {
 		}, nil)
 		testlib.AssertSkipped(t, err)
 	})
+	t.Run("no images ignores unused build args", func(t *testing.T) {
+		_, err := makeArgs(testctx.Wrap(t.Context(), testctx.Snapshot, testctx.WithEnv(map[string]string{})), config.DockerV2{
+			Dockerfile: filepath.Join("testdata", "dockerfiles", "pinned-digest"),
+			Images:     []string{"{{ if not .IsSnapshot }}ghcr.io/foo/bar{{ end }}"},
+			BuildArgs: map[string]string{
+				"RELEASE_ONLY": "{{ .Env.RELEASE_ONLY }}",
+			},
+		}, nil)
+		testlib.AssertSkipped(t, err)
+	})
 	t.Run("no tags", func(t *testing.T) {
 		_, err := makeArgs(testctx.Wrap(t.Context()), config.DockerV2{
 			Dockerfile: "a",

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -96,6 +96,10 @@ func (r *redacter) replacePartial(s string) (redacted, pending string) {
 	if len(r.secrets) == 0 {
 		return s, ""
 	}
+	// Only writes ending in a secret prefix need the streaming matcher.
+	if !r.hasIncompleteSuffix(s) {
+		return r.Replace(s), ""
+	}
 
 	var b strings.Builder
 	for i := 0; i < len(s); {
@@ -112,6 +116,15 @@ func (r *redacter) replacePartial(s string) (redacted, pending string) {
 		i++
 	}
 	return b.String(), ""
+}
+
+func (r *redacter) hasIncompleteSuffix(s string) bool {
+	for i := max(0, len(s)-r.maxLen+1); i < len(s); i++ {
+		if r.isIncompleteSecret(s[i:]) {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *redacter) isIncompleteSecret(s string) bool {

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -225,7 +226,7 @@ func TestRedactWriter(t *testing.T) {
 		_, err := io.WriteString(w, "key123")
 		require.NoError(t, err)
 		require.Empty(t, buf.String())
-		closeWriter(t, w)
+		require.NoError(t, w.Close())
 		require.Equal(t, "key123", buf.String())
 	})
 
@@ -256,13 +257,59 @@ func TestRedactString(t *testing.T) {
 	})
 }
 
+func TestWriterMatchesStringAcrossChunks(t *testing.T) {
+	t.Parallel()
+	env := []string{
+		"SHORT_TOKEN=aba",
+		"LONG_TOKEN=abacus",
+		"OTHER_TOKEN=bac",
+		"UNICODE_TOKEN=\xc3\xa9_secret",
+	}
+	for _, input := range []string{
+		"ordinary output\n",
+		"abacus aba bac\n",
+		"prefix abacus and a trailing ab",
+		"aba",
+		"abacus",
+		"\xc3\xa9_secret and \xc3\xa9",
+	} {
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+			for size := 1; size <= len(input); size++ {
+				var out bytes.Buffer
+				w := Writer(&out, env)
+				for i := 0; i < len(input); i += size {
+					_, err := io.WriteString(w, input[i:min(i+size, len(input))])
+					require.NoError(t, err)
+				}
+				require.NoError(t, w.Close())
+				require.Equal(t, String(input, env), out.String(), "chunk size %d", size)
+			}
+		})
+	}
+}
+
 type errWriter struct{ err error }
 
 func (e *errWriter) Write([]byte) (int, error) { return 0, e.err }
 
-func closeWriter(tb testing.TB, w io.Writer) {
-	tb.Helper()
-	closer, ok := w.(io.Closer)
-	require.True(tb, ok)
-	require.NoError(tb, closer.Close())
+func BenchmarkWriter(b *testing.B) {
+	data := []byte(strings.Repeat("building package example.com/project/internal/component\n", 600))
+	for _, count := range []int{0, 1, 16, 64} {
+		b.Run(fmt.Sprintf("secrets=%d", count), func(b *testing.B) {
+			env := make([]string, count)
+			for i := range env {
+				env[i] = fmt.Sprintf("SERVICE_%d_TOKEN=secret-value-%032d", i, i)
+			}
+			w := Writer(io.Discard, env)
+			b.ReportAllocs()
+			b.SetBytes(int64(len(data)))
+			for b.Loop() {
+				if _, err := w.Write(data); err != nil {
+					b.Fatal(err)
+				}
+			}
+			require.NoError(b, w.Close())
+		})
+	}
 }


### PR DESCRIPTION
<!-- If applied, this commit will... -->

## Summary

Fix seven regressions found while reviewing the changes after `v2.18.1`:

- Preserve target and artifact template fields during Rust preparation, sharing build-option resolution with the build pipeline.
- Restore Docker v2 build-argument template context and empty-image skipping while retaining effective `FROM` overrides.
- Render Homebrew descriptions only once, preserving literal template delimiters.
- Install universal macOS binaries when a cask mixes archives and raw binaries.
- Accept literal executable paths containing apostrophes or spaces in healthcheck.
- Preserve directory-symlink traversal when a copy source ends with `/`.
- Restore normal-output redaction throughput without losing cross-write secret handling.

Also simplify Docker flag construction and close handling, replace blob regression polling with deterministic synchronization, and include `go mod tidy`.

The Windows `rustup` fixture now records environment values literally, so pipe characters in target-context fixtures are not interpreted as batch commands.

<!-- Why is this change being made? -->

## Motivation

Recent fixes introduced compatibility regressions at template, path, and packaging boundaries. The streaming redactor also started checking every secret against every ordinary output byte.

Each fix is isolated in its own commit, with focused regression coverage. For normal-output redaction, benchstat reported these medians for 33.6 KB chunks with 64 secrets (`Go 1.27.1`, `GOMAXPROCS=2`, 10 samples):

| `v2.18.1` | Reviewed HEAD (`6ceb354cd`) | This branch |
|---:|---:|---:|
| 47.4 us | 5,331 us | 49.9 us |

Focused local regression and race runs and targeted golangci-lint runs passed. Blob unit coverage was exercised separately from its MinIO bootstrap locally. The full Ubuntu and Windows CI test jobs passed at `7ebed533b` in [build run 34032079529](https://github.com/goreleaser/goreleaser/actions/runs/34032079529); the other workflows also passed.

<!-- # Provide links to any relevant tickets, URLs or other resources -->

## References

- [Reviewed commit range](https://github.com/goreleaser/goreleaser/compare/v2.18.1...6ceb354cd7e212d7ca65592003564abe7ab65bad)
- Follow-ups to #7076, #7080, #7086, #7089, #7095, #7101, and #7104.

AI-assisted review and implementation with GitHub Copilot.
