### PR TITLE
ci: enable verbose test output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,11 +55,11 @@ jobs:
           # identical flags apart from -count=1, 331s with the cache on and
           # 129s without.
           - os: ubuntu-latest
-            test-args: TEST_OPTIONS=-count=1
+            test-args: TEST_OPTIONS="-count=1 -v"
           # the race detector is OS-independent and coverage is only uploaded
           # from ubuntu, so skip both on windows to speed up the slowest job.
           - os: windows-latest
-            test-args: RACE=false COVER=false TEST_OPTIONS=-count=1
+            test-args: RACE=false COVER=false TEST_OPTIONS="-count=1 -v"
     runs-on: ${{ matrix.os }}
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"


### PR DESCRIPTION
## Change

Add `-v` to `TEST_OPTIONS` in both CI test jobs. This keeps individual test and subtest durations in the Actions logs, including successful tests.

Keep verbose output enabled in CI for future comparisons. Preserve `-count=1`, Linux race detection and coverage, and the Windows race/coverage exclusions. Local `task test` defaults and build-cache keys do not change.

## Initial timing data

These are sampled successful `main` push runs. Times below are for the `task test` step, which includes test compilation and linking as well as execution; they are not total job times.

| Run (UTC) | Ubuntu test step | Windows test step |
| --- | --- | --- |
| [September 1, 12:04](https://github.com/goreleaser/goreleaser/actions/runs/33505689108) | 3m05s | 1m44s |
| [September 3, 03:56](https://github.com/goreleaser/goreleaser/actions/runs/33713184069) | 5m50s | 3m29s |
| [September 4, 12:53](https://github.com/goreleaser/goreleaser/actions/runs/33875082159) | 2m38s | 1m58s |
| [September 5, 14:39](https://github.com/goreleaser/goreleaser/actions/runs/33972457701) | 2m32s | 3m02s |
| [September 5, 23:37](https://github.com/goreleaser/goreleaser/actions/runs/33999152482) | 3m00s | 2m02s |
| [September 6, 05:10](https://github.com/goreleaser/goreleaser/actions/runs/34013301740) | 3m18s | 2m07s |

The September 3 Go 1.27.1 update had Go cache misses on both platforms and a Flatpak cache miss on Ubuntu. Build steps alone took 98s on Ubuntu and 128s on Windows, versus 12s and 16s in the latest run. That spike is not evidence of a test-only regression.

For September 5 at 14:39 versus the latest run, existing package summaries show:

| Package | Ubuntu before / after | Windows before / after |
| --- | --- | --- |
| `cmd` | 14.171s / 31.133s | 14.089s / 31.233s |
| `internal/pipe/flatpak` | 3.689s / 31.668s | 0.045s / 0.212s |
| `internal/pipe/git` | 3.020s / 2.527s | 13.798s / 23.508s |

These are investigation targets, not proven causes. Verbose output will identify the individual tests before we change them. Durations are not additive because packages and parallel tests overlap. This PR adds visibility only; it does not claim a speed improvement.