### PR TITLE
fix(github): honor short Retry-After delays

### DIFF
--- a/internal/client/github.go
+++ b/internal/client/github.go
@@ -70,7 +70,11 @@ func githubError(err error, resp *github.Response) error {
 	if rle, ok := errors.AsType[*github.RateLimitError](err); ok {
 		he.RetryAfter = max(time.Until(rle.Rate.Reset.Time), time.Second)
 	} else if arle, ok := errors.AsType[*github.AbuseRateLimitError](err); ok {
-		he.RetryAfter = max(*must(arle.RetryAfter), time.Minute)
+		if d := *must(arle.RetryAfter); d > 0 {
+			he.RetryAfter = d
+		} else {
+			he.RetryAfter = time.Minute
+		}
 	}
 	return he
 }

--- a/internal/client/github_test.go
+++ b/internal/client/github_test.go
@@ -167,6 +167,70 @@ func TestGitHubUploadReleaseIDNotInt(t *testing.T) {
 	)
 }
 
+func TestGitHubSecondaryRateLimitHonorsRetryAfter(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		retryAfter string
+		expected   time.Duration
+	}{
+		{"short delay", "1", time.Second},
+		{"absent header", "", time.Minute},
+		{"longer delay", "90", 90 * time.Second},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				var calls atomic.Int32
+
+				transport := httpmock.NewMockTransport()
+				transport.RegisterResponder(http.MethodGet, "https://api.github.com/rate_limit",
+					func(req *http.Request) (*http.Response, error) {
+						resp := httpmock.NewStringResponse(http.StatusOK, fmt.Sprintf(
+							`{"resources":{"core":{"remaining":5000,"reset":%d}}}`,
+							time.Now().Add(time.Hour).Unix(),
+						))
+						resp.Request = req
+						return resp, nil
+					})
+				transport.RegisterResponder(http.MethodGet, "https://api.github.com/repos/owner/repo/compare/v1...v2",
+					func(req *http.Request) (*http.Response, error) {
+						if calls.Add(1) == 1 {
+							resp := httpmock.NewStringResponse(http.StatusForbidden,
+								`{"message":"You have exceeded a secondary rate limit","documentation_url":"https://docs.github.com/rest/overview/rate-limits-for-the-rest-api#about-secondary-rate-limits"}`)
+							resp.Request = req
+							if tt.retryAfter != "" {
+								resp.Header.Set("Retry-After", tt.retryAfter)
+							}
+							return resp, nil
+						}
+						resp := httpmock.NewStringResponse(http.StatusOK, `{"commits":[]}`)
+						resp.Request = req
+						return resp, nil
+					})
+
+				ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+					Retry: config.Retry{
+						Attempts: 3,
+						Delay:    10 * time.Millisecond,
+						MaxDelay: 5 * time.Minute,
+					},
+				})
+
+				api, err := github.NewClient(github.WithHTTPClient(&http.Client{Transport: transport}))
+				require.NoError(t, err)
+				client := &githubClient{client: api}
+
+				start := time.Now()
+				_, err = client.Changelog(ctx, Repo{Owner: "owner", Name: "repo"}, "v1", "v2")
+				elapsed := time.Since(start)
+
+				require.NoError(t, err)
+				require.Equal(t, int32(2), calls.Load())
+				require.Equal(t, tt.expected, elapsed)
+			})
+		})
+	}
+}
+
 func TestGitHubReleaseURLTemplate(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
Closes #6918.

`githubError` used `max(*must(arle.RetryAfter), time.Minute)`, where the minute was doing two jobs — fallback for a missing header, and floor for a present one. `must` returns a pointer to the zero value when the header is absent, so both cases collapsed into the same expression and a `Retry-After: 1` became 60s.

Now it branches on whether the value is usable, keeping the minute for absence only.

Added `TestGitHubSecondaryRateLimitHonorsRetryAfter` with the three virtual-clock cases from the issue — short (1s), absent (1m), longer (1m30s). It fails on current code with 1m0s for the short case.

Left `TestGitHubChangelogRetriesOnSecondaryRateLimit` alone; its `MaxDelay: 2s` comment was describing this bug, happy to update it if you'd like.