### PR TITLE
fix(project): evaluate name candidates lazily

### DIFF
--- a/internal/pipe/project/project.go
+++ b/internal/pipe/project/project.go
@@ -24,18 +24,19 @@ func (Pipe) Default(ctx *context.Context) error {
 		return nil
 	}
 
-	for _, candidate := range []string{
-		cargoName(),
-		ctx.Config.Release.GitHub.Name,
-		ctx.Config.Release.GitLab.Name,
-		ctx.Config.Release.Gitea.Name,
-		moduleName(ctx),
-		gitRemote(ctx),
+	for _, candidate := range []func() string{
+		cargoName,
+		func() string { return ctx.Config.Release.GitHub.Name },
+		func() string { return ctx.Config.Release.GitLab.Name },
+		func() string { return ctx.Config.Release.Gitea.Name },
+		func() string { return moduleName(ctx) },
+		func() string { return gitRemote(ctx) },
 	} {
-		if candidate == "" {
+		name := candidate()
+		if name == "" {
 			continue
 		}
-		ctx.Config.ProjectName = candidate
+		ctx.Config.ProjectName = name
 		return nil
 	}
 


### PR DESCRIPTION
Closes #6921.

The candidate slice is a composite literal, so Go evaluates every element before the loop body runs. That means `moduleName` and `gitRemote` shell out to `go list -m` and `git ls-remote` even when an earlier candidate already won.

Changed it to `[]func() string` so each candidate only runs when it's reached. Same order, same precedence, same error handling.

The ten existing tests in this package cover every selection path and all still pass.

I haven't added the command count regressions. There's no command recorder in `testlib` right now, and faking `go`/`git` on `PATH` needs different shims on Windows and Linux. Happy to add them if you want, just wanted to check the approach first.