### PR TITLE
fix(builder/go): register the generated C header after compiling

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -279,19 +279,6 @@ func (*Builder) Build(ctx *context.Context, build config.Build, options api.Opti
 		return err
 	}
 
-	for _, a := range allbinaries {
-		if a.Type == artifact.CShared || a.Type == artifact.CArchive {
-			fullPathWithoutExt := strings.TrimSuffix(a.Path, options.Ext)
-			if ha := getHeaderArtifactForLibrary(
-				build,
-				options.Target.(Target),
-				fullPathWithoutExt,
-			); ha != nil {
-				ctx.Artifacts.Add(ha)
-			}
-		}
-	}
-
 	t := options.Target.(Target)
 	details, err := withOverrides(ctx, build, t)
 	if err != nil {
@@ -341,6 +328,17 @@ func (*Builder) Build(ctx *context.Context, build config.Build, options api.Opti
 	for _, a := range allbinaries {
 		if err := base.ChTimes(build, tpl.WithArtifact(a), a); err != nil {
 			return err
+		}
+		if a.Type == artifact.CShared || a.Type == artifact.CArchive {
+			fullPathWithoutExt := strings.TrimSuffix(a.Path, options.Ext)
+			if ha := getHeaderArtifactForLibrary(build, t, fullPathWithoutExt); ha != nil {
+				// the header goes into the archives next to its library, so it
+				// needs the same mod timestamp to stay reproducible.
+				if err := base.ChTimes(build, tpl.WithArtifact(ha), ha); err != nil {
+					return err
+				}
+				ctx.Artifacts.Add(ha)
+			}
 		}
 		if elf.IsDynamicallyLinked(a.Path) {
 			a.Extra[artifact.ExtranDynLink] = true

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -2349,7 +2349,7 @@ func TestBuildCgoLibraryHeaderTimestampFailure(t *testing.T) {
 		Path:   output,
 		Ext:    ext,
 	})
-	header := filepath.ToSlash(strings.TrimSuffix(output, ext) + ".h")
+	header := strings.TrimSuffix(output, ext) + ".h"
 	require.ErrorContains(t, err, "chtimes: "+header+":")
 	require.ErrorContains(t, err, `parsing "invalid": invalid syntax`)
 	require.FileExists(t, header)

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -2322,6 +2322,44 @@ func TestBuildCgoLibraryFailureDoesNotRegisterStaleHeader(t *testing.T) {
 	require.Empty(t, ctx.Artifacts.List())
 }
 
+func TestBuildCgoLibraryHeaderTimestampFailure(t *testing.T) {
+	folder := t.TempDir()
+	writeGoMod(t, folder, "github.com/foo/bar")
+	writeCExportMain(t, folder)
+
+	ext := cArchiveExt()
+	output := filepath.Join(folder, "dist", runtimeTarget, "cexport"+ext)
+	require.NoError(t, os.MkdirAll(filepath.Dir(output), 0o755))
+
+	build := config.Build{
+		ID:           "cexport",
+		Dir:          folder,
+		Main:         ".",
+		Tool:         "go",
+		Command:      "build",
+		Buildmode:    "c-archive",
+		ModTimestamp: `{{ if eq .ArtifactExt ".h" }}invalid{{ else }}1700000000{{ end }}`,
+		Env:          []string{"CGO_ENABLED=1"},
+	}
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{Builds: []config.Build{build}})
+
+	err := Default.Build(ctx, build, api.Options{
+		Target: mustParse(t, runtimeTarget),
+		Name:   "cexport" + ext,
+		Path:   output,
+		Ext:    ext,
+	})
+	header := filepath.ToSlash(strings.TrimSuffix(output, ext) + ".h")
+	require.ErrorContains(t, err, "chtimes: "+header+":")
+	require.ErrorContains(t, err, `parsing "invalid": invalid syntax`)
+	require.FileExists(t, header)
+	require.Empty(t, ctx.Artifacts.List())
+
+	info, err := os.Stat(output)
+	require.NoError(t, err)
+	require.Equal(t, time.Unix(1700000000, 0).UTC(), info.ModTime().UTC())
+}
+
 func writeCExportMain(tb testing.TB, folder string) {
 	tb.Helper()
 	require.NoError(tb, os.MkdirAll(folder, 0o755))

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -2199,3 +2199,118 @@ func mustParse(tb testing.TB, target string) Target {
 	require.NoError(tb, err)
 	return got.(Target)
 }
+
+func TestBuildCgoLibraryRegistersGeneratedHeader(t *testing.T) {
+	modTime := time.Date(2023, time.November, 14, 22, 13, 20, 0, time.UTC)
+
+	for mode, ext := range map[string]string{
+		"c-archive": cArchiveExt(),
+		"c-shared":  cSharedExt(),
+	} {
+		t.Run(mode, func(t *testing.T) {
+			folder := t.TempDir()
+			writeGoMod(t, folder, "github.com/foo/bar")
+			writeCExportMain(t, folder)
+
+			target := mustParse(t, runtimeTarget)
+			build := config.Build{
+				ID:           "cexport",
+				Dir:          folder,
+				Main:         ".",
+				Tool:         "go",
+				Command:      "build",
+				Buildmode:    mode,
+				ModTimestamp: fmt.Sprintf("%d", modTime.Unix()),
+				Env:          []string{"CGO_ENABLED=1"},
+			}
+			options := api.Options{
+				Target: target,
+				Name:   "cexport" + ext,
+				Path:   filepath.Join(folder, "dist", runtimeTarget, "cexport"+ext),
+				Ext:    ext,
+			}
+			require.NoError(t, os.MkdirAll(filepath.Dir(options.Path), 0o755))
+
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{Builds: []config.Build{build}})
+			require.NoError(t, Default.Build(ctx, build, options))
+
+			libraries := ctx.Artifacts.Filter(artifact.ByType(artifactType(target, mode))).List()
+			require.Len(t, libraries, 1)
+			require.Equal(t, filepath.ToSlash(options.Path), libraries[0].Path)
+
+			headers := ctx.Artifacts.Filter(artifact.ByType(artifact.Header)).List()
+			require.Len(t, headers, 1)
+			require.Equal(t, filepath.ToSlash(filepath.Join(folder, "dist", runtimeTarget, "cexport.h")), headers[0].Path)
+			require.Equal(t, "cexport.h", headers[0].Name)
+			require.Equal(t, target.Target, headers[0].Target)
+			require.Equal(t, build.ID, headers[0].Extra[artifact.ExtraID])
+			require.Equal(t, "cexport.h", headers[0].Extra[artifact.ExtraBinary])
+			require.Equal(t, ".h", headers[0].Extra[artifact.ExtraExt])
+
+			// headers go into the archives, so they need the same mod
+			// timestamp the library gets, otherwise archives stop being
+			// reproducible.
+			info, err := os.Stat(headers[0].Path)
+			require.NoError(t, err)
+			require.Equal(t, modTime, info.ModTime().UTC())
+		})
+	}
+}
+
+func TestBuildCgoLibraryFailureDoesNotRegisterStaleHeader(t *testing.T) {
+	folder := t.TempDir()
+	writeGoMod(t, folder, "github.com/foo/bar")
+	writeCExportMain(t, folder)
+
+	target := mustParse(t, runtimeTarget)
+	output := filepath.Join(folder, "dist", runtimeTarget, "cexport.a")
+	require.NoError(t, os.MkdirAll(filepath.Dir(output), 0o755))
+	require.NoError(t, os.WriteFile(strings.TrimSuffix(output, ".a")+".h", []byte("stale"), 0o644))
+
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{Builds: []config.Build{{
+		ID:        "cexport",
+		Dir:       folder,
+		Main:      ".",
+		Tool:      "go",
+		Command:   "build",
+		Buildmode: "c-archive",
+		Flags:     []string{"-flag-that-dont-exists-to-force-failure"},
+	}}})
+
+	err := Default.Build(ctx, ctx.Config.Builds[0], api.Options{
+		Target: target,
+		Name:   "cexport.a",
+		Path:   output,
+		Ext:    ".a",
+	})
+	require.ErrorContains(t, err, `flag provided but not defined: -flag-that-dont-exists-to-force-failure`)
+	require.Empty(t, ctx.Artifacts.List())
+}
+
+func writeCExportMain(tb testing.TB, folder string) {
+	tb.Helper()
+	require.NoError(tb, os.MkdirAll(folder, 0o755))
+	require.NoError(tb, os.WriteFile(
+		filepath.Join(folder, "main.go"),
+		[]byte("package main\n\nimport \"C\"\n\n//export Add\nfunc Add(a, b C.int) C.int {\n\treturn a + b\n}\n\nfunc main() {}\n"),
+		0o644,
+	))
+}
+
+func cArchiveExt() string {
+	if runtime.GOOS == "windows" {
+		return ".lib"
+	}
+	return ".a"
+}
+
+func cSharedExt() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return ".dylib"
+	case "windows":
+		return ".dll"
+	default:
+		return ".so"
+	}
+}


### PR DESCRIPTION
Closes #6897

## Problem

`getHeaderArtifactForLibrary` returns `nil` when the header file is absent, and it was called **before** `base.Exec`:

```go
mains, allbinaries, err := checkBuild(build, options)
...
for _, a := range allbinaries {           // header discovery
    ...
}
...
if err := base.Exec(ctx, cmd, env, build.Dir); err != nil {   // compiler
```

The issue describes this as affecting *clean* builds. It is worse than that: GoReleaser refuses to run against a non-empty `dist` (`dist is not empty, remove it before running goreleaser`), so the header can **never** exist when discovery runs. Every `c-archive` and `c-shared` build was affected.

Verified on `main` with `buildmode: c-shared` — `dist/lib_darwin_arm64_v8.0/cexport.h` exists on disk, `artifacts.json` lists only the library, and `tar tzf` shows the archive contains `cexport.dylib` alone. Headers feed `archives`, `nfpms`, `makeself` and `reportsizes`, so a shipped C library was unusable by any consumer.

Introduced by `c3bfb5a5b` (#6254), which correctly stopped registering nonexistent headers but placed the check before compilation.

## Fix

Header discovery moves into the loop that registers the binaries, after the build. The header also gets `base.ChTimes`, so a `mod_timestamp` build stays reproducible — without it the header would carry a wall-clock mtime into the archive while the library was pinned.

## Tests

- `TestBuildCgoLibraryRegistersGeneratedHeader` — real `c-archive` and `c-shared` builds, asserting the header artifact and its mod timestamp.
- `TestBuildCgoLibraryFailureDoesNotRegisterStaleHeader` — keeps `c3bfb5a5b`'s guarantee: a failed build must not register a leftover header.
- `TestBuildCgoLibraryHeaderTimestampFailure` - a real C archive build verifies that a header-specific timestamp error is returned, no artifacts are registered, and the library timestamp is set. This covers the new error path without changing the coverage threshold.
