### PR TITLE
fix(builder/go): give a single ellipsis main an exact output path

### DIFF
--- a/internal/builders/golang/build.go
+++ b/internal/builders/golang/build.go
@@ -452,7 +452,14 @@ func buildGoBuildLine(
 		// NOTE: build.Main will never be empty here
 		cmd = append(cmd, "-o", options.Path, build.Main)
 	} else {
-		cmd = append(cmd, "-o", filepath.Dir(options.Path))
+		output := filepath.Dir(options.Path)
+		if len(mains) == 1 {
+			// go names the output itself when -o is a directory, dropping the
+			// extension registered for the target, e.g. `.wasm`. A single main
+			// can get an exact path instead.
+			output = artifact.Path
+		}
+		cmd = append(cmd, "-o", output)
 		cmd = append(cmd, slices.Sorted(maps.Values(mains))...)
 	}
 	return cmd, nil

--- a/internal/builders/golang/build_test.go
+++ b/internal/builders/golang/build_test.go
@@ -2387,3 +2387,73 @@ func cSharedExt() string {
 		return ".so"
 	}
 }
+
+func TestBuildVariadicWasmArtifactsExistWithModTimestamp(t *testing.T) {
+	modTime := time.Date(2023, time.November, 14, 22, 13, 20, 0, time.UTC)
+
+	folder := testlib.Mktmp(t)
+	writeGoMod(t, folder, "github.com/foo/bar")
+	writeGoodMain(t, filepath.Join(folder, "cmd", "foo"))
+
+	target := mustParse(t, "js_wasm")
+	build := config.Build{
+		ID:           "foo",
+		Main:         "./cmd/...",
+		Tool:         "go",
+		Command:      "build",
+		ModTimestamp: fmt.Sprintf("%d", modTime.Unix()),
+	}
+	options := api.Options{
+		Target: target,
+		Name:   "foo.wasm",
+		Path:   filepath.Join(folder, "dist", target.Target, "foo.wasm"),
+		Ext:    ".wasm",
+	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(options.Path), 0o755))
+
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{Builds: []config.Build{build}})
+	require.NoError(t, Default.Build(ctx, build, options))
+
+	bins := ctx.Artifacts.Filter(artifact.ByType(artifact.Binary)).List()
+	require.Len(t, bins, 1)
+	require.Equal(t, filepath.ToSlash(filepath.Join("dist", target.Target, "foo.wasm")), bins[0].Path)
+	info, err := os.Stat(bins[0].Path)
+	require.NoError(t, err)
+	require.NotZero(t, info.Size())
+	require.Equal(t, modTime, info.ModTime().UTC())
+}
+
+func TestBuildGoBuildLineEllipsisOutput(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join("dist", "foo_js_wasm")
+	path := filepath.Join(dir, "app.wasm")
+
+	// go names the output itself when -o is a directory, which drops the
+	// registered extension. A single main gets the exact path instead.
+	for name, tt := range map[string]struct {
+		mains map[string]string
+		want  []string
+	}{
+		"single main gets an exact output path": {
+			mains: map[string]string{"app": "./cmd/app"},
+			want:  []string{"go", "build", "-o", path, "./cmd/app"},
+		},
+		"several mains get an output directory": {
+			mains: map[string]string{"app": "./cmd/app", "other": "./cmd/other"},
+			want:  []string{"go", "build", "-o", dir, "./cmd/app", "./cmd/other"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			build := config.Build{Main: "./cmd/...", Tool: "go", Command: "build"}
+			ctx := testctx.WrapWithCfg(t.Context(), config.Project{Builds: []config.Build{build}})
+			cmd, err := buildGoBuildLine(ctx, build, build.BuildDetails, api.Options{
+				Path:   filepath.Join(dir, "foo.wasm"),
+				Target: mustParse(t, "js_wasm"),
+			}, &artifact.Artifact{Name: "app.wasm", Path: path}, tt.mains, nil)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, cmd)
+		})
+	}
+}


### PR DESCRIPTION
Closes #6898

## Problem

An ellipsis `main` always passed an output **directory**:

```go
cmd = append(cmd, "-o", filepath.Dir(options.Path))
```

go then names each output after its package and drops the extension that
`extFor` registered for the target. `GOEXE` is empty for `js/wasm` and
`wasip1/wasm`, so `go build -o <dir>` writes `foo` while GoReleaser registered
`foo.wasm`. Only wasm goes out of step: `main: ./cmd/foo` is fine, because it
uses `-o <path>`.

Three outcomes with `main: ./...` and `targets: [js_wasm]`:

| config | result |
|---|---|
| bare | **"build succeeded"**, registering a nonexistent `dist/x_js_wasm/foo.wasm` |
| `mod_timestamp` | `chtimes ...: no such file or directory` |
| `archives` | `failed to add ...: lstat ...: no such file or directory` |

Reporting success while writing a path that does not exist into
`artifacts.json` is the part that matters.

## Fix

When the ellipsis resolves to exactly one main package, give go the exact `-o`
path, the same as a non-ellipsis build. go honours the name even when it is not
the one it would choose (`-o out/custom.lib` writes `custom.lib`), so nothing
needs a rename afterwards.

```go
output := filepath.Dir(options.Path)
if len(mains) == 1 {
	output = artifact.Path
}
cmd = append(cmd, "-o", output)
```

Several main packages still need a directory. That case keeps the old
behaviour, and it stays wrong for wasm. It is left alone on purpose: no user
has reported it, and the alternative is to copy `cmd/go` output-naming rules
into GoReleaser, which is not a stable interface to copy.

## Tests

Both fail without the fix:

- `TestBuildVariadicWasmArtifactsExistWithModTimestamp` — the issue, end to end,
  with a real wasm build and `mod_timestamp`.
- `TestBuildGoBuildLineEllipsisOutput` — the `-o` shape for one main against
  several.
