### PR TITLE
docs(builder/go): explain that ellipsis discovery uses the host context

### DIFF
--- a/internal/builders/golang/gomain/gomain.go
+++ b/internal/builders/golang/gomain/gomain.go
@@ -22,7 +22,7 @@ import (
 
 // ErrNoMains happens when, after scanning the module, we still didn't find any
 // 'func main'.
-var ErrNoMains = errors.New("directory does not contain any main function\nLearn more at https://goreleaser.com/errors/no-main\n") //nolint:revive,staticcheck
+var ErrNoMains = errors.New("directory does not contain any main function\nif the main packages are behind build tags or OS constraints, set 'main' to the package path instead of an ellipsis\nLearn more at https://goreleaser.com/errors/no-main\n") //nolint:revive,staticcheck
 
 // ErrNoMain happens when no 'func main' is found at a specific path.
 type ErrNoMain struct {

--- a/www/content/customization/builds/builders/go.md
+++ b/www/content/customization/builds/builders/go.md
@@ -567,33 +567,32 @@ Binary names will be inferred just like `go build` does.
 If you have multiple build configurations that change only the `main` and
 `binary` portions, this might be your friend.
 
-> [!WARNING]
-> **Discovery uses the host build context**
->
-> GoReleaser looks for `main` packages using the environment it runs in.
-> It does not apply the `tags` and `flags` of the build, nor the `GOOS` and
-> `GOARCH` of each target.
->
-> Because of that, an ellipsis path does not see a `main` package that is
-> behind a build constraint:
->
-> ```yaml {filename=".goreleaser.yaml"}
-> builds:
->   - main: ./... # cmd/feature/main.go has `//go:build feature`
->     tags: [feature]
-> ```
->
-> This fails with `directory does not contain any main function`, and a
-> `main` package with `//go:build linux` is skipped when you release from
-> macOS.
->
-> Set `main` to the package path in that case, and use one build per package:
->
-> ```yaml {filename=".goreleaser.yaml"}
-> builds:
->   - id: feature
->     main: ./cmd/feature
->     tags: [feature]
-> ```
+### Discovery uses the host build context
+
+GoReleaser looks for `main` packages using the environment it runs in.
+It does not apply the `tags` and `flags` of the build, nor the `GOOS` and
+`GOARCH` of each target.
+
+Because of that, an ellipsis path does not see a `main` package whose build
+constraints are not satisfied in that environment:
+
+```yaml {filename=".goreleaser.yaml"}
+builds:
+  - main: ./... # cmd/feature/main.go has `//go:build feature`
+    tags: [feature]
+```
+
+This fails with `directory does not contain any main function`, and a
+`main` package with `//go:build linux` is skipped when you release from
+macOS.
+
+Set `main` to the package path in that case, and use one build per package:
+
+```yaml {filename=".goreleaser.yaml"}
+builds:
+  - id: feature
+    main: ./cmd/feature
+    tags: [feature]
+```
 
 {{< g_templates >}}

--- a/www/content/customization/builds/builders/go.md
+++ b/www/content/customization/builds/builders/go.md
@@ -567,4 +567,33 @@ Binary names will be inferred just like `go build` does.
 If you have multiple build configurations that change only the `main` and
 `binary` portions, this might be your friend.
 
+> [!WARNING]
+> **Discovery uses the host build context**
+>
+> GoReleaser looks for `main` packages using the environment it runs in.
+> It does not apply the `tags` and `flags` of the build, nor the `GOOS` and
+> `GOARCH` of each target.
+>
+> Because of that, an ellipsis path does not see a `main` package that is
+> behind a build constraint:
+>
+> ```yaml {filename=".goreleaser.yaml"}
+> builds:
+>   - main: ./... # cmd/feature/main.go has `//go:build feature`
+>     tags: [feature]
+> ```
+>
+> This fails with `directory does not contain any main function`, and a
+> `main` package with `//go:build linux` is skipped when you release from
+> macOS.
+>
+> Set `main` to the package path in that case, and use one build per package:
+>
+> ```yaml {filename=".goreleaser.yaml"}
+> builds:
+>   - id: feature
+>     main: ./cmd/feature
+>     tags: [feature]
+> ```
+
 {{< g_templates >}}

--- a/www/content/resources/errors/no-main.md
+++ b/www/content/resources/errors/no-main.md
@@ -39,6 +39,30 @@ For more information, check the [builds documentation](/customization/builds/bui
 
 Run goreleaser in the root of the project.
 
+## If your `main` is an ellipsis path and the package is behind a build tag
+
+GoReleaser discovers `main` packages using the environment it runs in. It does
+not apply the `tags` and `flags` of the build, nor the `GOOS` and `GOARCH` of
+each target, so a package guarded by a build constraint is not found:
+
+```yaml {filename=".goreleaser.yaml"}
+builds:
+  - main: ./... # cmd/feature/main.go has `//go:build feature`
+    tags: [feature]
+```
+
+Set `main` to the package path instead, and use one build per package:
+
+```yaml {filename=".goreleaser.yaml"}
+builds:
+  - id: feature
+    main: ./cmd/feature
+    tags: [feature]
+```
+
+The same applies to a `main` package that only builds on one operating system,
+for example one with `//go:build linux` when you release from macOS.
+
 ## If you are building in `plugin`, `c-shared` or `c-archive` build modes
 
 You can set `no_main_check` to `true`:

--- a/www/content/resources/errors/no-main.md
+++ b/www/content/resources/errors/no-main.md
@@ -41,27 +41,12 @@ Run goreleaser in the root of the project.
 
 ## If your `main` is an ellipsis path and the package is behind a build tag
 
-GoReleaser discovers `main` packages using the environment it runs in. It does
-not apply the `tags` and `flags` of the build, nor the `GOOS` and `GOARCH` of
-each target, so a package guarded by a build constraint is not found:
+Ellipsis discovery uses the host build context, so it can miss packages behind
+build tags or OS constraints. Set `main` to the package path instead, and use one
+build per package.
 
-```yaml {filename=".goreleaser.yaml"}
-builds:
-  - main: ./... # cmd/feature/main.go has `//go:build feature`
-    tags: [feature]
-```
-
-Set `main` to the package path instead, and use one build per package:
-
-```yaml {filename=".goreleaser.yaml"}
-builds:
-  - id: feature
-    main: ./cmd/feature
-    tags: [feature]
-```
-
-The same applies to a `main` package that only builds on one operating system,
-for example one with `//go:build linux` when you release from macOS.
+For details and examples, see
+[Discovery uses the host build context](/customization/builds/builders/go/#discovery-uses-the-host-build-context).
 
 ## If you are building in `plugin`, `c-shared` or `c-archive` build modes
 


### PR DESCRIPTION
Closes #6899

## What the issue reports

Both halves reproduce on `main`. `gomain.All` builds a `packages.Config` with only `Mode` and `Dir` — no `Env`, no `BuildFlags`:

- `main: ./...` with `tags: [feature]` and a main behind `//go:build feature` fails with `directory does not contain any main function`. Ambient `GOFLAGS=-tags=feature` succeeds.
- Releasing from macOS with `cmd/macos` and `cmd/linuxer`, discovery finds only `./cmd/macos` and builds it for both targets; the linux build then fails with `build constraints exclude all Go files`.

## Why this is documentation and not a code change

I started on the obvious fix — pass the target environment and selection flags into `packages.Load` — and backed it out:

- **Cost.** `gomain.All` runs `packages.Load` with `NeedTypes|NeedSyntax|NeedTypesInfo|NeedDeps`, once per target. Today every call shares one environment, so loads 2..N are nearly free. A per-target environment forces a distinct full type check per `GOOS`/`GOARCH` across the whole matrix.
- **It makes validation target dependent.** `checkBuildElipsis` rejects a config when an ellipsis resolves to more than one main and `binary` or `id` is set. If discovery is target aware, the same config errors on one target and passes on another.
- **It shifts artifact IDs.** Auto-assigned IDs key off the number of main packages found, which would become target dependent.
- **The payoff is small.** Both failures are loud, never silent, and the workaround is one line: name the package. Ellipsis is opt-in and documented as sugar for `go build -o dir . ./cmd/foo ./cmd/bar` — if the mains are conditionally compiled, list them.

So the limit is now stated where users meet it rather than worked around.

## Changes

- A host build context subsection in the ellipsis section of the Go builder page, with the failing config and the fix.
- A short section in the `no-main` error page that links to the Go builder subsection for details and examples.
- `ErrNoMains` now says to set `main` to the package path when the mains are behind build tags or OS constraints, so the error points at the cause.

No behaviour change.