### PR TITLE
test(nfpm): close the temp binary in TestSkipSign

### DIFF
--- a/internal/pipe/nfpm/nfpm_test.go
+++ b/internal/pipe/nfpm/nfpm_test.go
@@ -1975,8 +1975,9 @@ func TestSkipSign(t *testing.T) {
 		require.NoError(tb, os.Mkdir(dist, 0o755))
 		require.NoError(tb, os.Mkdir(filepath.Join(dist, "mybin"), 0o755))
 		binPath := filepath.Join(dist, "mybin", "mybin")
-		_, err := os.Create(binPath)
+		f, err := os.Create(binPath)
 		require.NoError(tb, err)
+		require.NoError(tb, f.Close())
 		ctx := testctx.WrapWithCfg(t.Context(), config.Project{
 			ProjectName: "mybin",
 			Dist:        dist,


### PR DESCRIPTION
Close the empty binary file that `TestSkipSign` creates for each subtest.

The setup helper in `internal/pipe/nfpm/nfpm_test.go` discarded the `*os.File`
returned by `os.Create`:

```go
_, err := os.Create(binPath)
require.NoError(tb, err)
```

The operating-system handle then stayed open until a garbage-collection
finalizer closed it. That closure is asynchronous, so it can happen after the
test finishes. On Windows, `t.TempDir` cleanup cannot delete a file that still
has an open handle. The parent test then fails while both subtests pass:

```text
TempDir RemoveAll cleanup: unlinkat D:\tmp\TestSkipSign4214046935\002\dist\mybin\mybin:
The process cannot access the file because it is being used by another process.
--- FAIL: TestSkipSign
    --- PASS: TestSkipSign/skip_sign_not_set
    --- PASS: TestSkipSign/skip_sign_set
```

Every other test in this file already closes the handle. This change applies
the same pattern in the shared setup helper, which removes both leaked
handles.

This is a test resource-ownership defect on `main`. It is not a regression from
any recent change. A local diagnostic that disabled garbage collection and
inspected open files confirmed the leak on unchanged `main`, and confirmed that
the added `Close()` removes it.

No signing assertions, test selection, retries, or CI settings change.

Seen in the Windows job of https://github.com/goreleaser/goreleaser/pull/7112.
