### PR TITLE
fix(healthcheck): upx ignores the configured binary

### DIFF
--- a/internal/pipe/upx/upx.go
+++ b/internal/pipe/upx/upx.go
@@ -2,6 +2,7 @@
 package upx
 
 import (
+	"cmp"
 	"fmt"
 	"os"
 	"os/exec"
@@ -19,15 +20,24 @@ import (
 
 type Pipe struct{}
 
-func (Pipe) String() string                         { return "upx" }
-func (Pipe) Skip(ctx *context.Context) bool         { return len(ctx.Config.UPXs) == 0 }
-func (Pipe) Dependencies(*context.Context) []string { return []string{"upx"} }
+const defaultBinary = "upx"
+
+func (Pipe) String() string                 { return "upx" }
+func (Pipe) Skip(ctx *context.Context) bool { return len(ctx.Config.UPXs) == 0 }
+
+func (Pipe) Dependencies(ctx *context.Context) []string {
+	var bins []string
+	for _, upx := range ctx.Config.UPXs {
+		bins = append(bins, cmp.Or(upx.Binary, defaultBinary))
+	}
+	return bins
+}
 
 func (Pipe) Default(ctx *context.Context) error {
 	for i := range ctx.Config.UPXs {
 		upx := &ctx.Config.UPXs[i]
 		if upx.Binary == "" {
-			upx.Binary = "upx"
+			upx.Binary = defaultBinary
 		}
 	}
 	return nil

--- a/internal/pipe/upx/upx_test.go
+++ b/internal/pipe/upx/upx_test.go
@@ -298,3 +298,27 @@ func TestFindBinaries(t *testing.T) {
 		}), 1)
 	})
 }
+
+func TestDependencies(t *testing.T) {
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		UPXs: []config.UPX{
+			{Binary: "my-upx"},
+			{},
+		},
+	})
+
+	// Default has not run here, so the second entry falls back on its own.
+	require.Equal(t, []string{"my-upx", "upx"}, Pipe{}.Dependencies(ctx))
+}
+
+func TestDependenciesAfterDefault(t *testing.T) {
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		UPXs: []config.UPX{
+			{},
+			{Binary: "my-upx"},
+		},
+	})
+
+	require.NoError(t, Pipe{}.Default(ctx))
+	require.Equal(t, []string{"upx", "my-upx"}, Pipe{}.Dependencies(ctx))
+}


### PR DESCRIPTION
`goreleaser healthcheck` demands the literal `upx` in `$PATH` and exits 1, even when `upx[].binary` points at an executable that exists. `Run` calls `exec.LookPath(upx.Binary)`, so the release itself works and only the healthcheck fails.

```yaml
upx:
  - enabled: true
    binary: /tmp/fakebin/my-upx
signs:
  - cmd: /tmp/fakebin/my-upx
sboms:
  - cmd: /tmp/fakebin/my-upx
```

```
$ goreleaser healthcheck

before:                                after:
  ✓ git                                  ✓ git
  ✓ go                                   ✓ go
  ✓ /tmp/fakebin/my-upx                  ✓ /tmp/fakebin/my-upx
  ⚠ upx - not present in path            done!
  ⨯ one or more checks failed
```

The same config proves the shape, since `signs[].cmd` and `sboms[].cmd` point at the same file and both pass. `sign.go` and `sbom.go` build their dependency list from the config; `upx.go` returned a hardcoded `[]string{"upx"}`.

`makeself` is the other pipe with a hardcoded name, and it is correct as it stands, because it runs `exec.CommandContext(ctx, "makeself", ...)` with no configurable binary. `upx` is the only one where the config and the check disagree.

`Dependencies` falls back on the default rather than reading `Binary` bare. `cmd/healthcheck.go` runs `defaults.Pipe{}` before the checkers so `Binary` is always populated in practice, but the existing `TestDependencyCheckersCoverExternalBinaries` in `pkg/healthcheck` calls `Dependencies` on a config that has not been through `Default`, and returning an empty string there would silently check nothing. The constant is shared with `Default` so the two cannot drift, the same way `sign.go` keeps `defaultGpg`.

Verification:

- The before and after above are real `goreleaser healthcheck` runs from binaries built on `main` and on this branch.
- With `binary` omitted, the check still reports `upx - not present in path`, so the default path is unchanged.
- Two tests added, covering `Dependencies` before and after `Default` runs. Reverting to the hardcoded list fails both. Removing just the fallback fails one of them and also fails the existing `pkg/healthcheck` test, which is what the fallback is there for.
- `go test ./internal/pipe/upx/... ./cmd/... ./pkg/healthcheck/...` green, and green on `main` too. No existing test changed.

AI disclosure: written with Claude Code. I ran the healthcheck before and after and ran the mutations myself.
