### PR TITLE
fix(git): tag not in the local repository is not an error

### DIFF
--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -259,6 +259,11 @@ func getTagContents(ctx *context.Context, tag string) (subject, contents, body s
 	if err != nil {
 		return "", "", "", err
 	}
+	if out == "" {
+		// the tag is not in the local repository, e.g. when
+		// GORELEASER_CURRENT_TAG names a tag that was never fetched.
+		return "", "", "", nil
+	}
 	parts := strings.Split(out, "\x00")
 	if len(parts) != 3 {
 		return "", "", "", fmt.Errorf("unexpected git tag output for %q: %q", tag, out)

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -458,6 +458,22 @@ func TestTagFromCINotInRepository(t *testing.T) {
 	require.Empty(t, ctx.Git.TagBody)
 }
 
+func TestTagFromCINotInRepositoryValidates(t *testing.T) {
+	testlib.Mktmp(t)
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
+	testlib.GitCommit(t, "commit1")
+	testlib.GitTag(t, "v0.0.1")
+	t.Setenv("GORELEASER_CURRENT_TAG", "v0.0.2")
+
+	ctx := testctx.Wrap(t.Context())
+	err := Pipe{}.Run(ctx)
+	var wrongRef ErrWrongRef
+	require.ErrorAs(t, err, &wrongRef)
+	require.Equal(t, "v0.0.2", wrongRef.tag)
+	require.Equal(t, ctx.Git.Commit, wrongRef.commit)
+}
+
 func TestNoPreviousTag(t *testing.T) {
 	testlib.Mktmp(t)
 	testlib.GitInit(t)

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -442,6 +442,22 @@ func TestTagFromCI(t *testing.T) {
 	}
 }
 
+func TestTagFromCINotInRepository(t *testing.T) {
+	testlib.Mktmp(t)
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
+	testlib.GitCommit(t, "commit1")
+	testlib.GitTag(t, "v0.0.1")
+	t.Setenv("GORELEASER_CURRENT_TAG", "v0.0.2")
+
+	ctx := testctx.Wrap(t.Context(), testctx.Skip(skips.Validate))
+	testlib.AssertSkipped(t, Pipe{}.Run(ctx))
+	require.Equal(t, "v0.0.2", ctx.Git.CurrentTag)
+	require.Empty(t, ctx.Git.TagSubject)
+	require.Empty(t, ctx.Git.TagContents)
+	require.Empty(t, ctx.Git.TagBody)
+}
+
 func TestNoPreviousTag(t *testing.T) {
 	testlib.Mktmp(t)
 	testlib.GitInit(t)


### PR DESCRIPTION
A tag that is not in the local repository no longer fails the run.

`getTagContents` runs `git tag -l <tag>`, which prints nothing and exits 0 when the tag is not in the local repository. The output shape check added in #6850 turned that empty output into an error:

```
⨯ release failed after 0s   error=couldn't get tag contents: unexpected git tag output for "v0.17.0": ""
```

Users hit this with `GORELEASER_CURRENT_TAG` set to a tag that the checkout never fetched. Before #6850, the three separate `git tag -l` calls each returned an empty string in that case, so the subject, contents and body were empty and the release continued.

This restores that behavior: empty output gives empty strings. Output that is not empty and does not have the three fields is still an error.

`TestTagFromCINotInRepository` sets `GORELEASER_CURRENT_TAG` to a tag that is not in the repository. With the fix removed, it fails with the exact error from the issue.

Closes #7122
