### PR TITLE
feat: graduate stable features out of experimental

### DIFF
--- a/internal/builders/bun/build.go
+++ b/internal/builders/bun/build.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
@@ -45,14 +44,8 @@ func (b *Builder) Dependencies() []string {
 	return []string{"bun"}
 }
 
-var once sync.Once
-
 // WithDefaults implements build.Builder.
 func (b *Builder) WithDefaults(build config.Build) (config.Build, error) {
-	once.Do(func() {
-		log.Warn("you are using the experimental Bun builder")
-	})
-
 	if len(build.Targets) == 0 {
 		build.Targets = defaultTargets()
 	}

--- a/internal/builders/deno/build.go
+++ b/internal/builders/deno/build.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
@@ -40,14 +39,8 @@ func (b *Builder) Dependencies() []string {
 	return []string{"deno"}
 }
 
-var once sync.Once
-
 // WithDefaults implements build.Builder.
 func (b *Builder) WithDefaults(build config.Build) (config.Build, error) {
-	once.Do(func() {
-		log.Warn("you are using the experimental Deno builder")
-	})
-
 	if len(build.Targets) == 0 {
 		build.Targets = defaultTargets()
 	}

--- a/internal/builders/poetry/build.go
+++ b/internal/builders/poetry/build.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
@@ -71,14 +70,8 @@ func (Target) String() string {
 	return defaultTarget
 }
 
-var once sync.Once
-
 // WithDefaults implements build.Builder.
 func (b *Builder) WithDefaults(build config.Build) (config.Build, error) {
-	once.Do(func() {
-		log.Warn("you are using the experimental POETRY builder")
-	})
-
 	if len(build.Targets) == 0 {
 		build.Targets = []string{defaultTarget}
 	}

--- a/internal/builders/rust/build.go
+++ b/internal/builders/rust/build.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
@@ -117,14 +116,8 @@ func (b *Builder) Parse(target string) (api.Target, error) {
 	return t, nil
 }
 
-var once sync.Once
-
 // WithDefaults implements build.Builder.
 func (b *Builder) WithDefaults(build config.Build) (config.Build, error) {
-	once.Do(func() {
-		log.Warn("you are using the experimental Rust builder")
-	})
-
 	if len(build.Targets) == 0 {
 		build.Targets = defaultTargets()
 	}

--- a/internal/builders/uv/build.go
+++ b/internal/builders/uv/build.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
@@ -71,14 +70,8 @@ func (Target) String() string {
 	return defaultTarget
 }
 
-var once sync.Once
-
 // WithDefaults implements build.Builder.
 func (b *Builder) WithDefaults(build config.Build) (config.Build, error) {
-	once.Do(func() {
-		log.Warn("you are using the experimental UV builder")
-	})
-
 	if len(build.Targets) == 0 {
 		build.Targets = []string{defaultTarget}
 	}

--- a/internal/builders/zig/build.go
+++ b/internal/builders/zig/build.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/caarlos0/log"
 	"github.com/goreleaser/goreleaser/v2/internal/artifact"
@@ -63,14 +62,8 @@ func (b *Builder) Parse(target string) (api.Target, error) {
 	return t, nil
 }
 
-var once sync.Once
-
 // WithDefaults implements build.Builder.
 func (b *Builder) WithDefaults(build config.Build) (config.Build, error) {
-	once.Do(func() {
-		log.Warn("you are using the experimental Zig builder")
-	})
-
 	if len(build.Targets) == 0 {
 		build.Targets = defaultTargets()
 	}

--- a/www/content/customization/general/git.md
+++ b/www/content/customization/general/git.md
@@ -60,8 +60,6 @@ which is different from what other git sorting options might give you.
 
 {{< g_version "v2.12" >}}
 
-{{< g_experimental >}}
-
 {{< g_featpro >}}
 
 Like semver sorting, but smarter: if the current version is not a pre-release,


### PR DESCRIPTION
Remove the experimental marker from the six builders and the one Pro option that have long since stabilized.

**Warning + `var once sync.Once` removed** — Zig, Rust, Bun, Deno, UV, Poetry.
**`{{< g_experimental >}}` removed** — `tag_sort: smartsemver` docs section.

**Kept, deliberately:** MCP registry publisher, Node.js SEA builder, nfpm `msix`.

## Why

The precedent is `dockers_v2`: experimental for ~9 months, marker dropped in e8d5686 (v2.16).

| Feature | Released | Age |
|---|---|---|
| Zig, Rust | v2.5 (2024-12) | ~21 mo |
| Bun, Deno | v2.6 (2025-01) | ~20 mo |
| UV, Poetry | v2.9 (2025-04) | ~17 mo |
| `smartsemver` | v2.12 (2025-09) | ~12 mo |

All are well past that bar, still get regular fixes, and none has had a breaking config change in a long time. UV and Poetry have a tiny surface (`buildmode: wheel|sdist`), and `smartsemver` is a single enum value that never had a runtime warning.

There was also a consistency bug: the six builders printed `you are using the experimental X builder` on every run, but their docs pages carry no `{{< g_experimental >}}`. The shortcode was added after those pages landed and they were never backfilled — so the binary and the docs disagreed, and users got a scary warning with no page explaining it. That is what prompted the discussion below.

The three that keep their marker are either too new (`msix` ~2 mo, Node SEA ~4 mo, and Node SEA is experimental upstream too) or shaped by an upstream API that is not settled yet (MCP Registry / `server.json`).

## Notes

- No behavior change beyond the dropped log lines; nothing else in these builders is touched.
- `smartsemver` has no runtime marker on the Pro side (verified `internal/pipe/git/git.go`), and pro-internal's `git.md` is identical to this one, so this is the complete removal.
- Not touched, per the audit: `GORELEASER_EXPERIMENTAL=defaultgoarm` (opt-in by design), the experimental Go targets in `golang/targets.go` (upstream Go), and the `nfpms.changelog` note (upstream nfpm/chglog).
- Still open: mention the graduations in the release blog post. No draft exists yet.

## Links

- goreleaser/goreleaser-pro-internal#1620 — the audit this implements
- #7120 — "Is Rust still experimental?"
- e8d5686 — the `dockers_v2` precedent
