### PR TITLE
fix(git): force column.ui=never so tag output is not columnized

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -24,6 +24,7 @@ func IsRepo(ctx context.Context) bool {
 func RunWithEnv(ctx context.Context, env []string, args ...string) (string, error) {
 	extraArgs := []string{
 		"-c", "log.showSignature=false",
+		"-c", "column.ui=never",
 	}
 	args = append(extraArgs, args...)
 	/* #nosec */

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -70,3 +70,22 @@ func TestClean(t *testing.T) {
 		require.Empty(t, out)
 	})
 }
+
+func TestGitColumnUI(t *testing.T) {
+	ctx := t.Context()
+	testlib.Mktmp(t)
+	testlib.GitInit(t)
+	testlib.GitCommit(t, "foo")
+	testlib.GitTag(t, "1.2.3")
+	testlib.GitTag(t, "nightly")
+	_, err := git.Run(ctx, "config", "column.ui", "always")
+	require.NoError(t, err)
+
+	tags, err := git.CleanAllLines(git.Run(ctx, "tag", "--points-at", "HEAD", "--sort", "-version:refname"))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"1.2.3", "nightly"}, tags)
+
+	out, err := git.Run(ctx, "tag", "-l", "--format=%(refname:short)%00%(objecttype)", "1.2.3")
+	require.NoError(t, err)
+	require.Equal(t, "1.2.3\x00commit\n", out)
+}

--- a/internal/pipe/git/git_test.go
+++ b/internal/pipe/git/git_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/caarlos0/log"
+	"github.com/goreleaser/goreleaser/v2/internal/git"
 	"github.com/goreleaser/goreleaser/v2/internal/skips"
 	"github.com/goreleaser/goreleaser/v2/internal/testctx"
 	"github.com/goreleaser/goreleaser/v2/internal/testlib"
@@ -119,6 +120,40 @@ func TestAnnotatedTagsWithApostrophes(t *testing.T) {
 	require.Equal(t, "don't break it", ctx.Git.TagSubject)
 	require.Equal(t, "don't break it\n\nit's the user's message", ctx.Git.TagContents)
 	require.Equal(t, "it's the user's message", ctx.Git.TagBody)
+}
+
+func TestAnnotatedTagsWithColumnUI(t *testing.T) {
+	testlib.Mktmp(t)
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
+	testlib.GitCommit(t, "commit1")
+	testlib.GitAnnotatedTag(t, "v0.0.1", "first version\n\nlalalla\nlalal\nlah")
+	_, err := git.Run(t.Context(), "config", "column.ui", "always")
+	require.NoError(t, err)
+	ctx := testctx.Wrap(t.Context())
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, "v0.0.1", ctx.Git.CurrentTag)
+	require.Equal(t, "first version", ctx.Git.TagSubject)
+	require.Equal(t, "first version\n\nlalalla\nlalal\nlah", ctx.Git.TagContents)
+	require.Equal(t, "lalalla\nlalal\nlah", ctx.Git.TagBody)
+}
+
+func TestTagSortOrderWithColumnUI(t *testing.T) {
+	testlib.Mktmp(t)
+	testlib.GitInit(t)
+	testlib.GitRemoteAdd(t, "git@github.com:foo/bar.git")
+	testlib.GitCommit(t, "commit1")
+	testlib.GitTag(t, "v0.0.2")
+	testlib.GitTag(t, "v0.0.1")
+	_, err := git.Run(t.Context(), "config", "column.ui", "always")
+	require.NoError(t, err)
+	ctx := testctx.WrapWithCfg(t.Context(), config.Project{
+		Git: config.Git{
+			TagSort: "-version:refname",
+		},
+	})
+	require.NoError(t, Pipe{}.Run(ctx))
+	require.Equal(t, "v0.0.2", ctx.Git.CurrentTag)
 }
 
 func TestBranch(t *testing.T) {


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Also, add tests and the respective documentation changes as well.

-->

## Problem

When the user has `column.ui = always` (or `column.tag = always`) in their git configuration, `git tag` prints its output in columns even when stdout is a pipe. GoReleaser parses that output, so:

- `getTagContents` fails hard with `couldn't get tag contents: unexpected git tag output for "v1": ...` because the NUL separators in `--format=%(contents:subject)%00%(contents)%00%(contents:body)` are replaced by column padding and the split yields 1 part instead of 3 (a hard failure since #6850).
- `gitTagsPointingAt` returns all tags pointing at `HEAD` on a single line, so with two tags on `HEAD` `CurrentTag` becomes e.g. `"v1.0.0-rc1  v1.0.0"`.

## Root cause

`internal/git/git.go:24-27` (`RunWithEnv`) forces `-c log.showSignature=false` but nothing for `column.*`. Since `cmd.Env` stays `nil` when no extra env is passed, the child `git` inherits the full environment and reads the user's `~/.gitconfig` (and the repository and system configs), so a `column.ui = always` there reaches every `git tag` invocation.

Affected callers: `internal/pipe/git/git.go` `getTagContents` (`git tag -l --format=...`) and `gitTagsPointingAt` (`git tag --points-at ...`).

## Fix

Add `-c column.ui=never` next to the existing `-c log.showSignature=false` in `RunWithEnv`, as suggested in the issue. `-c` is applied after all config files, so it also overrides a more specific `column.tag = always` set in the repository config (verified locally). This protects every `git` call GoReleaser makes now or later, not just the two known ones.

## How tested

Added `TestGitColumnUI` in `internal/git` and `TestAnnotatedTagsWithColumnUI` / `TestTagSortOrderWithColumnUI` in `internal/pipe/git`. Each sets `column.ui always` in the fixture repository's config (not the global one).

Before the fix (git 2.43.0, Linux):

```
--- FAIL: TestGitColumnUI (0.02s)
        	Error:      	elements differ
        	            	extra elements in list B:
        	            	 (string) (len=14) "nightly  1.2.3"
--- FAIL: TestAnnotatedTagsWithColumnUI (0.05s)
        	Error:      	Received unexpected error:
        	            	couldn't get tag contents: unexpected git tag output for "v0.0.1": "first version  lalalla        lah            lalal          \n               lalal                         lah\n"
--- FAIL: TestTagSortOrderWithColumnUI (0.07s)
        	Error:      	Received unexpected error:
        	            	git tag v0.0.2  v0.0.1 was not made against commit f454a831d7daa63ca258d6f6df329727c9022a26
```

After the fix:

```
--- PASS: TestGitColumnUI (0.02s)
--- PASS: TestAnnotatedTagsWithColumnUI (0.04s)
--- PASS: TestTagSortOrderWithColumnUI (0.04s)
ok  	github.com/goreleaser/goreleaser/v2/internal/git	1.179s
ok  	github.com/goreleaser/goreleaser/v2/internal/pipe/git	2.134s
ok  	github.com/goreleaser/goreleaser/v2/internal/testlib	1.066s
```

`gofumpt -l`, `go vet` and `golangci-lint run --tests` on the changed packages report no issues; `go build ./...` passes.

## Links

- Closes https://github.com/goreleaser/goreleaser/issues/7125
- Related: #6850 (made the tag-contents parse a hard failure), #7122 / #7124 (same class of problem, different cause)

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.
